### PR TITLE
Auto-inject --head for in-box gh pr create

### DIFF
--- a/apps/cli/src/commands/git.ts
+++ b/apps/cli/src/commands/git.ts
@@ -1,5 +1,5 @@
 import type { BoxRecord, ExecResult } from '@agentbox/core';
-import { GH_PR_OPS, hashRpcParams, type GhPrOp } from '@agentbox/relay';
+import { GH_PR_OPS, hashRpcParams, injectPrCreateHead as injectHead, type GhPrOp } from '@agentbox/relay';
 import { mintHostInitiatedToken } from '@agentbox/sandbox-docker';
 import { Command } from 'commander';
 import { resolveBoxOrExit } from '../box-ref.js';
@@ -247,11 +247,8 @@ const PR_OP_DESCRIPTIONS: Record<GhPrOp, string> = {
  * sufficient — base stays whatever the user picked / repo default.
  */
 function injectPrCreateHead(op: GhPrOp, box: { gitWorktrees?: { kind: string; branch: string }[] }, args: string[]): string[] {
-  if (op !== 'create') return args;
-  if (args.some((a) => a === '--head' || a.startsWith('--head='))) return args;
   const rootWt = (box.gitWorktrees ?? []).find((w) => w.kind === 'root');
-  if (!rootWt) return args;
-  return ['--head', rootWt.branch, ...args];
+  return injectHead(op, rootWt?.branch, args);
 }
 
 function buildPrSubcommand(op: GhPrOp): Command {

--- a/packages/relay/src/gh.ts
+++ b/packages/relay/src/gh.ts
@@ -38,6 +38,28 @@ export function isGhPrOp(value: string): value is GhPrOp {
 /** Read-only ops never trigger the host confirmation prompt. */
 export const GH_PR_READ_ONLY_OPS: ReadonlySet<GhPrOp> = new Set(['view', 'list']);
 
+/**
+ * Default `gh pr create`'s `--head` to the box's branch so the PR is for the
+ * box's work, not whatever the host main repo happens to have checked out
+ * (`gh` infers head from the cwd's HEAD, which is the user's own branch — or
+ * an untracked one, which aborts with "you must first push the current branch
+ * to a remote, or use the --head flag"). Only injected for `create`, only when
+ * the caller didn't already pass `--head`, and only when we resolved a real
+ * branch (not empty / detached `HEAD`). The host CLI's `agentbox git pr create`
+ * already injects this; the relay covers the in-box `agentbox-ctl git pr` /
+ * `gh pr` path, which forwards args verbatim.
+ */
+export function injectPrCreateHead(
+  op: GhPrOp,
+  branch: string | undefined,
+  args: string[],
+): string[] {
+  if (op !== 'create') return args;
+  if (!branch || branch === 'HEAD') return args;
+  if (args.some((a) => a === '--head' || a.startsWith('--head='))) return args;
+  return ['--head', branch, ...args];
+}
+
 /** Wire params for every `gh.pr.<op>` method. Mirrors the new ctl command surface. */
 export interface GhPrRpcParams {
   /** Container path the ctl ran in; used to pick the registered worktree. */

--- a/packages/relay/src/host-actions.ts
+++ b/packages/relay/src/host-actions.ts
@@ -24,6 +24,7 @@ import {
   assertGhReady,
   checkoutGuards,
   GH_PR_READ_ONLY_OPS,
+  injectPrCreateHead,
   isGhPrOp,
   refuseCheckoutByDefault,
   refuseMergeBypass,
@@ -318,7 +319,23 @@ async function runGhPrRpc(
     }
   }
 
-  return runHostGh(['pr', op, ...args], lookup.workspacePath);
+  // Default `--head` to the box's branch for `create` (the host repo cwd isn't
+  // on the box branch, so gh can't infer it). Resolve the branch from the
+  // sandbox HEAD the same way `runGitRpc` does; a failed probe leaves args
+  // unchanged (today's behavior). Only probed when we'd actually inject.
+  let finalArgs = args;
+  if (op === 'create' && !args.some((a) => a === '--head' || a.startsWith('--head='))) {
+    const backend = await resolveCloudBackend(deps.backendName);
+    const handle: CloudHandle = { sandboxId: lookup.cloudSandboxId };
+    const containerPath = params.path ?? '/workspace';
+    const branchProbe = await backend.exec(
+      handle,
+      `git -C ${shellQuote(containerPath)} rev-parse --abbrev-ref HEAD`,
+    );
+    const branch = branchProbe.exitCode === 0 ? (branchProbe.stdout ?? '').trim() : '';
+    finalArgs = injectPrCreateHead(op, branch, args);
+  }
+  return runHostGh(['pr', op, ...finalArgs], lookup.workspacePath);
 }
 
 /**

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -51,6 +51,7 @@ export {
   checkoutGuards,
   GH_PR_OPS,
   GH_PR_READ_ONLY_OPS,
+  injectPrCreateHead,
   isGhPrOp,
   refuseCheckoutByDefault,
   refuseMergeBypass,

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -7,6 +7,7 @@ import {
   assertGhReady,
   checkoutGuards,
   GH_PR_READ_ONLY_OPS,
+  injectPrCreateHead,
   isGhPrOp,
   refuseCheckoutByDefault,
   refuseMergeBypass,
@@ -1138,7 +1139,11 @@ async function handleGhPrRpc(
     }
   }
 
-  return runHostGh(['pr', op, ...args], worktree.hostMainRepo);
+  // Default `--head` to the box's branch for `create` (the host repo cwd isn't
+  // on the box branch, so gh can't infer it). Done after token validation —
+  // which hashes the incoming `params`, not this post-injection argv.
+  const finalArgs = injectPrCreateHead(op, worktree.branch, args);
+  return runHostGh(['pr', op, ...finalArgs], worktree.hostMainRepo);
 }
 
 /**

--- a/packages/relay/test/gh.test.ts
+++ b/packages/relay/test/gh.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { injectPrCreateHead } from '../src/gh.js';
+
+describe('injectPrCreateHead', () => {
+  it('prepends --head <branch> for create when none was passed', () => {
+    expect(injectPrCreateHead('create', 'agentbox/box-one', ['--title', 'T'])).toEqual([
+      '--head',
+      'agentbox/box-one',
+      '--title',
+      'T',
+    ]);
+  });
+
+  it('is a no-op for non-create ops', () => {
+    expect(injectPrCreateHead('view', 'agentbox/box-one', ['7'])).toEqual(['7']);
+    expect(injectPrCreateHead('merge', 'agentbox/box-one', ['42'])).toEqual(['42']);
+  });
+
+  it('does not double-inject when --head is already present', () => {
+    expect(injectPrCreateHead('create', 'agentbox/box-one', ['--head', 'feat/x'])).toEqual([
+      '--head',
+      'feat/x',
+    ]);
+    expect(injectPrCreateHead('create', 'agentbox/box-one', ['--head=feat/x'])).toEqual([
+      '--head=feat/x',
+    ]);
+  });
+
+  it('leaves args unchanged when no usable branch resolved', () => {
+    expect(injectPrCreateHead('create', undefined, ['--title', 'T'])).toEqual(['--title', 'T']);
+    expect(injectPrCreateHead('create', '', ['--title', 'T'])).toEqual(['--title', 'T']);
+    expect(injectPrCreateHead('create', 'HEAD', ['--title', 'T'])).toEqual(['--title', 'T']);
+  });
+});

--- a/packages/relay/test/server.test.ts
+++ b/packages/relay/test/server.test.ts
@@ -514,7 +514,7 @@ exit 0
     expect(body.stderr).toMatch(/denied by user/);
   });
 
-  it('gh.pr.create with AGENTBOX_PROMPT=off runs gh and forwards args', async () => {
+  it('gh.pr.create with AGENTBOX_PROMPT=off runs gh and injects --head <box branch>', async () => {
     await registerWithWorktree();
     process.env.AGENTBOX_PROMPT = 'off';
     const r = await fetchJson(handle, 'POST', '/rpc', {
@@ -527,7 +527,28 @@ exit 0
     expect(r.status).toBe(200);
     const body = r.body as { exitCode: number; stdout: string };
     expect(body.exitCode).toBe(0);
-    expect(body.stdout).toContain('stub: gh pr create --title T --body B --draft');
+    // The relay defaults --head to the registered box branch so gh doesn't have
+    // to infer it from the host repo's (different) checked-out branch.
+    expect(body.stdout).toContain(
+      'stub: gh pr create --head agentbox/box-one --title T --body B --draft',
+    );
+  });
+
+  it('gh.pr.create does not double-inject --head when the caller passed one', async () => {
+    await registerWithWorktree();
+    process.env.AGENTBOX_PROMPT = 'off';
+    const r = await fetchJson(handle, 'POST', '/rpc', {
+      token: 't1',
+      body: {
+        method: 'gh.pr.create',
+        params: { path: '/workspace', args: ['--head', 'feature/x', '--title', 'T'] },
+      },
+    });
+    expect(r.status).toBe(200);
+    const body = r.body as { exitCode: number; stdout: string };
+    expect(body.exitCode).toBe(0);
+    expect(body.stdout).toContain('stub: gh pr create --head feature/x --title T');
+    expect(body.stdout).not.toContain('agentbox/box-one');
   });
 
   it('gh.pr.view returns 500 with exit 64 when no worktree is registered', async () => {


### PR DESCRIPTION
## Summary
- `agentbox-ctl git pr create` (and `gh pr create`) from inside a box forward args verbatim to the relay, which ran `gh pr create` in the host repo **without `--head`**. The host repo isn't checked out on the box's branch, and `agentbox/*` branches deliberately get no upstream tracking, so `gh` aborted with *"you must first push the current branch to a remote, or use the --head flag"*. It only worked when `--head` was passed manually.
- Fix: default `--head` to the box's branch **at the relay** (the single host-side executor for the in-box path), for `create` only when the caller didn't already pass `--head`.
- Shared helper `injectPrCreateHead(op, branch, args)` added to `@agentbox/relay`; the host CLI's existing `agentbox git pr create` injection now delegates to it, so both surfaces use one rule.
- Covers docker (registered `worktree.branch`) and cloud (probed sandbox HEAD).
- Does **not** touch the intentional `agentbox/*` upstream-tracking skip on push.

## Test plan
- [x] `pnpm build`, `pnpm typecheck`, `pnpm lint` clean
- [x] `pnpm test` (relay 90 -> 95: new `gh.test.ts` + no-double-inject case; full suite 335 passing)
- [x] Updated `server.test.ts` asserts `gh pr create` emits `--head agentbox/box-one` and never double-injects when the caller supplies `--head`
- [ ] Manual on host (after this is built/installed): from inside a box, `agentbox-ctl git push` then `agentbox-ctl git pr create --base main --title t --body b` (no `--head`) succeeds and the PR head is the box branch

Note: this very PR was opened with an explicit `--head` because the running host relay predates the fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to `gh pr create` argv shaping after existing auth/prompt gates; no changes to push upstream tracking or token binding.
> 
> **Overview**
> **Fixes in-box `gh pr create`** when the relay runs `gh` in the host repo without `--head`: GitHub CLI would infer head from the host checkout (wrong branch or missing upstream) and fail unless `--head` was passed manually.
> 
> A shared **`injectPrCreateHead`** in `@agentbox/relay` prepends `--head <box branch>` for **`create` only**, when the caller did not already pass `--head` and a real branch name exists (not empty / detached `HEAD`). The host CLI’s `agentbox git pr create` path now delegates to the same helper instead of duplicating logic.
> 
> The relay applies injection on **both** execution paths: docker uses the registered worktree branch; **cloud** probes sandbox `git rev-parse --abbrev-ref HEAD` before injecting. Injection runs **after** host-initiated token validation so params hashing is unchanged.
> 
> New unit tests cover the helper and relay behavior (including no double-inject when `--head` is supplied).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53dd1919ac6912297046f1313f7b6bebee8743c9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->