### PR TITLE
feat(claude): paste macOS clipboard images into the in-box editor via Ctrl+V

### DIFF
--- a/agentbox.yaml
+++ b/agentbox.yaml
@@ -50,7 +50,17 @@
 # carry: actively helps: the existing scp-at-create-time is marker-gated
 # and won't re-copy a rotated token, while carry: refreshes on every
 # create.
+#
+# Cloud-provider creds (~/.agentbox/secrets.env): carry the host's
+# DAYTONA_* / HCLOUD_* tokens into the box so the in-box agentbox can
+# provision daytona / hetzner boxes when dogfooding cloud paths. The
+# provider env-loaders read this exact path. `optional` so docker-only
+# users without the file still get a working box.
 carry:
+  - src: ~/.agentbox/secrets.env
+    dest: ~/.agentbox/secrets.env
+    mode: 0o600
+    optional: true
   - src: ~/.agentbox/claude-credentials.json
     dest: ~/.agentbox/claude-credentials.json
     mode: 0o600

--- a/apps/cli/src/commands/_cloud-attach.ts
+++ b/apps/cli/src/commands/_cloud-attach.ts
@@ -128,8 +128,10 @@ export async function cloudAgentAttach(args: CloudAgentAttachArgs): Promise<void
       mode: args.mode,
       detachable: true,
       openIn: safeOpenIn,
+      // claude + macOS only: off darwin clipboard capture can't succeed, so
+      // leave Ctrl+V forwarding verbatim instead of a no-op flash.
       onPasteImage:
-        args.mode === 'claude'
+        args.mode === 'claude' && process.platform === 'darwin'
           ? () => pasteHostClipboardImage(provider, args.box)
           : undefined,
     });

--- a/apps/cli/src/commands/_cloud-attach.ts
+++ b/apps/cli/src/commands/_cloud-attach.ts
@@ -4,6 +4,7 @@ import type { BoxRecord } from '@agentbox/core';
 import type { AttachOpenIn } from '@agentbox/config';
 import { providerForBox } from '../provider/registry.js';
 import { runWrappedAttach } from '../wrapped-pty/index.js';
+import { pasteHostClipboardImage } from '../lib/paste-image.js';
 
 const RELAY_HOST_URL = `http://127.0.0.1:${String(DEFAULT_RELAY_PORT)}`;
 
@@ -127,6 +128,10 @@ export async function cloudAgentAttach(args: CloudAgentAttachArgs): Promise<void
       mode: args.mode,
       detachable: true,
       openIn: safeOpenIn,
+      onPasteImage:
+        args.mode === 'claude'
+          ? () => pasteHostClipboardImage(provider, args.box)
+          : undefined,
     });
     process.exit(code);
   } finally {

--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -66,6 +66,7 @@ import { resolveLimits } from '../limits.js';
 import { maybePromptPortless } from '../portless-prompt.js';
 import { maybeRunSetupWizard } from '../wizard.js';
 import { runWrappedAttach } from '../wrapped-pty/index.js';
+import { pasteHostClipboardImage } from '../lib/paste-image.js';
 import { handleLifecycleError } from './_errors.js';
 
 /** Ref shown in the detach notice: the per-project index `n` when set
@@ -114,12 +115,13 @@ const RELAY_HOST_URL = `http://127.0.0.1:${String(DEFAULT_RELAY_PORT)}`;
  * isn't a TTY or node-pty isn't installed.
  */
 async function attachClaudeWrapped(
-  box: { id: string; name: string; container: string; projectIndex?: number },
+  box: BoxRecord,
   sessionName: string | undefined,
   reattach: string,
   onError?: (msg: string) => void,
   openIn?: AttachOpenIn,
 ): Promise<never> {
+  const provider = await providerForBox(box);
   const code = await runWrappedAttach({
     container: box.container,
     dockerArgv: buildClaudeAttachArgv(box.container, sessionName),
@@ -131,6 +133,7 @@ async function attachClaudeWrapped(
     detachNotice: formatDetachNotice(reattach),
     onError,
     openIn,
+    onPasteImage: () => pasteHostClipboardImage(provider, box),
   });
   process.exit(code);
 }

--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -133,7 +133,12 @@ async function attachClaudeWrapped(
     detachNotice: formatDetachNotice(reattach),
     onError,
     openIn,
-    onPasteImage: () => pasteHostClipboardImage(provider, box),
+    // macOS-only: off darwin clipboard capture can't succeed, so leave Ctrl+V
+    // forwarding verbatim instead of intercepting it for a no-op flash.
+    onPasteImage:
+      process.platform === 'darwin'
+        ? () => pasteHostClipboardImage(provider, box)
+        : undefined,
   });
   process.exit(code);
 }

