### PR TITLE
fix(relay): reclaim a host relay missing AGENTBOX_CLI_ENTRY instead of reusing it

### DIFF
--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -175,7 +175,7 @@ function isLoopbackAddress(addr: string | undefined): boolean {
  *   POST /admin/host-initiated/mint — loopback only; mints a one-time token scoped to (boxId, method).
  *   POST /admin/notices/set     — loopback only; sets an informational box notice (returns {id}).
  *   POST /admin/notices/clear   — loopback only; clears a box notice by id.
- *   GET  /healthz               — liveness probe (no auth).
+ *   GET  /healthz               — liveness + capability probe (no auth); reports {pid, cliEntry}.
  */
 export function createRelayServer(opts: RelayServerOptions): RelayServerHandle {
   const log = opts.logger ?? (() => {});
@@ -224,7 +224,18 @@ export function createRelayServer(opts: RelayServerOptions): RelayServerHandle {
     const route = `${req.method ?? 'GET'} ${url.pathname}`;
 
     if (route === 'GET /healthz') {
-      send(res, 200, { ok: true, boxes: registry.size(), events: events.size() });
+      // `cliEntry` and `pid` let the host-side `ensureRelay` distinguish a
+      // *capable* relay from one that's merely alive: a relay spawned without
+      // AGENTBOX_CLI_ENTRY silently fails every cp/download/checkpoint host
+      // action (exit 64) for its whole lifetime. Reporting it here lets the
+      // caller reclaim (kill by `pid`) and respawn instead of reusing it.
+      send(res, 200, {
+        ok: true,
+        boxes: registry.size(),
+        events: events.size(),
+        pid: process.pid,
+        cliEntry: Boolean(process.env.AGENTBOX_CLI_ENTRY),
+      });
       return;
     }
 

--- a/packages/relay/test/server.test.ts
+++ b/packages/relay/test/server.test.ts
@@ -73,6 +73,22 @@ describe('relay server', () => {
     expect(r.body).toMatchObject({ ok: true });
   });
 
+  it('healthz reports pid and AGENTBOX_CLI_ENTRY capability so ensureRelay can reclaim a crippled relay', async () => {
+    const prev = process.env.AGENTBOX_CLI_ENTRY;
+    try {
+      delete process.env.AGENTBOX_CLI_ENTRY;
+      const without = await fetchJson(handle, 'GET', '/healthz');
+      expect(without.body).toMatchObject({ ok: true, pid: process.pid, cliEntry: false });
+
+      process.env.AGENTBOX_CLI_ENTRY = '/some/cli/index.js';
+      const withEntry = await fetchJson(handle, 'GET', '/healthz');
+      expect(withEntry.body).toMatchObject({ cliEntry: true });
+    } finally {
+      if (prev === undefined) delete process.env.AGENTBOX_CLI_ENTRY;
+      else process.env.AGENTBOX_CLI_ENTRY = prev;
+    }
+  });
+
   it('rejects /events without a bearer token', async () => {
     const r = await fetchJson(handle, 'POST', '/events', { body: { type: 'x' } });
     expect(r.status).toBe(401);

--- a/packages/sandbox-docker/src/relay.ts
+++ b/packages/sandbox-docker/src/relay.ts
@@ -67,32 +67,110 @@ export async function ensureRelay(opts: EnsureRelayOptions = {}): Promise<RelayE
     log(`removed legacy relay container ${RELAY_CONTAINER_NAME}`);
   }
 
-  if (await pingHealthz(500)) {
-    return ENDPOINT;
-  }
-
-  const existingPid = await readPidFile();
-  if (existingPid !== null && (await processAlive(existingPid))) {
-    // Pid exists but healthz isn't responding yet — give it a beat to finish
-    // startup. If it stays unresponsive, leave it alone (someone might be
-    // debugging it) and let downstream POSTs fail as best-effort.
-    for (let i = 0; i < 10; i++) {
-      if (await pingHealthz(300)) return ENDPOINT;
-      await delay(200);
+  const health = await fetchHealthz(500);
+  if (health !== null) {
+    // A relay is answering on the port. Only reuse it if it can actually run
+    // host-side CLI actions. A relay spawned during a transient window where
+    // the CLI dist didn't exist comes up without AGENTBOX_CLI_ENTRY and then
+    // silently returns exit 64 for every cp/download/checkpoint for its whole
+    // lifetime — and bare liveness can never detect that, so it's never
+    // replaced. `cliEntry === false` (new relay, capability missing) → reclaim
+    // and respawn. `cliEntry === undefined` (a relay from before this field
+    // existed) is reused as before to avoid needlessly cycling old relays.
+    if (health.cliEntry !== false) {
+      return ENDPOINT;
     }
-    log(`relay pid ${String(existingPid)} alive but /healthz unresponsive — proceeding anyway`);
-    return ENDPOINT;
-  }
-  if (existingPid !== null) {
-    await unlink(PID_FILE).catch(() => {});
+    log('relay is alive but lacks AGENTBOX_CLI_ENTRY (cp/download/checkpoint would fail) — reclaiming');
+    await reclaimRelay(health.pid, log);
+    // fall through to a fresh spawn below
+  } else {
+    const existingPid = await readPidFile();
+    if (existingPid !== null && (await processAlive(existingPid))) {
+      // Pid exists but healthz isn't responding yet — give it a beat to finish
+      // startup. If it stays unresponsive, leave it alone (someone might be
+      // debugging it) and let downstream POSTs fail as best-effort.
+      for (let i = 0; i < 10; i++) {
+        if (await pingHealthz(300)) return ENDPOINT;
+        await delay(200);
+      }
+      log(`relay pid ${String(existingPid)} alive but /healthz unresponsive — proceeding anyway`);
+      return ENDPOINT;
+    }
+    if (existingPid !== null) {
+      await unlink(PID_FILE).catch(() => {});
+    }
   }
 
   const relayBin = resolveRelayBin();
-  const logFd = openSync(LOG_FILE, 'a');
-  // The relay shells out to this CLI entry for the checkpoint.create RPC
-  // (it only knows the box id; the CLI resolves the rest). Resolve best-effort
-  // — if not found the relay's handler reports a clear error.
+  // The relay shells back into this CLI entry for the cp / download /
+  // checkpoint host actions (it only knows the box id; the CLI resolves the
+  // rest). Resolve it BEFORE spawning and fail loud if missing: a relay
+  // without it answers /healthz fine but 64s every such action, and the
+  // capability gate above would just keep reclaiming + respawning it. A null
+  // here almost always means the CLI dist is mid-rebuild — surface that
+  // instead of producing a half-working relay.
   const cliEntry = resolveCliEntry();
+  if (cliEntry === null) {
+    throw new Error(
+      'cannot start the host relay: agentbox CLI entry not found ' +
+        '(is the build complete / dist present?). Set AGENTBOX_CLI_ENTRY to override.',
+    );
+  }
+  return spawnRelay(relayBin, cliEntry, log);
+}
+
+/**
+ * Stop a relay that's alive but missing AGENTBOX_CLI_ENTRY so a capable one
+ * can take the port. Tries the pid the relay reported via /healthz first, then
+ * the pidfile pid. Fails loud if the port is still held afterward — a silent
+ * "couldn't reclaim" would just resurrect the original broken-relay bug.
+ */
+async function reclaimRelay(reportedPid: number | undefined, log: (line: string) => void): Promise<void> {
+  const pidFromFile = await readPidFile();
+  const seen = new Set<number>();
+  for (const pid of [reportedPid, pidFromFile]) {
+    if (typeof pid !== 'number' || pid <= 0 || seen.has(pid)) continue;
+    seen.add(pid);
+    if (!(await processAlive(pid))) continue;
+    log(`stopping crippled relay pid ${String(pid)}`);
+    await killPid(pid);
+  }
+  await unlink(PID_FILE).catch(() => {});
+  // Confirm the port actually freed; if a relay still answers we'd reuse the
+  // broken one again on the next call. Surface it rather than loop silently.
+  if (await pingHealthz(300)) {
+    throw new Error(
+      `a relay without AGENTBOX_CLI_ENTRY is still listening on :${String(PORT)} and could not be ` +
+        `stopped (reported pid ${String(reportedPid ?? 'unknown')}); kill it manually and retry`,
+    );
+  }
+}
+
+/** SIGTERM, wait for exit, then SIGKILL — same escalation as {@link stopRelay}. */
+async function killPid(pid: number): Promise<void> {
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch {
+    return; // already gone
+  }
+  for (let i = 0; i < 20; i++) {
+    if (!(await processAlive(pid))) return;
+    await delay(100);
+  }
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch {
+    // best-effort
+  }
+}
+
+/** Spawn the detached relay process wired with AGENTBOX_CLI_ENTRY, then wait for it to come up. */
+async function spawnRelay(
+  relayBin: string,
+  cliEntry: string,
+  log: (line: string) => void,
+): Promise<RelayEndpoint> {
+  const logFd = openSync(LOG_FILE, 'a');
   const child = spawn(
     process.execPath,
     [relayBin, 'serve', '--port', String(PORT), '--host', '0.0.0.0'],
@@ -101,7 +179,7 @@ export async function ensureRelay(opts: EnsureRelayOptions = {}): Promise<RelayE
       stdio: ['ignore', logFd, logFd],
       env: {
         ...process.env,
-        ...(cliEntry ? { AGENTBOX_CLI_ENTRY: cliEntry } : {}),
+        AGENTBOX_CLI_ENTRY: cliEntry,
       },
     },
   );
@@ -284,6 +362,10 @@ interface HealthzBody {
   ok: boolean;
   boxes: number;
   events: number;
+  /** The relay's own pid (for reclaiming). Absent on relays predating this field. */
+  pid?: number;
+  /** Whether the relay has AGENTBOX_CLI_ENTRY (can run cp/download/checkpoint). Absent on old relays. */
+  cliEntry?: boolean;
 }
 
 function fetchHealthz(timeoutMs: number): Promise<HealthzBody | null> {
@@ -307,7 +389,13 @@ function fetchHealthz(timeoutMs: number): Promise<HealthzBody | null> {
               typeof parsed.boxes === 'number' &&
               typeof parsed.events === 'number'
             ) {
-              resolveP({ ok: parsed.ok, boxes: parsed.boxes, events: parsed.events });
+              resolveP({
+                ok: parsed.ok,
+                boxes: parsed.boxes,
+                events: parsed.events,
+                pid: typeof parsed.pid === 'number' ? parsed.pid : undefined,
+                cliEntry: typeof parsed.cliEntry === 'boolean' ? parsed.cliEntry : undefined,
+              });
             } else {
               resolveP(null);
             }


### PR DESCRIPTION
## Problem

A box hit `relay: AGENTBOX_CLI_ENTRY not set; cannot run cp host-side` (exit 64) on `agentbox-ctl cp fromHost`.

Root cause: the host relay (a long-lived process) was spawned during a window where the CLI `dist/index.js` didn't exist — almost certainly mid-rebuild. `resolveCliEntry()` returned `null`, so the relay came up **without `AGENTBOX_CLI_ENTRY`** in its env. That env var is what `handleCpRpc` / `handleDownloadRpc` / `handleCheckpointRpc` need to shell back into the CLI; missing → every one of those host actions hard-returns exit 64 for the **entire lifetime** of that relay.

It never self-healed because `ensureRelay` short-circuits on bare liveness:

```ts
if (await pingHealthz(500)) return ENDPOINT;
```

The crippled relay answers `/healthz` fine, holds `:8787`, and is reused forever. Any newer spawn can't bind the port, dies, and the healthz probe is answered by the old broken relay — so it's declared "healthy."

## Fix

1. **`/healthz` reports capability** — `{pid, cliEntry}` — so the host can distinguish a *capable* relay from one that's merely alive.
2. **`ensureRelay` reclaims a crippled relay** — when a relay reports `cliEntry === false`, kill it (by reported pid, falling back to the pidfile pid; SIGTERM→SIGKILL) and respawn. Fails loud if the port can't be freed.
3. **Fail loud at spawn** — if `resolveCliEntry()` returns `null`, throw with an actionable message instead of spawning a half-working relay.
4. Relays predating the `cliEntry` field (`undefined`) are still reused as before, so this doesn't needlessly cycle old relays.

This lives in the shared `ensureRelay` (`@agentbox/sandbox-docker`), which brings up the host relay for **docker, daytona, hetzner, and vercel** — so the fix covers all providers.

## Test plan

- [x] `pnpm --filter @agentbox/relay --filter @agentbox/sandbox-docker build`
- [x] `pnpm lint`
- [x] `pnpm --filter @agentbox/relay --filter @agentbox/sandbox-docker test` (relay 120 passed incl. new healthz capability test, sandbox-docker 240 passed)
- Added a server test asserting `/healthz` reports `pid` + `cliEntry` toggling with the env var.

## Immediate operational note

The currently-running relay on the host predates this change and is the crippled one. To unblock right now: `kill <relay-pid> && rm -f ~/.agentbox/relay.pid`, then the next box command respawns a healthy relay (dist now exists).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes host relay lifecycle (kill/restart on :8787) and spawn preconditions; behavior is intentional but affects all providers using ensureRelay.
> 
> **Overview**
> Fixes a stuck **crippled host relay**: one that answers `/healthz` but was started without `AGENTBOX_CLI_ENTRY`, so **cp / download / checkpoint** RPCs always exit 64 until manual kill.
> 
> **`/healthz`** now exposes **`pid`** and **`cliEntry`** (whether `AGENTBOX_CLI_ENTRY` is set) so the host can tell *capable* from merely *alive*. **`ensureRelay`** (`@agentbox/sandbox-docker`, shared across sandbox providers) parses that response: if `cliEntry === false`, it **stops** the relay (healthz pid, then pidfile; SIGTERM→SIGKILL) and **respawns**; relays without the field (`undefined`) are still reused. **Spawn** now **requires** a resolvable CLI entry and always wires **`AGENTBOX_CLI_ENTRY`**—no more best-effort half-working processes.
> 
> A relay server test asserts **`pid`** / **`cliEntry`** track the env var.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ac9f420d3981756eee3cfa42d5f09b6123622a5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->