### PR TITLE
TUI: 3-line alert band above an intact footer

### DIFF
--- a/apps/cli/src/commands/dashboard.ts
+++ b/apps/cli/src/commands/dashboard.ts
@@ -100,6 +100,9 @@ function toSidebar(b: ListedBox): SidebarBox {
     sessionTitle: agent.sessionTitle,
     index: b.projectIndex,
     project: b.projectRoot,
+    // Only claude reports an AskUserQuestion payload; gated on claudeActivity
+    // === 'question' upstream (lifecycle.listBoxes) so it's undefined otherwise.
+    claudeQuestion: b.claudeQuestion,
   };
 }
 

--- a/apps/cli/src/dashboard/compositor.ts
+++ b/apps/cli/src/dashboard/compositor.ts
@@ -21,7 +21,7 @@ import {
   ADVANCED_HINT_GROUPS,
   type SidebarBox,
 } from './sidebar.js';
-import { renderFooter } from '../wrapped-pty/footer.js';
+import { ALERT_BAND_ROWS, renderAlertBand, renderFooter } from '../wrapped-pty/footer.js';
 import { popTerminalTitle, pushTerminalTitle, setTerminalTitle } from '../terminal/title.js';
 import { postAnswer, subscribePrompts, type PromptStream } from '../wrapped-pty/prompt-client.js';
 import type { BoxNoticeEvent, PromptAskEvent } from '@agentbox/relay';