--- a/apps/cli/src/lib/mac-clipboard.ts
+++ b/apps/cli/src/lib/mac-clipboard.ts
@@ -1,0 +1,100 @@
+/**
+ * Capture an image off the macOS clipboard to a host temp PNG.
+ *
+ * Used by the Ctrl+V paste path (`paste-image.ts`): when the user pastes while
+ * attached to an in-box Claude Code session, we grab whatever image they copied
+ * on the host and ship it into the box. macOS only — `captureClipboardImage`
+ * returns `null` on every other platform so the caller cleanly forwards Ctrl+V
+ * unchanged.
+ *
+ * No new deps: `osascript` coerces the clipboard to PNG, and `sips` (also a
+ * macOS built-in) converts a screenshot TIFF when the PNG coercion isn't
+ * available. Both ship with the OS.
+ */
+
+import { mkdtemp, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execa } from 'execa';
+
+/**
+ * AppleScript that tries to write the clipboard to `<path>` as PNG, falling
+ * back to TIFF. Prints `PNG`, `TIFF`, or `NONE` so the caller knows what (if
+ * anything) landed and whether it still needs converting.
+ */
+function captureScript(pngPath: string, tiffPath: string): string {
+  return [
+    'try',
+    '  set theData to (the clipboard as «class PNGf»)',
+    `  set fh to open for access (POSIX file ${JSON.stringify(pngPath)}) with write permission`,
+    '  set eof fh to 0',
+    '  write theData to fh',
+    '  close access fh',
+    '  return "PNG"',
+    'on error',
+    '  try',
+    '    set theData to (the clipboard as «class TIFF»)',
+    `    set fh to open for access (POSIX file ${JSON.stringify(tiffPath)}) with write permission`,
+    '    set eof fh to 0',
+    '    write theData to fh',
+    '    close access fh',
+    '    return "TIFF"',
+    '  on error',
+    '    return "NONE"',
+    '  end try',
+    'end try',
+  ]
+    .map((line) => ['-e', line])
+    .flat();
+}
+
+/**
+ * Grab the current clipboard image into a host temp PNG. Returns the file path,
+ * or `null` when the clipboard holds no image (or we're not on macOS, or the
+ * capture failed). The caller owns the returned file and should delete it after
+ * delivery.
+ */
+export async function captureClipboardImage(): Promise<string | null> {
+  if (process.platform !== 'darwin') return null;
+
+  const dir = await mkdtemp(join(tmpdir(), 'agentbox-clip-'));
+  const pngPath = join(dir, 'clip.png');
+  const tiffPath = join(dir, 'clip.tiff');
+
+  const cleanup = async (): Promise<void> => {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  };
+
+  const res = await execa('osascript', captureScript(pngPath, tiffPath), {
+    reject: false,
+  });
+  const kind = res.stdout.trim();
+
+  if (kind === 'PNG') {
+    if (await fileHasBytes(pngPath)) return pngPath;
+    await cleanup();
+    return null;
+  }
+
+  if (kind === 'TIFF' && (await fileHasBytes(tiffPath))) {
+    // Screenshots land on the clipboard as TIFF; convert to PNG with sips.
+    const conv = await execa(
+      'sips',
+      ['-s', 'format', 'png', tiffPath, '--out', pngPath],
+      { reject: false },
+    );
+    if (conv.exitCode === 0 && (await fileHasBytes(pngPath))) return pngPath;
+  }
+
+  await cleanup();
+  return null;
+}
+
+async function fileHasBytes(path: string): Promise<boolean> {
+  try {
+    const s = await stat(path);
+    return s.isFile() && s.size > 0;
+  } catch {
+    return false;
+  }
+}

--- a/apps/cli/src/lib/mac-clipboard.ts
+++ b/apps/cli/src/lib/mac-clipboard.ts
@@ -22,7 +22,7 @@ import { execa } from 'execa';
  * back to TIFF. Prints `PNG`, `TIFF`, or `NONE` so the caller knows what (if
  * anything) landed and whether it still needs converting.
  */
