### PR TITLE
feat(fork): agentbox fork + /agentbox for Claude/Codex/OpenCode

### DIFF
--- a/apps/cli/share/host-skills/agentbox-info/SKILL.md
+++ b/apps/cli/share/host-skills/agentbox-info/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: agentbox-info
+description: "Spin up isolated sandboxes (\"boxes\") for coding agents, run them in parallel, queue background runs with -i, and push commits safely through the host relay. Use when the user wants to run Claude Code / Codex / OpenCode in a sandbox, start more boxes, attach to a running box, or otherwise operate the `agentbox` CLI on their laptop."
+user-invocable: false
+---
+<!-- agentbox-managed:v1 -->
+
+# AgentBox (host-side)
+
+You are operating on the **user's host machine** (laptop / dev workstation), not inside a box. Use the `agentbox` CLI to provision isolated sandboxes for coding agents and to attach to them.
+
+If you find yourself *inside* a box (`/workspace` exists and `AGENTBOX_RELAY_URL` is set in the env), this is the wrong skill — use the in-box `/agentbox-setup` skill instead.
+
+## What AgentBox is, in one paragraph
+
+AgentBox spins up one isolated sandbox per agent run — a local Docker container (default), a Daytona cloud sandbox (`--provider daytona`), or a Hetzner VPS (`--provider hetzner`). Each box has its own `/workspace`, but the host's `.git/` is shared, so commits made inside the box land on the host immediately. The agent inside the box has **no host credentials** — `git push`, opening URLs in the host browser, capturing checkpoints, and all other host-side operations flow through a small host process called the **relay** that runs alongside the CLI.
+
+## The two starting commands
+
+### `agentbox create`
+
+Provision a box and stop. The box exists and is ready, but nothing is launched inside it.
+
+```sh
+agentbox create                       # docker, auto-named after the workspace
+agentbox create -n review             # docker, friendly name
+agentbox create --provider hetzner    # cloud VPS (requires `agentbox prepare --provider hetzner` once)
+agentbox create --attach              # drop into a shell inside the box after create
+```
+
+Useful flags: `-n <name>` (friendly box name), `--provider docker|daytona|hetzner`, `--attach`, `-w <path>` (workspace to mount; defaults to `cwd`), `--snapshot <ref>` (start from a checkpoint).
+
+Non-docker providers require a one-time `agentbox prepare --provider <name>` to bake the base image / snapshot.
+
+### `agentbox claude`
+
+Provision (same as `create`) and launch **Claude Code** inside the box, in a detachable tmux session. This is the main entry point most users want.
+
+```sh
+agentbox claude                       # docker, attaches your terminal
+agentbox claude -n review             # second box, named
+agentbox claude --provider hetzner    # cloud
+agentbox claude -- --model sonnet     # extra args after `--` go to claude itself
+```
+
+While attached: **`Ctrl+a d`** detaches without killing claude. The box keeps running. Reattach with `agentbox claude attach <name|n>`.
+
+Variants with the same shape for other agents: **`agentbox codex`**, **`agentbox opencode`**.
+
+## `-i` / `--initial-prompt`: background queue
+
+With `-i "<prompt>"`, `agentbox claude` (and `codex` / `opencode`) does **not** attach. It writes a job manifest to `~/.agentbox/queue/<id>.json` and exits immediately, printing the job id and log path. The host relay's queue loop drains these manifests respecting `queue.maxConcurrent` (global config; override per invocation with `--max-running <n>`).
+
+Use this to fan out parallel agent runs:
+
+```sh
+agentbox claude -i "fix the failing test in src/auth and open a PR"
+agentbox claude -i "draft a CHANGELOG entry from the last 20 commits"
+agentbox claude -i "audit our dependencies for known CVEs"
+```
+
+Each call returns instantly. The queue drains them concurrently up to `queue.maxConcurrent`. Inspect / attach later:
+
+```sh
+agentbox dashboard                    # TUI with status + leader-key actions
+agentbox claude attach <name|n>       # reattach to a specific box
+```
+
+Caveats: `-i` is currently **docker-only** (cloud sessions only start on attach, so background-mode has no place to seed the prompt). The host must have valid Claude Code credentials.
+
+## Forking the current session into a box
+
+From host Claude, run the **`/agentbox`** slash command (optional arg: `docker` | `daytona` | `hetzner`) to snapshot the *current* Claude Code session into a brand-new box that resumes it. With tmux or iTerm it opens in a new terminal tab; otherwise it starts in the background. The host session is unaffected — you get two parallel timelines. The underlying CLI is `agentbox fork` (`agentbox fork --help`); `/agentbox` requires `agentbox install` to have been run once. This is distinct from `-i`, which seeds a *new* prompt rather than resuming the live conversation.
+
+## Driving one agent from another (`drive`, `agent`, `queue wait-for`)
+
+When *you* are the host-side agent and want to orchestrate other agents running inside boxes — read what they're doing, send them a prompt, wait until they're done or need input — use these three command families. Everything is stateless / one-shot, and the human-text default switches to machine-friendly JSON with `--json`.
+
+### `agentbox drive <box>` — terminal driving
+
+Targets the running tmux session inside a box (auto-picks the agent session: `claude` → `codex` → `opencode` → the only running session; override with `--session <name>`). Provider-uniform — works the same on docker / daytona / hetzner.
+
+```sh
+agentbox drive snapshot 1                          # print rendered TUI as plain text
+agentbox drive snapshot 1 --with-cursor            # JSON envelope: { session, cols, rows, cursor, screen }
+agentbox drive snapshot 1 --ansi --rows -200:-1    # include color, walk into scrollback
+agentbox drive keypress 1 "<C-c>"                  # DSL: <Enter>, <C-x>, <Tab>, <F5>, <Up>, etc.
+agentbox drive send-text 1 "hello"                 # literal text, no DSL parsing, no trailing Enter
+agentbox drive prompt 1 "summarize /workspace/README" # type + Enter (the convenience action)
+agentbox drive wait 1 --text "✓" --timeout 60000   # block until <text> appears on screen
+agentbox drive resize 1 200 60
+```
+
+`keypress` uses a small DSL: `<Enter>`, `<Tab>`, `<Esc>`, `<Space>`, `<BS>`, `<Del>`, `<Up>/<Down>/<Left>/<Right>`, `<Home>/<End>/<PageUp>/<PageDown>`, `<F1>`–`<F12>`, `<C-a>`..`<C-z>`. Use `<<` for a literal `<`. Multiple args concatenate with no spaces (`"ls" "<Enter>"` → `ls\r`).
+
+### `agentbox agent <box>` — agent state introspection (Claude / Codex / OpenCode)
+
+Sub-second latency. State source by agent:
+
+- **Claude Code**: lifecycle hooks (`UserPromptSubmit`, `PreToolUse`, `Stop`, `Notification`, `ExitPlanMode`, `AskUserQuestion`, `PreCompact`/`PostCompact`, `StopFailure`, `SubagentStart`/`SubagentStop`).
+- **Codex**: tmux-pane scraper inside the box (codex 0.134.0's own hook firing is unreliable; staged hooks remain for the day that's fixed upstream).
+- **OpenCode**: a plugin (`agentbox-state.js`) seeded into the OpenCode config volume, subscribing to OpenCode's event bus.
+
+All three feed the same status pipeline; `agent state` / `agent wait-for` work the same regardless of which agent runs inside the box. Reports come from `~/.agentbox/boxes/<id>/status.json` and the relay event stream.
+
+```sh
+agentbox agent state 1                # → working | idle | waiting | end-plan | question | prompt | compacting | error
+agentbox agent state 1 --json         # full BoxStatusClaude (state, updatedAt, sessionTitle, plan?, question?)
+
+agentbox agent wait-for prompt 1 --timeout 600000      # block until Claude is at the input box, no pending plan/question
+agentbox agent wait-for end-plan 1                     # Claude just called ExitPlanMode; user has to approve
+agentbox agent wait-for question 1                     # AskUserQuestion picker is up
+agentbox agent wait-for idle 1                         # Stop hook fired (turn complete)
+agentbox agent wait-for compacting 1                   # Claude is summarizing context (PreCompact fired)
+agentbox agent wait-for error 1                        # Claude's turn ended with a failure (StopFailure)
+
+agentbox agent get-plan-question 1            # print the plan body OR question + options (human)
+agentbox agent get-plan-question 1 --json     # structured payload
+```
+
+The `prompt` state is derived: `idle` AND tmux session alive AND no pending plan/question — i.e. "ready for the next user message". Use it as the natural sync point after sending a new prompt.
+
+The `end-plan` and `question` matchers tolerate the race where Claude's `Notification:permission_prompt` hook flips the raw state to `waiting` immediately after the matcher hook fires — both states still match while the plan/question payload is pending, and only the matching `PostToolUse` (handled internally with `--clear-pending`) resets them.
+
+### `agentbox queue wait-for <event>` — queue + box lifecycle
+
+```sh
+agentbox queue wait-for new-box                          # any new box gets registered
+agentbox queue wait-for empty-queue --timeout 1800000    # all queued/running jobs settled
+agentbox queue wait-for box-running --box review
+agentbox queue wait-for box-paused  --box 2
+agentbox queue wait-for box-stopped --box 2
+agentbox queue wait-for job-done --job b45f1603841bd2b5  # terminal status (done/failed/cancelled)
+```
+
+All wait-for commands exit 0 on match, exit 1 on timeout, and accept `--json` for parseable output.
+
+### Recipe: queue a plan, then act per turn
+
+This is the canonical "drive a Claude Code from another Claude Code" loop. You queue an initial planning prompt, wait for the plan to land, capture it, decide, send the next message, repeat.
+
+```sh
+# 1. Kick off a box with a planning prompt.
+agentbox claude -n design -i "Plan how to add an OAuth login flow to apps/web, then enter plan mode. Don't start coding."
+
+# 2. Wait until Claude is at the ExitPlanMode approval prompt.
+agentbox agent wait-for end-plan design --timeout 600000
+
+# 3. Read the plan back as text (or JSON) and decide.
+PLAN=$(agentbox agent get-plan-question design)
+echo "$PLAN"
+
+# 4. Approve via tmux — option 1 ("Yes, and use auto mode") is already highlighted.
+agentbox drive keypress design "<Enter>"
+
+# 5. Wait for the turn to finish.
+agentbox agent wait-for prompt design --timeout 1200000
+
+# 6. Fan out follow-up work to a fresh box, in background, while reviewing this one.
+agentbox claude -i "Write the OAuth provider unit tests in apps/web/test/auth/"
+
+# 7. Block until everything settles before reporting back.
+agentbox queue wait-for empty-queue --timeout 3600000
+```
+
+The same shape covers `agent wait-for question` + `agent get-plan-question` (read the choices, send the answer index via `drive keypress 1 "<Down><Enter>"`, then `wait-for prompt`).
+
+### Quick mental model
+
+- `drive` = "send keystrokes / read screen" — provider-uniform tmux capture-pane / send-keys.
+- `agent` = "what is the Claude TUI currently doing" — hook-driven, race-free, machine-readable.
+- `queue wait-for` = "block on queue or box lifecycle transitions" — poll-based, no new endpoint.
+- All three commands are **stateless** — safe to invoke from any script, any agent, in parallel.
+- `--json` everywhere. Default human text is for the operator; an agent should pass `--json`.
+
+## Git through the host relay
+
+**The box has no SSH keys, GPG keys, or git remote credentials.** Don't ask the user to add any. When an in-box agent (or a script you run inside the box) does `git push` or `git pull`, the AgentBox-provided `agentbox-ctl git` wrapper POSTs a JSON-RPC call to the host relay (`POST /rpc`, bearer-auth, loopback-only). The relay runs the **real** `git push origin …` on the host, using the user's `SSH_AUTH_SOCK`, `~/.gitconfig`, and identity — and streams stdout/stderr back into the box's terminal. The box's exit code matches the host's.
+
+Implications for you, the host-side agent:
+
+- Inside the box you can `git commit … && git push` exactly as normal. No setup needed.
+- Pushes are gated host-side: the relay can require a confirm prompt for destructive operations (the user sees it in the dashboard footer, ~25 s TTL). If a push appears to hang, tell the user to check the dashboard.
+- The relay process is started lazily by the first `agentbox create` / `agentbox claude` and persists across runs (PID at `~/.agentbox/relay.pid`, log at `~/.agentbox/relay.log`). You normally don't need to manage it.
+
+## Other commands worth knowing
+
+| Command | What it does |
+| --- | --- |
+| `agentbox dashboard` | TUI status + switcher across all boxes. The leader is **`Ctrl+a`** (e.g. `Ctrl+a u` opens the box's web URL; `Ctrl+a s` opens the in-box browser; `Ctrl+a q` quits). |
+| `agentbox shell [n\|name]` | Interactive `bash -l` inside the box (also wrapped in tmux by default — detach with `Ctrl+a d`). |
+| `agentbox url [n\|name]` | Open the box's web app URL (`<box-name>.localhost` via Portless) in the host browser. |
+| `agentbox screen [n\|name]` | Open the box's **own** Chromium via VNC — useful for OAuth flows the agent inside the box initiates. |
+| `agentbox code [n\|name]` | Open VS Code / Cursor pointed at the box. |
+| `agentbox prepare --provider <name>` | One-time base image / snapshot build for `daytona` or `hetzner`. With no `--provider`, prints status across all providers. |
+| `agentbox prune --provider <name>` | Clean up orphan boxes / images / snapshots for a provider (docker + daytona supported; hetzner pending). |
+
+Per-project numeric index (`1`, `2`, …) and friendly name (`review`, `smoke`) both work wherever `<box>` is accepted. Index `1` is the first box created in the current workspace.
+
+## Operating principles
+
+1. **Never assume the host needs SSH keys forwarded into a box** — git is handled by the relay, by design.
+2. **Use `-i` whenever the user asks for parallel agent work** rather than spawning multiple foreground sessions. Then point them at `agentbox dashboard` to watch progress.
+3. **Pick the provider deliberately.** `docker` is the fast default. `--provider hetzner` gives a real VPS (heavier, isolated, requires `agentbox prepare --provider hetzner` once). `--provider daytona` is the managed cloud option.
+4. **Cross-check before recommending a command.** If a flag isn't listed here, run `agentbox <command> --help` (it's safe and read-only) before suggesting it to the user.
+5. **`/agentbox-setup` is a different skill.** It runs *inside* a box to generate `/workspace/agentbox.yaml`. Don't conflate it with `/agentbox` (host-side fork) or this reference skill.
+
+## Reference
+
+- Full docs live in the repo at `docs/` — start with `docs/architecture.md` and `docs/create-and-checkpoints.md` for the model, `docs/host-relay.md` for the relay, `docs/cloud-providers.md` for the cloud paths.
+- npm package: `@madarco/agentbox` — `npm -g install @madarco/agentbox` (or `npx @madarco/agentbox <command>`).

