### PR TITLE
feat(cli): add agentbox install wizard and agentbox doctor

### DIFF
--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -1,0 +1,70 @@
+/**
+ * `agentbox doctor` — full system + provider compatibility report.
+ *
+ * Reuses the shared probes in `../lib/doctor-checks.ts`. `agentbox install`
+ * runs the same checks for its compact one-line summary; doctor prints the
+ * full grouped detail. Exits non-zero only on a hard failure (Node too old,
+ * `~/.agentbox` not writable) — "provider not set up" stays exit 0 since
+ * that is the expected pre-onboarding state.
+ */
+
+import { Command } from 'commander';
+import {
+  formatDetailed,
+  runAllChecks,
+  runProviderChecks,
+  runSystemChecks,
+  worstStatus,
+  type CheckGroup,
+  type ProviderName,
+} from '../lib/doctor-checks.js';
+import { isKnownProvider } from '../provider/registry.js';
+
+interface DoctorOptions {
+  provider?: string;
+}
+
+export const doctorCommand = new Command('doctor')
+  .description(
+    'Diagnose system compatibility and provider readiness (Node, git, ssh, Docker daemon, provider credentials, prepared snapshots).',
+  )
+  .option(
+    '-p, --provider <name>',
+    'limit checks to one provider (docker | daytona | hetzner | vercel)',
+  )
+  .action(async (opts: DoctorOptions) => {
+    let groups: CheckGroup[];
+    if (opts.provider) {
+      const name = opts.provider.trim();
+      if (!isKnownProvider(name)) {
+        process.stderr.write(
+          'error: --provider must be one of: docker, daytona, hetzner, vercel\n',
+        );
+        process.exit(1);
+      }
+      groups = [
+        { title: 'system', results: await runSystemChecks() },
+        await runProviderChecks(name as ProviderName),
+      ];
+    } else {
+      groups = await runAllChecks();
+    }
+
+    process.stdout.write(formatDetailed(groups).join('\n') + '\n');
+
+    const worst = worstStatus(groups);
+    if (worst === 'fail') {
+      process.stdout.write(
+        '\nOne or more required checks failed. Fix the FAIL items above before continuing.\n',
+      );
+      process.exit(1);
+    }
+    if (worst === 'warn') {
+      process.stdout.write(
+        '\nWarnings are providers that need setup. Run `agentbox install` to configure one,\n' +
+          'or `agentbox prepare --status` to see remote snapshot inventory.\n',
+      );
+    } else {
+      process.stdout.write('\nAll checks passed.\n');
+    }
+  });

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -250,9 +250,10 @@ function isProviderName(s: string): s is ProviderName {
 
 /**
  * Drive the setup wizard. Returns true on a clean run, false if the user
- * cancelled at any prompt (the caller decides whether to write the marker —
- * for the explicit `install` command we record completion even on cancel
- * mid-flow, for the auto-trigger we do not).
+ * cancelled at any prompt. The first-run marker is written only on the
+ * success path (after the skill-install step), so a cancel from either
+ * caller leaves the system in the same "still pending" state — the
+ * auto-trigger will offer the wizard again on the next non-exempt command.
  */
 export async function runInstallWizard(opts: RunInstallWizardOptions = {}): Promise<boolean> {
   if (!ensureTty()) return false;

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -1,9 +1,38 @@
-import { intro, log, outro } from '@clack/prompts';
+/**
+ * `agentbox install` — interactive setup wizard:
+ *
+ *   1. Compact system compatibility check (one line).
+ *   2. Provider picker (single-select; docker default).
+ *   3. Provider login (skipped for docker; reuses each provider's existing
+ *      `ensure*Credentials` flow, including Vercel's "install sandbox CLI
+ *      then browser login" handling).
+ *   4. Confirm-then-run base image / snapshot prepare (default-yes for docker).
+ *   5. Install the host `/agentbox` skill files into Claude / Codex / OpenCode.
+ *   6. Write the first-run marker.
+ *   7. Tutorial outro.
+ *
+ * `--skills-only` runs just step 5 (the pre-wizard behavior of this command).
+ *
+ * `runInstallWizard` is also called from `index.ts` as a first-run auto-trigger
+ * when `~/.agentbox/setup-complete.json` is absent.
+ */
+
+import { confirm, intro, isCancel, log, note, outro, select, spinner } from '@clack/prompts';
 import { Command } from 'commander';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  formatCompact,
+  runProviderChecks,
+  runSystemChecks,
+  type CheckGroup,
+  type CheckResult,
+  type ProviderName,
+} from '../lib/doctor-checks.js';
+import { markSetupComplete } from '../lib/first-run.js';
+import { runPrepare } from './prepare.js';
 
 /** Marker on the line after the frontmatter of every skill we ship. Its
  *  presence in an existing target means we wrote it and may overwrite freely. */
@@ -15,20 +44,12 @@ const MANAGED_SENTINEL = '<!-- agentbox-managed:v1 -->';
 const LEGACY_INFO_MARKER = 'Drive AgentBox from the host:';
 
 interface InstallTarget {
-  /** Path relative to the bundled `share/host-skills/` dir. */
   src: string;
-  /** Absolute destination on the host. */
   dest: string;
-  /** When set, install only if this directory exists — i.e. the tool is set up
-   *  on this host. Absent dir = silently skip (don't write configs for a tool
-   *  the user doesn't use). */
+  /** Only install when this dir exists (i.e. the tool is set up on this host). */
   gateDir?: string;
 }
 
-/** The files `agentbox install` writes. Claude skills always install; the Codex
- *  prompt and OpenCode command install only when that tool's config dir exists.
- *  All three surface the same `/agentbox` fork command in their respective
- *  agent UIs (Codex shows it under `/prompts:`). */
 function installTargets(): InstallTarget[] {
   const home = homedir();
   const claudeSkills = join(home, '.claude', 'skills');
@@ -57,8 +78,8 @@ function installTargets(): InstallTarget[] {
 function resolveHostSkillsDir(): string {
   const here = dirname(fileURLToPath(import.meta.url));
   const candidates = [
-    resolve(here, '..', 'share', 'host-skills'), // bundled: dist/ -> ../share
-    resolve(here, '..', '..', 'share', 'host-skills'), // src: src/commands/ -> ../../share
+    resolve(here, '..', 'share', 'host-skills'),
+    resolve(here, '..', '..', 'share', 'host-skills'),
   ];
   for (const c of candidates) {
     if (existsSync(c)) return c;
@@ -68,13 +89,6 @@ function resolveHostSkillsDir(): string {
   );
 }
 
-interface InstallOptions {
-  force?: boolean;
-  dryRun?: boolean;
-}
-
-/** Decide whether we may write `target`. Missing or AgentBox-managed/legacy
- *  files are writable; a user-authored file is left alone unless --force. */
 function writableReason(target: string, force: boolean): 'new' | 'managed' | 'forced' | 'skip' {
   if (!existsSync(target)) return 'new';
   const existing = readFileSync(target, 'utf8');
@@ -84,61 +98,339 @@ function writableReason(target: string, force: boolean): 'new' | 'managed' | 'fo
   return force ? 'forced' : 'skip';
 }
 
+export interface InstallHostSkillsOptions {
+  force?: boolean;
+  dryRun?: boolean;
+  /** When true, suppress per-file log lines (the wizard wants one-line outcome). */
+  quiet?: boolean;
+}
+
+export interface InstallHostSkillsResult {
+  written: string[];
+  skipped: number;
+  /** Files that exist but were untouched because they're user-authored. */
+  blocked: string[];
+}
+
+/** Idempotent copy of the bundled host skill files. Used by both
+ *  `agentbox install --skills-only` and the wizard. */
+export function installHostSkills(opts: InstallHostSkillsOptions = {}): InstallHostSkillsResult {
+  const force = opts.force === true;
+  const dryRun = opts.dryRun === true;
+  const quiet = opts.quiet === true;
+  const srcDir = resolveHostSkillsDir();
+
+  const written: string[] = [];
+  const blocked: string[] = [];
+  let skipped = 0;
+
+  for (const t of installTargets()) {
+    const src = join(srcDir, t.src);
+    if (!existsSync(src)) {
+      if (!quiet) log.warn(`bundled file missing (skipped): ${src}`);
+      skipped++;
+      continue;
+    }
+    if (t.gateDir && !existsSync(t.gateDir)) continue;
+    const reason = writableReason(t.dest, force);
+    if (reason === 'skip') {
+      if (!quiet) log.warn(`user-modified file at ${t.dest}, skipping; pass --force to overwrite`);
+      blocked.push(t.dest);
+      skipped++;
+      continue;
+    }
+    if (dryRun) {
+      if (!quiet) log.info(`would write ${t.dest} (${reason})`);
+      written.push(t.dest);
+      continue;
+    }
+    mkdirSync(dirname(t.dest), { recursive: true });
+    writeFileSync(t.dest, readFileSync(src, 'utf8'));
+    written.push(t.dest);
+  }
+
+  return { written, skipped, blocked };
+}
+
+const PROVIDER_HINTS: Record<ProviderName, string> = {
+  docker: 'builds a ~1GB local image; no login needed',
+  hetzner: 'paste an API token from the Hetzner Console',
+  daytona: 'approve a browser sign-in link',
+  vercel: 'installs the Vercel sandbox CLI, then a browser sign-in',
+};
+
+const PROVIDER_LABEL: Record<ProviderName, string> = {
+  docker: 'Docker (local)',
+  hetzner: 'Hetzner (cloud VPS)',
+  daytona: 'Daytona (cloud sandbox)',
+  vercel: 'Vercel (cloud microVM)',
+};
+
+function ensureTty(): boolean {
+  if (process.stdin.isTTY && process.stdout.isTTY) return true;
+  process.stderr.write(
+    'agentbox install: an interactive terminal is required. ' +
+      'Run `agentbox <provider> login` and `agentbox prepare --provider <name>` instead.\n',
+  );
+  return false;
+}
+
+interface RunInstallWizardOptions {
+  /** Pre-pick the provider (skips the picker). */
+  provider?: string;
+  /** Auto-confirm the prepare step. */
+  yes?: boolean;
+  /** Forwarded to the embedded skill-copy step. */
+  force?: boolean;
+  dryRun?: boolean;
+  /** Set when the wizard was triggered automatically before another command. */
+  fromAutoTrigger?: boolean;
+}
+
+async function runProviderLogin(name: ProviderName): Promise<boolean> {
+  if (name === 'docker') return true;
+  if (name === 'daytona') {
+    const mod = await import('@agentbox/sandbox-daytona');
+    const status = await mod.getDaytonaStatus();
+    if (status.configured) {
+      log.info('daytona: already configured');
+      const rotate = await confirm({ message: 'Re-authenticate Daytona?', initialValue: false });
+      if (isCancel(rotate)) return false;
+      if (rotate) await mod.ensureDaytonaCredentials({ force: true });
+      return true;
+    }
+    await mod.ensureDaytonaCredentials();
+    return true;
+  }
+  if (name === 'hetzner') {
+    const mod = await import('@agentbox/sandbox-hetzner');
+    const status = mod.readHetznerCredStatus();
+    if (status.source !== 'none') {
+      log.info('hetzner: already configured');
+      const rotate = await confirm({ message: 'Re-authenticate Hetzner?', initialValue: false });
+      if (isCancel(rotate)) return false;
+      if (rotate) await mod.ensureHetznerCredentials({ force: true });
+      return true;
+    }
+    await mod.ensureHetznerCredentials();
+    return true;
+  }
+  // vercel
+  const mod = await import('@agentbox/sandbox-vercel');
+  const status = mod.readVercelCredStatus();
+  if (status.auth !== 'none') {
+    log.info(`vercel: already configured (${status.auth})`);
+    const rotate = await confirm({ message: 'Re-authenticate Vercel?', initialValue: false });
+    if (isCancel(rotate)) return false;
+    if (rotate) await mod.ensureVercelCredentials({ force: true });
+    return true;
+  }
+  await mod.ensureVercelCredentials();
+  return true;
+}
+
+function tutorialBody(provider: ProviderName): string {
+  // Docker is the default provider, so the prefix is implicit; the cloud
+  // providers need the explicit `agentbox <provider> claude` shorthand.
+  const startCmd = provider === 'docker' ? 'agentbox claude' : `agentbox ${provider} claude`;
+  return (
+    `Get started:\n` +
+    `  ${startCmd}        # or codex, opencode\n` +
+    `  Ctrl+a d                          # detach from the box\n` +
+    `  agentbox claude attach            # resume it later\n` +
+    `  agentbox install                  # set up another provider`
+  );
+}
+
+const KNOWN_PROVIDERS: ProviderName[] = ['docker', 'hetzner', 'daytona', 'vercel'];
+
+function isProviderName(s: string): s is ProviderName {
+  return (KNOWN_PROVIDERS as readonly string[]).includes(s);
+}
+
+/**
+ * Drive the setup wizard. Returns true on a clean run, false if the user
+ * cancelled at any prompt (the caller decides whether to write the marker —
+ * for the explicit `install` command we record completion even on cancel
+ * mid-flow, for the auto-trigger we do not).
+ */
+export async function runInstallWizard(opts: RunInstallWizardOptions = {}): Promise<boolean> {
+  if (!ensureTty()) return false;
+
+  intro('AgentBox setup');
+
+  // 1) Compact system check (full detail lives in `agentbox doctor`).
+  const sysResults = await runSystemChecks();
+  const sysGroup: CheckGroup = { title: 'system', results: sysResults };
+  process.stdout.write('  ' + formatCompact([sysGroup]) + '\n');
+  const hardFail = sysResults.find((r: CheckResult) => r.status === 'fail');
+  if (hardFail) {
+    log.error(`system check failed: ${hardFail.label} — ${hardFail.detail}`);
+    log.info('run `agentbox doctor` for full detail');
+    const cont = await confirm({ message: 'Continue anyway?', initialValue: false });
+    if (isCancel(cont) || !cont) {
+      outro('aborted');
+      return false;
+    }
+  } else {
+    log.info('run `agentbox doctor` for the full per-check report');
+  }
+
+  // 2) Provider picker.
+  let providerName: ProviderName;
+  if (opts.provider) {
+    const candidate = opts.provider.trim();
+    if (!isProviderName(candidate)) {
+      log.error(`unknown --provider: ${candidate}`);
+      return false;
+    }
+    providerName = candidate;
+  } else {
+    const picked = await select<ProviderName>({
+      message: 'Which provider do you want to set up?',
+      initialValue: 'docker',
+      options: KNOWN_PROVIDERS.map((p) => ({
+        value: p,
+        label: PROVIDER_LABEL[p],
+        hint: PROVIDER_HINTS[p],
+      })),
+    });
+    if (isCancel(picked)) {
+      outro('cancelled');
+      return false;
+    }
+    providerName = picked;
+  }
+
+  // 3) Login (skip docker).
+  if (providerName !== 'docker') {
+    const loggedIn = await runProviderLogin(providerName);
+    if (!loggedIn) {
+      outro('cancelled');
+      return false;
+    }
+  }
+
+  // 4) Optional remote/build prepare.
+  const prepareMsg =
+    providerName === 'docker'
+      ? 'Build the box image now? (~1GB, a few minutes)'
+      : `Bake the ${providerName} base snapshot now? (a few minutes, uses cloud time)`;
+  const wantPrepare = opts.yes
+    ? true
+    : await confirm({ message: prepareMsg, initialValue: true });
+  if (isCancel(wantPrepare)) {
+    outro('cancelled');
+    return false;
+  }
+  if (wantPrepare) {
+    try {
+      await runPrepare(providerName, {
+        cwd: process.cwd(),
+        yes: true,
+        suppressStatus: true,
+        suppressTip: true,
+      });
+    } catch (err) {
+      log.warn(
+        `prepare failed: ${err instanceof Error ? err.message : String(err)} — you can rerun \`agentbox prepare --provider ${providerName}\` later`,
+      );
+    }
+  } else {
+    log.info(
+      `skipped — the ${providerName} base will build lazily on first \`agentbox ${providerName === 'docker' ? '' : providerName + ' '}create\``,
+    );
+  }
+
+  // 5) Host /agentbox skill (idempotent).
+  const sp = spinner();
+  sp.start('installing host /agentbox skill…');
+  let skillRes: InstallHostSkillsResult;
+  try {
+    skillRes = installHostSkills({ force: opts.force, dryRun: opts.dryRun, quiet: true });
+    if (skillRes.written.length > 0) {
+      sp.stop(`host skill: wrote ${String(skillRes.written.length)} file(s)`);
+    } else {
+      sp.stop(`host skill: nothing to write (${String(skillRes.skipped)} skipped)`);
+    }
+    if (skillRes.blocked.length > 0) {
+      log.warn(
+        `user-modified host skill file(s) left in place: ${skillRes.blocked.join(', ')}\n` +
+          'pass `agentbox install --skills-only --force` to overwrite',
+      );
+    }
+  } catch (err) {
+    sp.stop('host skill: failed');
+    log.warn(err instanceof Error ? err.message : String(err));
+  }
+
+  // 6) First-run marker (so the auto-trigger doesn't fire again).
+  markSetupComplete(providerName);
+
+  // 7) Tutorial outro.
+  note(tutorialBody(providerName), 'Next steps');
+
+  // Brief check post-setup so the user sees what's now ready.
+  const providerGroup = await runProviderChecks(providerName);
+  process.stdout.write('  ' + formatCompact([sysGroup, providerGroup]) + '\n');
+
+  outro(
+    opts.fromAutoTrigger
+      ? 'Setup complete — continuing with your command…'
+      : 'Setup complete',
+  );
+  return true;
+}
+
+interface InstallOptions {
+  skillsOnly?: boolean;
+  force?: boolean;
+  dryRun?: boolean;
+  provider?: string;
+  yes?: boolean;
+}
+
 export const installCommand = new Command('install')
   .description(
-    "Install AgentBox's host-side /agentbox fork command into Claude (~/.claude/skills), and — when detected — into Codex (~/.codex/prompts) and OpenCode (~/.config/opencode/commands). Idempotent.",
+    'Interactive setup wizard: system check, pick a provider, log in, prepare its base image/snapshot, and install the host /agentbox skill. `--skills-only` runs just the skill install.',
   )
-  .option('--force', 'overwrite existing files even if not AgentBox-managed')
+  .option('--skills-only', 'only install the host /agentbox skill files (no wizard, no login, no prepare)')
+  .option('--force', 'overwrite existing skill files even if not AgentBox-managed')
   .option('--dry-run', 'print what would be written without changing anything')
-  .action((opts: InstallOptions) => {
-    intro('Installing AgentBox host commands...');
-    const force = opts.force === true;
-    const dryRun = opts.dryRun === true;
-
-    let srcDir: string;
-    try {
-      srcDir = resolveHostSkillsDir();
-    } catch (err) {
-      log.error(err instanceof Error ? err.message : String(err));
-      process.exit(1);
-    }
-
-    const written: string[] = [];
-    let skipped = 0;
-
-    for (const t of installTargets()) {
-      const src = join(srcDir, t.src);
-      if (!existsSync(src)) {
-        log.warn(`bundled file missing (skipped): ${src}`);
-        skipped++;
-        continue;
+  .option(
+    '-p, --provider <name>',
+    'pre-select the provider to set up (docker | daytona | hetzner | vercel)',
+  )
+  .option('-y, --yes', 'auto-confirm the prepare step')
+  .action(async (opts: InstallOptions) => {
+    if (opts.skillsOnly) {
+      intro('Installing AgentBox host commands...');
+      let res: InstallHostSkillsResult;
+      try {
+        res = installHostSkills({ force: opts.force, dryRun: opts.dryRun });
+      } catch (err) {
+        log.error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
       }
-      // Tool not set up on this host — skip silently (don't seed configs for a
-      // tool the user doesn't use).
-      if (t.gateDir && !existsSync(t.gateDir)) continue;
-      const reason = writableReason(t.dest, force);
-      if (reason === 'skip') {
-        log.warn(`user-modified file at ${t.dest}, skipping; pass --force to overwrite`);
-        skipped++;
-        continue;
+      if (opts.dryRun) {
+        outro(
+          `dry-run: ${String(res.written.length)} file(s) would be written, ${String(res.skipped)} skipped`,
+        );
+        return;
       }
-      if (dryRun) {
-        log.info(`would write ${t.dest} (${reason})`);
-        written.push(t.dest);
-        continue;
+      if (res.written.length === 0) {
+        outro(`nothing installed (${String(res.skipped)} skipped)`);
+        return;
       }
-      mkdirSync(dirname(t.dest), { recursive: true });
-      writeFileSync(t.dest, readFileSync(src, 'utf8'));
-      written.push(t.dest);
-    }
-
-    if (dryRun) {
-      outro(`dry-run: ${String(written.length)} file(s) would be written, ${String(skipped)} skipped`);
+      outro(`installed: ${res.written.join(', ')}`);
       return;
     }
-    if (written.length === 0) {
-      outro(`nothing installed (${String(skipped)} skipped)`);
-      return;
-    }
-    outro(`installed: ${written.join(', ')}`);
+
+    const ok = await runInstallWizard({
+      provider: opts.provider,
+      yes: opts.yes,
+      force: opts.force,
+      dryRun: opts.dryRun,
+    });
+    if (!ok) process.exit(1);
   });

--- a/apps/cli/src/commands/prepare.ts
+++ b/apps/cli/src/commands/prepare.ts
@@ -309,15 +309,15 @@ export const prepareCommand = new Command('prepare')
 
     const providerName = opts.provider.trim();
     intro(`preparing ${providerName} base image`);
-    try {
-      await runPrepare(providerName, {
-        name: opts.name,
-        force: opts.force,
-        yes: opts.yes,
-      });
-    } catch {
-      process.exit(1);
-    }
+    // Errors propagate to `program.parseAsync().catch` so they reach the user
+    // via `console.error` — a bare `catch { process.exit(1) }` here would
+    // silently swallow getProvider() failures (e.g. an ensureCredentials cancel)
+    // that fall outside runPrepare's inner spinner error handler.
+    await runPrepare(providerName, {
+      name: opts.name,
+      force: opts.force,
+      yes: opts.yes,
+    });
   });
 
 /**

--- a/apps/cli/src/commands/prepare.ts
+++ b/apps/cli/src/commands/prepare.ts
@@ -195,6 +195,96 @@ async function showStatus(opts: { onlyProvider?: string }): Promise<void> {
   process.stdout.write(lines.join('\n') + '\n');
 }
 
+export interface RunPrepareOptions {
+  /** Snapshot name (Daytona only). */
+  name?: string;
+  /** Rebuild even if the image / snapshot already exists. */
+  force?: boolean;
+  /** Skip the Daytona cost-notice. */
+  yes?: boolean;
+  /** Host workspace dir (defaults to `process.cwd()`). */
+  cwd?: string;
+  /** Suppress the closing skill-install tip (the install wizard already does its own skill step). */
+  suppressTip?: boolean;
+  /** Suppress the post-prepare status block. */
+  suppressStatus?: boolean;
+}
+
+/**
+ * Run `provider.prepare` for `providerName`. Extracted so the install wizard
+ * can drive the same code path as `agentbox prepare --provider X`.
+ * Caller is responsible for any `intro(...)` framing; this function manages
+ * its own spinner inside.
+ */
+export async function runPrepare(providerName: string, opts: RunPrepareOptions = {}): Promise<void> {
+  if (!isKnownProvider(providerName)) {
+    process.stderr.write(
+      'error: --provider must be one of: docker, daytona, hetzner, vercel\n',
+    );
+    process.exit(1);
+  }
+
+  if (providerName === 'daytona' && !opts.yes && process.stdin.isTTY) {
+    process.stdout.write(
+      'This will trigger a Daytona image build (~7 min cold, ~seconds with cache) and ' +
+        'register a named snapshot in your org.\n' +
+        'Re-run with --yes to skip this notice.\n',
+    );
+  }
+
+  const provider = await getProvider(providerName);
+  if (typeof provider.prepare !== 'function') {
+    log.error(`provider '${providerName}' does not implement prepare`);
+    process.exit(1);
+  }
+
+  const cwd = opts.cwd ?? process.cwd();
+  const sp = spinner();
+  sp.start(`preparing ${providerName}…`);
+  try {
+    const result = await provider.prepare({
+      name: opts.name,
+      hostWorkspace: cwd,
+      force: opts.force,
+      onLog: (line) => sp.message(line.slice(0, 80)),
+    });
+    if (result.snapshotName !== undefined) {
+      sp.stop(`prepared ${providerName}: snapshot '${result.snapshotName}'`);
+      try {
+        const written = await setConfigValue(
+          'project',
+          'box.image',
+          result.snapshotName,
+          cwd,
+        );
+        log.success(`box.image = ${result.snapshotName} (written to ${written.path})`);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.warn(
+          `prepared snapshot '${result.snapshotName}', but failed to pin it into the project config: ${msg}\n` +
+            `Run \`agentbox config set --project box.image ${result.snapshotName}\` manually.`,
+        );
+      }
+    } else {
+      sp.stop(`prepared ${providerName}`);
+    }
+
+    if (!opts.suppressStatus) {
+      process.stdout.write('\n');
+      await showStatus({ onlyProvider: providerName });
+    }
+    if (!opts.suppressTip) {
+      log.info(
+        'tip: install the agentbox host skill so Claude Code on this machine can drive AgentBox for you:\n' +
+          '  npx skills add https://github.com/madarco/agentbox --skill agentbox',
+      );
+    }
+  } catch (err) {
+    sp.stop(`prepare failed: ${describeError(err)}`);
+    throw err;
+  }
+}
+
 export const prepareCommand = new Command('prepare')
   .description(
     'Build base sandbox images / snapshots, or show what is already prepared across providers.',
@@ -218,67 +308,14 @@ export const prepareCommand = new Command('prepare')
     }
 
     const providerName = opts.provider.trim();
-    if (!isKnownProvider(providerName)) {
-      process.stderr.write(
-        `error: --provider must be one of: docker, daytona, hetzner\n`,
-      );
-      process.exit(1);
-    }
-
     intro(`preparing ${providerName} base image`);
-    if (providerName === 'daytona' && !opts.yes && process.stdin.isTTY) {
-      process.stdout.write(
-        'This will trigger a Daytona image build (~7 min cold, ~seconds with cache) and ' +
-          'register a named snapshot in your org.\n' +
-          'Re-run with --yes to skip this notice.\n',
-      );
-    }
-
-    const provider = await getProvider(providerName);
-    if (typeof provider.prepare !== 'function') {
-      log.error(`provider '${providerName}' does not implement prepare`);
-      process.exit(1);
-    }
-
-    const sp = spinner();
-    sp.start(`preparing ${providerName}…`);
     try {
-      const result = await provider.prepare({
+      await runPrepare(providerName, {
         name: opts.name,
-        hostWorkspace: process.cwd(),
         force: opts.force,
-        onLog: (line) => sp.message(line.slice(0, 80)),
+        yes: opts.yes,
       });
-      if (result.snapshotName !== undefined) {
-        sp.stop(`prepared ${providerName}: snapshot '${result.snapshotName}'`);
-        try {
-          const written = await setConfigValue(
-            'project',
-            'box.image',
-            result.snapshotName,
-            process.cwd(),
-          );
-          log.success(`box.image = ${result.snapshotName} (written to ${written.path})`);
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          log.warn(
-            `prepared snapshot '${result.snapshotName}', but failed to pin it into the project config: ${msg}\n` +
-              `Run \`agentbox config set --project box.image ${result.snapshotName}\` manually.`,
-          );
-        }
-      } else {
-        sp.stop(`prepared ${providerName}`);
-      }
-
-      // Show the relevant status section after a successful prepare.
-      process.stdout.write('\n');
-      await showStatus({ onlyProvider: providerName });
-      log.info(
-        'tip: install the agentbox host skill so Claude Code on this machine can drive AgentBox for you:\n' +
-          '  npx skills add https://github.com/madarco/agentbox --skill agentbox',
-      );
-    } catch (err) {
-      sp.stop(`prepare failed: ${describeError(err)}`);
+    } catch {
       process.exit(1);
     }
   });

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -34,7 +34,9 @@ import { destroyCommand } from './commands/destroy.js';
 import { downloadCommand } from './commands/download.js';
 import { driveCommand } from './commands/drive.js';
 import { forkCommand } from './commands/fork.js';
-import { installCommand } from './commands/install.js';
+import { installCommand, runInstallWizard } from './commands/install.js';
+import { doctorCommand } from './commands/doctor.js';
+import { isFirstRun } from './lib/first-run.js';
 import { gitCommand } from './commands/git.js';
 import { listCommand } from './commands/list.js';
 import { logsCommand } from './commands/logs.js';
@@ -110,13 +112,54 @@ program.addCommand(vercelCommand);
 program.addCommand(dockerCommand);
 program.addCommand(updateCommand);
 program.addCommand(installCommand);
+program.addCommand(doctorCommand);
 
 program.configureHelp({ visibleCommands: () => [] });
 program.addHelpText('after', () => '\n' + buildGroupedHelp(program));
 
 await applyEngineOverrideAtStartup();
 
-program.parseAsync(rewriteProviderPrefix(process.argv)).catch((err: unknown) => {
+const argv = rewriteProviderPrefix(process.argv);
+
+// First-run auto-trigger: if the user has never completed `agentbox install`,
+// drop them through the wizard before running their actual command, then
+// fall through. Skipped for the wizard / doctor themselves, for help/version,
+// for internal/background workers, and any non-TTY invocation (CI must not
+// hang on a prompt — they get the existing per-provider credential errors).
+const FIRST_RUN_EXEMPT = new Set([
+  'install',
+  'doctor',
+  'help',
+  'relay',
+  '_run-queued-job',
+  'drive',
+  'screen',
+]);
+
+function isFirstRunHookEligible(args: readonly string[]): boolean {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return false;
+  const rest = args.slice(2);
+  if (rest.length === 0) return false;
+  for (const a of rest) {
+    if (a === '--help' || a === '-h' || a === '--version' || a === '-V') return false;
+  }
+  const first = rest[0];
+  if (typeof first !== 'string' || first.startsWith('-')) return false;
+  if (FIRST_RUN_EXEMPT.has(first)) return false;
+  return true;
+}
+
+if (isFirstRun() && isFirstRunHookEligible(argv)) {
+  try {
+    await runInstallWizard({ fromAutoTrigger: true });
+  } catch (err) {
+    process.stderr.write(
+      `install wizard failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+}
+
+program.parseAsync(argv).catch((err: unknown) => {
   console.error(err);
   process.exit(1);
 });

--- a/apps/cli/src/lib/doctor-checks.ts
+++ b/apps/cli/src/lib/doctor-checks.ts
@@ -1,0 +1,400 @@
+/**
+ * Shared compatibility/status checks consumed by `agentbox doctor` (full
+ * detail) and `agentbox install` (compact one-line summary).
+ *
+ * All probes are local, read-only, and offline-safe — they never call out to
+ * a cloud API. Remote snapshot inventory lives in `agentbox prepare --status`.
+ */
+
+import { accessSync, constants as fsConstants, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { execa } from 'execa';
+
+export type CheckStatus = 'ok' | 'warn' | 'fail';
+
+export interface CheckResult {
+  label: string;
+  status: CheckStatus;
+  detail: string;
+  hint?: string;
+}
+
+export interface CheckGroup {
+  /** Group title: 'system' | 'docker' | 'daytona' | 'hetzner' | 'vercel'. */
+  title: string;
+  results: CheckResult[];
+}
+
+export type ProviderName = 'docker' | 'daytona' | 'hetzner' | 'vercel';
+
+const ALL_PROVIDERS: ProviderName[] = ['docker', 'daytona', 'hetzner', 'vercel'];
+const NODE_MIN_MAJOR = 20;
+const NODE_MIN_MINOR = 10;
+
+async function probeVersion(bin: string, args: string[] = ['--version']): Promise<string | null> {
+  try {
+    const r = await execa(bin, args, { reject: false });
+    if (r.exitCode !== 0) return null;
+    const out = `${r.stdout ?? ''}${r.stderr ?? ''}`.trim().split('\n')[0] ?? '';
+    return out.length > 0 ? out : bin;
+  } catch {
+    return null;
+  }
+}
+
+function parseNodeMajorMinor(v: string): [number, number] {
+  const m = /^v?(\d+)\.(\d+)/.exec(v);
+  if (!m) return [0, 0];
+  return [Number(m[1]), Number(m[2])];
+}
+
+function firstLine(s: string): string {
+  const i = s.indexOf('\n');
+  return i === -1 ? s : s.slice(0, i);
+}
+
+function errSummary(err: unknown): string {
+  return err instanceof Error ? firstLine(err.message) : String(err);
+}
+
+function checkNode(): CheckResult {
+  const v = process.versions.node;
+  const [maj, min] = parseNodeMajorMinor(v);
+  const ok = maj > NODE_MIN_MAJOR || (maj === NODE_MIN_MAJOR && min >= NODE_MIN_MINOR);
+  return {
+    label: 'node',
+    status: ok ? 'ok' : 'fail',
+    detail: ok ? `v${v}` : `v${v} (need >=${String(NODE_MIN_MAJOR)}.${String(NODE_MIN_MINOR)})`,
+    hint: ok ? undefined : 'upgrade Node before continuing',
+  };
+}
+
+function checkPlatform(): CheckResult {
+  return { label: 'platform', status: 'ok', detail: `${process.platform}/${process.arch}` };
+}
+
+function checkAgentboxHome(): CheckResult {
+  const dir = join(homedir(), '.agentbox');
+  try {
+    mkdirSync(dir, { recursive: true });
+    accessSync(dir, fsConstants.W_OK);
+    return { label: '~/.agentbox', status: 'ok', detail: dir };
+  } catch (err) {
+    return {
+      label: '~/.agentbox',
+      status: 'fail',
+      detail: `not writable: ${err instanceof Error ? err.message : String(err)}`,
+      hint: 'check directory permissions',
+    };
+  }
+}
+
+async function checkGit(): Promise<CheckResult> {
+  const v = await probeVersion('git');
+  return v
+    ? { label: 'git', status: 'ok', detail: v }
+    : {
+        label: 'git',
+        status: 'warn',
+        detail: 'not found',
+        hint: 'install git — required for the workspace git-bundle seed',
+      };
+}
+
+async function checkSsh(): Promise<CheckResult> {
+  // ssh -V prints to stderr; probeVersion concatenates both streams.
+  const v = await probeVersion('ssh', ['-V']);
+  return v
+    ? { label: 'ssh', status: 'ok', detail: v }
+    : {
+        label: 'ssh',
+        status: 'warn',
+        detail: 'not found',
+        hint: 'install ssh — required for hetzner and cloud attach',
+      };
+}
+
+export async function runSystemChecks(): Promise<CheckResult[]> {
+  const [git, ssh] = await Promise.all([checkGit(), checkSsh()]);
+  return [checkNode(), checkPlatform(), checkAgentboxHome(), git, ssh];
+}
+
+async function dockerChecks(): Promise<CheckResult[]> {
+  const cli = await probeVersion('docker');
+  if (!cli) {
+    return [
+      {
+        label: 'docker cli',
+        status: 'warn',
+        detail: 'not found',
+        hint: 'install Docker Desktop, OrbStack, or docker engine',
+      },
+    ];
+  }
+  const cliRes: CheckResult = { label: 'docker cli', status: 'ok', detail: cli };
+
+  // Daemon reachability via `docker info` (same probe pattern as
+  // packages/sandbox-docker/src/docker.ts:dockerInfo).
+  const info = await execa('docker', ['info'], { reject: false });
+  if (info.exitCode !== 0) {
+    return [
+      cliRes,
+      {
+        label: 'docker daemon',
+        status: 'warn',
+        detail: 'unreachable',
+        hint: 'start Docker (Desktop / OrbStack / `systemctl start docker`)',
+      },
+    ];
+  }
+  const daemonRes: CheckResult = { label: 'docker daemon', status: 'ok', detail: 'reachable' };
+
+  // Probe the base image + shared volumes. Lazy-import to keep the docker
+  // package off the hot path for non-docker users.
+  const mod = await import('@agentbox/sandbox-docker');
+  let imgRes: CheckResult;
+  try {
+    const img = await mod.imageInfo(mod.DEFAULT_BOX_IMAGE);
+    imgRes = img.exists
+      ? { label: 'box image', status: 'ok', detail: `${mod.DEFAULT_BOX_IMAGE} built` }
+      : {
+          label: 'box image',
+          status: 'warn',
+          detail: `${mod.DEFAULT_BOX_IMAGE} not built`,
+          hint: 'run `agentbox prepare --provider docker` (or let the wizard do it)',
+        };
+  } catch (err) {
+    imgRes = {
+      label: 'box image',
+      status: 'warn',
+      detail: errSummary(err),
+    };
+  }
+
+  const volNames = [mod.SHARED_CLAUDE_VOLUME, mod.SHARED_CODEX_VOLUME, mod.SHARED_OPENCODE_VOLUME];
+  const vols = await Promise.all(
+    volNames.map(async (n) => ({ name: n, exists: await mod.volumeExists(n).catch(() => false) })),
+  );
+  const present = vols.filter((v) => v.exists).length;
+  const volRes: CheckResult = {
+    label: 'shared volumes',
+    status: 'ok',
+    detail: `${String(present)}/${String(vols.length)} present (seeded lazily)`,
+  };
+
+  return [cliRes, daemonRes, imgRes, volRes];
+}
+
+async function daytonaChecks(): Promise<CheckResult[]> {
+  try {
+    const mod = await import('@agentbox/sandbox-daytona');
+    const status = await mod.getDaytonaStatus();
+    if (!status.configured) {
+      return [
+        {
+          label: 'credentials',
+          status: 'warn',
+          detail: status.reason ?? 'not configured',
+          hint: '`agentbox daytona login`',
+        },
+      ];
+    }
+    const credRes: CheckResult = { label: 'credentials', status: 'ok', detail: 'configured' };
+    const snapRes: CheckResult =
+      status.snapshots.length > 0
+        ? {
+            label: 'base snapshot',
+            status: 'ok',
+            detail: `${String(status.snapshots.length)} agentbox snapshot(s)`,
+          }
+        : {
+            label: 'base snapshot',
+            status: 'warn',
+            detail: 'none',
+            hint: '`agentbox prepare --provider daytona`',
+          };
+    return [credRes, snapRes];
+  } catch (err) {
+    return [
+      {
+        label: 'credentials',
+        status: 'warn',
+        detail: errSummary(err),
+      },
+    ];
+  }
+}
+
+async function hetznerChecks(): Promise<CheckResult[]> {
+  try {
+    const mod = await import('@agentbox/sandbox-hetzner');
+    const cred = mod.readHetznerCredStatus();
+    const credRes: CheckResult =
+      cred.source === 'none'
+        ? {
+            label: 'credentials',
+            status: 'warn',
+            detail: 'HCLOUD_TOKEN not set',
+            hint: '`agentbox hetzner login`',
+          }
+        : { label: 'credentials', status: 'ok', detail: `token from ${cred.source}` };
+
+    const prepared = mod.readPreparedState();
+    const snapRes: CheckResult = prepared.base?.imageId
+      ? {
+          label: 'base snapshot',
+          status: 'ok',
+          detail: `image ${String(prepared.base.imageId)} (${prepared.base.cliVersion ?? '—'})`,
+        }
+      : {
+          label: 'base snapshot',
+          status: 'warn',
+          detail: 'not baked',
+          hint: '`agentbox prepare --provider hetzner`',
+        };
+    return [credRes, snapRes];
+  } catch (err) {
+    return [
+      {
+        label: 'credentials',
+        status: 'warn',
+        detail: errSummary(err),
+      },
+    ];
+  }
+}
+
+async function vercelChecks(): Promise<CheckResult[]> {
+  try {
+    const mod = await import('@agentbox/sandbox-vercel');
+    const cred = mod.readVercelCredStatus();
+    const credRes: CheckResult =
+      cred.auth === 'none'
+        ? {
+            label: 'credentials',
+            status: 'warn',
+            detail: 'not configured',
+            hint: '`agentbox vercel login`',
+          }
+        : {
+            label: 'credentials',
+            status: 'ok',
+            detail: `${cred.auth} (${cred.source})`,
+          };
+
+    const prepared = mod.readPreparedState();
+    const snapRes: CheckResult = prepared.base?.snapshotId
+      ? {
+          label: 'base snapshot',
+          status: 'ok',
+          detail: `${prepared.base.snapshotId.slice(0, 16)}… (${prepared.base.cliVersion ?? '—'})`,
+        }
+      : {
+          label: 'base snapshot',
+          status: 'warn',
+          detail: 'not baked',
+          hint: '`agentbox prepare --provider vercel`',
+        };
+    return [credRes, snapRes];
+  } catch (err) {
+    return [
+      {
+        label: 'credentials',
+        status: 'warn',
+        detail: errSummary(err),
+      },
+    ];
+  }
+}
+
+export async function runProviderChecks(name: ProviderName): Promise<CheckGroup> {
+  let results: CheckResult[];
+  switch (name) {
+    case 'docker':
+      results = await dockerChecks();
+      break;
+    case 'daytona':
+      results = await daytonaChecks();
+      break;
+    case 'hetzner':
+      results = await hetznerChecks();
+      break;
+    case 'vercel':
+      results = await vercelChecks();
+      break;
+  }
+  return { title: name, results };
+}
+
+export async function runAllChecks(): Promise<CheckGroup[]> {
+  const sys: CheckGroup = { title: 'system', results: await runSystemChecks() };
+  const providerGroups = await Promise.all(ALL_PROVIDERS.map((n) => runProviderChecks(n)));
+  return [sys, ...providerGroups];
+}
+
+function worstInResults(results: CheckResult[]): CheckStatus {
+  let worst: CheckStatus = 'ok';
+  for (const r of results) {
+    if (r.status === 'fail') return 'fail';
+    if (r.status === 'warn') worst = 'warn';
+  }
+  return worst;
+}
+
+export function worstStatus(groups: CheckGroup[]): CheckStatus {
+  let worst: CheckStatus = 'ok';
+  for (const g of groups) {
+    const w = worstInResults(g.results);
+    if (w === 'fail') return 'fail';
+    if (w === 'warn') worst = 'warn';
+  }
+  return worst;
+}
+
+function summaryToken(group: CheckGroup): string {
+  const worst = worstInResults(group.results);
+  if (group.title === 'system') {
+    if (worst === 'fail') return 'system FAIL';
+    if (worst === 'warn') return 'system warn';
+    return 'system ok';
+  }
+  if (worst === 'fail') return `${group.title} FAIL`;
+  if (worst === 'warn') {
+    // Distinguish "not configured" (warn on credentials) from other warns.
+    const cred = group.results.find((r) => r.label === 'credentials');
+    if (cred && cred.status === 'warn') return `${group.title} login needed`;
+    return `${group.title} not prepared`;
+  }
+  return `${group.title} ready`;
+}
+
+/** One-line summary used by the `install` wizard. */
+export function formatCompact(groups: CheckGroup[]): string {
+  return groups.map(summaryToken).join(' · ');
+}
+
+function pad(s: string, width: number): string {
+  return s.length >= width ? s : s + ' '.repeat(width - s.length);
+}
+
+function statusBadge(s: CheckStatus): string {
+  if (s === 'ok') return '[ ok ]';
+  if (s === 'warn') return '[warn]';
+  return '[FAIL]';
+}
+
+/** Multi-line grouped report used by `agentbox doctor`. */
+export function formatDetailed(groups: CheckGroup[]): string[] {
+  const lines: string[] = [];
+  for (const g of groups) {
+    if (lines.length > 0) lines.push('');
+    lines.push(`${g.title}:`);
+    for (const r of g.results) {
+      const badge = statusBadge(r.status);
+      const tail = r.hint ? `  (${r.hint})` : '';
+      lines.push(`  ${badge} ${pad(r.label, 18)} ${r.detail}${tail}`);
+    }
+  }
+  return lines;
+}

--- a/apps/cli/src/lib/first-run.ts
+++ b/apps/cli/src/lib/first-run.ts
@@ -1,0 +1,39 @@
+/**
+ * First-run detection for the `agentbox install` auto-trigger in `index.ts`.
+ *
+ * We can't rely on bare `~/.agentbox` existence — other flows (provider
+ * `login`, `~/.agentbox/logs/...`) create it lazily — so we write a dedicated
+ * marker at the end of a successful wizard run. Marker absent ⇒ first run.
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+const MARKER_VERSION = 1 as const;
+
+export function setupMarkerPath(): string {
+  return join(homedir(), '.agentbox', 'setup-complete.json');
+}
+
+export function isFirstRun(): boolean {
+  return !existsSync(setupMarkerPath());
+}
+
+export interface SetupMarker {
+  version: typeof MARKER_VERSION;
+  completedAt: string;
+  /** Provider the user picked during the wizard run that wrote the marker. */
+  provider?: string;
+}
+
+export function markSetupComplete(provider?: string): void {
+  const path = setupMarkerPath();
+  mkdirSync(dirname(path), { recursive: true });
+  const body: SetupMarker = {
+    version: MARKER_VERSION,
+    completedAt: new Date().toISOString(),
+    provider,
+  };
+  writeFileSync(path, JSON.stringify(body, null, 2) + '\n');
+}

--- a/packages/sandbox-vercel/test/push-credentials.test.ts
+++ b/packages/sandbox-vercel/test/push-credentials.test.ts
@@ -60,8 +60,12 @@ afterEach(async () => {
 
 describe('vercelBackend.provision — per-box credential push', () => {
   it('uploads + extracts a tarball for each agent that has host creds', async () => {
-    const runCommand = vi.fn(async () => ({ exitCode: 0 }));
-    const writeFiles = vi.fn(async () => undefined);
+    const runCommand = vi.fn<(opts: { args: string[] }) => Promise<{ exitCode: number }>>(
+      async () => ({ exitCode: 0 }),
+    );
+    const writeFiles = vi.fn<(files: Array<{ path: string; content: string }>) => Promise<undefined>>(
+      async () => undefined,
+    );
     mocks.get.mockResolvedValue({ name: 'box-1', writeFiles, runCommand });
 
     stage.claude.mockResolvedValue(stageResult(await fakeTarball('claude.tgz')));
@@ -75,7 +79,7 @@ describe('vercelBackend.provision — per-box credential push', () => {
     expect(writeFiles).toHaveBeenCalledTimes(3);
     expect(runCommand).toHaveBeenCalledTimes(3);
 
-    const remotes = writeFiles.mock.calls.map((c) => (c[0] as Array<{ path: string }>)[0].path);
+    const remotes = writeFiles.mock.calls.map((c) => c[0][0]?.path);
     expect(remotes).toEqual([
       '/tmp/agentbox-claude-creds.tar.gz',
       '/tmp/agentbox-codex-creds.tar.gz',
@@ -83,7 +87,7 @@ describe('vercelBackend.provision — per-box credential push', () => {
     ]);
 
     // Each extract targets the matching ~/.agentbox-creds/<kind> dest.
-    const extracts = runCommand.mock.calls.map((c) => (c[0] as { args: string[] }).args[1]);
+    const extracts = runCommand.mock.calls.map((c) => c[0].args[1] ?? '');
     expect(extracts[0]).toContain('/home/vscode/.agentbox-creds/claude');
     expect(extracts[1]).toContain('/home/vscode/.agentbox-creds/codex');
     expect(extracts[2]).toContain('/home/vscode/.agentbox-creds/opencode');
@@ -94,8 +98,12 @@ describe('vercelBackend.provision — per-box credential push', () => {
   });
 
   it('skips agents with no host credentials and still returns the handle', async () => {
-    const runCommand = vi.fn(async () => ({ exitCode: 0 }));
-    const writeFiles = vi.fn(async () => undefined);
+    const runCommand = vi.fn<(opts: { args: string[] }) => Promise<{ exitCode: number }>>(
+      async () => ({ exitCode: 0 }),
+    );
+    const writeFiles = vi.fn<(files: Array<{ path: string; content: string }>) => Promise<undefined>>(
+      async () => undefined,
+    );
     mocks.get.mockResolvedValue({ name: 'box-1', writeFiles, runCommand });
 
     stage.claude.mockResolvedValue(stageResult(await fakeTarball('claude.tgz')));
@@ -110,15 +118,19 @@ describe('vercelBackend.provision — per-box credential push', () => {
   });
 
   it('a non-zero extract is logged, not thrown', async () => {
-    const runCommand = vi.fn(async () => ({ exitCode: 2 }));
-    const writeFiles = vi.fn(async () => undefined);
+    const runCommand = vi.fn<(opts: { args: string[] }) => Promise<{ exitCode: number }>>(
+      async () => ({ exitCode: 2 }),
+    );
+    const writeFiles = vi.fn<(files: Array<{ path: string; content: string }>) => Promise<undefined>>(
+      async () => undefined,
+    );
     mocks.get.mockResolvedValue({ name: 'box-1', writeFiles, runCommand });
     stage.claude.mockResolvedValue(stageResult(await fakeTarball('claude.tgz')));
     stage.codex.mockResolvedValue(stageResult(null));
     stage.opencode.mockResolvedValue(stageResult(null));
 
     const logs: string[] = [];
-    const handle = await vercelBackend.provision({ name: 'box-1', onLog: (l) => logs.push(l) } as never);
+    const handle = await vercelBackend.provision({ name: 'box-1', onLog: (l: string) => logs.push(l) } as never);
     expect(handle).toEqual({ sandboxId: 'box-1' });
     expect(logs.some((l) => l.includes('claude credential extract failed'))).toBe(true);
   });
@@ -131,7 +143,7 @@ describe('vercelBackend.provision — per-box credential push', () => {
     stage.opencode.mockResolvedValue(stageResult(null));
 
     const logs: string[] = [];
-    const handle = await vercelBackend.provision({ name: 'box-1', onLog: (l) => logs.push(l) } as never);
+    const handle = await vercelBackend.provision({ name: 'box-1', onLog: (l: string) => logs.push(l) } as never);
     expect(handle).toEqual({ sandboxId: 'box-1' });
     expect(logs.some((l) => l.includes('agent credential push failed'))).toBe(true);
   });


### PR DESCRIPTION
## Summary

- New `agentbox install` interactive setup wizard: compact system check, single-provider picker with login/prepare hints (Docker default, no login), provider login via the existing `ensure*Credentials` flows (Vercel sandbox-CLI install + browser sign-in reused as-is), per-provider confirm before `prepare`, host `/agentbox` skill install, and a tutorial outro. `--skills-only` preserves the previous behavior.
- New `agentbox doctor` reports the same checks in full grouped detail; the wizard renders them collapsed to a one-line summary. Exits non-zero only on hard fails (Node < 20.10, `~/.agentbox` not writable) — "provider not configured" stays exit 0.
- First-run auto-trigger: if `~/.agentbox/setup-complete.json` is absent, the wizard runs once before any non-exempt command on a TTY, then falls through to the requested command. Exempt: `install`, `doctor`, `help`, `relay`, `_run-queued-job`, `drive`, `screen`, `--help`/`--version`/empty argv. Non-TTY always skips (CI never hangs).
- Refactors: `runPrepare(name, opts)` extracted from `prepare.ts` so the wizard and `prepare` share one code path; `installHostSkills(opts)` + `runInstallWizard(opts)` extracted from `install.ts` so both the subcommand and the first-run hook reuse them.

## Test plan

- [ ] `pnpm -C apps/cli build`, `pnpm -C apps/cli typecheck`, `pnpm lint` all clean
- [ ] `agentbox doctor` prints the system + 4 provider groups with correct ok/warn states
- [ ] `agentbox doctor --provider vercel` shows system + vercel only
- [ ] `agentbox install --skills-only --dry-run` matches the prior skill-copy behavior
- [ ] `agentbox install </dev/null` exits 1 with the "interactive terminal required" message
- [ ] Wizard via PTY: intro + compact `system ok` line + provider picker with all four hints; pick Docker → decline prepare → installs host skill → writes marker
- [ ] First-run auto-trigger: with no marker, `agentbox list` shows the wizard first; with marker, runs straight through
- [ ] Auto-trigger skips on `agentbox doctor`, `--help`, and non-TTY (`list </dev/null`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global CLI startup (first-run wizard) and drives provider login/prepare flows; mitigated by TTY/CI exemptions and reuse of existing credential helpers.
> 
> **Overview**
> Adds **`agentbox doctor`** for a grouped system and provider readiness report (Node, git, ssh, Docker daemon/image, credentials and base snapshots per provider). **`agentbox install`** becomes an interactive setup wizard—compact checks, provider selection, existing login flows, optional **`prepare`**, host `/agentbox` skills, and a **`~/.agentbox/setup-complete.json`** marker—while **`--skills-only`** keeps the old skill-copy-only behavior.
> 
> Shared **`doctor-checks`** powers both commands (detailed vs one-line output). **`runPrepare`** and **`installHostSkills`** / **`runInstallWizard`** are extracted so **`prepare`** and the wizard share one path. On first run (no marker), a **TTY-only** hook in **`index.ts`** runs the wizard once before most commands, then continues; exempt commands and non-interactive runs skip it. **`doctor`** exits **1** only on hard system failures; missing provider setup stays **0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e6791cd6bb3fc513946f4e622ca56f27e66ca63. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->