@@ -196,7 +196,10 @@ export class Compositor {
     initialId: string,
   ) {
     this.selectedId = initialId;
-    this.layout = computeLayout(this.out.columns ?? 100, this.out.rows ?? 30);
+    // Initial layout: no alert active yet (maps empty, no question payload),
+    // so requestedAlertH is 0; relayout() kicks in once SSE subscriptions
+    // populate or the poll fetches a question state.
+    this.layout = computeLayout(this.out.columns ?? 100, this.out.rows ?? 30, 0);
     this.parser = new InputParser({
       onEvent: (e) => {
         if (e.type === 'leader') {
@@ -322,7 +325,7 @@ export class Compositor {
         let changed = this.activePrompts.delete(boxId);
         if (this.activeNotices.delete(boxId)) changed = true;
         if (this.activeNotices.size === 0) this.stopNoticeSpinner();
-        if (changed) this.drawChrome();
+        if (changed) this.redrawForAlert();
       }
     }
     // Open subscriptions for boxes we don't already track.
@@ -334,21 +337,21 @@ export class Compositor {
         onPrompt: (ev) => {
           if (this.tornDown) return;
           this.activePrompts.set(boxId, ev);
-          this.drawChrome();
+          this.redrawForAlert();
         },
         onResolved: (id) => {
           if (this.tornDown) return;
           const current = this.activePrompts.get(boxId);
           if (current && current.id === id) {
             this.activePrompts.delete(boxId);
-            this.drawChrome();
+            this.redrawForAlert();
           }
         },
         onNotice: (ev) => {
           if (this.tornDown) return;
           this.activeNotices.set(boxId, ev);
           this.startNoticeSpinner();
-          this.drawChrome();
+          this.redrawForAlert();
         },
         onNoticeCleared: (id) => {
           if (this.tornDown) return;
@@ -356,7 +359,7 @@ export class Compositor {
           if (current && current.id === id) {
             this.activeNotices.delete(boxId);
             if (this.activeNotices.size === 0) this.stopNoticeSpinner();
-            this.drawChrome();
+            this.redrawForAlert();
           }
         },
         onError: () => {
@@ -388,9 +391,12 @@ export class Compositor {
   }
 
   private async poll(): Promise<void> {
-    const before = JSON.stringify(
-      this.boxes.map((b) => [b.id, b.state, b.activity, b.sessionTitle]),
-    );
+    const stateKey = (): string =>
+      JSON.stringify(
+        this.boxes.map((b) => [b.id, b.state, b.activity, b.sessionTitle]),
+      );
+    const before = stateKey();
+    const beforeAlertH = this.alertHeight();
     await this.refreshBoxes();
     if (this.busy) {
       // A start/shell action is mid-flight — don't yank the right pane.
@@ -410,11 +416,11 @@ export class Compositor {
         (this.lifecycleMenu != null && box?.state !== this.lifecycleMenu.state);
       if (reresolve) await this.spawnActive();
     }
-    if (
-      JSON.stringify(
-        this.boxes.map((b) => [b.id, b.state, b.activity, b.sessionTitle]),
-      ) !== before
-    ) {
+    const stateChanged = stateKey() !== before;
+    const alertChanged = this.alertHeight() !== beforeAlertH;
+    if (alertChanged) {
+      this.relayout();
+    } else if (stateChanged) {
       this.drawChrome();
     }
   }
@@ -476,7 +482,10 @@ export class Compositor {
       this.placeholder = target.lines;
     }
     this.prevRows = null;
-    this.drawChrome();
+    // Selection just changed (spawnActive → applyTarget) — the new box may
+    // have a different alert state than the previous one (prompt/notice/
+    // question), so reflow if the band height needs to flip.
+    if (!this.syncAlertLayout()) this.drawChrome();
     this.scheduleRender();
   }
 
@@ -1009,8 +1018,46 @@ export class Compositor {
     // Blue (SB_HEADER) so the whole right border matches the rounded header.
     for (let y = 0; y < sidebar.h; y++)
       s += cursorTo(sepX, y) + SB_HEADER + (y === 0 ? '╮' : '│') + SGR_RESET;
-    let status: string;
+    // Alert band: 3-line surface above the footer for the selected box's
+    // active relay prompt, notice (checkpoint), or claude AskUserQuestion.
+    // Painted only when `layout.alertH > 0`, which already gates on min size.
+    // Priority matches the wrapped-pty band: prompt > notice > question.
     const activePromptForSelected = this.activePrompts.get(this.selectedId);
+    const activeNoticeForSelected = this.activeNotices.get(this.selectedId);
+    if (this.layout.alertH > 0) {
+      const bandRows = this.layout.alertH;
+      let bandLines: string[] | null = null;
+      if (activePromptForSelected) {
+        bandLines = renderAlertBand(
+          { kind: 'prompt', prompt: activePromptForSelected },
+          this.layout.cols,
+          bandRows,
+        );
+      } else if (activeNoticeForSelected) {
+        bandLines = renderAlertBand(
+          { kind: 'notice', message: activeNoticeForSelected.message, frame: this.noticeFrame },
+          this.layout.cols,
+          bandRows,
+        );
+      } else {
+        const q = this.selectedBox()?.claudeQuestion;
+        if (q) {
+          bandLines = renderAlertBand({ kind: 'question', question: q }, this.layout.cols, bandRows);
+        }
+      }
+      if (bandLines) {
+        for (let i = 0; i < bandLines.length; i++) {
+          s += cursorTo(0, this.layout.alertY + i) + bandLines[i] + SGR_RESET;
+        }
+      }
+    }
+
+    // Footer (statusY row): stays at idle / pendingConfirm / flashMsg even when
+    // the band is showing prompt/notice/question above — keeps the calm status
+    // bar in place. Min-size fallback: when alertH was dropped to 0 by the
+    // layout but the selected box has an alert, surface the legacy
+    // prompt/notice replacement so a tiny terminal still shows the alert.
+    let status: string;
     if (this.pendingConfirm) {
       const w = this.layout.cols;
       const txt = ` Destroy ${this.pendingConfirm.name}?  y = confirm  ·  any other key = cancel `
@@ -1021,22 +1068,14 @@ export class Compositor {
       const w = this.layout.cols;
       const txt = ` ${this.flashMsg} `.slice(0, w).padEnd(w);
       status = `\x1b[7m${txt}\x1b[0m`;
-    } else if (activePromptForSelected) {
-      // Selected box has a pending relay prompt — reuse the wrapped-pty's
-      // `[!] <message>  <detail>  [y/N]` renderer so the two surfaces look
-      // identical. y/Y/Enter/n/N/Esc/Ctrl-c are intercepted in onEvent's
-      // forward branch above.
+    } else if (this.layout.alertH === 0 && activePromptForSelected) {
       status = renderFooter(
         { kind: 'prompt', prompt: activePromptForSelected },
         this.layout.cols,
       );
-    } else if (this.activeNotices.has(this.selectedId)) {
-      // Selected box is busy with a relay notice (e.g. checkpoint) — reuse
-      // the wrapped-pty's animated notice renderer. Informational, so it
-      // sits below a pending prompt in the priority chain.
-      const notice = this.activeNotices.get(this.selectedId)!;
+    } else if (this.layout.alertH === 0 && activeNoticeForSelected) {
       status = renderFooter(
-        { kind: 'notice', message: notice.message, frame: this.noticeFrame },
+        { kind: 'notice', message: activeNoticeForSelected.message, frame: this.noticeFrame },
         this.layout.cols,
       );
     } else {
@@ -1065,16 +1104,65 @@ export class Compositor {
     if (this.resizeTimer) clearTimeout(this.resizeTimer);
     this.resizeTimer = setTimeout(() => {
       this.resizeTimer = null;
-      this.layout = computeLayout(this.out.columns ?? 100, this.out.rows ?? 30);
-      this.prevRows = null;
-      const r = this.layout.right;
-      if (this.session && !this.layout.tooSmall) {
-        this.session.resize(Math.max(1, r.w), Math.max(1, r.h));
-      }
-      this.out.write(SYNC_BEGIN + '\x1b[2J' + SYNC_END);
-      this.drawChrome();
-      this.render();
+      this.relayout();
     }, RESIZE_DEBOUNCE_MS);
+  }
+
+  /**
+   * Requested band height for the currently-selected box. Returns
+   * `ALERT_BAND_ROWS` when the box has an active relay prompt, an active
+   * notice (checkpoint), or claude is in the `question` state with a payload;
+   * 0 otherwise. The layout silently drops the band to 0 if reserving it
+   * would push the right pane below MIN_RIGHT_H.
+   */
+  private alertHeight(): number {
+    const id = this.selectedId;
+    if (this.activePrompts.has(id)) return ALERT_BAND_ROWS;
+    if (this.activeNotices.has(id)) return ALERT_BAND_ROWS;
+    const box = this.selectedBox();
+    if (box?.claudeQuestion) return ALERT_BAND_ROWS;
+    return 0;
+  }
+
+  /**
+   * Recompute the layout against the current alert height, resize the inner
+   * session, and repaint. Called from `scheduleResize` (terminal resize) and
+   * from {@link syncAlertLayout} when the selected box's alert state flips.
+   */
+  private relayout(): void {
+    this.layout = computeLayout(
+      this.out.columns ?? 100,
+      this.out.rows ?? 30,
+      this.alertHeight(),
+    );
+    this.prevRows = null;
+    const r = this.layout.right;
+    if (this.session && !this.layout.tooSmall) {
+      this.session.resize(Math.max(1, r.w), Math.max(1, r.h));
+    }
+    this.out.write(SYNC_BEGIN + '\x1b[2J' + SYNC_END);
+    this.drawChrome();
+    this.render();
+  }
+
+  /**
+   * If the selected box's alert state implies a different band height than
+   * the current layout, run a full {@link relayout}; otherwise return false
+   * so the caller can take the lighter `drawChrome()` path. Used by all
+   * alert-state transitions (SSE handlers, poll, selection change).
+   */
+  private syncAlertLayout(): boolean {
+    if (this.alertHeight() !== this.layout.alertH) {
+      this.relayout();
+      return true;
+    }
+    return false;
+  }
+
+  /** Common path for alert-state transitions: relayout when the band's
+   *  visibility changes, drawChrome only when it doesn't. */
+  private redrawForAlert(): void {
+    if (!this.syncAlertLayout()) this.drawChrome();
   }
 
   private teardown(): void {

--- a/apps/cli/src/dashboard/layout.ts
+++ b/apps/cli/src/dashboard/layout.ts
@@ -15,6 +15,11 @@ export interface DashboardLayout {
   right: Rect;
   /** Full-width status line, single row at the bottom. */
   statusY: number;
+  /** Effective height of the 3-line alert band above the footer (0 when no
+   *  alert is active, or when the terminal is too small to host it). */
+  alertH: number;
+  /** Top row of the alert band (0-based). Equals `statusY` when alertH === 0. */
+  alertY: number;
   /** Right pane too small to host a usable terminal. */
   tooSmall: boolean;
 }
@@ -23,13 +28,28 @@ export const SIDEBAR_WIDTH = 33;
 const MIN_RIGHT_W = 20;
 const MIN_RIGHT_H = 4;
 
-export function computeLayout(cols: number, rows: number): DashboardLayout {
+/**
+ * Compute the screen layout. `requestedAlertH` is the desired band height
+ * (3 when the selected box has an active alert; 0 otherwise); the band is
+ * silently dropped to 0 if reserving it would push the right pane below
+ * `MIN_RIGHT_H`, keeping the inner PTY usable on tiny terminals.
+ */
+export function computeLayout(
+  cols: number,
+  rows: number,
+  requestedAlertH = 0,
+): DashboardLayout {
   const sidebarW = Math.min(SIDEBAR_WIDTH, Math.max(0, cols - MIN_RIGHT_W - 1));
   const sepX = sidebarW;
   const rightX = sidebarW + 1;
   const rightW = Math.max(0, cols - rightX);
   const statusY = rows - 1;
-  const paneH = Math.max(0, statusY); // rows above the status line
+  const desired = Math.max(0, requestedAlertH);
+  // Drop the band if it would starve the right pane; the compositor falls
+  // back to today's footer-replacement on this path so the alert isn't lost.
+  const alertH = statusY - desired >= MIN_RIGHT_H ? desired : 0;
+  const paneH = Math.max(0, statusY - alertH);
+  const alertY = statusY - alertH;
   return {
     cols,
     rows,
@@ -37,6 +57,8 @@ export function computeLayout(cols: number, rows: number): DashboardLayout {
     sepX,
     right: { x: rightX, y: 0, w: rightW, h: paneH },
     statusY,
+    alertH,
+    alertY,
     tooSmall: rightW < MIN_RIGHT_W || paneH < MIN_RIGHT_H,
   };
 }

--- a/apps/cli/src/dashboard/sidebar.ts
+++ b/apps/cli/src/dashboard/sidebar.ts
@@ -1,3 +1,5 @@
+import type { ClaudeQuestionPayload } from '@agentbox/ctl';
+
 export interface SidebarBox {
   id: string;
   name: string;
@@ -24,6 +26,10 @@ export interface SidebarBox {
    *  captured, freezing the box). Injected by the compositor; shown as
    *  `◆ checkpoint` in the activity cell. Outranked by `pendingPrompt`. */
   checkpointing?: boolean;
+  /** Last `AskUserQuestion` payload from the box's claude status; populated
+   *  only while `activity === 'question'`. The compositor renders it into the
+   *  alert band above the footer for the selected box. */
+  claudeQuestion?: ClaudeQuestionPayload;
 }
 
 /** Per-row ownership + styling map returned alongside the rendered lines so

--- a/apps/cli/src/wrapped-pty/footer.ts
+++ b/apps/cli/src/wrapped-pty/footer.ts
@@ -1,5 +1,6 @@
 import { BAR_BG, statusLine, type SidebarBox } from '../dashboard/sidebar.js';
 import type { PromptAskEvent } from '@agentbox/relay';
+import type { ClaudeQuestionPayload } from '@agentbox/ctl';
 
 /**
  * Footer rendering state. `idle` reuses the dashboard's `statusLine` shape
@@ -54,6 +55,10 @@ const URGENT = '\x1b[38;5;220m\x1b[1m'; // bright yellow + bold (active prompt)
 const TXT = '\x1b[38;5;250m'; // dim gray body text
 const SUBTLE = '\x1b[38;5;245m'; // very dim (Y/N hint)
 const RESET = '\x1b[0m';
+// Agent-question accent: cyan + bold, matching the dashboard sidebar's
+// "awaiting" hue — distinct from URGENT (relay prompt) so the two readings
+// don't collide when both could in principle stack.
+const QUESTION_ACCENT = '\x1b[38;5;51m\x1b[1m';
 // Notice footer = a full-width warning banner: bright yellow background with
 // near-black bold text. High contrast so the "box is frozen" state is
 // unmissable — deliberately louder than the dim-on-dark idle/prompt bars.
@@ -197,3 +202,127 @@ export const CURSOR_RESTORE = '\x1b8';
  */
 export const SYNC_BEGIN = '\x1b[?2026h';
 export const SYNC_END = '\x1b[?2026l';
+
+/**
+ * Alert-band state: the surface shown directly above the (idle) footer when
+ * a box needs the user's attention. The band is fixed at 3 rows; the inner
+ * PTY is resized down by 3 rows so the band never overlaps agent output.
+ *
+ * - `prompt`: a relay confirm prompt (hard-blocks an in-box RPC).
+ * - `notice`: an informational warning (checkpoint/snapshot in progress);
+ *   `frame` advances the spinner glyph.
+ * - `question`: the agent's `AskUserQuestion` payload (claude.state ===
+ *   'question'); shown as header + question text + option labels.
+ */
+export type AlertBandState =
+  | { kind: 'prompt'; prompt: PromptAskEvent }
+  | { kind: 'notice'; message: string; frame: number }
+  | { kind: 'question'; question: ClaudeQuestionPayload };
+
+/** Default band height; both TUIs reserve this many rows above the footer. */
+export const ALERT_BAND_ROWS = 3;
+
+function blankBar(cols: number, bg: string): string {
+  return `${bg}${' '.repeat(Math.max(0, cols))}${RESET}`;
+}
+
+function renderPromptBand(prompt: PromptAskEvent, cols: number, rows: number): string[] {
+  const def = prompt.defaultAnswer ?? 'n';
+  const yn = def === 'y' ? '[Y/n]' : '[y/N]';
+  const tag = ' [!] ';
+  const indent = ' '.repeat(tag.length);
+  const innerW = Math.max(0, cols - tag.length);
+  const contW = Math.max(0, cols - indent.length);
+
+  const msg = padTo(prompt.message, innerW);
+  const line1 = `${BAR_BG}${URGENT}${tag}${TXT}${msg}${RESET}`;
+
+  const detail = prompt.detail ?? '';
+  const detailPadded = padTo(detail, contW);
+  const line2 = `${BAR_BG}${TXT}${indent}${detailPadded}${RESET}`;
+
+  const hint = ` ${yn} `;
+  const leftW = Math.max(0, cols - hint.length);
+  const left = ' '.repeat(leftW);
+  const line3 = `${BAR_BG}${left}${SUBTLE}${hint}${RESET}`;
+
+  return [line1, line2, line3].slice(0, rows);
+}
+
+function renderNoticeBand(
+  message: string,
+  frame: number,
+  cols: number,
+  rows: number,
+): string[] {
+  const spinner = SPINNER_FRAMES[frame % SPINNER_FRAMES.length]!;
+  const prefix = ` ${spinner} `;
+  const indent = ' '.repeat(prefix.length);
+  const firstW = Math.max(0, cols - prefix.length);
+  const contW = Math.max(0, cols - indent.length);
+
+  const out: string[] = [];
+  let i = 0;
+  for (let r = 0; r < rows; r++) {
+    const isLast = r === rows - 1;
+    const w = r === 0 ? firstW : contW;
+    let cell: string;
+    if (i >= message.length) {
+      cell = ' '.repeat(w);
+    } else if (isLast) {
+      cell = padTo(message.slice(i), w);
+      i = message.length;
+    } else {
+      cell = message.slice(i, i + w).padEnd(w);
+      i += w;
+    }
+    const lead = r === 0 ? prefix : indent;
+    out.push(`${NOTICE_BG}${NOTICE_FG}${lead}${cell}${RESET}`);
+  }
+  return out;
+}
+
+function renderQuestionBand(
+  payload: ClaudeQuestionPayload,
+  cols: number,
+  rows: number,
+): string[] {
+  const q = payload.questions[0];
+  if (!q) return Array.from({ length: rows }, () => blankBar(cols, BAR_BG));
+
+  const tag = ' [?] ';
+  const indent = ' '.repeat(tag.length);
+  const innerW = Math.max(0, cols - tag.length);
+  const contW = Math.max(0, cols - indent.length);
+
+  const header = q.header && q.header.trim().length > 0 ? q.header : 'Question';
+  const headerPadded = padTo(header, innerW);
+  const line1 = `${BAR_BG}${QUESTION_ACCENT}${tag}${TXT}${headerPadded}${RESET}`;
+
+  const questionText = padTo(q.question, contW);
+  const line2 = `${BAR_BG}${TXT}${indent}${questionText}${RESET}`;
+
+  const optLabels = q.options.map((o) => o.label).join(' · ');
+  const optsLine = optLabels.length > 0 ? `options: ${optLabels}` : '';
+  const optsPadded = padTo(optsLine, contW);
+  const line3 = `${BAR_BG}${SUBTLE}${indent}${optsPadded}${RESET}`;
+
+  return [line1, line2, line3].slice(0, rows);
+}
+
+/**
+ * Render the 3-row alert band as an array of `rows` ANSI strings. Each
+ * element is a full-width painted row (background tint reset at EOL).
+ * Callers position the cursor at each row's column 1 and write the line
+ * inside the same synchronized-output wrap as the footer.
+ */
+export function renderAlertBand(
+  state: AlertBandState,
+  cols: number,
+  rows: number = ALERT_BAND_ROWS,
+): string[] {
+  if (cols <= 0 || rows <= 0) return Array.from({ length: Math.max(0, rows) }, () => '');
+  if (state.kind === 'prompt') return renderPromptBand(state.prompt, cols, rows);
+  if (state.kind === 'notice') return renderNoticeBand(state.message, state.frame, cols, rows);
+  return renderQuestionBand(state.question, cols, rows);
+}

--- a/apps/cli/src/wrapped-pty/run.ts
+++ b/apps/cli/src/wrapped-pty/run.ts
@@ -340,6 +340,10 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
       // resumes mid-animation when the prompt clears.
       if (bandState?.kind === 'notice') {
         bandState = { kind: 'notice', message: bandState.message, frame: noticeFrame };
+        // When the band is collapsed on a tiny terminal the notice renders
+        // through `footerState` instead, so re-derive it to pick up the new
+        // frame — otherwise the footer-fallback spinner glyph freezes.
+        if (bandReservedRows === 0) recomputeFooter();
         redrawChrome();
       }
     }, SPINNER_INTERVAL_MS);

--- a/apps/cli/src/wrapped-pty/run.ts
+++ b/apps/cli/src/wrapped-pty/run.ts
@@ -10,16 +10,20 @@ import {
   type LeaderAction,
 } from './input-router.js';
 import {
+  ALERT_BAND_ROWS,
   CURSOR_RESTORE,
   CURSOR_SAVE,
   cursorMoveTo,
+  renderAlertBand,
   renderFooter,
   SYNC_BEGIN,
   SYNC_END,
+  type AlertBandState,
   type FooterState,
 } from './footer.js';
 import { postAnswer, subscribePrompts, type PromptStream } from './prompt-client.js';
 import type { BoxNoticeEvent, PromptAskEvent } from '@agentbox/relay';
+import type { ClaudeQuestionPayload } from '@agentbox/ctl';
 
 export interface WrappedAttachOptions {
   /** Docker container name (only used for log lines). */
@@ -75,6 +79,10 @@ export interface WrappedAttachOptions {
 }
 
 const FOOTER_ROWS = 1;
+/** Min visible inner-PTY rows below which we collapse the band back into the
+ *  one-line footer (today's behavior). Keeps a tiny terminal usable instead of
+ *  driving the inner program to a 0-row pane. */
+const MIN_INNER_ROWS = 5;
 const STATUS_POLL_INTERVAL_MS = 3000;
 /** Spinner advance cadence while a `notice` footer is active. */
 const SPINNER_INTERVAL_MS = 120;
@@ -207,47 +215,63 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
   let footerState: FooterState = buildIdle();
   let lastSessionTitle: string | undefined;
   let lastActivity: string | undefined;
-  // Prompt + notice + flash are tracked independently of `footerState`;
-  // `recomputeFooter` derives the visible state (prompt > notice > flash > idle).
+  // Prompt + notice + question feed the alert band above the footer; flash +
+  // leader stay in the footer. `recomputeFooter` keeps the footer at idle/flash;
+  // `recomputeBand` derives the band visibility from prompt > notice > question.
   let capturingPrompt: PromptAskEvent | null = null;
   let activeNotice: BoxNoticeEvent | null = null;
   let noticeFrame = 0;
+  let questionPayload: ClaudeQuestionPayload | null = null;
+  let bandState: AlertBandState | null = null;
+  let bandReservedRows = 0; // 0 or ALERT_BAND_ROWS depending on band visibility
   let spinnerTimer: ReturnType<typeof setInterval> | null = null;
   // Transient confirmation shown after a Ctrl+a action fires.
   let flashMessage: string | null = null;
   let flashTimer: ReturnType<typeof setTimeout> | null = null;
 
+  /** Reserved rows above the inner pty: footer (always 1) + band (3 or 0). */
+  const reservedRows = (): number => FOOTER_ROWS + bandReservedRows;
+  /** Whether the current terminal has room for the band without collapsing
+   *  the inner pty below `MIN_INNER_ROWS`; gates the band on tiny terminals. */
+  const bandFits = (): boolean => {
+    const rs = process.stdout.rows ?? rows;
+    return rs - FOOTER_ROWS - ALERT_BAND_ROWS >= MIN_INNER_ROWS;
+  };
+
   // Lazy SGR mirror: when the inner pty's most recent attribute is bright
   // bold, our footer paint won't reset it correctly via the inner program's
-  // next byte. We always end the footer with SGR reset, but the inner
-  // program may be in the middle of a graphics run when the footer redraw
-  // happens — wrap the redraw in cursor save/restore + sync output so the
-  // inner program never sees our cursor moves and the user sees one atomic
-  // frame.
-  const redrawFooter = (): void => {
+  // next byte. We always end the chrome with SGR reset, but the inner program
+  // may be in the middle of a graphics run when the redraw happens — wrap the
+  // redraw in cursor save/restore + sync output so the inner program never
+  // sees our cursor moves and the user sees one atomic frame.
+  const redrawChrome = (): void => {
     const cs = process.stdout.columns ?? cols;
     const rs = process.stdout.rows ?? rows;
-    const line = renderFooter(footerState, cs);
-    // Position at the last row, then write. Save/restore around the lot so
-    // the inner pty's cursor doesn't move.
-    const payload =
-      SYNC_BEGIN +
-      CURSOR_SAVE +
-      cursorMoveTo(rs, 1) +
-      line +
-      CURSOR_RESTORE +
-      SYNC_END;
+    const footerLine = renderFooter(footerState, cs);
+    let payload = SYNC_BEGIN + CURSOR_SAVE;
+    if (bandReservedRows > 0 && bandState) {
+      const bandLines = renderAlertBand(bandState, cs, bandReservedRows);
+      for (let i = 0; i < bandLines.length; i++) {
+        const row = rs - FOOTER_ROWS - (bandLines.length - i);
+        payload += cursorMoveTo(row + 1, 1) + bandLines[i];
+      }
+    }
+    payload += cursorMoveTo(rs, 1) + footerLine + CURSOR_RESTORE + SYNC_END;
     process.stdout.write(payload);
   };
 
-  // Derive `footerState` from the current prompt / notice / flash / idle
-  // inputs. A pending prompt outranks a notice (it hard-blocks the box's
-  // RPC); a notice outranks a flash; a flash outranks idle. Called after any
-  // input changes.
+  // Derive `footerState` from flash > leader/idle. Prompt/notice/question are
+  // surfaced in the alert band above the footer (see `recomputeBand`); the
+  // footer keeps showing the calm status bar so the user always has context.
+  // **Min-size fallback**: when the band collapses on a tiny terminal
+  // (`bandReservedRows === 0` while `bandState != null`), prompt and notice
+  // fall back to the pre-band footer-replacement so they're not lost (the
+  // question state has no one-line footer renderer — sidebar marker only).
   const recomputeFooter = (): void => {
-    if (capturingPrompt) {
+    const collapsed = bandState !== null && bandReservedRows === 0;
+    if (collapsed && capturingPrompt) {
       footerState = { kind: 'prompt', prompt: capturingPrompt };
-    } else if (activeNotice) {
+    } else if (collapsed && activeNotice) {
       footerState = { kind: 'notice', message: activeNotice.message, frame: noticeFrame };
     } else if (flashMessage) {
       footerState = { kind: 'flash', message: flashMessage };
@@ -256,15 +280,67 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
     }
   };
 
+  // Derive the band's content + visibility from prompt > notice > question.
+  // Priority chain: a relay prompt hard-blocks an in-box RPC (most urgent);
+  // a notice means the box is frozen for a snapshot (loud animated banner);
+  // a question is the agent waiting for the user. When nothing is active the
+  // band collapses entirely.
+  const recomputeBand = (): void => {
+    if (capturingPrompt) {
+      bandState = { kind: 'prompt', prompt: capturingPrompt };
+    } else if (activeNotice) {
+      bandState = { kind: 'notice', message: activeNotice.message, frame: noticeFrame };
+    } else if (questionPayload) {
+      bandState = { kind: 'question', question: questionPayload };
+    } else {
+      bandState = null;
+    }
+  };
+
+  /** Resize the inner pty + reapply the scroll region for the current reserved
+   *  rows, then clear any rows that just changed ownership (the freed region
+   *  when the band collapses; the band area itself when it appears). Called
+   *  after `recomputeBand` whenever the band visibility flips. */
+  const relayoutForBand = (): void => {
+    const cs = process.stdout.columns ?? cols;
+    const rs = process.stdout.rows ?? rows;
+    const inner = Math.max(1, rs - reservedRows());
+    pty.resize(cs, inner);
+    process.stdout.write(`\x1b[1;${String(inner)}r`);
+    // Clear the chrome area (band + footer rows) so stale agent output left
+    // over from the previous scroll region doesn't show through under the
+    // newly painted band/footer.
+    let clear = SYNC_BEGIN + CURSOR_SAVE;
+    for (let r = inner + 1; r <= rs; r++) clear += cursorMoveTo(r, 1) + '\x1b[2K';
+    clear += CURSOR_RESTORE + SYNC_END;
+    process.stdout.write(clear);
+  };
+
+  /** Re-derive the band state and, if visibility changed, resize + reflow.
+   *  Always finishes with a chrome redraw so the band/footer are repainted.
+   *  Also re-derives the footer so the min-size fallback (prompt/notice in
+   *  the footer when the band collapses) keeps in sync. */
+  const applyBandChange = (): void => {
+    recomputeBand();
+    const wantRows = bandState && bandFits() ? ALERT_BAND_ROWS : 0;
+    if (wantRows !== bandReservedRows) {
+      bandReservedRows = wantRows;
+      relayoutForBand();
+    }
+    recomputeFooter();
+    redrawChrome();
+  };
+
   const startSpinner = (): void => {
     if (spinnerTimer) return;
     spinnerTimer = setInterval(() => {
       noticeFrame++;
-      // Only repaint while the notice is the visible state — if a prompt is
-      // covering it the frame still advances so it resumes mid-animation.
-      if (footerState.kind === 'notice') {
-        recomputeFooter();
-        redrawFooter();
+      // Advance the spinner frame whenever a notice is the live band; if the
+      // notice was outranked by a prompt the frame still advances so it
+      // resumes mid-animation when the prompt clears.
+      if (bandState?.kind === 'notice') {
+        bandState = { kind: 'notice', message: bandState.message, frame: noticeFrame };
+        redrawChrome();
       }
     }, SPINNER_INTERVAL_MS);
     if (typeof spinnerTimer.unref === 'function') spinnerTimer.unref();
@@ -289,7 +365,7 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
   // Apple Terminal/Ghostty).
   pty.onData((d: string) => {
     process.stdout.write(d);
-    redrawFooter();
+    redrawChrome();
   });
 
   // Ctrl+a leader chord map — keys mirror the dashboard's (`c`/`s`/`u`).
@@ -329,11 +405,11 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
       flashTimer = null;
       flashMessage = null;
       recomputeFooter();
-      redrawFooter();
+      redrawChrome();
     }, FLASH_DURATION_MS);
     if (typeof flashTimer.unref === 'function') flashTimer.unref();
     recomputeFooter();
-    redrawFooter();
+    redrawChrome();
   };
 
   // Ctrl+V image paste: hold a "Pasting image…" notice in the footer while the
@@ -348,7 +424,7 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
     }
     flashMessage = 'Pasting image…';
     recomputeFooter();
-    redrawFooter();
+    redrawChrome();
     let result: 'pasted' | 'no-image' | 'error' = 'error';
     try {
       result = await opts.onPasteImage();
@@ -365,11 +441,11 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
       flashTimer = null;
       flashMessage = null;
       recomputeFooter();
-      redrawFooter();
+      redrawChrome();
     }, FLASH_DURATION_MS);
     if (typeof flashTimer.unref === 'function') flashTimer.unref();
     recomputeFooter();
-    redrawFooter();
+    redrawChrome();
   };
 
   // Wire stdin -> pty (through the router so prompts + the leader can intercept).
@@ -383,14 +459,13 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
       // block the input flow on the network roundtrip.
       void postAnswer({ relayBaseUrl: opts.relayBaseUrl, body });
       capturingPrompt = null;
-      recomputeFooter();
-      redrawFooter();
+      applyBandChange();
     },
     leaderChords,
     onLeaderChange: (open) => {
       leaderActive = open;
       recomputeFooter();
-      redrawFooter();
+      redrawChrome();
     },
     onAction: (name) => {
       runAction(name);
@@ -405,16 +480,24 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
   };
   process.stdin.on('data', onStdinData);
 
-  // Resize: keep the pty one row shorter than the host terminal; the footer
-  // owns the last row directly. Re-apply the scroll region too — most
-  // terminals reset DECSTBM on resize.
+  // Resize: keep the pty `reservedRows` shorter than the host terminal; the
+  // footer owns the last row directly and the band (when active) owns the 3
+  // rows above it. Re-apply the scroll region too — most terminals reset
+  // DECSTBM on resize. The bandFits() check downgrades band → 0 if the new
+  // size is too small to host both.
   const onResize = (): void => {
     const cs = process.stdout.columns ?? cols;
     const rs = process.stdout.rows ?? rows;
-    const inner = Math.max(1, rs - FOOTER_ROWS);
+    // Re-evaluate band visibility against the new size first; a now-too-small
+    // terminal collapses the band, a now-big-enough one re-opens it. Refresh
+    // the footer so the collapsed-band fallback (prompt/notice in the footer)
+    // tracks the new reserve.
+    bandReservedRows = bandState && bandFits() ? ALERT_BAND_ROWS : 0;
+    const inner = Math.max(1, rs - reservedRows());
     pty.resize(cs, inner);
     process.stdout.write(`\x1b[1;${String(inner)}r`);
-    redrawFooter();
+    recomputeFooter();
+    redrawChrome();
   };
   process.stdout.on('resize', onResize);
 
@@ -424,10 +507,9 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
     boxId: opts.boxId,
     onPrompt: (ev: PromptAskEvent) => {
       capturingPrompt = ev;
-      recomputeFooter();
-      redrawFooter();
+      applyBandChange();
       // capture() returns a Promise that resolves with the answer body; the
-      // input-router's onAnswer callback already POSTs and resets the footer.
+      // input-router's onAnswer callback already POSTs and resets the band.
       // We just need to await so unhandled rejections (router.abort) don't
       // crash the process.
       router.capture(ev).catch((e: unknown) => {
@@ -440,26 +522,23 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
       });
     },
     onResolved: (id: string) => {
-      // Clear footer if it's still showing this id (sibling wrapper won).
+      // Clear band if it's still showing this id (sibling wrapper won).
       if (capturingPrompt && capturingPrompt.id === id) {
         capturingPrompt = null;
         router.abort('resolved-elsewhere');
-        recomputeFooter();
-        redrawFooter();
+        applyBandChange();
       }
     },
     onNotice: (ev: BoxNoticeEvent) => {
       activeNotice = ev;
       startSpinner();
-      recomputeFooter();
-      redrawFooter();
+      applyBandChange();
     },
     onNoticeCleared: (id: string) => {
       if (activeNotice && activeNotice.id === id) {
         activeNotice = null;
         stopSpinner();
-        recomputeFooter();
-        redrawFooter();
+        applyBandChange();
       }
     },
   });
@@ -495,12 +574,27 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
         lastEmittedTitle = desiredTitle;
         setTerminalTitle(desiredTitle);
       }
+      // Surface claude's AskUserQuestion payload to the band when the agent
+      // is in `question` state; clear it on any other state. Only meaningful
+      // for claude mode (codex/opencode have no question payload). The band's
+      // priority chain (`recomputeBand`) demotes question below prompt/notice,
+      // so it only shows when nothing more urgent is pending.
+      const nextQuestion =
+        opts.mode === 'claude' && status?.claude.state === 'question'
+          ? (status.claude.question ?? null)
+          : null;
+      const questionChanged =
+        (nextQuestion?.capturedAt ?? null) !== (questionPayload?.capturedAt ?? null);
+      if (questionChanged) {
+        questionPayload = nextQuestion;
+        applyBandChange();
+      }
       if (nextTitle === lastSessionTitle && nextActivity === lastActivity) return;
       lastSessionTitle = nextTitle;
       lastActivity = nextActivity;
       if (footerState.kind === 'idle') {
         recomputeFooter();
-        redrawFooter();
+        redrawChrome();
       }
     } catch (e) {
       // readBoxStatus already swallows the common cases (paused/stopped/pre-feature);
@@ -533,7 +627,7 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
   }
 
   // Initial paint so the idle footer appears immediately.
-  redrawFooter();
+  redrawChrome();
 
   // Wait for the pty to exit, then tear down everything.
   const exitCode = await new Promise<number>((resolve) => {
@@ -556,13 +650,14 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
   const csFinal = process.stdout.columns ?? cols;
   // Clear the scroll region first so the cursor moves below can reach row N
   // without the terminal trying to keep them inside the smaller region.
-  // Then move to the footer row, erase it, return the cursor.
-  process.stdout.write(
-    '\x1b[r' +
-      cursorMoveTo(rsFinal, 1) +
-      `\x1b[2K` +
-      cursorMoveTo(rsFinal, csFinal),
-  );
+  // Then erase every row owned by chrome (band + footer) so a stale band
+  // doesn't sit above the next shell prompt; return the cursor afterwards.
+  let teardownPaint = '\x1b[r';
+  for (let r = rsFinal - bandReservedRows; r <= rsFinal; r++) {
+    if (r >= 1) teardownPaint += cursorMoveTo(r, 1) + '\x1b[2K';
+  }
+  teardownPaint += cursorMoveTo(rsFinal, csFinal);
+  process.stdout.write(teardownPaint);
   // Restore the host terminal/tab title we saved at attach time.
   popTerminalTitle();
 

--- a/apps/cli/test/layout.test.ts
+++ b/apps/cli/test/layout.test.ts
@@ -25,4 +25,30 @@ describe('computeLayout', () => {
     expect(l.sidebar.w).toBeLessThan(SIDEBAR_WIDTH);
     expect(l.right.w).toBeGreaterThanOrEqual(0);
   });
+
+  it('reserves a 3-row alert band when requested', () => {
+    const l = computeLayout(120, 40, 3);
+    expect(l.alertH).toBe(3);
+    // alertY is the band's top row; right.h shrinks by the band height.
+    expect(l.alertY).toBe(36);
+    expect(l.right.h).toBe(36);
+    expect(l.sidebar.h).toBe(36);
+    // The footer row itself is unchanged.
+    expect(l.statusY).toBe(39);
+  });
+
+  it('omits the alert band when no height is requested', () => {
+    const l = computeLayout(120, 40);
+    expect(l.alertH).toBe(0);
+    expect(l.alertY).toBe(l.statusY);
+    expect(l.right.h).toBe(39);
+  });
+
+  it('drops the band to 0 when the terminal cannot host it (min-size fallback)', () => {
+    // statusY = 5, MIN_RIGHT_H = 4 → reserving 3 would leave paneH = 2 < 4,
+    // so the band collapses and the right pane keeps its full height.
+    const l = computeLayout(120, 6, 3);
+    expect(l.alertH).toBe(0);
+    expect(l.right.h).toBe(5);
+  });
 });

--- a/apps/cli/test/wrapped-pty/footer.test.ts
+++ b/apps/cli/test/wrapped-pty/footer.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { renderFooter, type FooterState } from '../../src/wrapped-pty/footer.js';
+import {
+  ALERT_BAND_ROWS,
+  renderAlertBand,
+  renderFooter,
+  type AlertBandState,
+  type FooterState,
+} from '../../src/wrapped-pty/footer.js';
 
 /**
  * Strip ANSI SGR/CSI sequences for human-readable assertions on the
@@ -225,5 +231,77 @@ describe('renderFooter — edge cases', () => {
     expect(renderFooter({ kind: 'notice', message: 'm', frame: 0 }, 80)).toMatch(
       /\x1b\[0m$/,
     );
+  });
+});
+
+describe('renderAlertBand', () => {
+  it('renders a prompt band as 3 rows with [!] tag, detail row, and right-aligned [y/N] hint', () => {
+    const state: AlertBandState = {
+      kind: 'prompt',
+      prompt: {
+        id: '1',
+        kind: 'confirm',
+        message: 'git push to origin',
+        detail: 'branch: agentbox/foo',
+      },
+    };
+    const lines = renderAlertBand(state, 80);
+    expect(lines).toHaveLength(ALERT_BAND_ROWS);
+    const visibleLines = lines.map(visible);
+    expect(visibleLines[0]).toContain('[!]');
+    expect(visibleLines[0]).toContain('git push to origin');
+    expect(visibleLines[1]).toContain('branch: agentbox/foo');
+    expect(visibleLines[2]).toContain('[y/N]');
+  });
+
+  it('renders a notice band with a spinner glyph + message, all rows on the yellow banner', () => {
+    const state: AlertBandState = {
+      kind: 'notice',
+      message: 'Checkpoint in progress — capturing box state…',
+      frame: 0,
+    };
+    const lines = renderAlertBand(state, 80);
+    expect(lines).toHaveLength(ALERT_BAND_ROWS);
+    const visibleLines = lines.map(visible);
+    // First line carries the spinner; full message visible somewhere in the band.
+    expect(visibleLines[0]).toMatch(/[◐◑◒◓]/);
+    expect(visibleLines.join(' ')).toContain('Checkpoint in progress');
+    // Every row should set the yellow background (NOTICE_BG = SGR 48;5;220).
+    for (const line of lines) expect(line).toContain('\x1b[48;5;220m');
+  });
+
+  it('renders a question band with header + question text + option labels', () => {
+    const state: AlertBandState = {
+      kind: 'question',
+      question: {
+        questions: [
+          {
+            question: 'Scope',
+            header: 'Which TUI?',
+            options: [{ label: 'Single-attach' }, { label: 'Dashboard' }, { label: 'Both' }],
+          },
+        ],
+        capturedAt: '2026-05-29T00:00:00Z',
+      },
+    };
+    const lines = renderAlertBand(state, 80);
+    expect(lines).toHaveLength(ALERT_BAND_ROWS);
+    const visibleLines = lines.map(visible);
+    expect(visibleLines[0]).toContain('[?]');
+    expect(visibleLines[0]).toContain('Which TUI?');
+    expect(visibleLines[1]).toContain('Scope');
+    expect(visibleLines[2]).toContain('Single-attach');
+    expect(visibleLines[2]).toContain('Dashboard');
+    expect(visibleLines[2]).toContain('Both');
+  });
+
+  it('honors a custom row count', () => {
+    const state: AlertBandState = {
+      kind: 'notice',
+      message: 'short',
+      frame: 0,
+    };
+    expect(renderAlertBand(state, 80, 1)).toHaveLength(1);
+    expect(renderAlertBand(state, 80, 5)).toHaveLength(5);
   });
 });

--- a/packages/sandbox-docker/src/lifecycle.ts
+++ b/packages/sandbox-docker/src/lifecycle.ts
@@ -3,7 +3,12 @@ import { readdir, rm, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { BoxState } from '@agentbox/core';
 import { AmbiguousBoxError, BoxNotFoundError } from '@agentbox/core';
-import type { AgentActivityState, BoxStatus, ClaudeActivityState } from '@agentbox/ctl';
+import type {
+  AgentActivityState,
+  BoxStatus,
+  ClaudeActivityState,
+  ClaudeQuestionPayload,
+} from '@agentbox/ctl';
 import { claudeSessionInfo, SHARED_CLAUDE_VOLUME, type ClaudeSessionInfo } from './claude.js';
 import { codexSessionInfo, SHARED_CODEX_VOLUME, type CodexSessionInfo } from './codex.js';
 import {
@@ -78,6 +83,10 @@ export interface ListedBox extends BoxRecord {
   claudeActivity?: ClaudeActivityState;
   /** Sanitized in-box terminal title Claude set; undefined when none. */
   claudeSessionTitle?: string;
+  /** Last captured `AskUserQuestion` payload — present only when
+   *  `claudeActivity === 'question'`. Surfaced to the dashboard so it can paint
+   *  the agent's question into the alert band above the footer. */
+  claudeQuestion?: ClaudeQuestionPayload;
   /** Codex activity from the persisted status file (Codex hooks); undefined when none. */
   codexActivity?: AgentActivityState;
   /** Sanitized in-box terminal title the Codex/OpenCode TUI set; undefined when none. */
@@ -152,6 +161,8 @@ export async function listBoxes(): Promise<ListedBox[]> {
           endpoints,
           claudeActivity: persisted?.claude.state,
           claudeSessionTitle: persisted?.claude.sessionTitle,
+          claudeQuestion:
+            persisted?.claude.state === 'question' ? persisted.claude.question : undefined,
           codexActivity: persisted?.codex?.state,
           codexSessionTitle: persisted?.codex?.sessionTitle,
           opencodeSessionTitle: persisted?.opencode?.sessionTitle,
@@ -179,6 +190,8 @@ export async function listBoxes(): Promise<ListedBox[]> {
         endpoints,
         claudeActivity: persisted?.claude.state,
         claudeSessionTitle: persisted?.claude.sessionTitle,
+        claudeQuestion:
+          persisted?.claude.state === 'question' ? persisted.claude.question : undefined,
         codexActivity: persisted?.codex?.state,
         codexSessionTitle: persisted?.codex?.sessionTitle,
         opencodeSessionTitle: persisted?.opencode?.sessionTitle,

--- a/packages/sandbox-vercel/test/push-credentials.test.ts
+++ b/packages/sandbox-vercel/test/push-credentials.test.ts
@@ -75,7 +75,9 @@ describe('vercelBackend.provision — per-box credential push', () => {
     expect(writeFiles).toHaveBeenCalledTimes(3);
     expect(runCommand).toHaveBeenCalledTimes(3);
 
-    const remotes = writeFiles.mock.calls.map((c) => (c[0] as Array<{ path: string }>)[0].path);
+    const remotes = (writeFiles.mock.calls as unknown as Array<[Array<{ path: string }>]>).map(
+      (c) => c[0][0]!.path,
+    );
     expect(remotes).toEqual([
       '/tmp/agentbox-claude-creds.tar.gz',
       '/tmp/agentbox-codex-creds.tar.gz',
@@ -83,7 +85,9 @@ describe('vercelBackend.provision — per-box credential push', () => {
     ]);
 
     // Each extract targets the matching ~/.agentbox-creds/<kind> dest.
-    const extracts = runCommand.mock.calls.map((c) => (c[0] as { args: string[] }).args[1]);
+    const extracts = (runCommand.mock.calls as unknown as Array<[{ args: string[] }]>).map(
+      (c) => c[0].args[1],
+    );
     expect(extracts[0]).toContain('/home/vscode/.agentbox-creds/claude');
     expect(extracts[1]).toContain('/home/vscode/.agentbox-creds/codex');
     expect(extracts[2]).toContain('/home/vscode/.agentbox-creds/opencode');
@@ -118,7 +122,7 @@ describe('vercelBackend.provision — per-box credential push', () => {
     stage.opencode.mockResolvedValue(stageResult(null));
 
     const logs: string[] = [];
-    const handle = await vercelBackend.provision({ name: 'box-1', onLog: (l) => logs.push(l) } as never);
+    const handle = await vercelBackend.provision({ name: 'box-1', onLog: (l: string) => logs.push(l) } as never);
     expect(handle).toEqual({ sandboxId: 'box-1' });
     expect(logs.some((l) => l.includes('claude credential extract failed'))).toBe(true);
   });
@@ -131,7 +135,7 @@ describe('vercelBackend.provision — per-box credential push', () => {
     stage.opencode.mockResolvedValue(stageResult(null));
 
     const logs: string[] = [];
-    const handle = await vercelBackend.provision({ name: 'box-1', onLog: (l) => logs.push(l) } as never);
+    const handle = await vercelBackend.provision({ name: 'box-1', onLog: (l: string) => logs.push(l) } as never);
     expect(handle).toEqual({ sandboxId: 'box-1' });
     expect(logs.some((l) => l.includes('agent credential push failed'))).toBe(true);
   });


### PR DESCRIPTION
## Summary

- Surfaces relay confirm prompts (`git push [y/N]`), checkpoint/snapshot notices, and the agent's `AskUserQuestion` payload in a fixed 3-line alert band directly above the footer instead of overwriting the status line. The inner PTY genuinely shrinks (resize + scroll-region reflow) so the band never overlaps agent output.
- Applies consistently to both interactive TUIs: the single-attach wrapped-pty (`agentbox claude` / `codex` / `opencode` / `shell`) and the multi-box `dashboard`. Min-size fallback collapses the band back to the legacy one-line footer-replacement on too-short terminals, so the alert is never lost.
- Plumbs `ClaudeQuestionPayload` from `BoxStatus.claude.question` through `ListedBox` and `SidebarBox` so the dashboard can paint the agent's question for the selected box (previously only sidebar markers were available).

## Test plan

- [x] `pnpm -w build`, `pnpm lint`, `pnpm -r test` — 355 tests pass (+7 new: 3 layout `alertH` math, 4 `renderAlertBand` prompt/notice/question/row-count).
- [x] Visual rendering of each band kind + idle footer (`renderAlertBand` at 80 cols and 40 cols narrow + 1-row degraded) — `[!]` yellow prompt with `[y/N]`, yellow notice banner with spinner, cyan `[?]` question with options.
- [x] Dashboard boots cleanly via the `pnpm drive` PTY harness (idle footer intact, resize redraws).
- [ ] End-to-end on a docker box (host-only): trigger a `git push` from inside a box → confirm 3-line band above intact footer, PTY visibly 3 rows shorter, `y`/`n` still answers, band clears, PTY grows back.
- [ ] End-to-end checkpoint notice: `agentbox checkpoint <box>` → animated 3-line yellow banner; clears on done.
- [ ] End-to-end agent question: drive Claude to `AskUserQuestion` → cyan question band with header + question + option labels.
- [ ] Same checks on the multi-box `dashboard`: right pane shrinks for the selected box's alert and grows back on selection change.
- [ ] Narrow/short terminal: band collapses to the legacy footer-replacement, PTY stays usable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches interactive terminal layout, PTY sizing, and resize/reflow paths in two TUIs; mitigated by min-size fallbacks and new unit tests, but end-to-end TUI behavior still needs manual verification.
> 
> **Overview**
> Adds a **fixed 3-line alert band** above the normal status footer in both the **wrapped attach** TUI and the **multi-box dashboard**, so relay confirms, checkpoint notices, and Claude **AskUserQuestion** no longer replace the idle status line.
> 
> The inner PTY / right pane **actually loses three rows** (`computeLayout` + PTY resize + scroll region) so alerts never overlap agent output. **Priority** is prompt → notice → question; the footer stays the calm **agentbox** bar unless the terminal is too short, when prompt/notice **fall back** to the old one-line footer rendering.
> 
> **`renderAlertBand`** in `footer.ts` centralizes the three-row UI (shared with single-attach). **`claudeQuestion`** is threaded from `listBoxes` / `ListedBox` into the dashboard sidebar for the selected box.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98be6855184f59da82940d392dce885e10880e86. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->