--- a/apps/cli/share/host-skills/agentbox/SKILL.md
+++ b/apps/cli/share/host-skills/agentbox/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: agentbox
+description: "Fork the current agent session into a new VM or local Docker container with all the project files, agent settings and session teleported into."
+disable-model-invocation: true
+context: fork
+agent: general-purpose
+allowed-tools: Bash
+---
+<!-- agentbox-managed:v1 -->
+
+Fork the current Claude Code session into a fresh AgentBox box.
+
+1. **Resolve the provider flag from `$ARGUMENTS`:**
+   - empty → no flag (uses the default docker provider)
+   - `docker` | `daytona` | `hetzner` → pass `--provider $ARGUMENTS`
+   - anything else → stop and tell the user the valid values are `docker`, `daytona`, `hetzner`
+
+2. **Fork.** Run, via the Bash tool, exactly one command:
+
+   ```
+   agentbox fork --session ${CLAUDE_SESSION_ID} [--provider $ARGUMENTS]
+   ```
+
+3. **Report.** In one line, give the user the new box name (parse it from the command output) and confirm their host session is unaffected. Do not summarize the conversation — the fork already carries it.
+
+## Troubleshooting
+
+- If agentbox command fails, tell the user to install AgentBox by writing `! npm -g install @madarco/agentbox` in the chat.
+- If `AGENTBOX_RELAY_URL` is set in the environment, you are running *inside* a box. This command is host-only in v1; tell the user box→box fork is not supported yet.

