### PR TITLE
feat: version base images + checkpoints; auto-invalidate on context c…

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -4,6 +4,15 @@
 // explicitly set DOCKER_CLI_HINTS in their shell still wins.
 process.env.DOCKER_CLI_HINTS ??= 'false';
 
+// Build-time CLI version stamps. The provider packages (sandbox-docker,
+// sandbox-hetzner, sandbox-daytona) read these lazily — at prepare/create/
+// checkpoint time, never at import — so the ESM-hoists-imports-first order
+// is fine. Set via env so the provider packages don't need a compile-time
+// dep on apps/cli's bundled-only version module.
+import { AGENTBOX_COMMIT, AGENTBOX_VERSION } from './version.js';
+process.env.AGENTBOX_CLI_VERSION = AGENTBOX_VERSION;
+process.env.AGENTBOX_CLI_COMMIT = AGENTBOX_COMMIT;
+
 import { Command } from 'commander';
 import { applyEngineOverrideAtStartup } from './engine-override.js';
 import { buildGroupedHelp } from './help.js';
@@ -44,7 +53,10 @@ import { rewriteProviderPrefix } from './provider/argv-prefix.js';
 
 const program = new Command();
 
-program.name('agentbox').description('Launch coding agents in isolated sandboxes').version('0.0.0');
+program
+  .name('agentbox')
+  .description('Launch coding agents in isolated sandboxes')
+  .version(AGENTBOX_VERSION);
 
 // Required so `agentbox download env --dry-run` binds --dry-run to the `env`
 // subcommand rather than the parent `download` (both define it). Positional

--- a/apps/cli/src/lib/carry-resolve.ts
+++ b/apps/cli/src/lib/carry-resolve.ts
@@ -18,6 +18,13 @@ export interface ResolvedCarryEntry {
   kind: 'file' | 'dir' | 'missing';
   bytes?: number;
   mode?: number;
+  /**
+   * Numeric uid that should own the carried file inside the box. Mirrors
+   * the field on `@agentbox/core`'s `ResolvedCarryEntry`. `resolveOne()`
+   * below already forwards `item.user` into the result; this field made
+   * the contract explicit so `carry-prompt.ts` can render the flag.
+   */
+  user?: number;
   optional: boolean;
   symlinkInfo?: 'safe' | 'outside-home';
 }

