### PR TITLE
fix(relay): refuse gh pr create when the box branch cannot be resolved

### DIFF
--- a/packages/relay/src/gh.ts
+++ b/packages/relay/src/gh.ts
@@ -56,9 +56,34 @@ export function injectPrCreateHead(
 ): string[] {
   if (op !== 'create') return args;
   if (!branch || branch === 'HEAD') return args;
-  if (args.some((a) => a === '--head' || a.startsWith('--head='))) return args;
+  if (hasHeadArg(args)) return args;
   return ['--head', branch, ...args];
 }
+
+function hasHeadArg(args: string[]): boolean {
+  return args.some((a) => a === '--head' || a.startsWith('--head='));
+}
+
+/**
+ * True when a `gh pr create` would run with no `--head` — i.e. we couldn't
+ * resolve the box's branch to inject and the caller didn't pass one. The
+ * relay must refuse rather than let `gh` fall back to the host repo's
+ * *checked-out* branch, which would open a PR for the wrong branch.
+ */
+export function prCreateNeedsHead(op: GhPrOp, args: string[]): boolean {
+  return op === 'create' && !hasHeadArg(args);
+}
+
+/** Ready-to-send refusal for a `create` that has no resolvable `--head`. */
+export const PR_CREATE_NO_HEAD_REFUSAL: GitRpcResult = {
+  exitCode: 65,
+  stdout: '',
+  stderr:
+    'gh pr create: refusing to run without --head — could not resolve this ' +
+    "box's branch, and falling back to the host repo's checked-out branch " +
+    'would open a PR for the wrong branch. Ensure the box branch is pushed, ' +
+    'or pass --head <branch> explicitly.\n',
+};
 
 /** Wire params for every `gh.pr.<op>` method. Mirrors the new ctl command surface. */
 export interface GhPrRpcParams {

--- a/packages/relay/src/gh.ts
+++ b/packages/relay/src/gh.ts
@@ -44,7 +44,7 @@ export const GH_PR_READ_ONLY_OPS: ReadonlySet<GhPrOp> = new Set(['view', 'list']
  * (`gh` infers head from the cwd's HEAD, which is the user's own branch — or
  * an untracked one, which aborts with "you must first push the current branch
  * to a remote, or use the --head flag"). Only injected for `create`, only when
- * the caller didn't already pass `--head`, and only when we resolved a real
+ * the caller didn't already pass `--head` (or its `-H` shorthand), and only when we resolved a real
  * branch (not empty / detached `HEAD`). The host CLI's `agentbox git pr create`
  * already injects this; the relay covers the in-box `agentbox-ctl git pr` /
  * `gh pr` path, which forwards args verbatim.
@@ -61,7 +61,10 @@ export function injectPrCreateHead(
 }
 
 function hasHeadArg(args: string[]): boolean {
-  return args.some((a) => a === '--head' || a.startsWith('--head='));
+  // `gh pr create` accepts `--head`, `--head=<b>`, and the `-H` shorthand in
+  // its `-H <b>` / `-H<b>` / `-H=<b>` forms. Recognize all so an explicit head
+  // neither gets double-injected nor triggers the no-head refusal.
+  return args.some((a) => a === '--head' || a.startsWith('--head=') || a.startsWith('-H'));
 }
 
 /**

--- a/packages/relay/src/host-actions.ts
+++ b/packages/relay/src/host-actions.ts
@@ -26,6 +26,8 @@ import {
   GH_PR_READ_ONLY_OPS,
   injectPrCreateHead,
   isGhPrOp,
+  PR_CREATE_NO_HEAD_REFUSAL,
+  prCreateNeedsHead,
   refuseCheckoutByDefault,
   refuseMergeBypass,
   runHostGh,
@@ -335,6 +337,8 @@ async function runGhPrRpc(
     const branch = branchProbe.exitCode === 0 ? (branchProbe.stdout ?? '').trim() : '';
     finalArgs = injectPrCreateHead(op, branch, args);
   }
+  // Never let `gh` fall back to the host repo's checked-out branch.
+  if (prCreateNeedsHead(op, finalArgs)) return PR_CREATE_NO_HEAD_REFUSAL;
   return runHostGh(['pr', op, ...finalArgs], lookup.workspacePath);
 }
 

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -53,6 +53,8 @@ export {
   GH_PR_READ_ONLY_OPS,
   injectPrCreateHead,
   isGhPrOp,
+  PR_CREATE_NO_HEAD_REFUSAL,
+  prCreateNeedsHead,
   refuseCheckoutByDefault,
   refuseMergeBypass,
   runHostGh,

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -9,6 +9,8 @@ import {
   GH_PR_READ_ONLY_OPS,
   injectPrCreateHead,
   isGhPrOp,
+  PR_CREATE_NO_HEAD_REFUSAL,
+  prCreateNeedsHead,
   refuseCheckoutByDefault,
   refuseMergeBypass,
   runHostGh,
@@ -1143,6 +1145,8 @@ async function handleGhPrRpc(
   // on the box branch, so gh can't infer it). Done after token validation —
   // which hashes the incoming `params`, not this post-injection argv.
   const finalArgs = injectPrCreateHead(op, worktree.branch, args);
+  // Never let `gh` fall back to the host repo's checked-out branch.
+  if (prCreateNeedsHead(op, finalArgs)) return PR_CREATE_NO_HEAD_REFUSAL;
   return runHostGh(['pr', op, ...finalArgs], worktree.hostMainRepo);
 }
 

--- a/packages/relay/test/gh.test.ts
+++ b/packages/relay/test/gh.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { injectPrCreateHead } from '../src/gh.js';
+import { injectPrCreateHead, prCreateNeedsHead } from '../src/gh.js';
 
 describe('injectPrCreateHead', () => {
   it('prepends --head <branch> for create when none was passed', () => {
@@ -30,5 +30,28 @@ describe('injectPrCreateHead', () => {
     expect(injectPrCreateHead('create', undefined, ['--title', 'T'])).toEqual(['--title', 'T']);
     expect(injectPrCreateHead('create', '', ['--title', 'T'])).toEqual(['--title', 'T']);
     expect(injectPrCreateHead('create', 'HEAD', ['--title', 'T'])).toEqual(['--title', 'T']);
+  });
+});
+
+describe('prCreateNeedsHead', () => {
+  it('is true for a create that still has no --head', () => {
+    expect(prCreateNeedsHead('create', ['--title', 'T'])).toBe(true);
+    // After injectPrCreateHead failed to resolve a branch:
+    expect(prCreateNeedsHead('create', injectPrCreateHead('create', '', ['--title', 'T']))).toBe(
+      true,
+    );
+  });
+
+  it('is false once --head is present (injected or caller-supplied)', () => {
+    expect(prCreateNeedsHead('create', ['--head', 'agentbox/box-one', '--title', 'T'])).toBe(false);
+    expect(prCreateNeedsHead('create', ['--head=feat/x'])).toBe(false);
+    expect(
+      prCreateNeedsHead('create', injectPrCreateHead('create', 'agentbox/box-one', ['--title', 'T'])),
+    ).toBe(false);
+  });
+
+  it('is false for non-create ops', () => {
+    expect(prCreateNeedsHead('view', ['7'])).toBe(false);
+    expect(prCreateNeedsHead('merge', ['42'])).toBe(false);
   });
 });

--- a/packages/relay/test/gh.test.ts
+++ b/packages/relay/test/gh.test.ts
@@ -26,6 +26,15 @@ describe('injectPrCreateHead', () => {
     ]);
   });
 
+  it('does not double-inject when the -H shorthand is already present', () => {
+    expect(injectPrCreateHead('create', 'agentbox/box-one', ['-H', 'feat/x'])).toEqual([
+      '-H',
+      'feat/x',
+    ]);
+    expect(injectPrCreateHead('create', 'agentbox/box-one', ['-Hfeat/x'])).toEqual(['-Hfeat/x']);
+    expect(injectPrCreateHead('create', 'agentbox/box-one', ['-H=feat/x'])).toEqual(['-H=feat/x']);
+  });
+
   it('leaves args unchanged when no usable branch resolved', () => {
     expect(injectPrCreateHead('create', undefined, ['--title', 'T'])).toEqual(['--title', 'T']);
     expect(injectPrCreateHead('create', '', ['--title', 'T'])).toEqual(['--title', 'T']);
@@ -48,6 +57,12 @@ describe('prCreateNeedsHead', () => {
     expect(
       prCreateNeedsHead('create', injectPrCreateHead('create', 'agentbox/box-one', ['--title', 'T'])),
     ).toBe(false);
+  });
+
+  it('is false when the -H shorthand supplied a head (no false refusal)', () => {
+    expect(prCreateNeedsHead('create', ['-H', 'feat/x', '--title', 'T'])).toBe(false);
+    expect(prCreateNeedsHead('create', ['-Hfeat/x'])).toBe(false);
+    expect(prCreateNeedsHead('create', ['-H=feat/x'])).toBe(false);
   });
 
   it('is false for non-create ops', () => {

--- a/packages/relay/test/server.test.ts
+++ b/packages/relay/test/server.test.ts
@@ -534,6 +534,35 @@ exit 0
     );
   });
 
+  it('gh.pr.create refuses (exit 65) when the box branch cannot be resolved', async () => {
+    // Register a worktree with an empty branch so injectPrCreateHead can't add
+    // --head; the relay must refuse rather than let gh fall back to the host
+    // repo's checked-out branch.
+    const r0 = await fetchJson(handle, 'POST', '/admin/register-box', {
+      body: {
+        boxId: 'b1',
+        token: 't1',
+        name: 'box-one',
+        worktrees: [{ containerPath: '/workspace', hostMainRepo: stubDir, branch: '' }],
+      },
+    });
+    expect(r0.status).toBe(204);
+    process.env.AGENTBOX_PROMPT = 'off';
+    const r = await fetchJson(handle, 'POST', '/rpc', {
+      token: 't1',
+      body: {
+        method: 'gh.pr.create',
+        params: { path: '/workspace', args: ['--title', 'T'] },
+      },
+    });
+    expect(r.status).toBe(500);
+    const body = r.body as { exitCode: number; stderr: string; stdout: string };
+    expect(body.exitCode).toBe(65);
+    expect(body.stderr).toMatch(/refusing to run without --head/);
+    // gh must not have been invoked.
+    expect(body.stdout).not.toContain('stub: gh pr create');
+  });
+
   it('gh.pr.create does not double-inject --head when the caller passed one', async () => {
     await registerWithWorktree();
     process.env.AGENTBOX_PROMPT = 'off';


### PR DESCRIPTION
Auto-injecting --head fixes the happy path, but if the branch cannot be resolved (cloud probe failure, or any edge) gh silently falls back to the host repo's checked-out branch and opens a PR for the wrong branch -- as seen when a box's create defaulted to the host's feat/test and collided with an existing PR.

Add prCreateNeedsHead + PR_CREATE_NO_HEAD_REFUSAL and guard both relay gh-pr handlers (docker + cloud): a create that still lacks --head after injection is refused (exit 65) with an actionable message instead of running gh. A box can now only ever target its own branch, or fail cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow relay guard on `gh pr create` only; behavior is fail-closed with tests and does not change other `gh.pr.*` ops.
> 
> **Overview**
> When **`gh pr create`** runs from a box but the relay cannot resolve the box branch (and the caller did not pass **`--head`**), the relay now **refuses** with exit **65** and an actionable message instead of invoking **`gh`**, which would otherwise infer head from the **host** repo’s checked-out branch and open a PR for the wrong branch.
> 
> Adds **`prCreateNeedsHead`**, **`PR_CREATE_NO_HEAD_REFUSAL`**, and a shared **`hasHeadArg`** helper in **`gh.ts`**, applies the guard in both **`handleGhPrRpc`** (docker) and **`runGhPrRpc`** (cloud), and exports the new API from the relay package. Unit and server tests cover the refusal path and ensure **`gh`** is not spawned when **`--head`** is still missing after injection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f69f20f5919c115e88467425fe7afdcb7d21cfd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->