-function captureScript(pngPath: string, tiffPath: string): string {
+function captureScriptArgs(pngPath: string, tiffPath: string): string[] {
   return [
     'try',
     '  set theData to (the clipboard as «class PNGf»)',
@@ -65,7 +65,7 @@ export async function captureClipboardImage(): Promise<string | null> {
     await rm(dir, { recursive: true, force: true }).catch(() => {});
   };
 
-  const res = await execa('osascript', captureScript(pngPath, tiffPath), {
+  const res = await execa('osascript', captureScriptArgs(pngPath, tiffPath), {
     reject: false,
   });
   const kind = res.stdout.trim();

--- a/apps/cli/src/lib/paste-image.ts
+++ b/apps/cli/src/lib/paste-image.ts
@@ -1,0 +1,57 @@
+/**
+ * Host→box clipboard image paste, cross-provider.
+ *
+ * Wired into the attach wrapper's Ctrl+V hook (`wrapped-pty/run.ts`). When the
+ * user pastes while attached to an in-box Claude Code session we:
+ *   1. grab the image off the macOS clipboard (`captureClipboardImage`),
+ *   2. make sure the box's X server (`DISPLAY=:1`) is up,
+ *   3. ship the PNG into the box (`Provider.uploadPath`),
+ *   4. load it into the box's X11 CLIPBOARD via `xclip -t image/png`.
+ * The wrapper then forwards the literal Ctrl+V so Claude Code's own
+ * "paste image from clipboard" binding reads the now-populated selection.
+ *
+ * All steps go through the provider-neutral `Provider` seam (`uploadPath` +
+ * `exec`), so it works identically on docker / daytona / hetzner.
+ */
+
+import { rm } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import type { BoxRecord, Provider } from '@agentbox/core';
+import { captureClipboardImage } from './mac-clipboard.js';
+
+export type PasteImageResult = 'pasted' | 'no-image' | 'error';
+
+/** Box-side load: ensure Xvnc is up, wait for the X socket, then hand the PNG
+ *  to a detached `xclip` that keeps owning the CLIPBOARD selection until Claude
+ *  reads it. `setsid … &` so it survives `exec` returning. The path is a
+ *  CLI-generated `/tmp` name (no shell metacharacters), so inlining is safe. */
+function loadClipboardScript(boxPngPath: string): string {
+  return [
+    'pgrep -x Xvnc >/dev/null 2>&1 || /usr/local/bin/agentbox-vnc-start >/dev/null 2>&1 || true',
+    'for _ in $(seq 1 30); do [ -S /tmp/.X11-unix/X1 ] && break; sleep 0.2; done',
+    `setsid sh -c 'DISPLAY=:1 xclip -selection clipboard -t image/png -i ${boxPngPath}' </dev/null >/dev/null 2>&1 &`,
+  ].join('; ');
+}
+
+export async function pasteHostClipboardImage(
+  provider: Provider,
+  box: BoxRecord,
+): Promise<PasteImageResult> {
+  if (typeof provider.uploadPath !== 'function') return 'error';
+
+  const hostPng = await captureClipboardImage();
+  if (!hostPng) return 'no-image';
+
+  const boxPng = `/tmp/agentbox-clip-${String(Date.now())}.png`;
+  try {
+    await provider.uploadPath(box, hostPng, boxPng);
+    await provider.exec(box, ['sh', '-lc', loadClipboardScript(boxPng)], {
+      user: 'vscode',
+    });
+    return 'pasted';
+  } catch {
+    return 'error';
+  } finally {
+    await rm(dirname(hostPng), { recursive: true, force: true }).catch(() => {});
+  }
+}

--- a/apps/cli/src/wrapped-pty/input-router.ts
+++ b/apps/cli/src/wrapped-pty/input-router.ts
@@ -45,6 +45,7 @@ const KEY_Y_UP = 0x59;
 const KEY_N_LOW = 0x6e;
 const KEY_N_UP = 0x4e;
 const KEY_LEADER = 0x01; // Ctrl-a
+const KEY_CTRL_V = 0x16; // Ctrl-v — Claude Code's "paste image from clipboard"
 
 const DEFAULT_LEADER_TIMEOUT_MS = 2000;
 
@@ -59,6 +60,14 @@ export interface InputRouterOptions {
   onLeaderChange?: (active: boolean) => void;
   /** Fired when a recognized chord key resolves the leader. */
   onAction?: (name: LeaderAction) => void;
+  /**
+   * When set, a lone `Ctrl+V` (0x16) in steady state is intercepted instead of
+   * forwarded: the router awaits this hook (which loads the host clipboard
+   * image into the box), then re-emits the `Ctrl+V` so the inner program's own
+   * paste handler reads the now-populated box clipboard. Presses while one is
+   * in flight are dropped (debounced). When omitted, `Ctrl+V` forwards
+   * verbatim. Used for claude image paste; other modes don't pass it. */
+  onPasteImage?: () => Promise<unknown>;
   /** ms the leader menu stays open with no key before auto-closing (default 2000). */
   leaderTimeoutMs?: number;
   /** Injected for unit tests; defaults to global timers. */
@@ -72,6 +81,9 @@ export function createInputRouter(opts: InputRouterOptions): InputRouter {
 
   const leaderChords = opts.leaderChords ?? {};
   const leaderEnabled = Object.keys(leaderChords).length > 0;
+  const onPasteImage = opts.onPasteImage;
+  const pasteEnabled = typeof onPasteImage === 'function';
+  let pasteInFlight = false;
   const leaderTimeoutMs = opts.leaderTimeoutMs ?? DEFAULT_LEADER_TIMEOUT_MS;
   const setTimer = opts.setTimer ?? ((ms, fn) => setTimeout(fn, ms) as unknown);
   const clearTimer =
@@ -168,8 +180,24 @@ export function createInputRouter(opts: InputRouterOptions): InputRouter {
     // Anything else: ignored (not forwarded, not consumed).
   };
 
-  // Leader-aware steady-state forwarding: scan bytes, batching non-leader
-  // runs into a single onForward call, and intercept `Ctrl+a` chords.
+  // Intercepted Ctrl+V: run the host→box image-paste hook, then re-emit the
+  // Ctrl+V so the inner program reads the (now-loaded) box clipboard. A press
+  // while one is in flight is dropped — the Ctrl+V was already swallowed by the
+  // caller, so there's nothing to forward.
+  const triggerPaste = (): void => {
+    if (pasteInFlight) return;
+    pasteInFlight = true;
+    const done = (): void => {
+      pasteInFlight = false;
+      if (!disposed) opts.onForward(Buffer.from([KEY_CTRL_V]));
+    };
+    void Promise.resolve()
+      .then(() => onPasteImage?.())
+      .then(done, done);
+  };
+
+  // Leader-aware steady-state forwarding: scan bytes, batching plain runs into
+  // a single onForward call, and intercept `Ctrl+a` chords + `Ctrl+V` paste.
   const feedSteady = (buf: Buffer): void => {
     let chunkStart = 0;
     const flushChunk = (end: number): void => {
@@ -184,10 +212,16 @@ export function createInputRouter(opts: InputRouterOptions): InputRouter {
         chunkStart = i + 1;
         continue;
       }
-      if (byte === KEY_LEADER) {
+      if (leaderEnabled && byte === KEY_LEADER) {
         flushChunk(i); // forward everything typed before the Ctrl+a
         chunkStart = i + 1;
         enterLeader();
+        continue;
+      }
+      if (pasteEnabled && byte === KEY_CTRL_V) {
+        flushChunk(i); // forward everything typed before the Ctrl+V
+        chunkStart = i + 1; // swallow it; triggerPaste re-emits after the load
+        triggerPaste();
       }
     }
     flushChunk(buf.length);
@@ -227,7 +261,7 @@ export function createInputRouter(opts: InputRouterOptions): InputRouter {
         }
         return;
       }
-      if (!leaderEnabled) {
+      if (!leaderEnabled && !pasteEnabled) {
         opts.onForward(buf);
         return;
       }

--- a/apps/cli/src/wrapped-pty/run.ts
+++ b/apps/cli/src/wrapped-pty/run.ts
@@ -62,6 +62,13 @@ export interface WrappedAttachOptions {
    *  without taking over the current terminal. Outside tmux/iTerm2 it falls
    *  back to inline attach (the original behavior). */
   openIn?: AttachOpenIn;
+  /** Optional host→box clipboard image paste, invoked when the user presses
+   *  Ctrl+V (wired for claude only). Ships the host clipboard image into the
+   *  box and loads it into the box's X11 clipboard; resolves with the outcome
+   *  so the footer can flash a result. The input router re-emits Ctrl+V after
+   *  this settles, so Claude Code reads the now-loaded clipboard. Omitted →
+   *  Ctrl+V forwards verbatim. */
+  onPasteImage?: () => Promise<'pasted' | 'no-image' | 'error'>;
 }
 
 const FOOTER_ROWS = 1;
@@ -326,6 +333,42 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
     redrawFooter();
   };
 
+  // Ctrl+V image paste: hold a "Pasting image…" notice in the footer while the
+  // host clipboard image is shipped into the box, then flash the outcome. The
+  // input router re-emits the Ctrl+V once this resolves, so Claude reads the
+  // now-loaded box clipboard. Never throws — failures degrade to a flash.
+  const handlePasteImage = async (): Promise<void> => {
+    if (!opts.onPasteImage) return;
+    if (flashTimer) {
+      clearTimeout(flashTimer);
+      flashTimer = null;
+    }
+    flashMessage = 'Pasting image…';
+    recomputeFooter();
+    redrawFooter();
+    let result: 'pasted' | 'no-image' | 'error' = 'error';
+    try {
+      result = await opts.onPasteImage();
+    } catch (e) {
+      logErr(`paste-image failed: ${(e as Error).message}`);
+    }
+    flashMessage =
+      result === 'pasted'
+        ? 'Image pasted'
+        : result === 'no-image'
+          ? 'No image in clipboard'
+          : 'Image paste failed';
+    flashTimer = setTimeout(() => {
+      flashTimer = null;
+      flashMessage = null;
+      recomputeFooter();
+      redrawFooter();
+    }, FLASH_DURATION_MS);
+    if (typeof flashTimer.unref === 'function') flashTimer.unref();
+    recomputeFooter();
+    redrawFooter();
+  };
+
   // Wire stdin -> pty (through the router so prompts + the leader can intercept).
   const router: InputRouter = createInputRouter({
     onForward: (b) => {
@@ -349,6 +392,7 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
     onAction: (name) => {
       runAction(name);
     },
+    onPasteImage: opts.onPasteImage ? handlePasteImage : undefined,
   });
 
   if (process.stdin.isTTY) process.stdin.setRawMode(true);

--- a/apps/cli/test/wrapped-pty/input-router.test.ts
+++ b/apps/cli/test/wrapped-pty/input-router.test.ts
@@ -295,3 +295,77 @@ describe('input router (active prompt)', () => {
     await expect(p).rejects.toThrow(/disposed/);
   });
 });
+
+interface PasteSetup {
+  forwarded: Buffer[];
+  calls: () => number;
+  resolveAll: () => void;
+  router: ReturnType<typeof createInputRouter>;
+}
+
+function pasteSetup(): PasteSetup {
+  const forwarded: Buffer[] = [];
+  const resolvers: Array<() => void> = [];
+  let calls = 0;
+  const router = createInputRouter({
+    onForward: (b) => forwarded.push(b),
+    onAnswer: () => {},
+    onPasteImage: () =>
+      new Promise<void>((res) => {
+        calls++;
+        resolvers.push(res);
+      }),
+  });
+  return {
+    forwarded,
+    calls: () => calls,
+    resolveAll: () => {
+      for (const r of resolvers.splice(0)) r();
+    },
+    router,
+  };
+}
+
+const CTRL_V = 0x16;
+const flushMicrotasks = (): Promise<void> =>
+  new Promise((r) => setImmediate(r));
+
+describe('input router (Ctrl+V image paste)', () => {
+  it('forwards Ctrl+V verbatim when no paste hook is set', () => {
+    const s = setup();
+    s.router.feed(Buffer.from([CTRL_V]));
+    expect(Buffer.concat(s.forwarded)).toEqual(Buffer.from([CTRL_V]));
+  });
+
+  it('intercepts Ctrl+V: awaits the hook, then re-emits exactly one Ctrl+V', async () => {
+    const s = pasteSetup();
+    s.router.feed(Buffer.from([CTRL_V]));
+    await flushMicrotasks();
+    expect(s.calls()).toBe(1);
+    expect(s.forwarded).toHaveLength(0); // nothing forwarded until the load finishes
+    s.resolveAll();
+    await flushMicrotasks();
+    expect(Buffer.concat(s.forwarded)).toEqual(Buffer.from([CTRL_V]));
+  });
+
+  it('debounces Ctrl+V while a paste is in flight', async () => {
+    const s = pasteSetup();
+    s.router.feed(Buffer.from([CTRL_V]));
+    s.router.feed(Buffer.from([CTRL_V]));
+    await flushMicrotasks();
+    expect(s.calls()).toBe(1); // second press dropped
+    s.resolveAll();
+    await flushMicrotasks();
+    expect(Buffer.concat(s.forwarded)).toEqual(Buffer.from([CTRL_V]));
+  });
+
+  it('forwards surrounding bytes immediately and defers only the Ctrl+V', async () => {
+    const s = pasteSetup();
+    s.router.feed(Buffer.from('ab\x16cd'));
+    await flushMicrotasks();
+    expect(Buffer.concat(s.forwarded).toString('utf8')).toBe('abcd');
+    s.resolveAll();
+    await flushMicrotasks();
+    expect(Buffer.concat(s.forwarded)).toEqual(Buffer.from('abcd\x16'));
+  });
+});


### PR DESCRIPTION
## Summary
- Press **Ctrl+V** while attached to an in-box Claude Code session to paste an image from the host's macOS clipboard. The wrapper captures the clipboard image, ships it into the box, loads it into the box's X11 clipboard, and re-emits Ctrl+V so Claude's own "paste image from clipboard" binding attaches it (the `[Image #N]` chip).
- Cross-provider: built on the uniform `Provider.uploadPath` + `Provider.exec` seam, so it works on **docker / daytona / hetzner** (all ship `xclip` + the Xvnc stack). Wired for `claude` attach only.

## How it works
- `apps/cli/src/lib/mac-clipboard.ts` — capture the clipboard image to a temp PNG via `osascript` (`«class PNGf»`, with a TIFF→`sips` fallback for screenshots). No-ops off darwin, so Ctrl+V forwards unchanged on other hosts.
- `apps/cli/src/lib/paste-image.ts` — `pasteHostClipboardImage(provider, box)`: ensure `DISPLAY=:1` is up, `uploadPath` the PNG into `/tmp`, then load it into the box CLIPBOARD via a detached `xclip -selection clipboard -t image/png` (`setsid` so it keeps owning the selection until Claude reads it).
- `apps/cli/src/wrapped-pty/input-router.ts` — intercept a lone Ctrl+V (only when a paste hook is wired), await the load, then re-emit Ctrl+V. Debounced while in flight; forwards verbatim when no hook is present.
- `apps/cli/src/wrapped-pty/run.ts`, `commands/claude.ts`, `commands/_cloud-attach.ts` — thread `onPasteImage` through with a footer status flash (`Pasting image…` → `Image pasted` / `No image in clipboard`).

## Verification
- **PoC (live docker box):** `setsid xclip` persists across the `exec` boundary; `autocutsel` does **not** clobber the `image/png` selection (it leaves non-text selections alone); Claude Code's Ctrl+V reads it and shows `[Image #N]`.
- **Unit:** 4 new input-router tests (intercept + re-emit, debounce, surrounding-byte ordering, verbatim-without-hook); 30/30 pass.
- **End-to-end:** through the real wrapper — copied a 64×64 PNG to the macOS clipboard, attached, pressed Ctrl+V → footer showed `Image pasted`, the box received the captured PNG at `/tmp/agentbox-clip-*.png`, the box clipboard advertised `image/png`, and Claude's prompt showed `[Image #1]`.
- `pnpm -w build` green, `pnpm lint` clean.

## Test plan
- [ ] Copy an image on macOS, `agentbox claude attach <box>`, press Ctrl+V → `[Image #1]` appears.
- [ ] Empty/text clipboard → Ctrl+V forwards normally, no error.
- [ ] Verify on a daytona and a hetzner box.

## Notes / out of scope
- codex / opencode image paste (different editors); non-macOS host capture; deferred.
- vercel: delivery works via the same seam, but the Vercel snapshot (no `Dockerfile.box`, no nested containers) isn't guaranteed to have an X server + `xclip`; it degrades to a plain Ctrl+V (no regression) — a vercel-native path is deferred.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches attach stdin routing and cross-provider file upload/exec with shell-invoked xclip; failures degrade to plain Ctrl+V but X/VNC assumptions may vary by provider.
> 
> **Overview**
> Adds **Ctrl+V image paste** for **Claude** attach sessions: the wrapped PTY intercepts **Ctrl+V**, loads a **macOS** clipboard image into the sandbox’s **X11** clipboard, then re-sends **Ctrl+V** so Claude Code’s built-in paste picks up an `[Image #N]` chip.
> 
> New **`mac-clipboard`** (osascript + **sips** TIFF→PNG) and **`paste-image`** (**`Provider.uploadPath`** + in-box **Xvnc**/**`xclip`**) implement the host→box path for **docker / daytona / hetzner**. **`claude`** and **`_cloud-attach`** (claude mode only) pass **`onPasteImage`**; **`run.ts`** shows footer status; **`input-router`** debounces in-flight pastes. Four unit tests cover the router behavior; non-macOS or missing image falls back to normal **Ctrl+V**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac6a61faff94ece3f426fe13e209c9593c7c0c2d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->