--- a/apps/cli/share/host-skills/codex/agentbox.md
+++ b/apps/cli/share/host-skills/codex/agentbox.md
@@ -1,0 +1,35 @@
+---
+description: Fork the current Codex session into a new AgentBox box and resume it there (opens in a new terminal tab).
+argument-hint: [provider]
+---
+<!-- agentbox-managed:v1 -->
+
+Fork the current Codex session into a fresh AgentBox box running Codex.
+
+Optional provider argument: `$ARGUMENTS` (docker | daytona | hetzner; default docker).
+
+## Steps
+
+1. **Pre-flight (stop on either):**
+   - If `AGENTBOX_RELAY_URL` is set in the environment, you are running *inside* a box — box→box fork is not supported yet; stop and tell the user.
+   - If `which agentbox` fails, tell the user to install AgentBox (`npm -g install @madarco/agentbox`) and stop.
+
+2. **Find the current Codex session id.** Codex exposes no session-id variable, so resolve it from the most recently written rollout file (that is the live session). Run via your shell tool:
+
+   ```
+   ls -t "$HOME"/.codex/sessions/*/*/*/rollout-*.jsonl 2>/dev/null | head -1 \
+     | xargs -I{} basename {} .jsonl \
+     | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+   ```
+
+   That prints the session `<uuid>`. If it prints nothing, stop and tell the user no Codex session was found for this machine.
+
+3. **Resolve the provider flag from `$ARGUMENTS`:** empty → none; `docker` | `daytona` | `hetzner` → `--provider $ARGUMENTS`; anything else → stop and report the valid values.
+
+4. **Fork.** Run, via your shell tool:
+
+   ```
+   agentbox fork --agent codex --session <uuid> [--provider <from step 3>]
+   ```
+
+5. **Report** the new box name from the command output. Your current Codex session is unaffected — you now have two parallel timelines.

--- a/apps/cli/share/host-skills/opencode/agentbox.md
+++ b/apps/cli/share/host-skills/opencode/agentbox.md
@@ -1,0 +1,26 @@
+---
+description: Spawn a parallel AgentBox box running OpenCode for this project (opens in a new terminal tab). Note - the current OpenCode session is not resumed yet; this starts a fresh session.
+---
+<!-- agentbox-managed:v1 -->
+
+Spawn a new AgentBox box running OpenCode for the current project, in a new terminal tab.
+
+Optional provider argument: `$ARGUMENTS` (docker | daytona | hetzner; default docker).
+
+**Note:** resuming an OpenCode session into a box isn't supported yet (sessions live in a shared SQLite DB), so this starts a **fresh** OpenCode session in the box — it does not carry the current conversation.
+
+## Steps
+
+1. **Pre-flight (stop on either):**
+   - If `AGENTBOX_RELAY_URL` is set in the environment, you are running *inside* a box — not supported; stop and tell the user.
+   - If `which agentbox` fails, tell the user to install AgentBox (`npm -g install @madarco/agentbox`) and stop.
+
+2. **Resolve the provider flag from `$ARGUMENTS`:** empty → none; `docker` | `daytona` | `hetzner` → `--provider $ARGUMENTS`; anything else → stop and report the valid values.
+
+3. **Fork.** Run, via your shell tool:
+
+   ```
+   agentbox fork --agent opencode [--provider <from step 2>]
+   ```
+
+4. **Report** the new box name from the command output.

--- a/apps/cli/src/commands/_cloud-attach.ts
+++ b/apps/cli/src/commands/_cloud-attach.ts
@@ -1,3 +1,4 @@
+import { spawn } from 'node:child_process';
 import { DEFAULT_RELAY_PORT } from '@agentbox/sandbox-docker';
 import type { BoxRecord } from '@agentbox/core';
 import type { AttachOpenIn } from '@agentbox/config';
@@ -84,15 +85,36 @@ export async function cloudAgentAttach(args: CloudAgentAttachArgs): Promise<void
     throw new Error(`provider '${provider.name}' does not support interactive attach`);
   }
   const command = buildCloudAttachInnerCommand(args.binary, args.extraArgs);
-  const spec = await provider.buildAttach(args.box, 'agent', {
-    sessionName: args.sessionName,
-    command,
-  });
   // Daytona-only: force inline attach. `spec.cleanup` would otherwise run as
   // soon as the host process returns from the spawn (before the new pane has
   // released the per-call SSH tunnel), breaking the detached attach.
   const safeOpenIn: AttachOpenIn | undefined =
     args.box.provider === 'daytona' ? 'same' : args.openIn;
