### PR TITLE
feat(portless): register vnc-<box>.localhost alias for every box

### DIFF
--- a/apps/cli/src/commands/screen.ts
+++ b/apps/cli/src/commands/screen.ts
@@ -97,7 +97,13 @@ export const screenCommand = new Command('screen')
 
         const engine = await detectEngine();
         const urls = buildVncUrls(box, engine);
-        const resolved = opts.loopback ? urls.loopbackUrl : (urls.orbUrl ?? urls.loopbackUrl);
+        // Preference when --loopback is off: portless > orb.local > loopback.
+        // Portless gives a stable name across box restarts (loopback port
+        // rerolls every `docker run`); orb.local is OrbStack-only; loopback is
+        // the always-available fallback. `--loopback` forces the raw port.
+        const resolved = opts.loopback
+          ? urls.loopbackUrl
+          : (urls.portlessUrl ?? urls.orbUrl ?? urls.loopbackUrl);
         if (!resolved) {
           throw new Error(
             `VNC URL unavailable (daemon may not be up); try \`agentbox inspect ${box.name}\``,

--- a/packages/core/src/box-record.ts
+++ b/packages/core/src/box-record.ts
@@ -43,6 +43,10 @@ export interface DockerBoxFields {
   portlessAlias?: string;
   /** Full user-facing URL the Portless proxy serves for this box. */
   portlessUrl?: string;
+  /** Portless route name registered for this box's noVNC port (`vnc-<box-name>`). */
+  portlessVncAlias?: string;
+  /** Full user-facing URL the Portless proxy serves for this box's VNC. */
+  portlessVncUrl?: string;
   /** Volume mounted at /var/lib/docker for the in-box dockerd. */
   dockerVolume?: string;
   /** True when this box's `dockerVolume` is the shared cache. */
@@ -202,6 +206,10 @@ export interface BoxRecord {
   portlessAlias?: string;
   /** Full user-facing URL the Portless proxy serves for this box. Docker only. */
   portlessUrl?: string;
+  /** Portless route name registered for this box's noVNC port (`vnc-<box-name>`). */
+  portlessVncAlias?: string;
+  /** Full user-facing URL the Portless proxy serves for this box's VNC. */
+  portlessVncUrl?: string;
   /** Volume mounted at /var/lib/docker for the in-box dockerd. Docker only. */
   dockerVolume?: string;
   /** True when this box's `dockerVolume` is the shared cache. Docker only. */

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -151,6 +151,34 @@ function parseLoopbackPort(url: string): number | undefined {
 }
 
 /**
+ * Register a single host Portless alias `<alias>.localhost -> <previewUrl>`
+ * when `previewUrl` resolves to a loopback `http://127.0.0.1:<port>` (Hetzner's
+ * `ssh -L` forward). For backends that return a public URL (Daytona's signed
+ * preview) the alias is naturally skipped. Best-effort: every Portless call
+ * already swallows; we never throw from here. Returns the resolved URL on
+ * success.
+ */
+async function registerHostPortlessAlias(args: {
+  alias: string;
+  previewUrl: string;
+  label: string;
+  onLog: (line: string) => void;
+}): Promise<string | undefined> {
+  const localPort = parseLoopbackPort(args.previewUrl);
+  if (localPort === undefined) return undefined;
+  const ok = await portlessAlias(args.alias, localPort);
+  if (!ok) {
+    args.onLog(
+      `portless: ${args.label} alias not registered (portless CLI missing or not running) — host URL stays http://127.0.0.1:${String(localPort)}`,
+    );
+    return undefined;
+  }
+  const url = await portlessGetUrl(args.alias);
+  args.onLog(`portless alias ${url} -> 127.0.0.1:${String(localPort)}`);
+  return url;
+}
+
+/**
  * Register the host Portless alias for `<boxName>.localhost -> <webPreviewUrl>`
  * and bring up the in-VPS mirror proxy so the same URL works from inside the
  * box. Best-effort: every step is gated on a previous step's success, and any
@@ -162,17 +190,13 @@ async function bootstrapPortlessForCloudBox(
   handle: CloudHandle,
   args: { boxName: string; webPreviewUrl: string; webPort: number; onLog: (line: string) => void },
 ): Promise<{ alias: string; url: string } | undefined> {
-  const localPort = parseLoopbackPort(args.webPreviewUrl);
-  if (localPort === undefined) return undefined;
-  const ok = await portlessAlias(args.boxName, localPort);
-  if (!ok) {
-    args.onLog(
-      `portless: alias not registered (portless CLI missing or not running) — host URL stays http://127.0.0.1:${String(localPort)}`,
-    );
-    return undefined;
-  }
-  const url = await portlessGetUrl(args.boxName);
-  args.onLog(`portless alias ${url} -> 127.0.0.1:${String(localPort)}`);
+  const url = await registerHostPortlessAlias({
+    alias: args.boxName,
+    previewUrl: args.webPreviewUrl,
+    label: 'web',
+    onLog: args.onLog,
+  });
+  if (!url) return undefined;
   if (backend.startInBoxPortless) {
     const mode = parsePortlessUrl(url) ?? { proxyPort: DEFAULT_PORTLESS_PROXY_PORT, tls: false };
     try {
@@ -454,6 +478,33 @@ export function createCloudProvider(
             portlessUrlResolved = r.url;
           }
         }
+        // Parallel `vnc-<box-name>.localhost` alias against the in-box noVNC
+        // port. Host-only — no in-box mirror; an agent inside the box opening
+        // its own VNC view is a degenerate self-loop. Same loopback-URL gate
+        // as the web path, so Daytona naturally skips and Hetzner registers.
+        let vncPreview: { url: string; token?: string } | undefined;
+        if (portlessOpt && vncEnabled) {
+          try {
+            vncPreview = await backend.previewUrl(handle, CLOUD_VNC_PORT);
+          } catch {
+            vncPreview = undefined;
+          }
+        }
+        let portlessVncAliasName: string | undefined;
+        let portlessVncUrlResolved: string | undefined;
+        if (portlessOpt && vncPreview) {
+          const vncAlias = `vnc-${name}`;
+          const url = await registerHostPortlessAlias({
+            alias: vncAlias,
+            previewUrl: vncPreview.url,
+            label: 'vnc',
+            onLog: log,
+          });
+          if (url) {
+            portlessVncAliasName = vncAlias;
+            portlessVncUrlResolved = url;
+          }
+        }
         // Per-service preview URLs. Each `services.*.expose.port` from
         // `agentbox.yaml` gets a direct preview URL alongside the main
         // WebProxy URL — lets users hit services without going through the
@@ -531,6 +582,8 @@ export function createCloudProvider(
           carry: carrySummary,
           portlessAlias: portlessAliasName,
           portlessUrl: portlessUrlResolved,
+          portlessVncAlias: portlessVncAliasName,
+          portlessVncUrl: portlessVncUrlResolved,
           vncEnabled,
           vncPassword,
           vncContainerPort: vncEnabled ? CLOUD_VNC_PORT : undefined,
@@ -642,11 +695,35 @@ export function createCloudProvider(
           portlessUrlResolved = r.url;
         }
       }
+      // Same story for the VNC alias — the ssh -L port for 6080 is fresh.
+      // Best-effort, silent (startBox has no onLog). Skipped when no VNC
+      // alias was set at create.
+      let portlessVncAliasName: string | undefined = box.portlessVncAlias;
+      let portlessVncUrlResolved: string | undefined = box.portlessVncUrl;
+      if (box.portlessVncAlias && box.vncEnabled) {
+        try {
+          const vncPreview = await backend.previewUrl(h, CLOUD_VNC_PORT);
+          const url = await registerHostPortlessAlias({
+            alias: box.portlessVncAlias,
+            previewUrl: vncPreview.url,
+            label: 'vnc',
+            onLog: () => {},
+          });
+          if (url) {
+            portlessVncAliasName = box.portlessVncAlias;
+            portlessVncUrlResolved = url;
+          }
+        } catch {
+          /* best-effort */
+        }
+      }
 
       const next: BoxRecord = {
         ...box,
         portlessAlias: portlessAliasName,
         portlessUrl: portlessUrlResolved,
+        portlessVncAlias: portlessVncAliasName,
+        portlessVncUrl: portlessVncUrlResolved,
         cloud: {
           ...(box.cloud ?? { backend: providerName, sandboxId: h.sandboxId }),
           webPort,
@@ -731,13 +808,21 @@ export function createCloudProvider(
         const msg = err instanceof Error ? err.message : String(err);
         if (!/not.?found|missing/i.test(msg)) throw err;
       }
-      // Best-effort: drop the host Portless alias so `<box>.localhost` stops
-      // pointing at a dead ssh -L. The in-VPS portless dies with the VPS.
+      // Best-effort: drop the host Portless aliases (web + vnc) so neither
+      // `<box>.localhost` nor `vnc-<box>.localhost` keeps pointing at a dead
+      // ssh -L. The in-VPS portless dies with the VPS.
       if (box.portlessAlias) {
         try {
           await portlessUnalias(box.portlessAlias);
         } catch {
           // portlessUnalias swallows already; paranoid catch in case.
+        }
+      }
+      if (box.portlessVncAlias) {
+        try {
+          await portlessUnalias(box.portlessVncAlias);
+        } catch {
+          // best-effort
         }
       }
       // Best-effort: stop the host poller and drop the registration.
@@ -875,6 +960,17 @@ export function createCloudProvider(
     ): Promise<string> {
       const h = handleFor(box);
       const kind = opts?.kind ?? 'web';
+      // Prefer the stable Portless URL when one was registered (Hetzner gets
+      // both; Daytona naturally skips since previewUrl is non-loopback). The
+      // `--loopback` flag forces the raw signed/loopback path instead.
+      if (!opts?.loopback) {
+        if (kind === 'web' && box.portlessAlias) {
+          return box.portlessUrl ?? `https://${box.portlessAlias}.localhost`;
+        }
+        if (kind === 'vnc' && box.portlessVncAlias) {
+          return box.portlessVncUrl ?? `https://${box.portlessVncAlias}.localhost`;
+        }
+      }
       // VNC port is fixed by Dockerfile.box (websockify serves noVNC on :6080).
       const port = kind === 'vnc' ? CLOUD_VNC_PORT : (box.cloud?.webPort ?? CLOUD_WEB_PROXY_PORT);
       // Always re-resolve through the SDK — cached URLs on the record may be

--- a/packages/sandbox-core/src/state.ts
+++ b/packages/sandbox-core/src/state.ts
@@ -83,6 +83,8 @@ function projectDockerFields(box: BoxRecord): DockerBoxFields {
     webHostPort: box.webHostPort,
     portlessAlias: box.portlessAlias,
     portlessUrl: box.portlessUrl,
+    portlessVncAlias: box.portlessVncAlias,
+    portlessVncUrl: box.portlessVncUrl,
     dockerVolume: box.dockerVolume,
     dockerCacheShared: box.dockerCacheShared,
     checkpointImage: box.checkpointImage,

--- a/packages/sandbox-core/test/state.test.ts
+++ b/packages/sandbox-core/test/state.test.ts
@@ -173,6 +173,8 @@ describe('state.ts', () => {
       vncHostPort: 49001,
       webHostPort: 49002,
       portlessAlias: 'shape.localhost',
+      portlessVncAlias: 'vnc-shape.localhost',
+      portlessVncUrl: 'https://vnc-shape.localhost',
       createdAt: '2026-05-12T12:00:00.000Z',
     };
     await recordBox(box, file);
@@ -184,6 +186,8 @@ describe('state.ts', () => {
     expect(r.docker?.vncHostPort).toBe(49001);
     expect(r.docker?.webHostPort).toBe(49002);
     expect(r.docker?.portlessAlias).toBe('shape.localhost');
+    expect(r.docker?.portlessVncAlias).toBe('vnc-shape.localhost');
+    expect(r.docker?.portlessVncUrl).toBe('https://vnc-shape.localhost');
   });
 
   it('cloud records do NOT get a docker shape mirrored in', async () => {

--- a/packages/sandbox-docker/src/create.ts
+++ b/packages/sandbox-docker/src/create.ts
@@ -947,13 +947,16 @@ export async function createBox(opts: CreateBoxOptions): Promise<CreatedBox> {
     );
   }
 
-  // Portless: register `https://<box-name>.localhost -> 127.0.0.1:<webHostPort>`.
-  // Best-effort — Portless is user-installed and never required; any failure
-  // here just leaves the box on its loopback URL. Skipped on OrbStack (which
-  // already has <container>.orb.local).
+  // Portless: register `https://<box-name>.localhost -> 127.0.0.1:<webHostPort>`
+  // and a parallel `https://vnc-<box-name>.localhost -> 127.0.0.1:<vncHostPort>`
+  // for the noVNC viewer. Best-effort — Portless is user-installed and never
+  // required; any failure here just leaves the box on its loopback URL.
+  // Skipped on OrbStack (which already has <container>.orb.local).
   let portlessAliasName: string | undefined;
   let portlessUrl: string | undefined;
-  if (opts.portless === true && webHostPort) {
+  let portlessVncAliasName: string | undefined;
+  let portlessVncUrl: string | undefined;
+  if (opts.portless === true && (webHostPort || (vncEnabled && vncHostPort))) {
     try {
       const engine = await detectEngine();
       if (engine === 'orbstack') {
@@ -962,17 +965,31 @@ export async function createBox(opts: CreateBoxOptions): Promise<CreatedBox> {
         const portless = await detectPortless();
         if (!portless.installed) {
           log('portless not installed — run `npm install -g portless` for a <name>.localhost URL');
-        } else if (await portlessAlias(name, webHostPort)) {
-          portlessAliasName = name;
-          // Resolve the real URL from the proxy: scheme + port depend on how
-          // the proxy was started (http://…:1355 no-TLS, or https://… on :443).
-          portlessUrl = await portlessGetUrl(name);
-          log(`portless alias ${portlessUrl} -> 127.0.0.1:${String(webHostPort)}`);
-          if (!portless.proxyRunning) {
+        } else {
+          if (webHostPort) {
+            if (await portlessAlias(name, webHostPort)) {
+              portlessAliasName = name;
+              // Resolve the real URL from the proxy: scheme + port depend on how
+              // the proxy was started (http://…:1355 no-TLS, or https://… on :443).
+              portlessUrl = await portlessGetUrl(name);
+              log(`portless alias ${portlessUrl} -> 127.0.0.1:${String(webHostPort)}`);
+            } else {
+              log('portless alias failed (best-effort) — box still reachable on the loopback URL');
+            }
+          }
+          if (vncEnabled && vncHostPort) {
+            const vncAlias = `vnc-${name}`;
+            if (await portlessAlias(vncAlias, vncHostPort)) {
+              portlessVncAliasName = vncAlias;
+              portlessVncUrl = await portlessGetUrl(vncAlias);
+              log(`portless alias ${portlessVncUrl} -> 127.0.0.1:${String(vncHostPort)}`);
+            } else {
+              log('portless vnc alias failed (best-effort) — VNC still reachable on the loopback URL');
+            }
+          }
+          if (!portless.proxyRunning && (portlessAliasName || portlessVncAliasName)) {
             log(`portless proxy not running — start it with \`${portlessStartHint()}\``);
           }
-        } else {
-          log('portless alias failed (best-effort) — box still reachable on the loopback URL');
         }
       }
     } catch (err) {
@@ -1006,6 +1023,8 @@ export async function createBox(opts: CreateBoxOptions): Promise<CreatedBox> {
     webHostPort: webHostPort ?? undefined,
     portlessAlias: portlessAliasName,
     portlessUrl,
+    portlessVncAlias: portlessVncAliasName,
+    portlessVncUrl,
     dockerVolume,
     dockerCacheShared: dockerCacheShared || undefined,
     projectRoot: opts.projectRoot,

--- a/packages/sandbox-docker/src/docker-provider.ts
+++ b/packages/sandbox-docker/src/docker-provider.ts
@@ -159,7 +159,8 @@ export const dockerProvider: Provider = {
     }
     const engine = await detectEngine();
     if (engine === 'orbstack' && !opts?.loopback) {
-      // OrbStack auto-routes <container>.orb.local to container :80.
+      // OrbStack auto-routes <container>.orb.local to the container; :80 is
+      // declared (EXPOSE 80) so no port suffix is needed.
       return `http://${box.container}.orb.local`;
     }
     if (box.portlessAlias && !opts?.loopback) {

--- a/packages/sandbox-docker/src/endpoints.ts
+++ b/packages/sandbox-docker/src/endpoints.ts
@@ -38,7 +38,12 @@ export async function getBoxEndpoints(
 
   if (record.vncEnabled && record.vncPassword) {
     const vncUrls = buildVncUrls(record, engine);
-    const url = vncUrls.orbUrl ?? vncUrls.loopbackUrl;
+    // Preference: portless (stable name) > orb.local > loopback. Mirrors the
+    // web endpoint's choice below and `agentbox screen`'s default.
+    const url =
+      engine === 'orbstack'
+        ? (vncUrls.orbUrl ?? vncUrls.loopbackUrl)
+        : (vncUrls.portlessUrl ?? vncUrls.loopbackUrl);
     endpoints.push({
       kind: 'vnc',
       name: 'vnc',

--- a/packages/sandbox-docker/src/lifecycle.ts
+++ b/packages/sandbox-docker/src/lifecycle.ts
@@ -52,7 +52,7 @@ import { launchDockerdDaemon, SHARED_DOCKER_CACHE_VOLUME } from './dockerd.js';
 import { launchVncDaemon, VNC_CONTAINER_PORT } from './vnc.js';
 import { WEB_CONTAINER_PORT } from './web.js';
 import { detectPortless, portlessAlias, portlessGetUrl, portlessUnalias } from './portless.js';
-import { getBoxEndpoints, type BoxEndpoints } from './endpoints.js';
+import { getBoxEndpoints, type BoxEndpoint, type BoxEndpoints } from './endpoints.js';
 import {
   ensureRelay,
   forgetBoxFromRelay,
@@ -115,20 +115,36 @@ export async function listBoxes(): Promise<ListedBox[]> {
             : undefined;
         const cachedWebUrl = webPort > 0 ? b.cloud?.previewUrls?.[webPort] : undefined;
         const webUrl = portlessWebUrl ?? cachedWebUrl;
+        const portlessVncBase =
+          b.portlessVncAlias !== undefined
+            ? (b.portlessVncUrl ?? `https://${b.portlessVncAlias}.localhost`)
+            : undefined;
+        const vncUrl =
+          portlessVncBase && b.vncPassword
+            ? `${portlessVncBase}/vnc.html?autoconnect=1&password=${encodeURIComponent(b.vncPassword)}`
+            : undefined;
+        const cloudEndpoints: BoxEndpoint[] = [];
+        if (webUrl) {
+          cloudEndpoints.push({
+            kind: 'web',
+            name: 'web',
+            containerPort: webPort,
+            url: webUrl,
+            reachable: true,
+          });
+        }
+        if (b.vncEnabled && b.vncPassword) {
+          cloudEndpoints.push({
+            kind: 'vnc',
+            name: 'vnc',
+            containerPort: b.vncContainerPort ?? 6080,
+            ...(vncUrl ? { url: vncUrl, reachable: true } : { reachable: false }),
+          });
+        }
         const endpoints: BoxEndpoints = {
           domain: webUrl ? safeHost(webUrl) : '',
           domainIsOrb: false,
-          endpoints: webUrl
-            ? [
-                {
-                  kind: 'web',
-                  name: 'web',
-                  containerPort: webPort,
-                  url: webUrl,
-                  reachable: true,
-                },
-              ]
-            : [],
+          endpoints: cloudEndpoints,
         };
         return {
           ...b,
@@ -309,24 +325,37 @@ export async function startBox(idOrName: string): Promise<StartedBox> {
       box.webHostPort = freshWebPort;
       await recordBox(box);
     }
-    // Docker reallocated the host port, so the Portless route now points at a
-    // stale port — re-register it. Best-effort and silent (startBox has no
-    // onLog); if the proxy/Portless is gone the box still works on loopback.
-    if (box.portlessAlias && box.webHostPort) {
-      try {
-        const portless = await detectPortless();
-        if (portless.installed) {
+  }
+  // Docker reallocated the ephemeral host ports above, so both Portless
+  // routes now point at stale ports — re-register them. Best-effort and
+  // silent (startBox has no onLog); if the proxy/Portless is gone the box
+  // still works on loopback.
+  if ((box.portlessAlias && box.webHostPort) || (box.portlessVncAlias && box.vncHostPort)) {
+    try {
+      const portless = await detectPortless();
+      if (portless.installed) {
+        let dirty = false;
+        if (box.portlessAlias && box.webHostPort) {
           await portlessAlias(box.portlessAlias, box.webHostPort);
           // The proxy's scheme/port can change between sessions — re-resolve.
           const url = await portlessGetUrl(box.portlessAlias);
           if (url !== box.portlessUrl) {
             box.portlessUrl = url;
-            await recordBox(box);
+            dirty = true;
           }
         }
-      } catch {
-        /* best-effort */
+        if (box.portlessVncAlias && box.vncHostPort) {
+          await portlessAlias(box.portlessVncAlias, box.vncHostPort);
+          const url = await portlessGetUrl(box.portlessVncAlias);
+          if (url !== box.portlessVncUrl) {
+            box.portlessVncUrl = url;
+            dirty = true;
+          }
+        }
+        if (dirty) await recordBox(box);
       }
+    } catch {
+      /* best-effort */
     }
   }
   // Relay's in-memory registry may have been lost if the relay restarted
@@ -477,12 +506,20 @@ export async function destroyBox(
       // best-effort — relay may be down or already wiped the entry
     }
   }
-  // Remove the Portless route so it doesn't dangle in the user's proxy config.
+  // Remove the Portless routes so they don't dangle in the user's proxy
+  // config. Web alias + VNC alias are independent — drop whichever was set.
   if (box.portlessAlias) {
     try {
       await portlessUnalias(box.portlessAlias);
     } catch {
       // best-effort — Portless may be uninstalled or the route already gone
+    }
+  }
+  if (box.portlessVncAlias) {
+    try {
+      await portlessUnalias(box.portlessVncAlias);
+    } catch {
+      // best-effort
     }
   }
   // Deregister each in-container worktree from the host main repo. Skip

--- a/packages/sandbox-docker/src/vnc.ts
+++ b/packages/sandbox-docker/src/vnc.ts
@@ -69,12 +69,15 @@ export interface VncUrls {
   orbUrl?: string;
   /** Loopback URL via the auto-allocated host port, e.g. http://127.0.0.1:54321/... Present whenever vncHostPort is known. */
   loopbackUrl?: string;
+  /** Portless URL, e.g. https://vnc-mybox.localhost/vnc.html?... Present when `portlessVncAlias` is set on the record. */
+  portlessUrl?: string;
 }
 
 /**
  * Build the noVNC URLs for a box, given the box record + (host engine).
  * `engine === 'orbstack'` triggers the `<container>.orb.local:6080` route;
- * either engine produces the loopback URL when the host port is resolved.
+ * a stored Portless alias gives `vnc-<name>.localhost`; either engine
+ * produces the loopback URL when the host port is resolved.
  * Returns an empty object when VNC isn't enabled or the password isn't known.
  */
 export function buildVncUrls(
@@ -84,6 +87,8 @@ export function buildVncUrls(
     vncHostPort?: number;
     vncContainerPort?: number;
     vncPassword?: string;
+    portlessVncAlias?: string;
+    portlessVncUrl?: string;
   },
   engine: 'orbstack' | 'docker-desktop' | 'other',
 ): VncUrls {
@@ -96,6 +101,10 @@ export function buildVncUrls(
   }
   if (record.vncHostPort) {
     urls.loopbackUrl = `http://127.0.0.1:${String(record.vncHostPort)}/vnc.html?${qs}`;
+  }
+  if (record.portlessVncAlias) {
+    const base = record.portlessVncUrl ?? `https://${record.portlessVncAlias}.localhost`;
+    urls.portlessUrl = `${base}/vnc.html?${qs}`;
   }
   return urls;
 }

--- a/packages/sandbox-docker/test/endpoints.test.ts
+++ b/packages/sandbox-docker/test/endpoints.test.ts
@@ -32,6 +32,10 @@ function webEndpoint(eps: Awaited<ReturnType<typeof getBoxEndpoints>>) {
   return eps.endpoints.find((e) => e.kind === 'web');
 }
 
+function vncEndpoint(eps: Awaited<ReturnType<typeof getBoxEndpoints>>) {
+  return eps.endpoints.find((e) => e.kind === 'vnc');
+}
+
 describe('getBoxEndpoints — Portless web URL', () => {
   it('uses the stored portlessUrl on Docker Desktop', async () => {
     const record = {
@@ -63,5 +67,60 @@ describe('getBoxEndpoints — Portless web URL', () => {
     };
     const eps = await getBoxEndpoints(record, 'orbstack', webStatus);
     expect(webEndpoint(eps)?.url).toBe('http://127.0.0.1:54321');
+  });
+});
+
+describe('getBoxEndpoints — Portless VNC URL', () => {
+  const vncBase: BoxRecord = {
+    ...baseRecord,
+    vncEnabled: true,
+    vncContainerPort: 6080,
+    vncHostPort: 64080,
+    vncPassword: 'pw12345A',
+  };
+
+  it('uses the stored portlessVncUrl on Docker Desktop', async () => {
+    const record = {
+      ...vncBase,
+      portlessVncAlias: 'vnc-mybox',
+      portlessVncUrl: 'http://vnc-mybox.localhost:1355',
+    };
+    const eps = await getBoxEndpoints(record, 'docker-desktop', webStatus);
+    expect(vncEndpoint(eps)?.url).toBe(
+      'http://vnc-mybox.localhost:1355/vnc.html?autoconnect=1&password=pw12345A',
+    );
+    expect(vncEndpoint(eps)?.reachable).toBe(true);
+  });
+
+  it('falls back to https://vnc-<name>.localhost when portlessVncUrl is absent', async () => {
+    const record = { ...vncBase, portlessVncAlias: 'vnc-mybox' };
+    const eps = await getBoxEndpoints(record, 'docker-desktop', webStatus);
+    expect(vncEndpoint(eps)?.url).toBe(
+      'https://vnc-mybox.localhost/vnc.html?autoconnect=1&password=pw12345A',
+    );
+  });
+
+  it('falls back to loopback VNC URL when no Portless route is registered', async () => {
+    const eps = await getBoxEndpoints(vncBase, 'docker-desktop', webStatus);
+    expect(vncEndpoint(eps)?.url).toBe(
+      'http://127.0.0.1:64080/vnc.html?autoconnect=1&password=pw12345A',
+    );
+  });
+
+  it('ignores the Portless VNC route on OrbStack (orb.local is preferred)', async () => {
+    const record = {
+      ...vncBase,
+      portlessVncAlias: 'vnc-mybox',
+      portlessVncUrl: 'http://vnc-mybox.localhost:1355',
+    };
+    const eps = await getBoxEndpoints(record, 'orbstack', webStatus);
+    expect(vncEndpoint(eps)?.url).toBe(
+      'http://agentbox-mybox.orb.local:6080/vnc.html?autoconnect=1&password=pw12345A',
+    );
+  });
+
+  it('omits the VNC endpoint when vncEnabled is false', async () => {
+    const eps = await getBoxEndpoints(baseRecord, 'docker-desktop', webStatus);
+    expect(vncEndpoint(eps)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Mints a second Portless alias per box at create time alongside the existing `<box>.localhost` web alias: `vnc-<box>.localhost` points at the noVNC port (container 6080 on docker, the SSH-forwarded local port on Hetzner). Gives the user a stable URL for the noVNC viewer instead of a random ephemeral loopback port that re-rolls on every stop/start.
- Wired uniformly across docker, daytona, and hetzner. Naturally no-ops on backends whose `previewUrl()` isn't loopback (Daytona), mirroring the existing web alias. Re-registered on `start` (host port reallocation) and dropped on `destroy`.
- `agentbox screen` and `agentbox inspect` now prefer the new URL on non-OrbStack engines; `agentbox url` grew a `--kind <web|vnc>` flag.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — all 515 tests green (5 new for the VNC URL preference matrix in `endpoints.test.ts`, 1 state round-trip case)
- [x] Docker e2e on Docker Desktop:
  - [x] `agentbox create -y --portless` registers both `<box>.localhost` and `vnc-<box>.localhost` (visible in `create.log`)
  - [x] `curl https://vnc-<box>.localhost/vnc.html -k` returns 200 (noVNC loads)
  - [x] `agentbox screen <box> --print` returns the Portless URL with `?autoconnect=1&password=…`
  - [x] `agentbox url <box> --kind vnc --print` returns `https://vnc-<box>.localhost`
  - [x] `agentbox stop && agentbox start` re-registers after host port re-rolls; noVNC still serves 200
  - [x] `agentbox destroy -y` removes both routes from `~/.portless/routes.json`
- [ ] Hetzner e2e (deferred — needs a fresh `agentbox prepare --provider hetzner`; logic mirrors docker, gated on the same `--portless` opt-in)
- [ ] Daytona graceful skip (deferred — verified by inspection: `parseLoopbackPort` returns undefined for Daytona's signed preview URL, same as today's web path)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Best-effort Portless registration with existing fallbacks; no auth or data-model breaking changes beyond new optional record fields.
> 
> **Overview**
> Adds a **second Portless alias per box** — `vnc-<name>.localhost` → the noVNC port — alongside the existing web alias, persisted on `BoxRecord` as `portlessVncAlias` / `portlessVncUrl`. Docker registers it at create; cloud (Hetzner loopback previews) registers at create/start via a shared `registerHostPortlessAlias` helper; both aliases are re-pointed after `start` when host ports change and removed on `destroy`.
> 
> **CLI / UX:** `agentbox url` gains `--kind web|vnc` (with VNC guards). `agentbox screen` and Docker `getBoxEndpoints` now prefer **Portless → OrbStack → loopback** for VNC on non-OrbStack engines (stable URL across restarts). Cloud `resolveUrl` and `list`/`inspect` surfaces include Portless VNC when present.
> 
> **Tests:** State round-trip and endpoint preference matrix for VNC Portless URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c99ec63304c4248de3f0c1b8ed8673b9bc2cb996. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->