--- a/apps/cli/src/session-teleport/codex.ts
+++ b/apps/cli/src/session-teleport/codex.ts
@@ -54,15 +54,20 @@ export async function resolveCodexTeleport(
 
   let picked: CodexSessionFile;
   if (opts.mode.kind === 'resume') {
-    const matches = all.filter((s) => s.uuid === opts.mode.id || s.uuid.startsWith(opts.mode.id));
+    // Alias to a local const so the narrowed type survives into the
+    // `.filter` callback. TS can't keep narrowing on a property access
+    // (`opts.mode`) across closures because the property could in principle
+    // be mutated between the check and each callback invocation.
+    const mode = opts.mode;
+    const matches = all.filter((s) => s.uuid === mode.id || s.uuid.startsWith(mode.id));
     if (matches.length === 0) {
       throw new TeleportError(
-        `Codex session "${opts.mode.id}" not found under ${sessionsRoot}.`,
+        `Codex session "${mode.id}" not found under ${sessionsRoot}.`,
       );
     }
     if (matches.length > 1) {
       throw new TeleportError(
-        `Codex session id "${opts.mode.id}" matched multiple files; pass the full uuid.`,
+        `Codex session id "${mode.id}" matched multiple files; pass the full uuid.`,
       );
     }
     picked = matches[0]!;

--- a/apps/cli/src/version.ts
+++ b/apps/cli/src/version.ts
@@ -1,0 +1,21 @@
+/**
+ * Build-time injected CLI version constants. tsup's `define` (apps/cli/tsup.config.ts)
+ * replaces these identifiers at bundle time:
+ *
+ *   __AGENTBOX_VERSION__ ← apps/cli/package.json `version`
+ *   __AGENTBOX_COMMIT__  ← `git rev-parse --short HEAD` at build time
+ *
+ * The `declare` lines below are for the typecheck of the unbundled source —
+ * tsup substitutes the literals before esbuild ever sees this file. The
+ * `?? '...'` fallbacks cover the unbundled dev case (running `tsx src/index.ts`
+ * before `pnpm build` populates the defines).
+ */
+
+declare const __AGENTBOX_VERSION__: string | undefined;
+declare const __AGENTBOX_COMMIT__: string | undefined;
+
+export const AGENTBOX_VERSION: string =
+  typeof __AGENTBOX_VERSION__ === 'string' ? __AGENTBOX_VERSION__ : '0.0.0-dev';
+
+export const AGENTBOX_COMMIT: string =
+  typeof __AGENTBOX_COMMIT__ === 'string' ? __AGENTBOX_COMMIT__ : 'dev';

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -1,4 +1,21 @@
 import { defineConfig } from 'tsup';
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(resolve(here, 'package.json'), 'utf8')) as { version: string };
+
+function gitShortSha(): string {
+  try {
+    return execSync('git rev-parse --short HEAD', { cwd: here, stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+  } catch {
+    return 'dev';
+  }
+}
 
 export default defineConfig({
   entry: ['src/index.ts'],
@@ -7,6 +24,12 @@ export default defineConfig({
   clean: true,
   dts: false,
   sourcemap: true,
+  // Substituted at bundle time — see apps/cli/src/version.ts for the
+  // matching `declare` lines that keep the unbundled typecheck honest.
+  define: {
+    __AGENTBOX_VERSION__: JSON.stringify(pkg.version),
+    __AGENTBOX_COMMIT__: JSON.stringify(gitShortSha()),
+  },
   // Published as the standalone `agent-box` npm package. Only the @agentbox/*
   // workspace libs are bundled (pure TS/ESM) so the package carries no
   // `workspace:*` deps. Every third-party dep stays external and is a real

--- a/packages/config/src/parse.ts
+++ b/packages/config/src/parse.ts
@@ -112,6 +112,19 @@ export function parseUserConfigObject(doc: unknown, where: string): Partial<User
 
   const out: Partial<UserConfig> = {};
   for (const [branchName, branchRaw] of Object.entries(doc)) {
+    // Top-level `schema` is a metadata stamp written by the loader on first
+    // save (future-proofs migrations). It's not a config section and never
+    // appears in `EffectiveConfig`; carry it through so writers preserve it
+    // round-trip, but skip the "must be a mapping" / leaf checks below.
+    if (branchName === 'schema') {
+      if (branchRaw !== undefined && branchRaw !== null) {
+        if (typeof branchRaw !== 'number' || !Number.isInteger(branchRaw)) {
+          throw new UserConfigError(`${where}.schema: must be an integer (got ${String(branchRaw)})`);
+        }
+        out.schema = branchRaw;
+      }
+      continue;
+    }
     const branchSpec = BRANCHES.get(branchName);
     if (!branchSpec) {
       throw new UserConfigError(

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -18,6 +18,14 @@ export type ProviderKind = 'docker' | 'daytona' | 'hetzner';
 export type AttachOpenIn = 'split' | 'window' | 'tab' | 'same';
 
 export interface UserConfig {
+  /**
+   * Config-file shape version. Stamped to `1` on first write so future
+   * migrations (e.g. a renamed key, a leaf-shape change) have a stable
+   * read-time discriminator. No behavioural effect yet — placeholder for
+   * later. Loader strips it before merge so it never leaks into
+   * `EffectiveConfig`.
+   */
+  schema?: number;
   box?: {
     provider?: ProviderKind;
     hostSnapshot?: boolean;

--- a/packages/config/src/write.ts
+++ b/packages/config/src/write.ts
@@ -50,6 +50,7 @@ export async function setConfigValue(
   const path = await configPathFor(scope, cwd);
   const current = await readExistingDoc(path);
   setLeaf(current, key, coerced);
+  stampSchema(current);
   // Re-parse to validate the merged document; any change that produces an
   // invalid file (shouldn't be possible here, but defence-in-depth) throws.
   parseUserConfig(stringifyYaml(current), path);
@@ -255,6 +256,18 @@ async function readExistingDoc(path: string): Promise<Partial<UserConfig>> {
     throw err;
   }
   return parseUserConfig(text, path);
+}
+
+/**
+ * Stamp `schema: 1` on a doc that hasn't been stamped yet. Idempotent — a
+ * doc already carrying any `schema` value is left alone. Future schema
+ * bumps live here.
+ */
+const CURRENT_CONFIG_SCHEMA = 1;
+function stampSchema(doc: Partial<UserConfig>): void {
+  if (typeof doc.schema !== 'number') {
+    doc.schema = CURRENT_CONFIG_SCHEMA;
+  }
 }
 
 function setLeaf(doc: Partial<UserConfig>, key: string, value: unknown): void {

--- a/packages/config/src/write.ts
+++ b/packages/config/src/write.ts
@@ -80,6 +80,7 @@ export async function unsetConfigValue(
   const current = await readExistingDoc(path);
   const existed = unsetLeaf(current, key);
   if (!existed) return { path, existed: false };
+  stampSchema(current);
   await atomicWriteYaml(path, current);
   if (scope === 'project') {
     const root = (await findProjectRoot(cwd)).root;

--- a/packages/sandbox-cloud/src/mock-backend.ts
+++ b/packages/sandbox-cloud/src/mock-backend.ts
@@ -51,6 +51,13 @@ export interface MockCloudBackend extends CloudBackend {
   readonly calls: ReadonlyArray<{ method: string; args: unknown[] }>;
   /** Sandboxes currently present in the backend (post any provision/destroy). */
   readonly sandboxes: ReadonlyArray<Readonly<SandboxRecord>>;
+  /**
+   * Empty the recorded `calls` log. Useful between assertions in a single
+   * test: do an action, assert, clear, do another action, assert again
+   * without the first batch polluting the filter. Tests previously poked
+   * `calls.length = 0`, which trips strict TS on the readonly array.
+   */
+  clearCalls(): void;
 }
 
 /** Make a fresh mock backend. Always returns a brand-new internal state. */
@@ -88,6 +95,9 @@ export function makeMockCloudBackend(opts: MockCloudBackendOptions = {}): MockCl
     },
     get sandboxes() {
       return Array.from(sandboxes.values());
+    },
+    clearCalls(): void {
+      calls.length = 0;
     },
 
     async provision(req: CloudProvisionRequest): Promise<CloudHandle> {

--- a/packages/sandbox-cloud/test/carry.test.ts
+++ b/packages/sandbox-cloud/test/carry.test.ts
@@ -113,7 +113,7 @@ describe('uploadCarryPaths', () => {
     expect(homeCmd).toContain('while [ "$parent" != "/home/vscode" ]');
 
     // Dest outside $HOME → no parent walk (system paths untouched).
-    backend.calls.length = 0;
+    backend.clearCalls();
     await uploadCarryPaths({
       backend,
       handle,
@@ -143,7 +143,7 @@ describe('uploadCarryPaths', () => {
     // user: 0 → chown to root explicitly (NOT a skip — the result must be
     // predictable across providers, especially docker where `docker cp`
     // would otherwise leak the host's uid:gid into the box).
-    backend.calls.length = 0;
+    backend.clearCalls();
     await uploadCarryPaths({
       backend,
       handle,

--- a/packages/sandbox-core/src/index.ts
+++ b/packages/sandbox-core/src/index.ts
@@ -16,3 +16,18 @@ export {
   pickFreshBranch,
   type DetectedGitRepo,
 } from './git-detect.js';
+export {
+  computeContextSha256,
+  DOCKER_CONTEXT_FILE_MAP,
+  preparedStatePathFor,
+  readCliStamp,
+  readPreparedStateRaw,
+  resolveContextFilesFrom,
+  sha256OfFile,
+  shortFingerprint,
+  writePreparedStateRaw,
+  type CliStamp,
+  type ContextFile,
+  type PreparedBaseSnapshot,
+  type PreparedProviderKind,
+} from './prepared-state.js';

--- a/packages/sandbox-core/src/prepared-state.ts
+++ b/packages/sandbox-core/src/prepared-state.ts
@@ -1,0 +1,231 @@
+/**
+ * Cross-provider versioning primitives for `~/.agentbox/<provider>-prepared.json`.
+ *
+ * Each provider records what it has baked (docker image / hetzner snapshot /
+ * daytona snapshot) under a per-provider JSON file with a shared `base.*`
+ * substructure so the CLI can detect when the on-disk artifact is stale
+ * relative to the current CLI's build context.
+ *
+ * The invalidation key is `base.contextSha256`: a deterministic SHA-256
+ * over every file in the build context (Dockerfile + scripts + baked
+ * config), keyed by the file's relative path. Two CLIs with the same
+ * staged runtime tree produce the same hash; an edit to any baked asset
+ * — even a one-byte tweak to `custom-system-CLAUDE.md` — flips it.
+ *
+ * Checkpoints embed the captured `contextSha256` so restoring an older
+ * checkpoint can warn the user that the baked layers predate the current
+ * base image.
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, resolve as pathResolve } from 'node:path';
+
+export type PreparedProviderKind = 'docker' | 'daytona' | 'hetzner';
+
+/**
+ * The cross-provider record. `TImage` is the provider's opaque image
+ * identifier: a string tag for docker/daytona, a numeric image id for
+ * hetzner. The `TExtra` slot lets a provider attach provider-specific
+ * fields (e.g. hetzner's `description` and `projects[]`) without forking
+ * the whole shape.
+ */
+export interface PreparedBaseSnapshot<TImage = string, TExtra = unknown> {
+  /** Schema version. Bumped when the on-disk shape changes incompatibly. */
+  schema: number;
+  base?: {
+    /** Provider-opaque image identifier (docker tag | hetzner imageId | daytona snapshot name). */
+    imageRef: TImage;
+    /** Deterministic SHA-256 of the build context — the invalidation key. */
+    contextSha256: string;
+    /** Informational: CLI version that produced this artifact. */
+    cliVersion: string;
+    /** Informational: git short SHA injected at CLI build time (or 'dev'). */
+    cliCommit?: string;
+    /** ISO timestamp of bake completion. */
+    createdAt: string;
+  };
+  /** Provider-specific extras (e.g. hetzner's per-project snapshot tier). */
+  extras?: TExtra;
+}
+
+export function preparedStatePathFor(provider: PreparedProviderKind): string {
+  return pathResolve(homedir(), '.agentbox', `${provider}-prepared.json`);
+}
+
+/**
+ * Read the prepared-state file for `provider`. Returns `null` when the file
+ * is missing, malformed, or carries a schema this code doesn't recognise —
+ * callers treat all three as "rebuild needed". Sync so it can run from
+ * non-async setup paths (mirrors the hetzner helper it generalises).
+ */
+export function readPreparedStateRaw(provider: PreparedProviderKind): unknown {
+  const path = preparedStatePathFor(provider);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Atomic write: write to `<path>.tmp` then rename. `mode: 0o600` because
+ * the file is informational but lives alongside `secrets.env` — same dir,
+ * same permissions hygiene.
+ */
+export function writePreparedStateRaw(provider: PreparedProviderKind, state: unknown): void {
+  const path = preparedStatePathFor(provider);
+  mkdirSync(dirname(path), { recursive: true });
+  const body = JSON.stringify(state, null, 2) + '\n';
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, body, { mode: 0o600 });
+  renameSync(tmp, path);
+}
+
+export async function sha256OfFile(path: string): Promise<string> {
+  const buf = await readFile(path);
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+export interface ContextFile {
+  /**
+   * Logical relative path. Used as the canonical key for hash determinism
+   * — two stagings with identical contents but different absolute paths
+   * must hash the same.
+   */
+  rel: string;
+  /** Absolute path the file is read from. */
+  abs: string;
+}
+
+/**
+ * Deterministic hash over a set of context files. Entries are sorted by
+ * `rel` then hashed as `<rel>\0<sha256(file)>\n` lines into a final SHA-256.
+ *
+ * - Sort order = determinism (the caller can pass files in any order).
+ * - NUL separator = no collision between a `rel` ending in hex and the
+ *   following digest.
+ * - Trailing newline per record = stable framing.
+ *
+ * Missing files raise — silently skipping would let a partial dev rebuild
+ * stamp a hash that doesn't represent what's actually in the image.
+ */
+export async function computeContextSha256(files: ContextFile[]): Promise<string> {
+  const sorted = [...files].sort((a, b) => (a.rel < b.rel ? -1 : a.rel > b.rel ? 1 : 0));
+  const outer = createHash('sha256');
+  for (const f of sorted) {
+    const inner = await sha256OfFile(f.abs);
+    outer.update(`${f.rel}\0${inner}\n`);
+  }
+  return outer.digest('hex');
+}
+
+/** Short form for log lines — first 12 hex chars of a sha256. */
+export function shortFingerprint(sha: string): string {
+  return sha.slice(0, 12);
+}
+
+/**
+ * CLI version stamps set by `apps/cli/src/index.ts` at startup via env vars
+ * (the values themselves come from tsup's build-time `define`). Providers
+ * record them onto prepared-state files and checkpoint manifests so a stale
+ * artifact carries a human-readable hint about which CLI built it.
+ *
+ * Fallbacks cover the unit-test and unbundled-dev paths (the CLI never
+ * loaded, env unset). `unknown` is a sentinel — never a real version.
+ */
+export interface CliStamp {
+  cliVersion: string;
+  cliCommit: string;
+}
+
+export function readCliStamp(): CliStamp {
+  return {
+    cliVersion: process.env.AGENTBOX_CLI_VERSION ?? 'unknown',
+    cliCommit: process.env.AGENTBOX_CLI_COMMIT ?? 'unknown',
+  };
+}
+
+/**
+ * Canonical map of files that go into the Docker base image build context
+ * — every file `Dockerfile.box` COPYs, plus the Dockerfile itself. Two
+ * layouts resolve the same logical entries:
+ *
+ *   - staged: `<contextDir>/<staged>` (production CLI runtime + dev with `apps/cli/runtime/docker`)
+ *   - dev:    `<sandboxDockerRoot>/<dev>` (workspace dev, no staged tree)
+ *
+ * Shared across providers because:
+ *   - sandbox-docker uses it to fingerprint its locally-built image.
+ *   - sandbox-daytona uses it to fingerprint the snapshot it bakes from the
+ *     same Dockerfile.box + the daytona-specific CLAUDE.md overlay.
+ *
+ * If you add a COPY line to `Dockerfile.box`, add the file here AND in
+ * `apps/cli/scripts/stage-runtime.mjs` — failure to do so means the image
+ * won't get re-built when that file changes.
+ */
+export const DOCKER_CONTEXT_FILE_MAP: Record<string, { staged: string; dev: string }> = {
+  'Dockerfile.box': { staged: 'Dockerfile.box', dev: 'Dockerfile.box' },
+  'ctl/bin.cjs': {
+    staged: 'packages/ctl/dist/bin.cjs',
+    dev: '../ctl/dist/bin.cjs',
+  },
+  'share/agentbox-setup/SKILL.md': {
+    staged: 'apps/cli/share/agentbox-setup/SKILL.md',
+    dev: '../../apps/cli/share/agentbox-setup/SKILL.md',
+  },
+  'scripts/agentbox-vnc-start': {
+    staged: 'packages/sandbox-docker/scripts/agentbox-vnc-start',
+    dev: 'scripts/agentbox-vnc-start',
+  },
+  'scripts/agentbox-dockerd-start': {
+    staged: 'packages/sandbox-docker/scripts/agentbox-dockerd-start',
+    dev: 'scripts/agentbox-dockerd-start',
+  },
+  'scripts/agentbox-checkpoint-cleanup': {
+    staged: 'packages/sandbox-docker/scripts/agentbox-checkpoint-cleanup',
+    dev: 'scripts/agentbox-checkpoint-cleanup',
+  },
+  'scripts/agentbox-open': {
+    staged: 'packages/sandbox-docker/scripts/agentbox-open',
+    dev: 'scripts/agentbox-open',
+  },
+  'scripts/custom-system-CLAUDE.md': {
+    staged: 'packages/sandbox-docker/scripts/custom-system-CLAUDE.md',
+    dev: 'scripts/custom-system-CLAUDE.md',
+  },
+  'scripts/claude-managed-settings.json': {
+    staged: 'packages/sandbox-docker/scripts/claude-managed-settings.json',
+    dev: 'scripts/claude-managed-settings.json',
+  },
+  'scripts/agentbox-codex-hooks.json': {
+    staged: 'packages/sandbox-docker/scripts/agentbox-codex-hooks.json',
+    dev: 'scripts/agentbox-codex-hooks.json',
+  },
+};
+
+/**
+ * Resolve every entry in `fileMap` to an absolute path. Tries `<contextDir>/<staged>`
+ * first; falls back to `<devRoot>/<dev>`. Returns `null` if any required file
+ * is missing — callers treat that as "can't fingerprint" and skip the
+ * cache-hit shortcut. Pure (no I/O beyond `existsSync`), so safe for use
+ * from the provider's prepare path.
+ */
+export function resolveContextFilesFrom(
+  fileMap: Record<string, { staged: string; dev: string }>,
+  opts: { contextDir: string; devRoot: string },
+): ContextFile[] | null {
+  const out: ContextFile[] = [];
+  for (const [rel, paths] of Object.entries(fileMap)) {
+    const candidates = [
+      pathResolve(opts.contextDir, paths.staged),
+      pathResolve(opts.devRoot, paths.dev),
+    ];
+    const hit = candidates.find((p) => existsSync(p));
+    if (!hit) return null;
+    out.push({ rel, abs: hit });
+  }
+  return out;
+}

--- a/packages/sandbox-core/test/prepared-state.test.ts
+++ b/packages/sandbox-core/test/prepared-state.test.ts
@@ -1,0 +1,197 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  computeContextSha256,
+  DOCKER_CONTEXT_FILE_MAP,
+  preparedStatePathFor,
+  readPreparedStateRaw,
+  resolveContextFilesFrom,
+  sha256OfFile,
+  writePreparedStateRaw,
+} from '../src/prepared-state.js';
+
+describe('computeContextSha256', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'agentbox-fp-'));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  async function write(name: string, body: string): Promise<{ rel: string; abs: string }> {
+    const abs = join(dir, name);
+    await writeFile(abs, body, 'utf8');
+    return { rel: name, abs };
+  }
+
+  it('is deterministic across runs on identical content', async () => {
+    const files = [
+      await write('a.txt', 'alpha\n'),
+      await write('b.txt', 'beta\n'),
+      await write('c.txt', 'gamma\n'),
+    ];
+    const a = await computeContextSha256(files);
+    const b = await computeContextSha256(files);
+    expect(a).toEqual(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is invariant to input ordering', async () => {
+    const files = [
+      await write('a.txt', 'alpha\n'),
+      await write('b.txt', 'beta\n'),
+      await write('c.txt', 'gamma\n'),
+    ];
+    const forward = await computeContextSha256(files);
+    const reversed = await computeContextSha256([...files].reverse());
+    expect(reversed).toEqual(forward);
+  });
+
+  it('changes when any file content changes', async () => {
+    const files = [await write('a.txt', 'alpha\n'), await write('b.txt', 'beta\n')];
+    const before = await computeContextSha256(files);
+    await writeFile(files[1]!.abs, 'beta-edited\n', 'utf8');
+    const after = await computeContextSha256(files);
+    expect(after).not.toEqual(before);
+  });
+
+  it('changes when a logical rel-path changes (same bytes, renamed)', async () => {
+    const a = await write('a.txt', 'shared\n');
+    const b = await write('b.txt', 'shared\n');
+    const ha = await computeContextSha256([a]);
+    const hb = await computeContextSha256([b]);
+    expect(ha).not.toEqual(hb);
+  });
+
+  it('matches a manual hash of two files', async () => {
+    const a = await write('a', 'A');
+    const b = await write('b', 'B');
+    const hash = await computeContextSha256([a, b]);
+    // Tip: the outer hash is sha256("a\0" + sha256("A") + "\nb\0" + sha256("B") + "\n").
+    // We don't recompute that here — just verify the function changes for a known mutation.
+    await writeFile(a.abs, 'AA', 'utf8');
+    const hash2 = await computeContextSha256([a, b]);
+    expect(hash2).not.toEqual(hash);
+  });
+});
+
+describe('sha256OfFile', () => {
+  it('hashes deterministically', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'agentbox-sha-'));
+    try {
+      const path = join(dir, 'f.txt');
+      await writeFile(path, 'hello\n', 'utf8');
+      const h = await sha256OfFile(path);
+      // sha256("hello\n") = 5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
+      expect(h).toEqual('5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('readPreparedStateRaw / writePreparedStateRaw', () => {
+  let prevHome: string | undefined;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'agentbox-prep-'));
+    prevHome = process.env.HOME;
+    process.env.HOME = dir;
+  });
+  afterEach(async () => {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('returns null when the file is missing', () => {
+    expect(readPreparedStateRaw('docker')).toBeNull();
+  });
+
+  it('returns null on malformed JSON without throwing', async () => {
+    await writeFile(preparedStatePathFor('docker'), 'not json', 'utf8').catch(async () => {
+      // dir may not exist yet — create it.
+      const { mkdir } = await import('node:fs/promises');
+      await mkdir(join(dir, '.agentbox'), { recursive: true });
+      await writeFile(preparedStatePathFor('docker'), 'not json', 'utf8');
+    });
+    expect(readPreparedStateRaw('docker')).toBeNull();
+  });
+
+  it('round-trips a state object', () => {
+    const state = { schema: 1, base: { contextSha256: 'abc', cliVersion: '0.7.0' } };
+    writePreparedStateRaw('docker', state);
+    expect(readPreparedStateRaw('docker')).toEqual(state);
+  });
+
+  it('produces per-provider distinct paths', () => {
+    expect(preparedStatePathFor('docker')).not.toEqual(preparedStatePathFor('daytona'));
+    expect(preparedStatePathFor('daytona')).not.toEqual(preparedStatePathFor('hetzner'));
+    expect(preparedStatePathFor('docker')).toMatch(/docker-prepared\.json$/);
+  });
+});
+
+describe('resolveContextFilesFrom', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'agentbox-ctxres-'));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('prefers staged over dev when both exist', async () => {
+    const { mkdir } = await import('node:fs/promises');
+    const stagedDir = join(dir, 'staged');
+    const devDir = join(dir, 'dev');
+    await mkdir(stagedDir, { recursive: true });
+    await mkdir(devDir, { recursive: true });
+    await writeFile(join(stagedDir, 'A.txt'), 'staged', 'utf8');
+    await writeFile(join(devDir, 'A.txt'), 'dev', 'utf8');
+    const map = { 'A.txt': { staged: 'A.txt', dev: 'A.txt' } };
+    const files = resolveContextFilesFrom(map, { contextDir: stagedDir, devRoot: devDir });
+    expect(files).not.toBeNull();
+    expect(files![0]!.abs).toEqual(join(stagedDir, 'A.txt'));
+  });
+
+  it('falls back to dev when staged is missing', async () => {
+    const { mkdir } = await import('node:fs/promises');
+    const stagedDir = join(dir, 'staged');
+    const devDir = join(dir, 'dev');
+    await mkdir(stagedDir, { recursive: true });
+    await mkdir(devDir, { recursive: true });
+    await writeFile(join(devDir, 'A.txt'), 'dev', 'utf8');
+    const map = { 'A.txt': { staged: 'A.txt', dev: 'A.txt' } };
+    const files = resolveContextFilesFrom(map, { contextDir: stagedDir, devRoot: devDir });
+    expect(files).not.toBeNull();
+    expect(files![0]!.abs).toEqual(join(devDir, 'A.txt'));
+  });
+
+  it('returns null when any file is missing in both layouts', async () => {
+    const { mkdir } = await import('node:fs/promises');
+    const stagedDir = join(dir, 'staged');
+    const devDir = join(dir, 'dev');
+    await mkdir(stagedDir, { recursive: true });
+    await mkdir(devDir, { recursive: true });
+    await writeFile(join(stagedDir, 'A.txt'), '', 'utf8');
+    // B is missing in both
+    const map = {
+      'A.txt': { staged: 'A.txt', dev: 'A.txt' },
+      'B.txt': { staged: 'B.txt', dev: 'B.txt' },
+    };
+    expect(resolveContextFilesFrom(map, { contextDir: stagedDir, devRoot: devDir })).toBeNull();
+  });
+
+  it('DOCKER_CONTEXT_FILE_MAP includes Dockerfile.box and the COPYed scripts', () => {
+    expect(DOCKER_CONTEXT_FILE_MAP['Dockerfile.box']).toBeDefined();
+    expect(DOCKER_CONTEXT_FILE_MAP['scripts/agentbox-vnc-start']).toBeDefined();
+    expect(DOCKER_CONTEXT_FILE_MAP['scripts/custom-system-CLAUDE.md']).toBeDefined();
+    expect(DOCKER_CONTEXT_FILE_MAP['ctl/bin.cjs']).toBeDefined();
+  });
+});

--- a/packages/sandbox-daytona/package.json
+++ b/packages/sandbox-daytona/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@agentbox/core": "workspace:*",
     "@agentbox/sandbox-cloud": "workspace:*",
+    "@agentbox/sandbox-core": "workspace:*",
     "@clack/prompts": "^0.9.0",
     "@daytonaio/sdk": "^0.179.0",
     "commander": "^12.1.0"

--- a/packages/sandbox-daytona/src/prepare.ts
+++ b/packages/sandbox-daytona/src/prepare.ts
@@ -31,9 +31,23 @@ import {
 import { getClient } from './backend.js';
 import { resolveDaytonaCustomClaudeMd, resolveDockerfileContext } from './dockerfile-context.js';
 import { ensureDaytonaEnvLoaded } from './env-loader.js';
+import {
+  computeDaytonaContextFingerprint,
+  preparedMatches,
+  readPreparedDaytonaState,
+  writePreparedDaytonaState,
+} from './prepared-state.js';
 
-/** Default snapshot name shape when `opts.name` is omitted. */
-function defaultSnapshotName(): string {
+/**
+ * Default snapshot name. Keyed on the first 12 chars of the build-context
+ * fingerprint so identical content produces the same snapshot name across
+ * machines / CLI runs (idempotent): if the named snapshot already exists
+ * on Daytona, prepare can short-circuit without uploading the build
+ * context again. Falls back to a timestamp when fingerprinting fails
+ * (partial dev rebuild).
+ */
+function defaultSnapshotName(fingerprint: string | null): string {
+  if (fingerprint) return `agentbox-base-${fingerprint.slice(0, 12)}`;
   return `agentbox-base-${Math.floor(Date.now() / 1000).toString()}`;
 }
 
@@ -86,7 +100,49 @@ async function stageAllAgentStatic(opts: { hostWorkspace?: string }): Promise<Ag
 export async function prepareDaytona(opts: PrepareOptions): Promise<PrepareResult> {
   ensureDaytonaEnvLoaded();
   const log = opts.onLog ?? (() => {});
-  const snapshotName = opts.name ?? defaultSnapshotName();
+
+  // Fingerprint the build context first so we can (a) name the snapshot
+  // deterministically and (b) detect cache hits against the recorded
+  // prepared state. Computed before staging so an early `null` (partial
+  // dev rebuild) doesn't waste a tar staging cycle.
+  const fingerprint = await computeDaytonaContextFingerprint();
+  const snapshotName =
+    opts.name ?? defaultSnapshotName(fingerprint?.contextSha256 ?? null);
+
+  const prepared = readPreparedDaytonaState();
+  if (
+    !opts.force &&
+    fingerprint &&
+    preparedMatches(prepared, fingerprint.contextSha256)
+  ) {
+    // Confirm the snapshot still exists on Daytona before short-circuiting.
+    // A "yes locally, no on the server" mismatch must rebuild.
+    try {
+      const existing = await getClient().snapshot.get(
+        prepared?.base?.imageRef ?? snapshotName,
+      );
+      if (existing?.name) {
+        log(
+          `daytona snapshot '${existing.name}' up to date ` +
+            `(fingerprint ${fingerprint.contextSha256.slice(0, 12)}) — skipping rebuild ` +
+            `(pass --force to override)`,
+        );
+        return { snapshotName: existing.name };
+      }
+      log(
+        `recorded snapshot '${prepared?.base?.imageRef ?? snapshotName}' not found on Daytona; rebuilding`,
+      );
+    } catch {
+      log(
+        `recorded snapshot lookup failed; rebuilding (pass --force to silence)`,
+      );
+    }
+  } else if (!opts.force && fingerprint && prepared?.base?.contextSha256) {
+    log(
+      `daytona build context changed (was ${prepared.base.contextSha256.slice(0, 12)}, ` +
+        `now ${fingerprint.contextSha256.slice(0, 12)}); rebuilding snapshot`,
+    );
+  }
 
   const ctx = resolveDockerfileContext();
   if (!ctx) {
@@ -159,6 +215,15 @@ export async function prepareDaytona(opts: PrepareOptions): Promise<PrepareResul
       },
     );
     log(`snapshot '${snapshot.name}' is ${snapshot.state ?? 'created'}`);
+    if (fingerprint) {
+      writePreparedDaytonaState({
+        snapshotName: snapshot.name ?? snapshotName,
+        contextSha256: fingerprint.contextSha256,
+      });
+      log(
+        `recorded daytona-prepared.json (fingerprint ${fingerprint.contextSha256.slice(0, 12)})`,
+      );
+    }
     return { snapshotName: snapshot.name ?? snapshotName };
   } finally {
     await Promise.all(stages.map((s) => s.staged.cleanup()));

--- a/packages/sandbox-daytona/src/prepared-state.ts
+++ b/packages/sandbox-daytona/src/prepared-state.ts
@@ -1,0 +1,111 @@
+/**
+ * Daytona provider's `~/.agentbox/daytona-prepared.json` reader/writer +
+ * build-context fingerprinting for the org-scoped base snapshot.
+ *
+ * The daytona prepare bakes the docker `Dockerfile.box` plus a daytona-
+ * specific `custom-system-CLAUDE.md` overlay. The fingerprint covers both
+ * — same canonical file map as the docker provider for the dockerfile
+ * inputs, plus one extra entry for the daytona overlay.
+ */
+
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  computeContextSha256,
+  DOCKER_CONTEXT_FILE_MAP,
+  readCliStamp,
+  readPreparedStateRaw,
+  resolveContextFilesFrom,
+  writePreparedStateRaw,
+  type ContextFile,
+  type PreparedBaseSnapshot,
+} from '@agentbox/sandbox-core';
+import { resolveDaytonaCustomClaudeMd, resolveDockerfileContext } from './dockerfile-context.js';
+
+const SCHEMA = 1 as const;
+
+export type PreparedDaytonaState = PreparedBaseSnapshot<string, never>;
+
+/**
+ * Resolve every file that influences the daytona base snapshot: the docker
+ * build context (shared map from sandbox-core) plus the daytona-specific
+ * CLAUDE.md overlay added by `Image.addLocalFile` in `prepare.ts`.
+ *
+ * Returns `null` if any file is missing — callers degrade to "always
+ * rebuild" rather than stamp a misleading fingerprint.
+ */
+export function resolveDaytonaContextFiles(): ContextFile[] | null {
+  const ctx = resolveDockerfileContext();
+  if (!ctx) return null;
+  // sandbox-daytona's package root = parent of src/ or parent of dist/.
+  // Mirrors the `resolve(here, '..', '..', '..')` walk in dockerfile-context.ts.
+  const here = dirname(fileURLToPath(import.meta.url));
+  const packageRoot = resolve(here, '..');
+  const monorepoRoot = resolve(here, '..', '..', '..');
+  // Docker's dev fallback is anchored at sandbox-docker's root, not
+  // sandbox-daytona's, so we pass the monorepo root and prefix the dev
+  // paths to walk into packages/sandbox-docker/.
+  //
+  // Simpler: just point devRoot at sandbox-docker's package root when it
+  // exists (legacy monorepo layout).
+  const dockerPackageRoot = resolve(monorepoRoot, 'packages', 'sandbox-docker');
+  const docker = resolveContextFilesFrom(DOCKER_CONTEXT_FILE_MAP, {
+    contextDir: ctx.context,
+    devRoot: existsSync(dockerPackageRoot) ? dockerPackageRoot : packageRoot,
+  });
+  if (!docker) return null;
+  const overlay = resolveDaytonaCustomClaudeMd();
+  if (!overlay) return null;
+  return [
+    ...docker,
+    // Daytona-specific overlay: separate logical name so a docker/daytona
+    // CLAUDE.md drift produces different fingerprints (the daytona snapshot
+    // contains both files in distinct locations).
+    { rel: 'daytona/custom-system-CLAUDE.md', abs: overlay },
+  ];
+}
+
+export interface DaytonaFingerprint {
+  contextSha256: string;
+  files: ContextFile[];
+}
+
+export async function computeDaytonaContextFingerprint(): Promise<DaytonaFingerprint | null> {
+  const files = resolveDaytonaContextFiles();
+  if (!files) return null;
+  return { contextSha256: await computeContextSha256(files), files };
+}
+
+export function readPreparedDaytonaState(): PreparedDaytonaState | null {
+  const raw = readPreparedStateRaw('daytona');
+  if (raw === null || typeof raw !== 'object') return null;
+  const parsed = raw as Partial<PreparedDaytonaState>;
+  if (parsed.schema !== SCHEMA) return null;
+  return { schema: SCHEMA, base: parsed.base };
+}
+
+export function writePreparedDaytonaState(opts: {
+  snapshotName: string;
+  contextSha256: string;
+}): void {
+  const stamp = readCliStamp();
+  const state: PreparedDaytonaState = {
+    schema: SCHEMA,
+    base: {
+      imageRef: opts.snapshotName,
+      contextSha256: opts.contextSha256,
+      cliVersion: stamp.cliVersion,
+      cliCommit: stamp.cliCommit,
+      createdAt: new Date().toISOString(),
+    },
+  };
+  writePreparedStateRaw('daytona', state);
+}
+
+export function preparedMatches(
+  state: PreparedDaytonaState | null,
+  current: string,
+): boolean {
+  return state?.base?.contextSha256 === current;
+}

--- a/packages/sandbox-docker/src/checkpoint.ts
+++ b/packages/sandbox-docker/src/checkpoint.ts
@@ -8,8 +8,13 @@ import {
   sanitizeMnemonic,
   setConfigValue,
 } from '@agentbox/config';
+import { readCliStamp } from '@agentbox/sandbox-core';
 import { execInBox, removeImage } from './docker.js';
 import { DEFAULT_BOX_IMAGE } from './image.js';
+import {
+  computeDockerContextFingerprint,
+  readPreparedDockerState,
+} from './prepared-state.js';
 import type { BoxRecord, GitWorktreeRecord } from './state.js';
 
 export const CHECKPOINTS_ROOT = join(homedir(), '.agentbox', 'checkpoints');
@@ -37,7 +42,16 @@ export function checkpointImageTag(projectRoot: string, name: string): string {
 }
 
 export interface CheckpointManifest {
-  schema: 2;
+  /**
+   * Schema history:
+   *   2 — original fields (image, parents, base, worktrees, source*, createdAt)
+   *   3 — adds `baseProvider`, `baseFingerprint`, `cliVersion`. A checkpoint
+   *       captured before the rebuild that produced the *current* base
+   *       image will have a stale `baseFingerprint`; the restore path warns
+   *       loudly so the user knows the box won't see the new base layers
+   *       until the checkpoint is removed and recaptured.
+   */
+  schema: 2 | 3;
   name: string;
   type: CheckpointType;
   /** Local Docker image tag this checkpoint resolves to (`agentbox-ckpt-<hash>:<name>`). */
@@ -64,6 +78,22 @@ export interface CheckpointManifest {
    * `/workspace`, which the bind logic doesn't touch).
    */
   worktrees?: GitWorktreeRecord[];
+  /**
+   * Provider whose base-image fingerprint this checkpoint was captured
+   * against. Schema-3+ only. Always `'docker'` today (docker is the only
+   * provider with local checkpoints); cloud-provider checkpoints will set
+   * it accordingly when they land.
+   */
+  baseProvider?: 'docker' | 'daytona' | 'hetzner';
+  /**
+   * Build-context fingerprint of the base image at the time the checkpoint
+   * was captured. Schema-3+ only. Missing → schema 2 → "unknown
+   * fingerprint" (caller surfaces a softer "this checkpoint predates
+   * versioning" warning).
+   */
+  baseFingerprint?: string;
+  /** CLI version that captured the checkpoint. Schema-3+ only. */
+  cliVersion?: string;
   createdAt: string;
 }
 
@@ -86,7 +116,10 @@ async function readManifest(dir: string): Promise<CheckpointManifest | null> {
   try {
     const raw = await readFile(join(dir, 'manifest.json'), 'utf8');
     const m = JSON.parse(raw) as CheckpointManifest;
-    if (m.schema !== 2) return null;
+    // Accept schema 2 (legacy — no baseFingerprint, restore warns softly)
+    // and schema 3 (current — full versioning). Anything else is treated
+    // as unreadable so an opaque file can't break list/resolve.
+    if (m.schema !== 2 && m.schema !== 3) return null;
     return m;
   } catch {
     return null;
@@ -398,8 +431,21 @@ export async function createCheckpoint(opts: CreateCheckpointOptions): Promise<C
   const base: 'worktree' | 'workspace' = (box.gitWorktrees ?? []).some((w) => w.kind === 'root')
     ? 'worktree'
     : 'workspace';
+  // Capture the base-image fingerprint so a future `create --checkpoint`
+  // can detect a stale checkpoint pinned to a now-rebuilt base. Prefer the
+  // recorded prepared state (cheap, no I/O on the build context), but fall
+  // back to recomputing if the prepared file is missing. Both paths may
+  // yield `null` (partial dev rebuild) — the manifest then omits the
+  // field and restore degrades to a softer warning.
+  const prepared = readPreparedDockerState();
+  let baseFingerprint: string | undefined = prepared?.base?.contextSha256;
+  if (!baseFingerprint) {
+    const fp = await computeDockerContextFingerprint();
+    baseFingerprint = fp?.contextSha256;
+  }
+  const stamp = readCliStamp();
   const manifest: CheckpointManifest = {
-    schema: 2,
+    schema: 3,
     name,
     type,
     image: tag,
@@ -409,6 +455,9 @@ export async function createCheckpoint(opts: CreateCheckpointOptions): Promise<C
     sourceBoxId: box.id,
     sourceBoxName: box.name,
     worktrees: box.gitWorktrees,
+    baseProvider: 'docker',
+    baseFingerprint,
+    cliVersion: stamp.cliVersion,
     createdAt: new Date().toISOString(),
   };
   await writeFile(join(dir, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n', 'utf8');

--- a/packages/sandbox-docker/src/create.ts
+++ b/packages/sandbox-docker/src/create.ts
@@ -74,6 +74,10 @@ import {
 import type { ResolvedCarryEntry } from '@agentbox/core';
 import { createSnapshot, snapshotPathFor } from './snapshot.js';
 import { resolveCheckpoint } from './checkpoint.js';
+import {
+  computeDockerContextFingerprint,
+  readPreparedDockerState,
+} from './prepared-state.js';
 import { launchCtlDaemon } from './ctl.js';
 import { writeBoxEnvFile } from './box-env.js';
 import { ensureHomeOwnedByVscode } from './home-ownership.js';
@@ -336,6 +340,41 @@ export async function createBox(opts: CreateBoxOptions): Promise<CreatedBox> {
     log(
       `starting from checkpoint ${opts.checkpointRef} (${head.manifest.type}, ${String(chain.length)} layer(s), image ${head.manifest.image})`,
     );
+
+    // Stale-checkpoint warning: the checkpoint image replaces the base image
+    // as the docker-run base, so any base-image update (a CLI upgrade, an
+    // edit to `custom-system-CLAUDE.md`, etc.) is invisible inside a box
+    // restored from a pre-update checkpoint. Compare the captured
+    // fingerprint with the current prepared state and surface the
+    // mismatch loudly. We never block — the user might intentionally pin
+    // an old image — but they need to know.
+    const ckptFingerprint = head.manifest.baseFingerprint;
+    const ckptCliVersion = head.manifest.cliVersion ?? 'unknown';
+    if (head.manifest.schema === 2) {
+      log(
+        `WARNING: checkpoint '${opts.checkpointRef}' was captured before checkpoint versioning landed.\n` +
+          `  Its base-image layers may be older than your current base image. If the box is missing\n` +
+          `  expected updates, remove the checkpoint with \`agentbox checkpoint rm ${opts.checkpointRef}\` and recreate it.`,
+      );
+    } else {
+      const prepared = readPreparedDockerState();
+      const currentFingerprint =
+        prepared?.base?.contextSha256 ??
+        (await computeDockerContextFingerprint())?.contextSha256;
+      if (
+        ckptFingerprint &&
+        currentFingerprint &&
+        ckptFingerprint !== currentFingerprint
+      ) {
+        log(
+          `WARNING: checkpoint '${opts.checkpointRef}' was captured against an older base image.\n` +
+            `  captured: cli ${ckptCliVersion}, fingerprint ${ckptFingerprint.slice(0, 12)}\n` +
+            `  current : cli ${prepared?.base?.cliVersion ?? 'unknown'}, fingerprint ${currentFingerprint.slice(0, 12)}\n` +
+            `  The restored box will keep the old base layers and will NOT include base-image updates.\n` +
+            `  To pick up updates: \`agentbox checkpoint rm ${opts.checkpointRef}\` and recreate from a fresh box.`,
+        );
+      }
+    }
   }
 
   const imageRef = checkpointImage ?? opts.image ?? DEFAULT_BOX_IMAGE;

--- a/packages/sandbox-docker/src/docker-provider.ts
+++ b/packages/sandbox-docker/src/docker-provider.ts
@@ -25,6 +25,12 @@ import { boxResourceStats } from './stats.js';
 import { detectEngine } from './host-export.js';
 import { portlessGetUrl } from './portless.js';
 import { DEFAULT_BOX_IMAGE, buildImage, imageExists } from './image.js';
+import {
+  computeDockerContextFingerprint,
+  preparedMatches,
+  readPreparedDockerState,
+  writePreparedDockerState,
+} from './prepared-state.js';
 import { downloadFromBox, uploadToBox } from './box-cp.js';
 
 /**
@@ -170,16 +176,39 @@ export const dockerProvider: Provider = {
     // Docker uses the rsync-into-named-volume flow at create time, so the
     // base image stays generic — no agent-config layering. `prepare` here is
     // just an explicit handle on the build step `agentbox create` does
-    // lazily on first use. Idempotent: skip if the image is already built
-    // unless force.
+    // lazily on first use. Idempotent: skip when the image exists *and* the
+    // build-context fingerprint matches the recorded one. `--force`
+    // overrides both checks.
     const ref = DEFAULT_BOX_IMAGE;
-    if (!opts.force && (await imageExists(ref))) {
-      opts.onLog?.(`docker image ${ref} already built — skipping (use --force to rebuild)`);
-      return {};
+    const fingerprint = await computeDockerContextFingerprint();
+    const prepared = readPreparedDockerState();
+
+    if (!opts.force) {
+      const exists = await imageExists(ref);
+      if (exists && fingerprint && preparedMatches(prepared, fingerprint.contextSha256)) {
+        opts.onLog?.(
+          `docker image ${ref} up to date (fingerprint ${fingerprint.contextSha256.slice(0, 12)}) — skipping (use --force to rebuild)`,
+        );
+        return {};
+      }
+      if (exists && !fingerprint) {
+        opts.onLog?.(
+          `docker image ${ref} present but build context could not be fingerprinted — skipping (use --force to rebuild)`,
+        );
+        return {};
+      }
     }
+
     opts.onLog?.(`building docker image ${ref}…`);
     await buildImage({ ref, onProgress: opts.onLog });
-    opts.onLog?.(`docker image ${ref} built`);
+    if (fingerprint) {
+      writePreparedDockerState({ imageRef: ref, contextSha256: fingerprint.contextSha256 });
+      opts.onLog?.(
+        `docker image ${ref} built; recorded fingerprint ${fingerprint.contextSha256.slice(0, 12)}`,
+      );
+    } else {
+      opts.onLog?.(`docker image ${ref} built (fingerprint unavailable, prepared state not written)`);
+    }
     return {};
   },
 };

--- a/packages/sandbox-docker/src/image.ts
+++ b/packages/sandbox-docker/src/image.ts
@@ -133,16 +133,53 @@ export interface EnsureImageOptions {
 export async function ensureImage(
   ref: string = DEFAULT_BOX_IMAGE,
   opts: EnsureImageOptions = {},
-): Promise<{ ref: string; built: boolean }> {
-  if (await imageExists(ref)) {
-    return { ref, built: false };
+): Promise<{ ref: string; built: boolean; reason?: string }> {
+  // Lazy import: prepared-state imports back into image.ts for the default
+  // DOCKERFILE_PATH/BUILD_CONTEXT_DIR constants, so loading it at top-level
+  // would create a circular ESM init order.
+  const {
+    computeDockerContextFingerprint,
+    readPreparedDockerState,
+    writePreparedDockerState,
+    preparedMatches,
+  } = await import('./prepared-state.js');
+
+  const fingerprint = await computeDockerContextFingerprint({
+    contextDir: opts.contextDir,
+  });
+  const prepared = readPreparedDockerState();
+  const exists = await imageExists(ref);
+
+  let reason: string | undefined;
+  if (!exists) {
+    reason = `image ${ref} not present`;
+  } else if (!fingerprint) {
+    // Couldn't enumerate the context (partial dev rebuild?). Don't rebuild
+    // unconditionally — that would surprise users mid-iteration. Trust the
+    // image-exists check and leave the prepared file untouched.
+    return { ref, built: false, reason: 'image present (fingerprint skipped)' };
+  } else if (!prepared) {
+    reason = 'no docker-prepared.json on disk';
+  } else if (!preparedMatches(prepared, fingerprint.contextSha256)) {
+    reason =
+      `build context changed (was ${prepared.base?.contextSha256?.slice(0, 12) ?? '<none>'}, ` +
+      `now ${fingerprint.contextSha256.slice(0, 12)})`;
   }
+
+  if (!reason) {
+    return { ref, built: false, reason: 'image up to date' };
+  }
+
+  opts.onProgress?.(`[image] rebuilding ${ref}: ${reason}`);
   await buildImage({
     ref,
     dockerfile: opts.dockerfile,
     contextDir: opts.contextDir,
     onProgress: opts.onProgress,
   });
-  return { ref, built: true };
+  if (fingerprint) {
+    writePreparedDockerState({ imageRef: ref, contextSha256: fingerprint.contextSha256 });
+  }
+  return { ref, built: true, reason };
 }
 

--- a/packages/sandbox-docker/src/index.ts
+++ b/packages/sandbox-docker/src/index.ts
@@ -134,6 +134,15 @@ export {
   imageInfo,
   type ImageInfo,
 } from './image.js';
+export {
+  computeDockerContextFingerprint,
+  preparedMatches,
+  readPreparedDockerState,
+  resolveContextFiles,
+  writePreparedDockerState,
+  type PreparedDockerState,
+  type ResolvedFingerprint,
+} from './prepared-state.js';
 export { volumeExists } from './docker.js';
 export {
   clearRelayNotice,

--- a/packages/sandbox-docker/src/prepared-state.ts
+++ b/packages/sandbox-docker/src/prepared-state.ts
@@ -1,0 +1,99 @@
+/**
+ * Docker provider's `~/.agentbox/docker-prepared.json` reader/writer + the
+ * build-context fingerprint that drives base-image invalidation.
+ *
+ * The fingerprint is a SHA-256 over every file `docker build` would COPY
+ * into the image — Dockerfile + scripts + baked config files. Two CLIs
+ * with identical staged runtime trees produce the same hash; a one-byte
+ * edit to any baked asset flips it, which is the signal `ensureImage()`
+ * uses to rebuild instead of reusing the cached image.
+ */
+
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  computeContextSha256,
+  DOCKER_CONTEXT_FILE_MAP,
+  readCliStamp,
+  readPreparedStateRaw,
+  resolveContextFilesFrom,
+  writePreparedStateRaw,
+  type ContextFile,
+  type PreparedBaseSnapshot,
+} from '@agentbox/sandbox-core';
+import { BUILD_CONTEXT_DIR, DEFAULT_BOX_IMAGE, DOCKERFILE_PATH } from './image.js';
+
+const SCHEMA = 1 as const;
+
+export type PreparedDockerState = PreparedBaseSnapshot<string, never>;
+
+/**
+ * Resolve every fingerprint input to an absolute path. The canonical file
+ * list lives in `@agentbox/sandbox-core` (DOCKER_CONTEXT_FILE_MAP) so the
+ * daytona provider can hash the same inputs without depending on this
+ * package. Two layouts are tried in order, mirroring `resolveDockerBuild()`
+ * in `image.ts`:
+ *   1. Build context dir (staged runtime / env override).
+ *   2. Sandbox-docker package root (dev fallback).
+ *
+ * Returns `null` when *any* required file is missing — callers treat that
+ * as "can't fingerprint" and skip the cache-hit shortcut (always rebuild).
+ */
+export function resolveContextFiles(opts: { contextDir?: string } = {}): ContextFile[] | null {
+  const ctx = opts.contextDir ?? BUILD_CONTEXT_DIR;
+  const here = dirname(fileURLToPath(import.meta.url));
+  // sandbox-docker's package root = parent of src/ or parent of dist/.
+  const packageRoot = resolve(here, '..');
+  return resolveContextFilesFrom(DOCKER_CONTEXT_FILE_MAP, {
+    contextDir: ctx,
+    devRoot: packageRoot,
+  });
+}
+
+export interface ResolvedFingerprint {
+  contextSha256: string;
+  /** Files that fed the hash (in canonical sorted order). */
+  files: ContextFile[];
+}
+
+export async function computeDockerContextFingerprint(opts: {
+  contextDir?: string;
+} = {}): Promise<ResolvedFingerprint | null> {
+  const files = resolveContextFiles(opts);
+  if (!files) return null;
+  return { contextSha256: await computeContextSha256(files), files };
+}
+
+export function readPreparedDockerState(): PreparedDockerState | null {
+  const raw = readPreparedStateRaw('docker');
+  if (raw === null || typeof raw !== 'object') return null;
+  const parsed = raw as Partial<PreparedDockerState>;
+  if (parsed.schema !== SCHEMA) return null;
+  return { schema: SCHEMA, base: parsed.base };
+}
+
+export function writePreparedDockerState(opts: {
+  imageRef?: string;
+  contextSha256: string;
+}): void {
+  const stamp = readCliStamp();
+  const state: PreparedDockerState = {
+    schema: SCHEMA,
+    base: {
+      imageRef: opts.imageRef ?? DEFAULT_BOX_IMAGE,
+      contextSha256: opts.contextSha256,
+      cliVersion: stamp.cliVersion,
+      cliCommit: stamp.cliCommit,
+      createdAt: new Date().toISOString(),
+    },
+  };
+  writePreparedStateRaw('docker', state);
+}
+
+/** Convenience for `ensureImage` and `prepare` — true when the stamped fingerprint matches. */
+export function preparedMatches(state: PreparedDockerState | null, current: string): boolean {
+  return state?.base?.contextSha256 === current;
+}
+
+/** Re-export so callers don't reach into image.ts just for the Dockerfile path. */
+export { DOCKERFILE_PATH };

--- a/packages/sandbox-docker/test/checkpoint-manifest-schema.test.ts
+++ b/packages/sandbox-docker/test/checkpoint-manifest-schema.test.ts
@@ -1,0 +1,102 @@
+// ESM static imports are hoisted, so a `process.env.HOME = ...` in this file
+// body would run AFTER checkpoint.ts (which captures `homedir()` at module
+// load via `CHECKPOINTS_ROOT`). Pre-set HOME in a vitest globalSetup-style
+// constant assigned at the very top, then load checkpoint.ts *dynamically*
+// inside each test — by then HOME is the temp dir.
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const TEST_HOME = mkdtempSync(join(tmpdir(), 'agentbox-ckpt-mf-'));
+process.env.HOME = TEST_HOME;
+// `os.homedir()` on darwin honours USERPROFILE on Windows and HOME on POSIX;
+// vitest doesn't override USERPROFILE so HOME alone is sufficient on CI.
+
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { afterAll, describe, expect, it } from 'vitest';
+import { projectDirSegment } from '@agentbox/config';
+
+async function writeManifest(
+  projectRoot: string,
+  name: string,
+  manifest: Record<string, unknown> & { schema: number },
+): Promise<void> {
+  const segment = projectDirSegment(projectRoot);
+  const dir = join(TEST_HOME, '.agentbox', 'checkpoints', segment, name);
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    join(dir, 'manifest.json'),
+    JSON.stringify(manifest, null, 2) + '\n',
+    'utf8',
+  );
+}
+
+describe('checkpoint manifest schema', () => {
+  afterAll(async () => {
+    await rm(TEST_HOME, { recursive: true, force: true });
+  });
+
+  it('reads a schema-3 manifest with baseFingerprint + cliVersion', async () => {
+    const { resolveCheckpoint } = await import('../src/checkpoint.js');
+    const projectRoot = '/tmp/projA-' + Date.now().toString(36);
+    await writeManifest(projectRoot, 'cp1', {
+      schema: 3,
+      name: 'cp1',
+      type: 'layered',
+      image: 'agentbox-ckpt-aaaa:cp1',
+      parents: [],
+      base: 'workspace',
+      sourceBoxId: 'box1',
+      sourceBoxName: 'demo',
+      baseProvider: 'docker',
+      baseFingerprint: 'abc123def456',
+      cliVersion: '0.7.0',
+      createdAt: '2026-05-26T00:00:00.000Z',
+    });
+    const got = await resolveCheckpoint(projectRoot, 'cp1');
+    expect(got).not.toBeNull();
+    expect(got!.manifest.schema).toBe(3);
+    expect(got!.manifest.baseFingerprint).toBe('abc123def456');
+    expect(got!.manifest.cliVersion).toBe('0.7.0');
+    expect(got!.manifest.baseProvider).toBe('docker');
+  });
+
+  it('reads a schema-2 manifest gracefully (no fingerprint)', async () => {
+    const { resolveCheckpoint } = await import('../src/checkpoint.js');
+    const projectRoot = '/tmp/projB-' + Date.now().toString(36);
+    await writeManifest(projectRoot, 'legacy', {
+      schema: 2,
+      name: 'legacy',
+      type: 'flattened',
+      image: 'agentbox-ckpt-bbbb:legacy',
+      parents: [],
+      base: 'workspace',
+      sourceBoxId: 'box2',
+      sourceBoxName: 'legacy-box',
+      createdAt: '2025-12-01T00:00:00.000Z',
+    });
+    const got = await resolveCheckpoint(projectRoot, 'legacy');
+    expect(got).not.toBeNull();
+    expect(got!.manifest.schema).toBe(2);
+    expect(got!.manifest.baseFingerprint).toBeUndefined();
+    expect(got!.manifest.cliVersion).toBeUndefined();
+  });
+
+  it('returns null for an unknown schema (treated as unreadable)', async () => {
+    const { resolveCheckpoint } = await import('../src/checkpoint.js');
+    const projectRoot = '/tmp/projC-' + Date.now().toString(36);
+    await writeManifest(projectRoot, 'future', {
+      schema: 99,
+      name: 'future',
+      type: 'layered',
+      image: 'x',
+      parents: [],
+      base: 'workspace',
+      sourceBoxId: 'b',
+      sourceBoxName: 'b',
+      createdAt: '2030-01-01T00:00:00.000Z',
+    });
+    const got = await resolveCheckpoint(projectRoot, 'future');
+    expect(got).toBeNull();
+  });
+});

--- a/packages/sandbox-hetzner/src/prepare.ts
+++ b/packages/sandbox-hetzner/src/prepare.ts
@@ -29,10 +29,9 @@
  * step boundaries from `progress()`.
  */
 
-import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { createHash } from 'node:crypto';
 import type { Provider } from '@agentbox/core';
+import { computeContextSha256, readCliStamp } from '@agentbox/sandbox-core';
 import {
   stageClaudeStaticForUpload,
   stageCodexStaticForUpload,
@@ -119,7 +118,7 @@ export async function prepareHetzner(
   const progress = (step: string) => log(`prepare-hetzner: ${step}`);
 
   // Skip-fast: if a base snapshot is already recorded *and* its image is
-  // still on Hetzner *and* the install script's sha hasn't changed *and*
+  // still on Hetzner *and* the build-context fingerprint hasn't changed *and*
   // --force was not passed, return the existing record.
   const existingState = readPreparedState();
   // Prefer an explicit override; otherwise auto-detect the published-CLI
@@ -128,19 +127,20 @@ export async function prepareHetzner(
     cliRuntimeRoot: opts.cliRuntimeRoot ?? findStagedCliRuntimeRoot(),
     repoRoot: opts.repoRoot,
   });
-  const installAsset = assets.find((a) => a.name === 'install-box.sh');
-  if (!installAsset) {
-    throw new Error('prepare: missing install-box.sh asset (this should have been caught earlier)');
-  }
-  const installSha = await sha256OfFile(installAsset.localPath);
+  // Fingerprint = hash of every asset we scp into the prepare VPS. Keyed on
+  // logical name (stable across staged-vs-monorepo layouts) so two CLIs with
+  // the same staged tree produce the same hash.
+  const contextSha = await computeContextSha256(
+    assets.map((a) => ({ rel: a.name, abs: a.localPath })),
+  );
 
   if (!opts.force && existingState.base) {
     const remote = await client
       .getImage(existingState.base.imageId)
       .catch(() => null);
-    if (remote && existingState.base.installScriptSha256 === installSha) {
+    if (remote && existingState.base.contextSha256 === contextSha) {
       progress(
-        `base snapshot ${String(existingState.base.imageId)} already exists (sha matches); skipping rebuild (pass --force to override)`,
+        `base snapshot ${String(existingState.base.imageId)} already exists (fingerprint ${contextSha.slice(0, 12)} matches); skipping rebuild (pass --force to override)`,
       );
       return {
         snapshotName: existingState.base.description,
@@ -150,7 +150,9 @@ export async function prepareHetzner(
     if (!remote) {
       progress(`recorded base snapshot ${String(existingState.base.imageId)} is gone on Hetzner; rebuilding`);
     } else {
-      progress(`install script changed; rebuilding base snapshot`);
+      progress(
+        `build context changed (was ${existingState.base.contextSha256?.slice(0, 12) ?? '<none>'}, now ${contextSha.slice(0, 12)}); rebuilding base snapshot`,
+      );
     }
   }
 
@@ -321,11 +323,14 @@ export async function prepareHetzner(
     // about the new snapshot.
     progress('persisting hetzner-prepared.json');
     const state = readPreparedState();
+    const cliStamp = readCliStamp();
     state.base = {
       imageId: ready.id,
       description: ready.description,
       createdAt: new Date().toISOString(),
-      installScriptSha256: installSha,
+      contextSha256: contextSha,
+      cliVersion: cliStamp.cliVersion,
+      cliCommit: cliStamp.cliCommit,
     };
     writePreparedState(state);
     log(`prepare-hetzner: wrote ${preparedStatePath()}`);
@@ -373,11 +378,6 @@ export async function prepareHetzner(
   } finally {
     await key.cleanup();
   }
-}
-
-async function sha256OfFile(path: string): Promise<string> {
-  const buf = await readFile(path);
-  return createHash('sha256').update(buf).digest('hex');
 }
 
 /**

--- a/packages/sandbox-hetzner/src/prepared-state.ts
+++ b/packages/sandbox-hetzner/src/prepared-state.ts
@@ -16,11 +16,24 @@
  * accept `schema: 1` for now.
  */
 
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { dirname, resolve } from 'node:path';
+import { preparedStatePathFor, readPreparedStateRaw, writePreparedStateRaw } from '@agentbox/sandbox-core';
 
-const SCHEMA = 1 as const;
+/**
+ * Schema history:
+ *   1 — `base.imageId`, `base.description`, `base.createdAt`,
+ *       `base.installScriptSha256?`
+ *   2 — `base.installScriptSha256` → `base.contextSha256` (now covers every
+ *       asset we scp'd in, not just the install script); `base.cliVersion`
+ *       and `base.cliCommit?` added so we can warn when an old snapshot
+ *       predates the running CLI.
+ *
+ * Read-time migration is lossy in one direction: a schema-1 file is lifted
+ * to schema 2 by *renaming* `installScriptSha256` to `contextSha256`. The
+ * hash doesn't change but the meaning narrows (install script only → full
+ * asset list), so the next `agentbox prepare --provider hetzner` run will
+ * recompute and overwrite.
+ */
+const SCHEMA = 2 as const;
 
 export interface PreparedBaseSnapshot {
   /** Hetzner image id (numeric — opaque, but stable across `getImage` calls). */
@@ -29,8 +42,15 @@ export interface PreparedBaseSnapshot {
   description: string;
   /** ISO timestamp of bake-completion. */
   createdAt: string;
-  /** Hash of the install script we baked from (so re-bake on script change). */
-  installScriptSha256?: string;
+  /**
+   * Deterministic SHA-256 of the build context (every file scp'd into the
+   * prepare VPS). Rebuild when it changes.
+   */
+  contextSha256?: string;
+  /** CLI version that produced this snapshot (informational). */
+  cliVersion?: string;
+  /** Git short SHA of the CLI build (informational). */
+  cliCommit?: string;
 }
 
 export interface PreparedProjectSnapshot {
@@ -49,38 +69,66 @@ export interface PreparedHetznerState {
   projects: Record<string, PreparedProjectSnapshot>;
 }
 
+interface LegacyV1Base {
+  imageId: number;
+  description: string;
+  createdAt: string;
+  installScriptSha256?: string;
+}
+
+interface LegacyV1State {
+  schema: 1;
+  base?: LegacyV1Base;
+  projects?: Record<string, PreparedProjectSnapshot>;
+}
+
 export function preparedStatePath(): string {
-  return resolve(homedir(), '.agentbox', 'hetzner-prepared.json');
+  return preparedStatePathFor('hetzner');
 }
 
 export function readPreparedState(): PreparedHetznerState {
-  const path = preparedStatePath();
-  if (!existsSync(path)) return { schema: SCHEMA, projects: {} };
-  try {
-    const raw = readFileSync(path, 'utf8');
-    const parsed = JSON.parse(raw) as Partial<PreparedHetznerState>;
-    if (parsed.schema !== SCHEMA) {
-      // Unknown schema: don't crash, just refuse to read — the file will be
-      // overwritten on the next successful prepare.
-      return { schema: SCHEMA, projects: {} };
-    }
-    return {
-      schema: SCHEMA,
-      base: parsed.base,
-      projects: parsed.projects ?? {},
-    };
-  } catch {
+  const raw = readPreparedStateRaw('hetzner');
+  if (raw === null || typeof raw !== 'object') return { schema: SCHEMA, projects: {} };
+  const parsed = raw as Partial<PreparedHetznerState> | LegacyV1State;
+  if ((parsed as { schema?: unknown }).schema === 1) {
+    const v1 = parsed as LegacyV1State;
+    return migrateFromV1(v1);
+  }
+  if (parsed.schema !== SCHEMA) {
+    // Unknown schema: don't crash, just refuse to read — the file will be
+    // overwritten on the next successful prepare.
     return { schema: SCHEMA, projects: {} };
   }
+  return {
+    schema: SCHEMA,
+    base: parsed.base,
+    projects: parsed.projects ?? {},
+  };
+}
+
+function migrateFromV1(v1: LegacyV1State): PreparedHetznerState {
+  // The v1 `installScriptSha256` covered only `install-box.sh`, not the full
+  // asset list a v2 `contextSha256` represents. Lifting it forward as a
+  // placeholder fingerprint means the next prepare run will mismatch and
+  // rebuild — exactly what we want, since the broader hash semantics also
+  // changed.
+  const base: PreparedBaseSnapshot | undefined = v1.base
+    ? {
+        imageId: v1.base.imageId,
+        description: v1.base.description,
+        createdAt: v1.base.createdAt,
+        contextSha256: v1.base.installScriptSha256,
+      }
+    : undefined;
+  return {
+    schema: SCHEMA,
+    base,
+    projects: v1.projects ?? {},
+  };
 }
 
 export function writePreparedState(state: PreparedHetznerState): void {
-  const path = preparedStatePath();
-  mkdirSync(dirname(path), { recursive: true });
-  const body = JSON.stringify(state, null, 2) + '\n';
-  const tmp = `${path}.tmp`;
-  writeFileSync(tmp, body, { mode: 0o600 });
-  renameSync(tmp, path);
+  writePreparedStateRaw('hetzner', state);
 }
 
 /**

--- a/packages/sandbox-hetzner/test/prepared-state-migration.test.ts
+++ b/packages/sandbox-hetzner/test/prepared-state-migration.test.ts
@@ -1,0 +1,81 @@
+// Set HOME before any import that reads `homedir()` at module load.
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const TEST_HOME = mkdtempSync(join(tmpdir(), 'agentbox-hetz-mig-'));
+process.env.HOME = TEST_HOME;
+
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { afterAll, describe, expect, it } from 'vitest';
+import {
+  preparedStatePath,
+  readPreparedState,
+  writePreparedState,
+} from '../src/prepared-state.js';
+
+async function writeRaw(content: unknown): Promise<void> {
+  const path = preparedStatePath();
+  await mkdir(join(TEST_HOME, '.agentbox'), { recursive: true });
+  await writeFile(path, JSON.stringify(content, null, 2) + '\n', 'utf8');
+}
+
+describe('hetzner prepared-state schema migration', () => {
+  afterAll(async () => {
+    await rm(TEST_HOME, { recursive: true, force: true });
+  });
+
+  it('lifts a schema-1 file forward by renaming installScriptSha256 → contextSha256', async () => {
+    await writeRaw({
+      schema: 1,
+      base: {
+        imageId: 42,
+        description: 'agentbox-base-1234567890',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        installScriptSha256: 'deadbeefcafebabe',
+      },
+      projects: { foo: { imageId: 7, description: 'p-foo', createdAt: '2026-01-02T00:00:00.000Z' } },
+    });
+    const got = readPreparedState();
+    expect(got.schema).toBe(2);
+    expect(got.base?.imageId).toBe(42);
+    expect(got.base?.contextSha256).toBe('deadbeefcafebabe');
+    expect(got.projects['foo']?.imageId).toBe(7);
+    // `installScriptSha256` is dropped; the new field carries the value.
+    expect((got.base as unknown as { installScriptSha256?: string }).installScriptSha256).toBeUndefined();
+  });
+
+  it('returns an empty state for an unrecognised schema', async () => {
+    await writeRaw({ schema: 99, base: { imageId: 1, description: 'x', createdAt: 'y' } });
+    const got = readPreparedState();
+    expect(got.schema).toBe(2);
+    expect(got.base).toBeUndefined();
+    expect(got.projects).toEqual({});
+  });
+
+  it('round-trips schema-2 unchanged', async () => {
+    const before = {
+      schema: 2 as const,
+      base: {
+        imageId: 100,
+        description: 'agentbox-base-v2',
+        createdAt: '2026-02-01T00:00:00.000Z',
+        contextSha256: 'aaaa1111bbbb2222',
+        cliVersion: '0.7.0',
+        cliCommit: 'abc1234',
+      },
+      projects: {},
+    };
+    writePreparedState(before);
+    const got = readPreparedState();
+    expect(got).toEqual(before);
+  });
+
+  it('returns an empty state when no file exists', async () => {
+    await rm(preparedStatePath(), { force: true });
+    const got = readPreparedState();
+    expect(got.schema).toBe(2);
+    expect(got.base).toBeUndefined();
+    expect(got.projects).toEqual({});
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,9 @@ importers:
       '@agentbox/sandbox-cloud':
         specifier: workspace:*
         version: link:../sandbox-cloud
+      '@agentbox/sandbox-core':
+        specifier: workspace:*
+        version: link:../sandbox-core
       '@clack/prompts':
         specifier: ^0.9.0
         version: 0.9.1


### PR DESCRIPTION
…hange

Every provider (docker/daytona/hetzner) now records a content-hash of its build context in `~/.agentbox/<provider>-prepared.json` and refuses to reuse a baked image when that hash changes. Checkpoint manifests bump to schema 3 carrying the capturing CLI's version + base fingerprint so `create --snapshot <ref>` can warn loudly when restoring against a now-rebuilt base. Top-level `schema: 1` stamp added to user config files to future-proof migrations. CLI `--version` now reads from package.json via tsup `define` (was hardcoded "0.0.0").

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when Docker/Daytona/Hetzner rebuild base artifacts and how checkpoint restore behaves (warnings only), but logic is heavily tested and failures degrade to rebuild rather than silent wrong images.
> 
> **Overview**
> Introduces **content-hash versioning** for provider base artifacts and checkpoints so baked images/snapshots are not reused after the build context changes.
> 
> The CLI now injects **real version and git commit** at bundle time (`tsup` `define`) and exposes them via env for providers; `--version` no longer shows `0.0.0`. Shared logic in `@agentbox/sandbox-core` computes a deterministic **`contextSha256`** over Dockerfile and copied assets, persisted in `~/.agentbox/<provider>-prepared.json`.
> 
> **Docker**, **Daytona**, and **Hetzner** `prepare` / `ensureImage` paths skip rebuilds when the fingerprint matches (with `--force` override); Daytona also uses fingerprint-based snapshot names and verifies the snapshot still exists on the server. **Docker checkpoints** move to **schema 3**, recording `baseFingerprint` and `cliVersion`; **create from checkpoint** logs warnings when the base image has moved on (non-blocking). User config files get a top-level **`schema: 1`** stamp on write for future migrations.
> 
> Smaller fixes: explicit `user` on carry entries, Codex resume TypeScript narrowing, and `MockCloudBackend.clearCalls()` for tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e059903632f313a87d3d1023a038eeae7a46c738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->