### PR TITLE
feat(agents): auto-skip permission prompts in isolated boxes by default

### DIFF
--- a/apps/cli/src/commands/_run-queued-job.ts
+++ b/apps/cli/src/commands/_run-queued-job.ts
@@ -29,6 +29,7 @@ import { resolveClaudeAuth } from '../auth.js';
 import { resolveLimits } from '../limits.js';
 import { openCommandLog } from '../lib/log-file.js';
 import { buildPromptArgs } from '../lib/queue/build-prompt-args.js';
+import { applyClaudeSkipPermissions, applyCodexSkipPermissions } from '../lib/skip-permissions.js';
 
 export const runQueuedJobCommand = new Command('_run-queued-job')
   .description('internal: run a queued background agent job (do not invoke directly)')
@@ -185,7 +186,7 @@ async function runDockerJob(
     log.write(`starting claude session`);
     await startClaudeSession({
       container: result.record.container,
-      claudeArgs: promptedArgs,
+      claudeArgs: applyClaudeSkipPermissions(promptedArgs, cfg.effective),
       sessionName: cfg.effective.claude.sessionName,
       boxName: result.record.name,
     });
@@ -197,7 +198,7 @@ async function runDockerJob(
     log.write(`starting codex session`);
     await startCodexSession({
       container: result.record.container,
-      codexArgs: promptedArgs,
+      codexArgs: applyCodexSkipPermissions(promptedArgs, cfg.effective),
       sessionName: cfg.effective.codex.sessionName,
     });
   } else if (job.agent === 'opencode') {

--- a/apps/cli/src/commands/_run-queued-job.ts
+++ b/apps/cli/src/commands/_run-queued-job.ts
@@ -234,5 +234,14 @@ function buildOverridesFromJob(job: QueueJob): Partial<UserConfig> {
     else if (job.agent === 'codex') out.codex = { sessionName: opts.sessionName };
     else if (job.agent === 'opencode') out.opencode = { sessionName: opts.sessionName };
   }
+  // Per-box `--no-dangerously-skip-permissions` must survive the queue round-trip
+  // so the worker honors the user's safety opt-out instead of the built-in `true`.
+  if (opts.dangerouslySkipPermissions !== undefined) {
+    if (job.agent === 'claude-code') {
+      out.claude = { ...out.claude, dangerouslySkipPermissions: opts.dangerouslySkipPermissions };
+    } else if (job.agent === 'codex') {
+      out.codex = { ...out.codex, dangerouslySkipPermissions: opts.dangerouslySkipPermissions };
+    }
+  }
   return out;
 }

--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -40,6 +40,7 @@ import {
   MissingAgentCredsError,
 } from '../lib/queue/assert-creds.js';
 import { buildPromptArgs } from '../lib/queue/build-prompt-args.js';
+import { applyClaudeSkipPermissions } from '../lib/skip-permissions.js';
 import { parseMaxOption } from '../lib/queue/parse-max-option.js';
 import { submitQueueJob } from '../lib/queue/submit.js';
 import {
@@ -157,6 +158,8 @@ interface ClaudeCreateOptions {
   isolateClaudeConfig?: boolean;
   withPlaywright?: boolean;
   withEnv?: boolean;
+  /** --dangerously-skip-permissions / --no-...: per-box override of claude.dangerouslySkipPermissions. */
+  dangerouslySkipPermissions?: boolean;
   /** --carry-yes (or AGENTBOX_CARRY_YES=1): auto-approve the carry: block. */
   carryYes?: boolean;
   /** --carry <mode>: 'skip' disables carry for this run (also AGENTBOX_CARRY=skip). */
@@ -210,6 +213,8 @@ function buildClaudeCliOverrides(opts: ClaudeCreateOptions): Partial<UserConfig>
   if (opts.sharedDockerCache === true) box.dockerCacheShared = true;
   const claude: NonNullable<UserConfig['claude']> = {};
   if (opts.sessionName !== undefined) claude.sessionName = opts.sessionName;
+  if (opts.dangerouslySkipPermissions !== undefined)
+    claude.dangerouslySkipPermissions = opts.dangerouslySkipPermissions;
   const out: Partial<UserConfig> = {};
   if (Object.keys(box).length > 0) out.box = box;
   if (Object.keys(claude).length > 0) out.claude = claude;
@@ -377,6 +382,14 @@ export const claudeCommand = new Command('claude')
     'use a per-box ~/.claude volume instead of the shared agentbox-claude-config',
   )
   .option('--with-playwright', 'also install @playwright/cli@latest globally inside the box')
+  .option(
+    '--dangerously-skip-permissions',
+    'launch claude with --dangerously-skip-permissions (auto-accept tool use); on by default since boxes are isolated',
+  )
+  .option(
+    '--no-dangerously-skip-permissions',
+    'do not pass --dangerously-skip-permissions to claude in this box',
+  )
   .option(
     '--with-env',
     'copy host env/config files (.env*, secrets.toml, agentbox.yaml, ...) into /workspace at create time (gitignore-bypassing)',
@@ -619,6 +632,9 @@ export const claudeCommand = new Command('claude')
     if (wiz.action === 'launch-with-prompt' && wiz.initialPrompt) {
       effectiveClaudeArgs = buildPromptArgs('claude-code', wiz.initialPrompt, claudeArgs);
     }
+    // Auto-accept tool use by default (boxes are isolated). One injection here
+    // flows to both the docker session start and the cloud attach below.
+    effectiveClaudeArgs = applyClaudeSkipPermissions(effectiveClaudeArgs, cfg.effective);
 
     // Validate branch selection before any provider work so a typo doesn't
     // leave a half-created box.
@@ -840,6 +856,8 @@ export const claudeCommand = new Command('claude')
 
 interface ClaudeStartOptions {
   sessionName?: string;
+  /** Inherited from the parent `claude` command via optsWithGlobals. */
+  dangerouslySkipPermissions?: boolean;
   syncConfig?: boolean; // commander: --no-sync-config => false; default true
   attachIn?: string; // raw `--attach-in <mode>` value, validated below.
   inline?: boolean; // -i / --inline: shortcut for --attach-in same.
@@ -860,6 +878,12 @@ async function startOrAttachClaude(
   const attachIn = resolveAttachInOption(opts);
   const cliOverrides: Partial<UserConfig> = {};
   if (opts.sessionName) cliOverrides.claude = { sessionName: opts.sessionName };
+  if (opts.dangerouslySkipPermissions !== undefined) {
+    cliOverrides.claude = {
+      ...cliOverrides.claude,
+      dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
+    };
+  }
   if (attachIn !== undefined) cliOverrides.attach = { openIn: attachIn };
   const cfg = await loadEffectiveConfig(box.workspacePath, { cliOverrides });
   const sessionName = cfg.effective.claude.sessionName;
@@ -968,7 +992,7 @@ async function startOrAttachClaude(
     onProgress: (line) => s.message(clampSpinnerLine(line)),
   });
 
-  let effectiveArgs = claudeArgs;
+  let effectiveArgs = applyClaudeSkipPermissions(claudeArgs, cfg.effective);
   if (resumePrepared) {
     s.message('uploading claude session into box');
     try {
@@ -1129,8 +1153,14 @@ const claudeStartCommand = new Command('start')
           return;
         }
         const cfg = await loadEffectiveConfig(box.workspacePath, {
-          cliOverrides: attachIn ? { attach: { openIn: attachIn } } : {},
+          cliOverrides: {
+            ...(attachIn ? { attach: { openIn: attachIn } } : {}),
+            ...(opts.dangerouslySkipPermissions !== undefined
+              ? { claude: { dangerouslySkipPermissions: opts.dangerouslySkipPermissions } }
+              : {}),
+          },
         });
+        effectiveClaudeArgs = applyClaudeSkipPermissions(effectiveClaudeArgs, cfg.effective);
         if (resumePrepared) {
           try {
             const provider = await providerForBox(box);

--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -93,6 +93,7 @@ function pickCreateOpts(opts: ClaudeCreateOptions): import('@agentbox/relay').Qu
     sharedDockerCache: opts.sharedDockerCache,
     portless: opts.portless,
     sessionName: opts.sessionName,
+    dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
     memory: opts.memory,
     cpus: opts.cpus,
     pidsLimit: opts.pidsLimit,

--- a/apps/cli/src/commands/codex.ts
+++ b/apps/cli/src/commands/codex.ts
@@ -87,6 +87,7 @@ function pickCodexCreateOpts(opts: CodexCreateOptions): import('@agentbox/relay'
     sharedDockerCache: opts.sharedDockerCache,
     portless: opts.portless,
     sessionName: opts.sessionName,
+    dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
     memory: opts.memory,
     cpus: opts.cpus,
     pidsLimit: opts.pidsLimit,

--- a/apps/cli/src/commands/codex.ts
+++ b/apps/cli/src/commands/codex.ts
@@ -42,6 +42,7 @@ import {
 } from '../lib/queue/assert-creds.js';
 import { parseMaxOption } from '../lib/queue/parse-max-option.js';
 import { submitQueueJob } from '../lib/queue/submit.js';
+import { applyCodexSkipPermissions } from '../lib/skip-permissions.js';
 import {
   ATTACH_IN_HELP,
   INLINE_HELP,
@@ -135,6 +136,8 @@ interface CodexCreateOptions {
   isolateCodexConfig?: boolean;
   withPlaywright?: boolean;
   withEnv?: boolean;
+  /** --dangerously-skip-permissions / --no-...: per-box override of codex.dangerouslySkipPermissions. */
+  dangerouslySkipPermissions?: boolean;
   /** --carry-yes (or AGENTBOX_CARRY_YES=1): auto-approve the carry: block. */
   carryYes?: boolean;
   /** --carry <mode>: 'skip' disables carry for this run (also AGENTBOX_CARRY=skip). */
@@ -184,6 +187,8 @@ function buildCodexCliOverrides(opts: CodexCreateOptions): Partial<UserConfig> {
   if (opts.sharedDockerCache === true) box.dockerCacheShared = true;
   const codex: NonNullable<UserConfig['codex']> = {};
   if (opts.sessionName !== undefined) codex.sessionName = opts.sessionName;
+  if (opts.dangerouslySkipPermissions !== undefined)
+    codex.dangerouslySkipPermissions = opts.dangerouslySkipPermissions;
   const out: Partial<UserConfig> = {};
   if (Object.keys(box).length > 0) out.box = box;
   if (Object.keys(codex).length > 0) out.codex = codex;
@@ -323,6 +328,14 @@ export const codexCommand = new Command('codex')
     'use a per-box ~/.codex volume instead of the shared agentbox-codex-config',
   )
   .option('--with-playwright', 'also install @playwright/cli@latest globally inside the box')
+  .option(
+    '--dangerously-skip-permissions',
+    'launch codex with --dangerously-bypass-approvals-and-sandbox (never prompt for approval); on by default since boxes are isolated',
+  )
+  .option(
+    '--no-dangerously-skip-permissions',
+    'do not pass --dangerously-bypass-approvals-and-sandbox to codex in this box',
+  )
   .option(
     '--with-env',
     'copy host env/config files (.env*, secrets.toml, agentbox.yaml, ...) into /workspace at create time (gitignore-bypassing)',
@@ -547,7 +560,7 @@ export const codexCommand = new Command('codex')
         binary: 'codex',
         sessionName: cfg.effective.codex.sessionName,
         mode: 'codex',
-        extraArgs: codexArgs,
+        extraArgs: applyCodexSkipPermissions(codexArgs, cfg.effective),
         verbose: opts.verbose === true,
         openIn: cfg.effective.attach.openIn,
         attach: opts.attach !== false,
@@ -639,7 +652,7 @@ export const codexCommand = new Command('codex')
         },
       });
 
-      let effectiveCodexArgs = codexArgs;
+      let effectiveCodexArgs = applyCodexSkipPermissions(codexArgs, cfg.effective);
       if (resumePrepared) {
         s.message('uploading codex session into box');
         cmdLog.write('uploading codex session into box');
@@ -716,6 +729,8 @@ export const codexCommand = new Command('codex')
 
 interface CodexStartOptions {
   sessionName?: string;
+  /** Inherited from the parent `codex` command via optsWithGlobals. */
+  dangerouslySkipPermissions?: boolean;
   syncConfig?: boolean; // commander: --no-sync-config => false; default true
   attachIn?: string; // raw `--attach-in <mode>` value, validated below.
   inline?: boolean; // -i / --inline: shortcut for --attach-in same.
@@ -736,6 +751,12 @@ async function startOrAttachCodex(
   const attachIn = resolveAttachInOption(opts);
   const cliOverrides: Partial<UserConfig> = {};
   if (opts.sessionName) cliOverrides.codex = { sessionName: opts.sessionName };
+  if (opts.dangerouslySkipPermissions !== undefined) {
+    cliOverrides.codex = {
+      ...cliOverrides.codex,
+      dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
+    };
+  }
   if (attachIn !== undefined) cliOverrides.attach = { openIn: attachIn };
   const cfg = await loadEffectiveConfig(box.workspacePath, { cliOverrides });
   const sessionName = cfg.effective.codex.sessionName;
@@ -806,7 +827,7 @@ async function startOrAttachCodex(
     onProgress: (line) => s.message(clampSpinnerLine(line)),
   });
 
-  let effectiveArgs = codexArgs;
+  let effectiveArgs = applyCodexSkipPermissions(codexArgs, cfg.effective);
   if (resumePrepared) {
     s.message('uploading codex session into box');
     try {
@@ -951,8 +972,14 @@ const codexStartCommand = new Command('start')
           return;
         }
         const cfg = await loadEffectiveConfig(box.workspacePath, {
-          cliOverrides: attachIn ? { attach: { openIn: attachIn } } : {},
+          cliOverrides: {
+            ...(attachIn ? { attach: { openIn: attachIn } } : {}),
+            ...(opts.dangerouslySkipPermissions !== undefined
+              ? { codex: { dangerouslySkipPermissions: opts.dangerouslySkipPermissions } }
+              : {}),
+          },
         });
+        effectiveCodexArgs = applyCodexSkipPermissions(effectiveCodexArgs, cfg.effective);
         if (resumePrepared) {
           try {
             const provider = await providerForBox(box);

--- a/apps/cli/src/commands/dashboard.ts
+++ b/apps/cli/src/commands/dashboard.ts
@@ -42,6 +42,7 @@ import { providerForBox } from '../provider/registry.js';
 import { NEW_BOX_ID, NEW_BOX_LABEL, type SidebarBox } from '../dashboard/sidebar.js';
 import { buildCloudAttachInnerCommand } from './_cloud-attach.js';
 import { handleLifecycleError } from './_errors.js';
+import { applyClaudeSkipPermissions, applyCodexSkipPermissions } from '../lib/skip-permissions.js';
 
 interface DashboardOptions {
   project?: boolean;

--- a/apps/cli/src/commands/dashboard.ts
+++ b/apps/cli/src/commands/dashboard.ts
@@ -317,7 +317,12 @@ export const dashboardCommand = new Command('dashboard')
           { volume: claudeVolume },
           { image: box.image, isolate: claudeVolume !== SHARED_CLAUDE_VOLUME },
         );
-        await startClaudeSession({ container: box.container, claudeArgs: [], boxName: box.name });
+        const claudeCfg = await loadEffectiveConfig(box.workspacePath);
+        await startClaudeSession({
+          container: box.container,
+          claudeArgs: applyClaudeSkipPermissions([], claudeCfg.effective),
+          boxName: box.name,
+        });
         const info = await claudeSessionInfo(box.container);
         // Attach only once the agent TUI has drawn — see waitForTmuxPaneContent.
         await waitForTmuxPaneContent(box.container, info.sessionName);
@@ -337,7 +342,11 @@ export const dashboardCommand = new Command('dashboard')
         // Install codex if the box image lacks it (checkpoint predating Codex).
         await ensureCodexInstalled(box.container);
         if (box.codexConfigVolume) await seedCodexHooks(box.codexConfigVolume, box.image);
-        await startCodexSession({ container: box.container, codexArgs: [] });
+        const codexCfg = await loadEffectiveConfig(box.workspacePath);
+        await startCodexSession({
+          container: box.container,
+          codexArgs: applyCodexSkipPermissions([], codexCfg.effective),
+        });
         await waitForTmuxPaneContent(box.container, DEFAULT_CODEX_SESSION);
         return {
           kind: 'attach',
@@ -426,7 +435,10 @@ export const dashboardCommand = new Command('dashboard')
         if (!agent) return { boxId: result.record.id };
         if (agent === 'codex') {
           await ensureCodexInstalled(ctr, { onProgress });
-          await startCodexSession({ container: ctr, codexArgs: [] });
+          await startCodexSession({
+            container: ctr,
+            codexArgs: applyCodexSkipPermissions([], cfg.effective),
+          });
           // Attach only once the agent TUI has drawn — see waitForTmuxPaneContent.
           await waitForTmuxPaneContent(ctr, DEFAULT_CODEX_SESSION);
           return {
@@ -454,7 +466,11 @@ export const dashboardCommand = new Command('dashboard')
           };
         }
         await rebuildPluginNativeDeps(ctr, { volume: result.record.claudeConfigVolume });
-        await startClaudeSession({ container: ctr, claudeArgs: [], boxName: result.record.name });
+        await startClaudeSession({
+          container: ctr,
+          claudeArgs: applyClaudeSkipPermissions([], cfg.effective),
+          boxName: result.record.name,
+        });
         const info = await claudeSessionInfo(ctr);
         await waitForTmuxPaneContent(ctr, info.sessionName);
         return {

--- a/apps/cli/src/lib/skip-permissions.ts
+++ b/apps/cli/src/lib/skip-permissions.ts
@@ -40,7 +40,13 @@ const CODEX_CONFLICTING = new Set([
 ]);
 
 function inject(args: string[], flag: string, conflicting: Set<string>): string[] {
-  if (args.some((a) => conflicting.has(a))) return args;
+  // Match both `--permission-mode plan` and `--permission-mode=plan` — the flag
+  // name is everything before the first `=` when the user uses inline syntax.
+  const hasConflict = args.some((a) => {
+    const eq = a.indexOf('=');
+    return conflicting.has(eq === -1 ? a : a.slice(0, eq));
+  });
+  if (hasConflict) return args;
   return [flag, ...args];
 }
 

--- a/apps/cli/src/lib/skip-permissions.ts
+++ b/apps/cli/src/lib/skip-permissions.ts
@@ -1,0 +1,57 @@
+/**
+ * Inject the per-agent "skip permission prompts" flag into a fresh agent
+ * launch, driven by `claude.dangerouslySkipPermissions` /
+ * `codex.dangerouslySkipPermissions`. A box is an isolated sandbox, so
+ * auto-accepting tool use removes friction the box already makes safe — hence
+ * the config defaults to on (see BUILT_IN_DEFAULTS in @agentbox/config).
+ *
+ * Applied at the command layer (where the effective config is resolved) to the
+ * arg array that flows to BOTH the docker session start (`startXxxSession`) and
+ * the cloud attach (`extraArgs` -> `buildCloudAttachInnerCommand`), so one
+ * call covers every provider.
+ *
+ * If the user already passed a flag that controls the same surface (e.g.
+ * `claude -- --permission-mode plan`, `codex -- -a never`), we leave their args
+ * untouched — an explicit choice always wins.
+ */
+import type { EffectiveConfig } from '@agentbox/config';
+
+/** Claude's full permission-bypass flag (auto-accept all tool use). */
+export const CLAUDE_SKIP_PERMISSIONS_FLAG = '--dangerously-skip-permissions';
+/**
+ * Codex's only "never prompt" flag. It disables codex's own internal sandbox in
+ * addition to approval prompts — redundant-but-safe here since the AgentBox box
+ * is already the sandbox.
+ */
+export const CODEX_SKIP_PERMISSIONS_FLAG = '--dangerously-bypass-approvals-and-sandbox';
+
+// User args that already govern claude's permission behavior — presence means
+// "the user decided", so we don't inject.
+const CLAUDE_CONFLICTING = new Set([CLAUDE_SKIP_PERMISSIONS_FLAG, '--permission-mode']);
+// Likewise for codex's approval / sandbox surface.
+const CODEX_CONFLICTING = new Set([
+  CODEX_SKIP_PERMISSIONS_FLAG,
+  '--yolo',
+  '--full-auto',
+  '-a',
+  '--ask-for-approval',
+  '-s',
+  '--sandbox',
+]);
+
+function inject(args: string[], flag: string, conflicting: Set<string>): string[] {
+  if (args.some((a) => conflicting.has(a))) return args;
+  return [flag, ...args];
+}
+
+/** Prepend claude's skip-permissions flag when the config enables it. */
+export function applyClaudeSkipPermissions(args: string[], cfg: EffectiveConfig): string[] {
+  if (!cfg.claude.dangerouslySkipPermissions) return args;
+  return inject(args, CLAUDE_SKIP_PERMISSIONS_FLAG, CLAUDE_CONFLICTING);
+}
+
+/** Prepend codex's bypass-approvals flag when the config enables it. */
+export function applyCodexSkipPermissions(args: string[], cfg: EffectiveConfig): string[] {
+  if (!cfg.codex.dangerouslySkipPermissions) return args;
+  return inject(args, CODEX_SKIP_PERMISSIONS_FLAG, CODEX_CONFLICTING);
+}

--- a/apps/cli/test/skip-permissions.test.ts
+++ b/apps/cli/test/skip-permissions.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CLAUDE_SKIP_PERMISSIONS_FLAG,
+  CODEX_SKIP_PERMISSIONS_FLAG,
+  applyClaudeSkipPermissions,
+  applyCodexSkipPermissions,
+} from '../src/lib/skip-permissions.js';
+import type { EffectiveConfig } from '@agentbox/config';
+
+const cfg = (claudeOn: boolean, codexOn: boolean): EffectiveConfig =>
+  ({
+    claude: { dangerouslySkipPermissions: claudeOn },
+    codex: { dangerouslySkipPermissions: codexOn },
+  }) as unknown as EffectiveConfig;
+
+describe('applyClaudeSkipPermissions', () => {
+  it('prepends the flag when enabled and no conflicting arg is present', () => {
+    expect(applyClaudeSkipPermissions(['-p', 'hi'], cfg(true, false))).toEqual([
+      CLAUDE_SKIP_PERMISSIONS_FLAG,
+      '-p',
+      'hi',
+    ]);
+  });
+
+  it('does nothing when the config disables it', () => {
+    expect(applyClaudeSkipPermissions(['-p', 'hi'], cfg(false, false))).toEqual(['-p', 'hi']);
+  });
+
+  it('respects an explicit --permission-mode (space syntax)', () => {
+    const args = ['--permission-mode', 'plan'];
+    expect(applyClaudeSkipPermissions(args, cfg(true, false))).toEqual(args);
+  });
+
+  it('respects an explicit --permission-mode=plan (inline syntax)', () => {
+    const args = ['--permission-mode=plan'];
+    expect(applyClaudeSkipPermissions(args, cfg(true, false))).toEqual(args);
+  });
+});
+
+describe('applyCodexSkipPermissions', () => {
+  it('prepends the bypass flag when enabled', () => {
+    expect(applyCodexSkipPermissions(['hi'], cfg(false, true))).toEqual([
+      CODEX_SKIP_PERMISSIONS_FLAG,
+      'hi',
+    ]);
+  });
+
+  it('respects an explicit --ask-for-approval=never (inline syntax)', () => {
+    const args = ['--ask-for-approval=never'];
+    expect(applyCodexSkipPermissions(args, cfg(false, true))).toEqual(args);
+  });
+
+  it('respects a short -a approval flag', () => {
+    const args = ['-a', 'never'];
+    expect(applyCodexSkipPermissions(args, cfg(false, true))).toEqual(args);
+  });
+});

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -57,9 +57,11 @@ export interface UserConfig {
   };
   claude?: {
     sessionName?: string;
+    dangerouslySkipPermissions?: boolean;
   };
   codex?: {
     sessionName?: string;
+    dangerouslySkipPermissions?: boolean;
   };
   opencode?: {
     sessionName?: string;
@@ -153,9 +155,11 @@ export interface EffectiveConfig {
   };
   claude: {
     sessionName: string;
+    dangerouslySkipPermissions: boolean;
   };
   codex: {
     sessionName: string;
+    dangerouslySkipPermissions: boolean;
   };
   opencode: {
     sessionName: string;
@@ -268,9 +272,11 @@ export const BUILT_IN_DEFAULTS: EffectiveConfig = {
   },
   claude: {
     sessionName: 'claude',
+    dangerouslySkipPermissions: true,
   },
   codex: {
     sessionName: 'codex',
+    dangerouslySkipPermissions: true,
   },
   opencode: {
     sessionName: 'opencode',
@@ -495,9 +501,21 @@ export const KEY_REGISTRY: readonly KeyDescriptor[] = [
     description: 'tmux session name for `agentbox claude`.',
   },
   {
+    key: 'claude.dangerouslySkipPermissions',
+    type: 'bool',
+    description:
+      'Launch claude in new boxes with --dangerously-skip-permissions (auto-accept tool use). Safe because boxes are isolated; on by default. Override per-box with --no-dangerously-skip-permissions.',
+  },
+  {
     key: 'codex.sessionName',
     type: 'string',
     description: 'tmux session name for `agentbox codex`.',
+  },
+  {
+    key: 'codex.dangerouslySkipPermissions',
+    type: 'bool',
+    description:
+      'Launch codex in new boxes with --dangerously-bypass-approvals-and-sandbox (never prompt for approval). Safe because boxes are isolated; on by default. Override per-box with --no-dangerously-skip-permissions.',
   },
   {
     key: 'opencode.sessionName',

--- a/packages/relay/src/queue.ts
+++ b/packages/relay/src/queue.ts
@@ -85,6 +85,8 @@ export interface QueueJobCreateOpts {
   sharedDockerCache?: boolean;
   portless?: boolean;
   sessionName?: string;
+  /** Per-box override of `<agent>.dangerouslySkipPermissions` (`--no-...`). */
+  dangerouslySkipPermissions?: boolean;
   memory?: string;
   cpus?: string;
   pidsLimit?: string;


### PR DESCRIPTION
## What

Adds typed config keys that auto-inject each agent's "skip permission prompts" flag on every new box, **on by default** — because a box is an isolated sandbox, so the agents' interactive permission prompts add friction without buying safety.

| Config key | Default | Injects |
|---|---|---|
| `claude.dangerouslySkipPermissions` | `true` | `claude --dangerously-skip-permissions` |
| `codex.dangerouslySkipPermissions` | `true` | `codex --dangerously-bypass-approvals-and-sandbox` |

Per-box override: `--no-dangerously-skip-permissions`. Global/project/workspace override via the normal config layers (`agentbox config set claude.dangerouslySkipPermissions false`), precedence CLI > workspace > project > global > default.

## How

- New schema keys in `packages/config/src/types.ts` (UserConfig, EffectiveConfig, BUILT_IN_DEFAULTS, KEY_REGISTRY) — mirrors the existing `claude.sessionName` pattern, so `config get/set/unset` work for free.
- New CLI flags `--dangerously-skip-permissions` / `--no-dangerously-skip-permissions` on the `claude` and `codex` commands, threaded into the existing `cliOverrides` so precedence is preserved.
- Shared injector `apps/cli/src/lib/skip-permissions.ts` applied at the command layer to the arg array that flows to **all** launch paths: docker (`startXxxSession`), cloud attach (`extraArgs` → `buildCloudAttachInnerCommand`), the background queue worker (`_run-queued-job.ts`), and the dashboard.
- Injection is suppressed when the user already passed the flag or a conflicting one (`--permission-mode`, `-a/--ask-for-approval`, `-s/--sandbox`, `--yolo`, `--full-auto`), and the flag is de-duped if already present after `--`.

## Scope notes

- **codex**: its only "never prompt" flag is `--dangerously-bypass-approvals-and-sandbox`, which also disables codex's own internal sandbox — redundant-but-safe since the AgentBox box already is the sandbox.
- **opencode**: intentionally out of scope. Verified against the box image (`opencode` v1.15.12): the TUI has no skip-permissions flag (only `opencode run` does) and the binary has no `OPENCODE_PERMISSION` env var, so auto-skip would require injecting `"permission": "allow"` into `opencode.json` — a separate, larger change.

## Testing

- `pnpm build` (all packages) + CLI typecheck + eslint on changed files: green.
- `@agentbox/config` unit tests: 85 passed (schema-drift test validates the new registry keys).
- Live docker e2e (`agentbox/box:dev`):
  - default → box launches `claude --dangerously-skip-permissions` and `codex --enable hooks --dangerously-bypass-hook-trust --dangerously-bypass-approvals-and-sandbox`
  - `--no-dangerously-skip-permissions` → bare `claude`
  - `claude -- --dangerously-skip-permissions` → flag appears exactly once (no dup)
  - `config get/set/unset` round-trip + invalid-value rejection verified

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Defaults enable full tool auto-approval for Claude and Codex; misconfiguration or a weak sandbox boundary could allow destructive agent actions without prompts, though users can disable via config or `--no-dangerously-skip-permissions`.
> 
> **Overview**
> **Claude and Codex in AgentBox boxes now auto-launch with permission prompts skipped by default**, on the theory that isolated sandboxes already bound risk. New config keys `claude.dangerouslySkipPermissions` and `codex.dangerouslySkipPermissions` default to **true** and map to `--dangerously-skip-permissions` and `--dangerously-bypass-approvals-and-sandbox` respectively.
> 
> A shared **`skip-permissions` helper** prepends those flags when config allows, but **does not override** explicit user args (e.g. `--permission-mode`, codex `-a` / `-s` / `--yolo`). **`agentbox claude` / `agentbox codex`** gain `--dangerously-skip-permissions` and `--no-dangerously-skip-permissions`, wired through `cliOverrides` like other per-box settings.
> 
> The injector is applied everywhere agent argv is built: **create/start**, **cloud** `extraArgs`, the **queue worker**, and **dashboard** session starts. **OpenCode** is unchanged. Config is registered in **`@agentbox/config`** (types, built-in defaults, `KEY_REGISTRY`) so `config get/set` works without extra CLI work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13b9f19a3f736aacb52b1a0f9c53c5ea1ca97455. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->