+
+  // New-terminal attaches (tab/window/split) re-invoke `agentbox <agent> attach`
+  // in the fresh pane, and that re-invocation carries NO `extraArgs` — so for a
+  // resume/teleport launch (`claude --resume <id>`, etc.) the session would
+  // otherwise be created fresh, dropping the resumed session. Pre-create the
+  // session detached here with the full command; the re-invoked attach then
+  // finds it via `tmux has-session` and just attaches. (Inline attach runs the
+  // full command itself, so it doesn't need this.)
+  if (safeOpenIn && safeOpenIn !== 'same' && args.extraArgs && args.extraArgs.length > 0) {
+    const pre = await provider.buildAttach(args.box, 'agent', {
+      sessionName: args.sessionName,
+      command,
+      detached: true,
+    });
+    try {
+      await runDetached(pre.argv);
+    } finally {
+      if (pre.cleanup) await pre.cleanup();
+    }
+  }
+
+  const spec = await provider.buildAttach(args.box, 'agent', {
+    sessionName: args.sessionName,
+    command,
+  });
   try {
     const code = await runWrappedAttach({
       container: args.box.name,
@@ -110,4 +132,19 @@ export async function cloudAgentAttach(args: CloudAgentAttachArgs): Promise<void
   } finally {
     if (spec.cleanup) await spec.cleanup();
   }
+}
+
+/**
+ * Run an attach-style argv non-interactively to completion (used for the
+ * `detached` session pre-start). stdio is ignored — the remote command only
+ * creates + configures the tmux session and exits; there's nothing to show.
+ * Resolves on exit regardless of code (a non-zero here shouldn't block the
+ * subsequent attach, which surfaces any real failure to the user).
+ */
+function runDetached(argv: string[]): Promise<void> {
+  return new Promise((resolve) => {
+    const child = spawn(argv[0]!, argv.slice(1), { stdio: 'ignore' });
+    child.on('error', () => resolve());
+    child.on('exit', () => resolve());
+  });
 }

--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -59,6 +59,7 @@ import {
 } from '../session-teleport/index.js';
 import { clampSpinnerLine } from '../spinner-line.js';
 import { makeProgressReporter } from '../lib/progress.js';
+import { maybeShowInstallHint } from '../lib/install-hint.js';
 import { openCommandLog } from '../lib/log-file.js';
 import { resolveLimits } from '../limits.js';
 import { maybePromptPortless } from '../portless-prompt.js';
@@ -715,6 +716,7 @@ export const claudeCommand = new Command('claude')
       for (const f of rebuild.failed) {
         log.warn(`plugin install failed for ${f.dir}; claude may still load it. stderr:\n${f.stderr.trim()}`);
       }
+      maybeShowInstallHint();
 
       if (opts.attach === false) {
         outro(

--- a/apps/cli/src/commands/fork.ts
+++ b/apps/cli/src/commands/fork.ts
@@ -6,6 +6,20 @@ import { join } from 'node:path';
 import { detectHostTerminal } from '../terminal/host.js';
 import { encodeClaudeProjectsDir } from '../session-teleport/cwd-encoding.js';
 import { claudeCommand } from './claude.js';
+import { codexCommand } from './codex.js';
+import { opencodeCommand } from './opencode.js';
+
+type ForkAgent = 'claude' | 'codex' | 'opencode';
+const FORK_AGENTS = ['claude', 'codex', 'opencode'] as const;
+
+/** The create-style command each agent forks through. fork forwards a curated
+ *  argv and lets the delegate run its own create+teleport+attach pipeline
+ *  (incl. the new-tab spawn, tagged with that agent's attach mode). */
+const AGENT_COMMAND: Record<ForkAgent, Command> = {
+  claude: claudeCommand,
+  codex: codexCommand,
+  opencode: opencodeCommand,
+};
 
 interface ForkOptions {
   workspace: string;
@@ -14,6 +28,7 @@ interface ForkOptions {
   name?: string;
   attachIn?: string;
   carryYes?: boolean;
+  agent?: string;
 }
 
 /** fork's attach modes: claude's split|window|tab|same plus `background`
@@ -24,11 +39,28 @@ const FORK_ATTACH_VALUES = ['window', 'tab', 'split', 'background', 'same'] as c
  *  which Claude window the user meant — they must pass --session. */
 const RECENT_SESSION_MS = 5 * 60 * 1000;
 
-/** `--resume <id>` when --session is given; otherwise `--continue`, but refuse
- *  first if several sessions in this cwd were written to recently (ambiguous —
- *  the newest-by-mtime heuristic claude's `--continue` uses would be a guess). */
-function resolveSessionArgs(opts: ForkOptions): string[] {
+/** Session args fork forwards to the delegate command, per agent:
+ *  - claude: `--resume <id>` when given; else `--continue`, but refuse first if
+ *    several sessions in this cwd were written to recently (the newest-by-mtime
+ *    heuristic claude's `--continue` uses would be a guess). The Codex/OpenCode
+ *    paths can't read the cwd's session list the same way, so they're simpler.
+ *  - codex: `--resume <uuid>` when given; else `--continue` (codex teleport is
+ *    already cwd-scoped). The Codex `/agentbox` prompt resolves the live uuid
+ *    and passes it, since Codex exposes no session-id variable.
+ *  - opencode: no resume — teleport is a stub, so fork starts a fresh box.
+ *    `--session` is rejected (resume isn't possible yet). */
+function resolveSessionArgs(agent: ForkAgent, opts: ForkOptions): string[] {
+  if (agent === 'opencode') {
+    if (opts.session) {
+      throw new Error(
+        'OpenCode session resume is not supported yet; `agentbox fork --agent opencode` starts a fresh box. Drop --session.',
+      );
+    }
+    return [];
+  }
   if (opts.session) return ['--resume', opts.session];
+  if (agent === 'codex') return ['--continue'];
+  // claude: guard against an ambiguous newest-by-mtime pick.
   const dir = join(homedir(), '.claude', 'projects', encodeClaudeProjectsDir(opts.workspace));
   if (!existsSync(dir)) return ['--continue']; // claude emits the clear "run claude here first" error
   const now = Date.now();
@@ -76,12 +108,16 @@ function resolveAttachArgs(attachIn: string): string[] {
 
 export const forkCommand = new Command('fork')
   .description(
-    'Fork the current host Claude Code session into a new box and resume it there. Opens the box in a new terminal tab under iTerm/tmux; otherwise starts it in the background.',
+    'Fork the current host agent session into a new box and resume it there. Opens the box in a new terminal tab under iTerm/tmux; otherwise starts it in the background.',
   )
   .option('-w, --workspace <path>', 'host workspace to mount', process.cwd())
   .option(
+    '--agent <name>',
+    'which agent to fork: claude (default), codex, or opencode. OpenCode starts a fresh box (session resume not supported yet).',
+  )
+  .option(
     '--session <id>',
-    'host Claude Code session id to resume (default: the newest session for this cwd; refuses if several were used recently)',
+    'host agent session id to resume (default: the newest session for this cwd; claude refuses if several were used recently). Ignored for --agent opencode.',
   )
   .option('--provider <name>', "sandbox backend: 'docker' (default), 'daytona', or 'hetzner'")
   .option('-n, --name <name>', 'box name (default: fork-<HHMMSS>)')
@@ -95,13 +131,19 @@ export const forkCommand = new Command('fork')
   )
   .action(async (opts: ForkOptions) => {
     // Box→box guard: AGENTBOX_RELAY_URL is only set inside a box. Fork teleports
-    // a *host* Claude session into a new box; it can't run from inside one yet.
+    // a *host* agent session into a new box; it can't run from inside one yet.
     // Checked here (not just in the /agentbox skill) so an LLM that calls the
     // CLI directly still gets a clear refusal instead of a confusing failure.
     if ((process.env.AGENTBOX_RELAY_URL ?? '').trim().length > 0) {
       log.error(
-        'agentbox fork runs on the host only: it teleports a host Claude Code session into a new box. You appear to be inside a box (AGENTBOX_RELAY_URL is set) — box→box fork is not supported yet.',
+        'agentbox fork runs on the host only: it teleports a host agent session into a new box. You appear to be inside a box (AGENTBOX_RELAY_URL is set) — box→box fork is not supported yet.',
       );
+      process.exit(2);
+    }
+
+    const agent = (opts.agent?.trim() || 'claude') as ForkAgent;
+    if (!(FORK_AGENTS as readonly string[]).includes(agent)) {
+      log.error(`--agent: expected one of ${FORK_AGENTS.join(', ')}, got "${opts.agent ?? ''}"`);
       process.exit(2);
     }
 
@@ -117,7 +159,7 @@ export const forkCommand = new Command('fork')
 
     let sessionArgs: string[];
     try {
-      sessionArgs = resolveSessionArgs(opts);
+      sessionArgs = resolveSessionArgs(agent, opts);
     } catch (err) {
       log.error(err instanceof Error ? err.message : String(err));
       process.exit(2);
@@ -135,9 +177,10 @@ export const forkCommand = new Command('fork')
       ...resolveAttachArgs(attachIn),
     ];
 
-    // Delegate to the existing `claude` create+teleport+attach pipeline. It
-    // runs prepareTeleport (pre-flight) -> createBox -> uploadTeleport ->
-    // startClaudeSession, and (for --attach-in window) spawnInNewTerminal. The
-    // action terminates the process itself (process.exit) on every path.
-    await claudeCommand.parseAsync(subArgv, { from: 'user' });
+    // Delegate to the chosen agent's existing create+teleport+attach pipeline.
+    // It runs prepareTeleport (pre-flight) -> createBox -> uploadTeleport ->
+    // startSession, and (for --attach-in tab/window) spawnInNewTerminal tagged
+    // with that agent's attach mode. The action terminates the process itself
+    // (process.exit) on every path.
+    await AGENT_COMMAND[agent].parseAsync(subArgv, { from: 'user' });
   });

--- a/apps/cli/src/commands/fork.ts
+++ b/apps/cli/src/commands/fork.ts
@@ -1,0 +1,143 @@
+import { log } from '@clack/prompts';
+import { Command } from 'commander';
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { detectHostTerminal } from '../terminal/host.js';
+import { encodeClaudeProjectsDir } from '../session-teleport/cwd-encoding.js';
+import { claudeCommand } from './claude.js';
+
+interface ForkOptions {
+  workspace: string;
+  session?: string;
+  provider?: string;
+  name?: string;
+  attachIn?: string;
+  carryYes?: boolean;
+}
+
+/** fork's attach modes: claude's split|window|tab|same plus `background`
+ *  (never attach — always leave Claude running in the box). */
+const FORK_ATTACH_VALUES = ['window', 'tab', 'split', 'background', 'same'] as const;
+
+/** Two host JSONLs both touched inside this window means we can't safely guess
+ *  which Claude window the user meant — they must pass --session. */
+const RECENT_SESSION_MS = 5 * 60 * 1000;
+
+/** `--resume <id>` when --session is given; otherwise `--continue`, but refuse
+ *  first if several sessions in this cwd were written to recently (ambiguous —
+ *  the newest-by-mtime heuristic claude's `--continue` uses would be a guess). */
+function resolveSessionArgs(opts: ForkOptions): string[] {
+  if (opts.session) return ['--resume', opts.session];
+  const dir = join(homedir(), '.claude', 'projects', encodeClaudeProjectsDir(opts.workspace));
+  if (!existsSync(dir)) return ['--continue']; // claude emits the clear "run claude here first" error
+  const now = Date.now();
+  const recent = readdirSync(dir)
+    .filter((f) => f.endsWith('.jsonl'))
+    .map((f) => {
+      try {
+        return statSync(join(dir, f)).mtimeMs;
+      } catch {
+        return 0;
+      }
+    })
+    .filter((m) => now - m < RECENT_SESSION_MS);
+  if (recent.length > 1) {
+    throw new Error(
+      `multiple recent Claude sessions for this cwd — pass --session <id> to choose. List them with: ls "${dir}"`,
+    );
+  }
+  return ['--continue'];
+}
+
+/** Default box name when -n is omitted: tags forks distinctly in `agentbox list`. */
+function defaultForkName(): string {
+  const now = new Date();
+  const hh = String(now.getHours()).padStart(2, '0');
+  const mm = String(now.getMinutes()).padStart(2, '0');
+  const ss = String(now.getSeconds()).padStart(2, '0');
+  return `fork-${hh}${mm}${ss}`;
+}
+
+/**
+ * Translate fork's `--attach-in` + the detected host terminal into the claude
+ * flag that produces the right behavior. The key difference from a bare
+ * `agentbox claude --attach-in window` is the fallback: when no tmux/iTerm is
+ * present, fork goes to **background** (`--no-attach`) rather than inline
+ * attach — fork is typically driven from another Claude (the `/agentbox`
+ * slash command's subagent), whose terminal must not be taken over.
+ */
+function resolveAttachArgs(attachIn: string): string[] {
+  if (attachIn === 'background') return ['--no-attach'];
+  if (attachIn === 'same') return ['--attach-in', 'same'];
+  // window | tab | split: spawn a new pane only if we can; else background.
+  return detectHostTerminal() === 'unknown' ? ['--no-attach'] : ['--attach-in', attachIn];
+}
+
+export const forkCommand = new Command('fork')
+  .description(
+    'Fork the current host Claude Code session into a new box and resume it there. Opens the box in a new terminal tab under iTerm/tmux; otherwise starts it in the background.',
+  )
+  .option('-w, --workspace <path>', 'host workspace to mount', process.cwd())
+  .option(
+    '--session <id>',
+    'host Claude Code session id to resume (default: the newest session for this cwd; refuses if several were used recently)',
+  )
+  .option('--provider <name>', "sandbox backend: 'docker' (default), 'daytona', or 'hetzner'")
+  .option('-n, --name <name>', 'box name (default: fork-<HHMMSS>)')
+  .option(
+    '--attach-in <mode>',
+    'where to open the forked session: window | tab | split | background | same (default: tab). Falls back to background outside tmux/iTerm.',
+  )
+  .option(
+    '--carry-yes',
+    "auto-approve agentbox.yaml's carry: block (fork skips carry by default — it does not silently re-copy host files into the new box)",
+  )
+  .action(async (opts: ForkOptions) => {
+    // Box→box guard: AGENTBOX_RELAY_URL is only set inside a box. Fork teleports
+    // a *host* Claude session into a new box; it can't run from inside one yet.
+    // Checked here (not just in the /agentbox skill) so an LLM that calls the
+    // CLI directly still gets a clear refusal instead of a confusing failure.
+    if ((process.env.AGENTBOX_RELAY_URL ?? '').trim().length > 0) {
+      log.error(
+        'agentbox fork runs on the host only: it teleports a host Claude Code session into a new box. You appear to be inside a box (AGENTBOX_RELAY_URL is set) — box→box fork is not supported yet.',
+      );
+      process.exit(2);
+    }
+
+    const attachIn = opts.attachIn ?? 'tab';
+    if (!(FORK_ATTACH_VALUES as readonly string[]).includes(attachIn)) {
+      log.error(`--attach-in: expected one of ${FORK_ATTACH_VALUES.join(', ')}, got "${attachIn}"`);
+      process.exit(2);
+    }
+
+    // Tolerate an LLM passing `--provider ""` (or whitespace): treat a blank
+    // value as "not passed" so it falls through to the default docker provider.
+    const provider = opts.provider?.trim();
+
+    let sessionArgs: string[];
+    try {
+      sessionArgs = resolveSessionArgs(opts);
+    } catch (err) {
+      log.error(err instanceof Error ? err.message : String(err));
+      process.exit(2);
+    }
+
+    const subArgv = [
+      '-y',
+      ...(opts.carryYes ? ['--carry-yes'] : ['--carry', 'skip']),
+      '-w',
+      opts.workspace,
+      '-n',
+      opts.name ?? defaultForkName(),
+      ...(provider ? ['--provider', provider] : []),
+      ...sessionArgs,
+      ...resolveAttachArgs(attachIn),
+    ];
+
+    // Delegate to the existing `claude` create+teleport+attach pipeline. It
+    // runs prepareTeleport (pre-flight) -> createBox -> uploadTeleport ->
+    // startClaudeSession, and (for --attach-in window) spawnInNewTerminal. The
+    // action terminates the process itself (process.exit) on every path.
+    await claudeCommand.parseAsync(subArgv, { from: 'user' });
+  });

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -14,9 +14,39 @@ const MANAGED_SENTINEL = '<!-- agentbox-managed:v1 -->';
  *  that old file predates the sentinel. */
 const LEGACY_INFO_MARKER = 'Drive AgentBox from the host:';
 
-/** Host skills this command installs, keyed by the bundled source subdir. The
- *  same name is used for the target dir under ~/.claude/skills/. */
-const SKILLS = ['agentbox', 'agentbox-info'] as const;
+interface InstallTarget {
+  /** Path relative to the bundled `share/host-skills/` dir. */
+  src: string;
+  /** Absolute destination on the host. */
+  dest: string;
+  /** When set, install only if this directory exists — i.e. the tool is set up
+   *  on this host. Absent dir = silently skip (don't write configs for a tool
+   *  the user doesn't use). */
+  gateDir?: string;
+}
+
+/** The files `agentbox install` writes. Claude skills always install; the Codex
+ *  prompt and OpenCode command install only when that tool's config dir exists.
+ *  All three surface the same `/agentbox` fork command in their respective
+ *  agent UIs (Codex shows it under `/prompts:`). */
+function installTargets(): InstallTarget[] {
+  const home = homedir();
+  const claudeSkills = join(home, '.claude', 'skills');
+  return [
+    { src: join('agentbox', 'SKILL.md'), dest: join(claudeSkills, 'agentbox', 'SKILL.md') },
+    { src: join('agentbox-info', 'SKILL.md'), dest: join(claudeSkills, 'agentbox-info', 'SKILL.md') },
+    {
+      src: join('codex', 'agentbox.md'),
+      dest: join(home, '.codex', 'prompts', 'agentbox.md'),
+      gateDir: join(home, '.codex'),
+    },
+    {
+      src: join('opencode', 'agentbox.md'),
+      dest: join(home, '.config', 'opencode', 'commands', 'agentbox.md'),
+      gateDir: join(home, '.config', 'opencode'),
+    },
+  ];
+}
 
 /**
  * Locate the bundled `share/host-skills/` directory. This module is bundled
@@ -56,12 +86,12 @@ function writableReason(target: string, force: boolean): 'new' | 'managed' | 'fo
 
 export const installCommand = new Command('install')
   .description(
-    "Install AgentBox's host-side Claude Code skills into ~/.claude/skills (the /agentbox fork command + the agentbox-info reference). Idempotent.",
+    "Install AgentBox's host-side /agentbox fork command into Claude (~/.claude/skills), and — when detected — into Codex (~/.codex/prompts) and OpenCode (~/.config/opencode/commands). Idempotent.",
   )
-  .option('--force', 'overwrite existing skill files even if not AgentBox-managed')
+  .option('--force', 'overwrite existing files even if not AgentBox-managed')
   .option('--dry-run', 'print what would be written without changing anything')
   .action((opts: InstallOptions) => {
-    intro('Installing AgentBox host skills...');
+    intro('Installing AgentBox host commands...');
     const force = opts.force === true;
     const dryRun = opts.dryRun === true;
 
@@ -73,33 +103,33 @@ export const installCommand = new Command('install')
       process.exit(1);
     }
 
-    const skillsRoot = join(homedir(), '.claude', 'skills');
     const written: string[] = [];
     let skipped = 0;
 
-    for (const name of SKILLS) {
-      const src = join(srcDir, name, 'SKILL.md');
-      const targetDir = join(skillsRoot, name);
-      const target = join(targetDir, 'SKILL.md');
+    for (const t of installTargets()) {
+      const src = join(srcDir, t.src);
       if (!existsSync(src)) {
-        log.warn(`bundled skill missing (skipped): ${src}`);
+        log.warn(`bundled file missing (skipped): ${src}`);
         skipped++;
         continue;
       }
-      const reason = writableReason(target, force);
+      // Tool not set up on this host — skip silently (don't seed configs for a
+      // tool the user doesn't use).
+      if (t.gateDir && !existsSync(t.gateDir)) continue;
+      const reason = writableReason(t.dest, force);
       if (reason === 'skip') {
-        log.warn(`user-modified file at ${target}, skipping; pass --force to overwrite`);
+        log.warn(`user-modified file at ${t.dest}, skipping; pass --force to overwrite`);
         skipped++;
         continue;
       }
       if (dryRun) {
-        log.info(`would write ${target} (${reason})`);
-        written.push(target);
+        log.info(`would write ${t.dest} (${reason})`);
+        written.push(t.dest);
         continue;
       }
-      mkdirSync(targetDir, { recursive: true });
-      writeFileSync(target, readFileSync(src, 'utf8'));
-      written.push(target);
+      mkdirSync(dirname(t.dest), { recursive: true });
+      writeFileSync(t.dest, readFileSync(src, 'utf8'));
+      written.push(t.dest);
     }
 
     if (dryRun) {

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -1,0 +1,114 @@
+import { intro, log, outro } from '@clack/prompts';
+import { Command } from 'commander';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Marker on the line after the frontmatter of every skill we ship. Its
+ *  presence in an existing target means we wrote it and may overwrite freely. */
+const MANAGED_SENTINEL = '<!-- agentbox-managed:v1 -->';
+
+/** Substring unique to the pre-rename `agentbox` host skill. Lets `install`
+ *  replace it in place during the agentbox → agentbox-info rename even though
+ *  that old file predates the sentinel. */
+const LEGACY_INFO_MARKER = 'Drive AgentBox from the host:';
+
+/** Host skills this command installs, keyed by the bundled source subdir. The
+ *  same name is used for the target dir under ~/.claude/skills/. */
+const SKILLS = ['agentbox', 'agentbox-info'] as const;
+
+/**
+ * Locate the bundled `share/host-skills/` directory. This module is bundled
+ * into the CLI at `<root>/dist/index.js`; `share/` ships as a sibling of
+ * `dist/` in both the dev tree and the published package. The src-tree
+ * candidate covers running unbundled (e.g. tsx).
+ */
+function resolveHostSkillsDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    resolve(here, '..', 'share', 'host-skills'), // bundled: dist/ -> ../share
+    resolve(here, '..', '..', 'share', 'host-skills'), // src: src/commands/ -> ../../share
+  ];
+  for (const c of candidates) {
+    if (existsSync(c)) return c;
+  }
+  throw new Error(
+    `could not locate bundled host skills; tried:\n  ${candidates.join('\n  ')}`,
+  );
+}
+
+interface InstallOptions {
+  force?: boolean;
+  dryRun?: boolean;
+}
+
+/** Decide whether we may write `target`. Missing or AgentBox-managed/legacy
+ *  files are writable; a user-authored file is left alone unless --force. */
+function writableReason(target: string, force: boolean): 'new' | 'managed' | 'forced' | 'skip' {
+  if (!existsSync(target)) return 'new';
+  const existing = readFileSync(target, 'utf8');
+  if (existing.includes(MANAGED_SENTINEL) || existing.includes(LEGACY_INFO_MARKER)) {
+    return 'managed';
+  }
+  return force ? 'forced' : 'skip';
+}
+
+export const installCommand = new Command('install')
+  .description(
+    "Install AgentBox's host-side Claude Code skills into ~/.claude/skills (the /agentbox fork command + the agentbox-info reference). Idempotent.",
+  )
+  .option('--force', 'overwrite existing skill files even if not AgentBox-managed')
+  .option('--dry-run', 'print what would be written without changing anything')
+  .action((opts: InstallOptions) => {
+    intro('Installing AgentBox host skills...');
+    const force = opts.force === true;
+    const dryRun = opts.dryRun === true;
+
+    let srcDir: string;
+    try {
+      srcDir = resolveHostSkillsDir();
+    } catch (err) {
+      log.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+
+    const skillsRoot = join(homedir(), '.claude', 'skills');
+    const written: string[] = [];
+    let skipped = 0;
+
+    for (const name of SKILLS) {
+      const src = join(srcDir, name, 'SKILL.md');
+      const targetDir = join(skillsRoot, name);
+      const target = join(targetDir, 'SKILL.md');
+      if (!existsSync(src)) {
+        log.warn(`bundled skill missing (skipped): ${src}`);
+        skipped++;
+        continue;
+      }
+      const reason = writableReason(target, force);
+      if (reason === 'skip') {
+        log.warn(`user-modified file at ${target}, skipping; pass --force to overwrite`);
+        skipped++;
+        continue;
+      }
+      if (dryRun) {
+        log.info(`would write ${target} (${reason})`);
+        written.push(target);
+        continue;
+      }
+      mkdirSync(targetDir, { recursive: true });
+      writeFileSync(target, readFileSync(src, 'utf8'));
+      written.push(target);
+    }
+
+    if (dryRun) {
+      outro(`dry-run: ${String(written.length)} file(s) would be written, ${String(skipped)} skipped`);
+      return;
+    }
+    if (written.length === 0) {
+      outro(`nothing installed (${String(skipped)} skipped)`);
+      return;
+    }
+    outro(`installed: ${written.join(', ')}`);
+  });

--- a/apps/cli/src/help.ts
+++ b/apps/cli/src/help.ts
@@ -12,7 +12,7 @@ export interface HelpGroup {
 }
 
 export const HELP_GROUPS: HelpGroup[] = [
-  { title: 'Create & run', commands: ['create', 'claude', 'codex', 'opencode'] },
+  { title: 'Create & run', commands: ['create', 'claude', 'fork', 'codex', 'opencode'] },
   {
     title: 'Access',
     commands: ['dashboard', 'url', 'screen', 'code', 'shell', 'open', 'logs', 'drive'],
@@ -27,6 +27,7 @@ export const HELP_GROUPS: HelpGroup[] = [
       'wait',
       'prune',
       'self-update',
+      'install',
       'config',
       'relay',
       'docker',

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -32,6 +32,8 @@ import { hetznerCommand } from '@agentbox/sandbox-hetzner/cli';
 import { destroyCommand } from './commands/destroy.js';
 import { downloadCommand } from './commands/download.js';
 import { driveCommand } from './commands/drive.js';
+import { forkCommand } from './commands/fork.js';
+import { installCommand } from './commands/install.js';
 import { gitCommand } from './commands/git.js';
 import { listCommand } from './commands/list.js';
 import { logsCommand } from './commands/logs.js';
@@ -68,6 +70,7 @@ program.enablePositionalOptions();
 
 program.addCommand(createCommand);
 program.addCommand(claudeCommand);
+program.addCommand(forkCommand);
 program.addCommand(codexCommand);
 program.addCommand(gitCommand);
 program.addCommand(opencodeCommand);
@@ -104,6 +107,7 @@ program.addCommand(daytonaCommand);
 program.addCommand(hetznerCommand);
 program.addCommand(dockerCommand);
 program.addCommand(updateCommand);
+program.addCommand(installCommand);
 
 program.configureHelp({ visibleCommands: () => [] });
 program.addHelpText('after', () => '\n' + buildGroupedHelp(program));

--- a/apps/cli/src/lib/install-hint.ts
+++ b/apps/cli/src/lib/install-hint.ts
@@ -1,0 +1,23 @@
+import { log } from '@clack/prompts';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Print a one-time tip pointing at `agentbox install` when the host `/agentbox`
+ * fork skill isn't installed yet. Gated by a marker file so it shows at most
+ * once per host. Best-effort — never throws into the caller's happy path.
+ */
+export function maybeShowInstallHint(): void {
+  try {
+    const skill = join(homedir(), '.claude', 'skills', 'agentbox', 'SKILL.md');
+    if (existsSync(skill)) return;
+    const marker = join(homedir(), '.agentbox', 'install-hint-shown');
+    if (existsSync(marker)) return;
+    mkdirSync(join(homedir(), '.agentbox'), { recursive: true });
+    writeFileSync(marker, '');
+    log.info("tip: run 'agentbox install' to enable the /agentbox fork command in host Claude");
+  } catch {
+    // Non-fatal: a missing HOME or unwritable dir must not break create.
+  }
+}

--- a/apps/cli/src/terminal/host.ts
+++ b/apps/cli/src/terminal/host.ts
@@ -118,33 +118,45 @@ async function spawnInITerm2(args: SpawnInNewTerminalArgs): Promise<SpawnInNewTe
   const cmdLine = `cd ${shellQuote(args.cwd)} && exec ${inner}`;
   const cmdLit = `"${appleScriptEscape(cmdLine)}"`;
 
-  let script: string;
+  // Always create the tab/window/split first, then `write text` into its
+  // session. The `... with default profile command "<cmd>"` parameter form is
+  // unreliable on iTerm 3.7 betas — it fails (returns `missing value`) and the
+  // command bounces to Terminal.app instead of running in iTerm. The
+  // create-then-write-text form is the supported path and works across
+  // versions, so every mode uses it.
+  let lines: string[];
   let noteKind: string;
   switch (args.mode) {
     case 'split':
-      // iTerm2's AppleScript dictionary doesn't expose a `split … with command`
-      // form, so we split, then `write text` into the new session.
-      script =
-        'tell application "iTerm" to ' +
-        'tell current session of current window to ' +
-        `tell (split vertically with default profile) to write text ${cmdLit}`;
+      lines = [
+        'tell application "iTerm"',
+        '  tell current session of current window to set _s to (split vertically with default profile)',
+        `  tell _s to write text ${cmdLit}`,
+        'end tell',
+      ];
       noteKind = 'iTerm2 split';
       break;
     case 'tab':
-      script =
-        'tell application "iTerm" to ' +
-        `tell current window to create tab with default profile command ${cmdLit}`;
+      lines = [
+        'tell application "iTerm"',
+        '  tell current window to set _t to (create tab with default profile)',
+        `  tell current session of _t to write text ${cmdLit}`,
+        'end tell',
+      ];
       noteKind = 'iTerm2 tab';
       break;
     case 'window':
-      script =
-        'tell application "iTerm" to ' +
-        `create window with default profile command ${cmdLit}`;
+      lines = [
+        'tell application "iTerm"',
+        '  set _w to (create window with default profile)',
+        `  tell current session of _w to write text ${cmdLit}`,
+        'end tell',
+      ];
       noteKind = 'iTerm2 window';
       break;
   }
 
-  const r = await runQuiet('osascript', ['-e', script]);
+  const r = await runQuiet('osascript', ['-e', lines.join('\n')]);
   if (r.code !== 0) {
     return {
       launched: false,

--- a/apps/cli/test/commands.test.ts
+++ b/apps/cli/test/commands.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { checkpointCommand } from '../src/commands/checkpoint.js';
 import { claudeCommand } from '../src/commands/claude.js';
 import { createCommand } from '../src/commands/create.js';
+import { forkCommand } from '../src/commands/fork.js';
+import { installCommand } from '../src/commands/install.js';
 import { daytonaCommand } from '@agentbox/sandbox-daytona/cli';
 import { dockerCommand } from '../src/commands/docker.js';
 import { destroyCommand } from '../src/commands/destroy.js';
@@ -60,6 +62,28 @@ describe('lifecycle CLI surface', () => {
 
   it('create is still wired (regression check)', () => {
     expect(createCommand.name()).toBe('create');
+  });
+
+  it('fork takes --session/--provider/--name/--attach-in/--workspace/--carry-yes', () => {
+    expect(forkCommand.name()).toBe('fork');
+    const longs = forkCommand.options.map((o) => o.long);
+    expect(longs).toEqual(
+      expect.arrayContaining([
+        '--session',
+        '--provider',
+        '--name',
+        '--attach-in',
+        '--workspace',
+        '--carry-yes',
+      ]),
+    );
+  });
+
+  it('install takes --force and --dry-run, no subcommands', () => {
+    expect(installCommand.name()).toBe('install');
+    expect(installCommand.commands).toHaveLength(0);
+    const longs = installCommand.options.map((o) => o.long);
+    expect(longs).toEqual(expect.arrayContaining(['--force', '--dry-run']));
   });
 
   it('open is files-only (Finder + --path), no --browser/--loopback/--upper', () => {

--- a/apps/cli/test/commands.test.ts
+++ b/apps/cli/test/commands.test.ts
@@ -64,11 +64,12 @@ describe('lifecycle CLI surface', () => {
     expect(createCommand.name()).toBe('create');
   });
 
-  it('fork takes --session/--provider/--name/--attach-in/--workspace/--carry-yes', () => {
+  it('fork takes --agent/--session/--provider/--name/--attach-in/--workspace/--carry-yes', () => {
     expect(forkCommand.name()).toBe('fork');
     const longs = forkCommand.options.map((o) => o.long);
     expect(longs).toEqual(
       expect.arrayContaining([
+        '--agent',
         '--session',
         '--provider',
         '--name',

--- a/apps/cli/test/help.test.ts
+++ b/apps/cli/test/help.test.ts
@@ -17,6 +17,8 @@ import { hetznerCommand } from '@agentbox/sandbox-hetzner/cli';
 import { destroyCommand } from '../src/commands/destroy.js';
 import { downloadCommand } from '../src/commands/download.js';
 import { driveCommand } from '../src/commands/drive.js';
+import { forkCommand } from '../src/commands/fork.js';
+import { installCommand } from '../src/commands/install.js';
 import { listCommand } from '../src/commands/list.js';
 import { logsCommand } from '../src/commands/logs.js';
 import { openCommand } from '../src/commands/open.js';
@@ -45,6 +47,7 @@ function buildProgram(): Command {
   for (const cmd of [
     createCommand,
     claudeCommand,
+    forkCommand,
     codexCommand,
     opencodeCommand,
     codeCommand,
@@ -77,6 +80,7 @@ function buildProgram(): Command {
     hetznerCommand,
     dockerCommand,
     updateCommand,
+    installCommand,
   ]) {
     program.addCommand(cmd);
   }

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -144,6 +144,17 @@ export interface BuildAttachOptions {
   command?: string;
   /** Plain (non-tmux) attach: skip the tmux wrap, just run `command` directly. */
   noTmux?: boolean;
+  /**
+   * Build a "create the tmux session detached, do NOT attach" argv instead of
+   * an interactive attach. The CLI uses this to pre-start a cloud session with
+   * its full launch `command` (e.g. `claude --resume <id>`) before opening the
+   * attach in a new terminal tab — the new tab re-invokes `agentbox <agent>
+   * attach` without those args, so without a pre-start it would create the
+   * session fresh. With the session already running, the re-invoked attach
+   * finds it (`tmux has-session`) and just attaches. Cloud providers honor
+   * this; Docker ignores it (its sessions start at create time anyway).
+   */
+  detached?: boolean;
 }
 
 /** Optional checkpoint capability — not every provider supports it. */

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -926,7 +926,11 @@ export function createCloudProvider(
       const inner = renderInnerCommand(kind, opts);
       // -t forces TTY allocation on the remote side (the SSH default of
       // skipping TTY when a command is provided would break tmux + readline).
-      const argv = [...baseArgv.slice(1), '-t', inner];
+      // A `detached` build only creates the session (no `exec tmux attach`), so
+      // it runs as a plain non-interactive exec — no TTY needed.
+      const argv = opts?.detached
+        ? [...baseArgv.slice(1), inner]
+        : [...baseArgv.slice(1), '-t', inner];
       // Keep argv[0] = the program name (ssh) so callers can split.
       const fullArgv = [baseArgv[0]!, ...argv];
       const cleanup = backend.revokeAttachToken
@@ -1098,12 +1102,16 @@ function renderInnerCommand(kind: AttachKind, opts?: BuildAttachOptions): string
   const cwdQ = shellSingle(CLOUD_WORKSPACE_DIR);
   const fallbackQ = shellSingle(fallback);
   const configSnippet = buildTmuxConfigShellSnippet(sessionName);
-  return [
+  const lines = [
     `command -v tmux >/dev/null || { echo "tmux not installed in sandbox"; exit 127; }`,
     `tmux has-session -t ${sessionQ} 2>/dev/null || tmux new-session -d -c ${cwdQ} -s ${sessionQ} ${fallbackQ}`,
     configSnippet,
-    `exec tmux attach -t ${sessionQ}`,
-  ].join('; ');
+  ];
+  // `detached`: create + configure the session but don't attach. Used to
+  // pre-start a session with its full launch command before a new-tab attach
+  // re-invokes `agentbox <agent> attach` (which carries no launch args).
+  if (opts?.detached) return lines.join('; ');
+  return [...lines, `exec tmux attach -t ${sessionQ}`].join('; ');
 }
 
 function defaultSessionName(kind: AttachKind): string {


### PR DESCRIPTION
## Summary

Adds `agentbox fork` — snapshot the **current host agent session** and resume it in a fresh box, opening it in a new terminal tab (iTerm/tmux) or background. Plus a user-invocable `/agentbox` command installed into Claude, Codex, and OpenCode.

- **`agentbox fork`** (`apps/cli/src/commands/fork.ts`): thin wrapper over each agent's existing create+teleport+attach pipeline. Flags: `--agent claude|codex|opencode` (default claude), `--session`, `--provider`, `-n`, `--attach-in` (default `tab`), `--carry-yes`. Background fallback when no tmux/iTerm (never hijacks the calling terminal). LLM-resilience guards: refuses inside a box (`AGENTBOX_RELAY_URL`), tolerates empty `--provider`, rejects `--session` with `--agent opencode`.
- **`agentbox install`**: writes the `/agentbox` command into `~/.claude/skills` (fork command + renamed `agentbox-info` reference), and — when detected — `~/.codex/prompts/agentbox.md` and `~/.config/opencode/commands/agentbox.md`. Idempotent via an `<!-- agentbox-managed:v1 -->` sentinel. `agentbox claude` prints a one-time install tip.
- **Per-agent session pinning**: Claude uses the `${CLAUDE_SESSION_ID}` skill placeholder; Codex (no session-id variable) has its agent resolve the live uuid from the newest rollout file; OpenCode starts a fresh box (session teleport not implemented yet).

## Fixes folded in

- **iTerm new-tab spawn** (`terminal/host.ts`): the `create window/tab ... command "..."` AppleScript parameter is broken on iTerm 3.7 betas (bounces to Terminal.app); switched all modes to create-then-`write text`.
- **Cloud resume on new-tab attach** (`core/provider.ts`, `sandbox-cloud/cloud-provider.ts`, `_cloud-attach.ts`): cloud sessions start lazily at attach, and the new-tab re-invocation of `agentbox <agent> attach` carried no `--resume`, so hetzner forks started fresh. Added a `detached` build option and pre-create the resumed session before the new-tab spawn.

## Scope

v1 is **host→box** only; box→box fork is deferred (needs `downloadPath` from the source box + a relay endpoint). OpenCode resume is deferred (sessions live in a multi-tenant SQLite DB).

## Test plan

- [x] `pnpm -w build`, typecheck, lint, `vitest` (329 pass) green
- [x] `agentbox install` writes all 4 agent files; idempotent re-run
- [x] Docker fork resumes the Claude session in a new iTerm tab; background fallback works
- [x] `fork --agent codex` resumed a real Codex session in a box; `fork --agent opencode` started a fresh box
- [x] Live **Hetzner** fork now launches `claude --resume <id>` in the box (was fresh before)
- [ ] Manual: `/agentbox` in Claude, `/prompts:agentbox` in Codex, `/agentbox` in OpenCode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New fork/install orchestration touches session teleport and terminal/cloud attach paths; cloud detached pre-start fixes resume correctness but adds attach complexity.
> 
> **Overview**
> Adds **`agentbox fork`** to teleport the current **host** Claude/Codex/OpenCode session into a new sandbox (default new iTerm/tmux tab, **background** when no splittable terminal so the caller’s session isn’t hijacked). It delegates to each agent’s existing create + session-teleport + attach flow, with guards for in-box runs (`AGENTBOX_RELAY_URL`), ambiguous recent Claude sessions, and no OpenCode resume yet.
> 
> Adds **`agentbox install`** to ship bundled host skills/prompts (`/agentbox` fork + **`agentbox-info`** reference) into Claude, and into Codex/OpenCode when those config dirs exist, with idempotent **`agentbox-managed`** overwrite rules. **`agentbox claude`** shows a one-time tip to run install when the fork skill is missing.
> 
> Fixes **cloud resume on new-tab attach**: pre-creates the tmux session **detached** with the full launch command (`claude --resume …`) before the tab re-invokes attach without extra args. **iTerm** spawning now uses create-then-`write text` instead of broken `command` parameters on 3.7 betas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e4506267ff60d9b41b5c45e1631cd41a0c57286. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->