### PR TITLE
Feat/vercel backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ agentbox dashboard
 npm -g install @madarco/agentbox
 ```
 
-Requirements: macOS (arm64 or Intel), Docker ([Docker Desktop](https://www.docker.com/products/docker-desktop/) or [OrbStack](https://orbstack.dev/)), Node `>=20.10`. The first `agentbox create` / `agentbox claude` builds the `agentbox/box:dev` image (~1 GB, one-time).
+Requirements: macOS (arm64 or Intel) or Linux, Docker ([Docker Desktop](https://www.docker.com/products/docker-desktop/) or [OrbStack](https://orbstack.dev/)), Node `>=20.10`. The first `agentbox create` / `agentbox claude` builds the `agentbox/box:dev` image (~1 GB, one-time).
 Uses `portless` to give box web apps the same URL from inside the box and on the host.
 
 ## Cloud Providers

--- a/apps/cli/src/checkpoint-lookup.ts
+++ b/apps/cli/src/checkpoint-lookup.ts
@@ -6,11 +6,18 @@
  * checkpoint …" — if the named checkpoint doesn't exist for the active
  * provider, the wizard falls through to the normal setup flow instead of
  * misleadingly skipping it.
+ *
+ * For cloud providers the local manifest is only half the story: the provider
+ * snapshot it points at can expire or be deleted out-of-band. We probe the
+ * backend for liveness and prune the dangling manifest when it's gone, so the
+ * wizard re-asks the setup wizard (start-from-scratch) rather than booting
+ * from a snapshot that would 410 mid-create.
  */
 
 import type { ProviderName } from '@agentbox/core';
 import { resolveCheckpoint } from '@agentbox/sandbox-docker';
-import { resolveCloudCheckpoint } from '@agentbox/sandbox-cloud';
+import { probeCloudCheckpoint, resolveCloudCheckpoint } from '@agentbox/sandbox-cloud';
+import { cloudBackendForProvider } from './provider/cloud-backend.js';
 
 export async function checkpointExistsForProvider(
   provider: ProviderName,
@@ -23,5 +30,18 @@ export async function checkpointExistsForProvider(
   // v1: every cloud backend ships its checkpoints under the
   // `~/.agentbox/cloud-checkpoints/<backend>/…` tree. The provider name is
   // also the backend name so the lookup is a 1:1 mapping.
-  return (await resolveCloudCheckpoint(projectRoot, provider, ref)) !== null;
+  if ((await resolveCloudCheckpoint(projectRoot, provider, ref)) === null) return false;
+  // Manifest present — confirm the provider snapshot it points at is still
+  // bootable. A gone snapshot is pruned here so the next read sees nothing and
+  // the create path provisions from the base image. A probe failure (network /
+  // creds) is treated as "assume live": we never strand a usable checkpoint on
+  // a transient error.
+  try {
+    const backend = await cloudBackendForProvider(provider);
+    if (!backend) return true;
+    const { live } = await probeCloudCheckpoint(backend, projectRoot, ref);
+    return live;
+  } catch {
+    return true;
+  }
 }

--- a/apps/cli/src/commands/dashboard.ts
+++ b/apps/cli/src/commands/dashboard.ts
@@ -49,6 +49,20 @@ interface DashboardOptions {
 }
 
 /**
+ * Whether the dashboard should keep a box's attach session alive (pooled)
+ * across box switches rather than re-spawning it each time. Worth it only for
+ * providers with no persistent connection where reconnecting is expensive and
+ * the attach has no per-call cleanup to defer — currently Vercel (no SSH; each
+ * `sbx exec` pays a credential refresh + SDK handshake + remote tmux attach).
+ * Docker (local exec) and hetzner (SSH ControlMaster) reconnect cheaply;
+ * daytona mints+revokes a per-call SSH token, so pooling it would change token
+ * lifetime semantics. Add future no-SSH providers here.
+ */
+function providerSupportsKeepAlive(provider: BoxRecord['provider']): boolean {
+  return provider === 'vercel';
+}
+
+/**
  * Sidebar / switch order: group by project (so the global view doesn't
  * interleave per-project indices), then projectIndex, then name.
  */
@@ -272,6 +286,7 @@ export const dashboardCommand = new Command('dashboard')
           args: spec.argv.slice(1),
           ...(spec.cleanup ? { cleanup: spec.cleanup } : {}),
           mode: which,
+          ...(providerSupportsKeepAlive(record.provider) ? { keepAlive: true } : {}),
         };
       };
 

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -41,8 +41,7 @@ const MANAGED_SENTINEL = '<!-- agentbox-managed:v1 -->';
 /** Compact half-block "agentbox" wordmark shown above the wizard's clack gutter.
  *  Brand blue (256-color 39) echoes the dashboard sidebar; dropped when NO_COLOR. */
 const BANNER = (() => {
-  const art =
-    '▄▀█ █▀▀ █▀▀ █▄░█ ▀█▀ █▄▄ █▀█ ▀▄▀\n' + '█▀█ █▄█ ██▄ █░▀█ ░█░ █▄█ █▄█ █░█';
+  const art = '▄▀█ █▀▀ █▀▀ █▄░█ ▀█▀ █▄▄ █▀█ ▀▄▀\n' + '█▀█ █▄█ ██▄ █░▀█ ░█░ █▄█ █▄█ █░█';
   const tinted = process.env.NO_COLOR ? art : `\x1b[38;5;39m${art}\x1b[0m`;
   return `\n${tinted}\n\n`;
 })();
@@ -270,7 +269,7 @@ export async function runInstallWizard(opts: RunInstallWizardOptions = {}): Prom
   if (!ensureTty()) return false;
 
   process.stdout.write(BANNER);
-  intro('setup');
+  intro('Check system compatibility');
 
   // 1) Compact system check (full detail lives in `agentbox doctor`).
   const sysResults = await runSystemChecks();
@@ -285,8 +284,6 @@ export async function runInstallWizard(opts: RunInstallWizardOptions = {}): Prom
       outro('aborted');
       return false;
     }
-  } else {
-    log.info('run `agentbox doctor` for the full per-check report');
   }
 
   // 2) Provider picker.

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -39,12 +39,121 @@ import { runPrepare } from './prepare.js';
 const MANAGED_SENTINEL = '<!-- agentbox-managed:v1 -->';
 
 /** Compact half-block "agentbox" wordmark shown above the wizard's clack gutter.
- *  Brand blue (256-color 39) echoes the dashboard sidebar; dropped when NO_COLOR. */
+ *  Brand blue (256-color 39) echoes the dashboard sidebar. */
+const LOGO_L1 = '▄▀█ █▀▀ █▀▀ █▄░█ ▀█▀ █▄▄ █▀█ ▀▄▀';
+const LOGO_L2 = '█▀█ █▄█ ██▄ █░▀█ ░█░ █▄█ █▄█ █░█';
+const LOGO_WIDTH = LOGO_L1.length; // both lines are the same cell width
+
+/** Static fallback banner (no animation): solid brand blue, dropped when NO_COLOR. */
 const BANNER = (() => {
-  const art = '▄▀█ █▀▀ █▀▀ █▄░█ ▀█▀ █▄▄ █▀█ ▀▄▀\n' + '█▀█ █▄█ ██▄ █░▀█ ░█░ █▄█ █▄█ █░█';
+  const art = `${LOGO_L1}\n${LOGO_L2}`;
   const tinted = process.env.NO_COLOR ? art : `\x1b[38;5;39m${art}\x1b[0m`;
   return `\n${tinted}\n\n`;
 })();
+
+// Synchronized-output toggles (DECSET/DECRST 2026): terminals that support it
+// commit each animation frame atomically, avoiding tearing/flicker.
+const SYNC_BEGIN = '\x1b[?2026h';
+const SYNC_END = '\x1b[?2026l';
+const HIDE_CURSOR = '\x1b[?25l';
+const SHOW_CURSOR = '\x1b[?25h';
+
+/** Braille spinner frames for the "Checking system…" line shown under the logo. */
+const SPIN = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** 256-color code for a logo cell `dist` columns from the shine band's center. */
+function shineColor(dist: number): number {
+  const d = Math.abs(dist);
+  if (d === 0) return 231; // white core
+  if (d === 1) return 159; // light cyan
+  if (d === 2) return 81; // cyan
+  return 39; // base brand blue
+}
+
+/** Render one logo line with the shine band centered at column `center`. */
+function paintLine(line: string, center: number): string {
+  let out = '';
+  let prev = -1;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    const c = shineColor(i - center);
+    if (c !== prev) {
+      out += `\x1b[38;5;${String(c)}m`;
+      prev = c;
+    }
+    out += ch;
+  }
+  return out + '\x1b[0m';
+}
+
+/**
+ * Draw the agentbox logo with a ~2s left-to-right "shine sweep", then settle to
+ * the solid brand-blue wordmark. Falls back to the instant static banner when a
+ * TTY isn't present or motion is suppressed (NO_COLOR / CI / AGENTBOX_NO_ANIM),
+ * leaving identical output to `BANNER` so `intro(...)` always starts clean.
+ */
+async function animateBanner(): Promise<void> {
+  if (
+    process.env.NO_COLOR ||
+    process.env.CI ||
+    process.env.AGENTBOX_NO_ANIM ||
+    !process.stdout.isTTY
+  ) {
+    process.stdout.write(BANNER);
+    return;
+  }
+
+  const restoreCursor = (): void => {
+    process.stdout.write(SHOW_CURSOR);
+  };
+  process.once('exit', restoreCursor);
+  process.once('SIGINT', restoreCursor);
+
+  const frameMs = 45;
+  // Band starts just off the left edge and exits past the right edge.
+  const start = -3;
+  const end = LOGO_WIDTH + 2;
+
+  // Layout reserved under the logo (so the sweep isn't pinned to the terminal's
+  // bottom edge): L2, a blank row, the "Checking system…" status row, then a
+  // trailing blank pad row. Reserve them up front (scrolling the view up if we
+  // are near the bottom), then return to the logo's first row to animate.
+  // Each frame redraws both logo lines + the status line, then moves the cursor
+  // back up to the logo's first row so the next frame paints in place.
+  const down = 4; // L2(+1) + blank(+2) + status(+3) + blank pad(+4)
+  process.stdout.write(`\n${HIDE_CURSOR}`);
+  process.stdout.write('\n'.repeat(down) + `\x1b[${String(down)}A`);
+
+  const statusLine = (spin: string): string =>
+    `  \x1b[38;5;51m${spin}\x1b[0m \x1b[38;5;245mChecking system…\x1b[0m`;
+
+  for (let center = start; center <= end; center++) {
+    const spin = SPIN[Math.floor((center - start) / 2) % SPIN.length];
+    const frame =
+      SYNC_BEGIN +
+      paintLine(LOGO_L1, center) +
+      '\n' +
+      paintLine(LOGO_L2, center) +
+      '\n\n\x1b[2K' + // down to the status row (col 0), clear it
+      statusLine(spin) +
+      '\x1b[3A\r' + // back up to the logo's first row
+      SYNC_END;
+    process.stdout.write(frame);
+    await sleep(frameMs);
+  }
+
+  // Settle the wordmark to solid brand blue (status line stays), hold briefly.
+  process.stdout.write(SYNC_BEGIN + `\x1b[38;5;39m${LOGO_L1}\n${LOGO_L2}\x1b[0m` + SYNC_END);
+  await sleep(250);
+
+  // Clear the status row and leave the cursor one blank line below the logo so
+  // the real (instant) system check prints its result there via `intro(...)`.
+  process.stdout.write(SYNC_BEGIN + '\n\x1b[2K\n\x1b[2K' + SHOW_CURSOR + SYNC_END);
+  process.removeListener('exit', restoreCursor);
+  process.removeListener('SIGINT', restoreCursor);
+}
 
 /** Substring unique to the pre-rename `agentbox` host skill. Lets `install`
  *  replace it in place during the agentbox → agentbox-info rename even though
@@ -268,7 +377,7 @@ function isProviderName(s: string): s is ProviderName {
 export async function runInstallWizard(opts: RunInstallWizardOptions = {}): Promise<boolean> {
   if (!ensureTty()) return false;
 
-  process.stdout.write(BANNER);
+  await animateBanner();
   intro('Check system compatibility');
 
   // 1) Compact system check (full detail lives in `agentbox doctor`).

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -38,6 +38,15 @@ import { runPrepare } from './prepare.js';
  *  presence in an existing target means we wrote it and may overwrite freely. */
 const MANAGED_SENTINEL = '<!-- agentbox-managed:v1 -->';
 
+/** Compact half-block "agentbox" wordmark shown above the wizard's clack gutter.
+ *  Brand blue (256-color 39) echoes the dashboard sidebar; dropped when NO_COLOR. */
+const BANNER = (() => {
+  const art =
+    '▄▀█ █▀▀ █▀▀ █▄░█ ▀█▀ █▄▄ █▀█ ▀▄▀\n' + '█▀█ █▄█ ██▄ █░▀█ ░█░ █▄█ █▄█ █░█';
+  const tinted = process.env.NO_COLOR ? art : `\x1b[38;5;39m${art}\x1b[0m`;
+  return `\n${tinted}\n\n`;
+})();
+
 /** Substring unique to the pre-rename `agentbox` host skill. Lets `install`
  *  replace it in place during the agentbox → agentbox-info rename even though
  *  that old file predates the sentinel. */
@@ -55,7 +64,10 @@ function installTargets(): InstallTarget[] {
   const claudeSkills = join(home, '.claude', 'skills');
   return [
     { src: join('agentbox', 'SKILL.md'), dest: join(claudeSkills, 'agentbox', 'SKILL.md') },
-    { src: join('agentbox-info', 'SKILL.md'), dest: join(claudeSkills, 'agentbox-info', 'SKILL.md') },
+    {
+      src: join('agentbox-info', 'SKILL.md'),
+      dest: join(claudeSkills, 'agentbox-info', 'SKILL.md'),
+    },
     {
       src: join('codex', 'agentbox.md'),
       dest: join(home, '.codex', 'prompts', 'agentbox.md'),
@@ -84,9 +96,7 @@ function resolveHostSkillsDir(): string {
   for (const c of candidates) {
     if (existsSync(c)) return c;
   }
-  throw new Error(
-    `could not locate bundled host skills; tried:\n  ${candidates.join('\n  ')}`,
-  );
+  throw new Error(`could not locate bundled host skills; tried:\n  ${candidates.join('\n  ')}`);
 }
 
 function writableReason(target: string, force: boolean): 'new' | 'managed' | 'forced' | 'skip' {
@@ -235,10 +245,11 @@ function tutorialBody(provider: ProviderName): string {
   const startCmd = provider === 'docker' ? 'agentbox claude' : `agentbox ${provider} claude`;
   return (
     `Get started:\n` +
-    `  ${startCmd}        # or codex, opencode\n` +
-    `  Ctrl+a d                          # detach from the box\n` +
-    `  agentbox claude attach            # resume it later\n` +
-    `  agentbox install                  # set up another provider`
+    `  ${startCmd}                       # for claude, codex, opencode\n` +
+    `   -> Setup wizard? -> Yes          # install dependencies and setup agentbox.yaml\n` +
+    `   -> Ctrl+a d                      # to detach from the box and leave claude running\n` +
+    `  agentbox claude attach 1          # resume it later\n` +
+    `  agentbox install                  # to set up another provider`
   );
 }
 
@@ -258,7 +269,8 @@ function isProviderName(s: string): s is ProviderName {
 export async function runInstallWizard(opts: RunInstallWizardOptions = {}): Promise<boolean> {
   if (!ensureTty()) return false;
 
-  intro('AgentBox setup');
+  process.stdout.write(BANNER);
+  intro('setup');
 
   // 1) Compact system check (full detail lives in `agentbox doctor`).
   const sysResults = await runSystemChecks();
@@ -317,9 +329,7 @@ export async function runInstallWizard(opts: RunInstallWizardOptions = {}): Prom
     providerName === 'docker'
       ? 'Build the box image now? (~1GB, a few minutes)'
       : `Bake the ${providerName} base snapshot now? (a few minutes, uses cloud time)`;
-  const wantPrepare = opts.yes
-    ? true
-    : await confirm({ message: prepareMsg, initialValue: true });
+  const wantPrepare = opts.yes ? true : await confirm({ message: prepareMsg, initialValue: true });
   if (isCancel(wantPrepare)) {
     outro('cancelled');
     return false;
@@ -350,9 +360,9 @@ export async function runInstallWizard(opts: RunInstallWizardOptions = {}): Prom
   try {
     skillRes = installHostSkills({ force: opts.force, dryRun: opts.dryRun, quiet: true });
     if (skillRes.written.length > 0) {
-      sp.stop(`host skill: wrote ${String(skillRes.written.length)} file(s)`);
+      sp.stop(`Agentbox Skills: Installed in ${String(skillRes.written.length)} locations`);
     } else {
-      sp.stop(`host skill: nothing to write (${String(skillRes.skipped)} skipped)`);
+      sp.stop(`Agentbox Skills: nothing to write (${String(skillRes.skipped)} skipped)`);
     }
     if (skillRes.blocked.length > 0) {
       log.warn(
@@ -361,7 +371,7 @@ export async function runInstallWizard(opts: RunInstallWizardOptions = {}): Prom
       );
     }
   } catch (err) {
-    sp.stop('host skill: failed');
+    sp.stop('Agentbox Skills: failed');
     log.warn(err instanceof Error ? err.message : String(err));
   }
 
@@ -377,8 +387,8 @@ export async function runInstallWizard(opts: RunInstallWizardOptions = {}): Prom
 
   outro(
     opts.fromAutoTrigger
-      ? 'Setup complete — continuing with your command…'
-      : 'Setup complete',
+      ? '✨ Setup complete — continuing with your command…'
+      : '✨ Setup complete',
   );
   return true;
 }
@@ -395,7 +405,10 @@ export const installCommand = new Command('install')
   .description(
     'Interactive setup wizard: system check, pick a provider, log in, prepare its base image/snapshot, and install the host /agentbox skill. `--skills-only` runs just the skill install.',
   )
-  .option('--skills-only', 'only install the host /agentbox skill files (no wizard, no login, no prepare)')
+  .option(
+    '--skills-only',
+    'only install the host /agentbox skill files (no wizard, no login, no prepare)',
+  )
   .option('--force', 'overwrite existing skill files even if not AgentBox-managed')
   .option('--dry-run', 'print what would be written without changing anything')
   .option(

--- a/apps/cli/src/commands/prepare.ts
+++ b/apps/cli/src/commands/prepare.ts
@@ -93,7 +93,9 @@ async function renderDocker(status: DockerStatus): Promise<string[]> {
     return out;
   }
   if (!status.image?.exists) {
-    out.push(`  image  ${DEFAULT_BOX_IMAGE}  (not built — run \`agentbox prepare --provider docker\`)`);
+    out.push(
+      `  image  ${DEFAULT_BOX_IMAGE}  (not built — run \`agentbox prepare --provider docker\`)`,
+    );
   } else {
     out.push(
       `  image  ${pad(DEFAULT_BOX_IMAGE, 30)} ${pad(humanBytes(status.image.sizeBytes), 10)} built ${humanAge(status.image.createdAt)}`,
@@ -103,7 +105,9 @@ async function renderDocker(status: DockerStatus): Promise<string[]> {
     if (v.exists) {
       out.push(`  vol    ${pad(v.name, 30)} present`);
     } else {
-      out.push(`  vol    ${pad(v.name, 30)} (none — seeded lazily on first \`agentbox claude/codex/opencode\`)`);
+      out.push(
+        `  vol    ${pad(v.name, 30)} (none — seeded lazily on first \`agentbox claude/codex/opencode\`)`,
+      );
     }
   }
   return out;
@@ -115,7 +119,13 @@ interface DaytonaStatusUnknown {
 }
 interface DaytonaStatusOk {
   configured: true;
-  snapshots: Array<{ name: string; state?: string; sizeGb?: number; createdAt?: string; errorReason?: string }>;
+  snapshots: Array<{
+    name: string;
+    state?: string;
+    sizeGb?: number;
+    createdAt?: string;
+    errorReason?: string;
+  }>;
   volumes: Array<{ name: string; state?: string; lastUsedAt?: string }>;
   reason?: string;
 }
@@ -126,7 +136,10 @@ async function daytonaStatus(): Promise<DaytonaStatusResult> {
     const mod = await import('@agentbox/sandbox-daytona');
     return (await mod.getDaytonaStatus()) as DaytonaStatusResult;
   } catch (err) {
-    return { configured: false, reason: err instanceof Error ? err.message.split('\n')[0] : String(err) };
+    return {
+      configured: false,
+      reason: err instanceof Error ? err.message.split('\n')[0] : String(err),
+    };
   }
 }
 
@@ -216,11 +229,12 @@ export interface RunPrepareOptions {
  * Caller is responsible for any `intro(...)` framing; this function manages
  * its own spinner inside.
  */
-export async function runPrepare(providerName: string, opts: RunPrepareOptions = {}): Promise<void> {
+export async function runPrepare(
+  providerName: string,
+  opts: RunPrepareOptions = {},
+): Promise<void> {
   if (!isKnownProvider(providerName)) {
-    process.stderr.write(
-      'error: --provider must be one of: docker, daytona, hetzner, vercel\n',
-    );
+    process.stderr.write('error: --provider must be one of: docker, daytona, hetzner, vercel\n');
     process.exit(1);
   }
 
@@ -251,12 +265,7 @@ export async function runPrepare(providerName: string, opts: RunPrepareOptions =
     if (result.snapshotName !== undefined) {
       sp.stop(`prepared ${providerName}: snapshot '${result.snapshotName}'`);
       try {
-        const written = await setConfigValue(
-          'project',
-          'box.image',
-          result.snapshotName,
-          cwd,
-        );
+        const written = await setConfigValue('project', 'box.image', result.snapshotName, cwd);
         log.success(`box.image = ${result.snapshotName} (written to ${written.path})`);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -266,7 +275,7 @@ export async function runPrepare(providerName: string, opts: RunPrepareOptions =
         );
       }
     } else {
-      sp.stop(`prepared ${providerName}`);
+      sp.stop(`${providerName} provider is ready`);
     }
 
     if (!opts.suppressStatus) {
@@ -293,10 +302,7 @@ export const prepareCommand = new Command('prepare')
     '-p, --provider <name>',
     'provider to prepare (docker | daytona | hetzner | vercel). Omit for status-only.',
   )
-  .option(
-    '-n, --name <name>',
-    'snapshot name (Daytona only; default: agentbox-base-<timestamp>)',
-  )
+  .option('-n, --name <name>', 'snapshot name (Daytona only; default: agentbox-base-<timestamp>)')
   .option('-f, --force', 'rebuild even if the image / snapshot already exists')
   .option('-y, --yes', 'skip confirmation prompts (cost / time warnings)')
   .option('--status', 'show status without preparing anything')

--- a/apps/cli/src/commands/prepare.ts
+++ b/apps/cli/src/commands/prepare.ts
@@ -275,7 +275,7 @@ export async function runPrepare(
         );
       }
     } else {
-      sp.stop(`${providerName} provider is ready`);
+      sp.stop(`${providerName.slice(0, 1).toUpperCase() + providerName.slice(1)} provider ready`);
     }
 
     if (!opts.suppressStatus) {

--- a/apps/cli/src/dashboard/compositor.ts
+++ b/apps/cli/src/dashboard/compositor.ts
@@ -56,6 +56,13 @@ export type RightTarget =
        *  ephemeral SSH token its `buildAttach` mints. */
       cleanup?: () => Promise<void>;
       mode?: 'claude' | 'shell' | 'codex' | 'opencode';
+      /** Keep this session alive (pooled) across box switches instead of
+       *  disposing it on switch-away. Set for providers where reconnecting is
+       *  expensive and has no per-attach cleanup (vercel) — see the dashboard's
+       *  `providerSupportsKeepAlive`. Reconnect-cheap providers (docker,
+       *  hetzner ControlMaster) and per-call-token providers (daytona) leave it
+       *  unset and keep the dispose-on-switch behaviour. */
+      keepAlive?: boolean;
     }
   | { kind: 'menu' }
   | { kind: 'lifecycle-menu'; state: 'paused' | 'stopped' }
@@ -103,6 +110,9 @@ export interface CompositorDeps {
 
 const POLL_MS = 1000;
 const FRAME_MS = 16;
+/** Max kept-alive (pooled) sessions. Each is a live remote attach process
+ *  (e.g. `sbx exec`) + a headless terminal, so the pool is LRU-bounded. */
+const KEEP_ALIVE_MAX = 6;
 const RESIZE_DEBOUNCE_MS = 120;
 /** Keep the expanded chord footer visible this long after the Ctrl-a leader
  *  resolves, so it's actually readable instead of flashing by. */
@@ -125,7 +135,17 @@ export class Compositor {
   private readonly inp = process.stdin;
   private boxes: SidebarBox[] = [];
   private selectedId: string;
+  /** The session currently shown in the right pane (may also be in
+   *  {@link liveSessions} when it's keep-alive). */
   private session: PtySession | null = null;
+  /**
+   * Pool of kept-alive sessions, keyed by box id, for providers whose attach
+   * is expensive to reconnect (vercel). Hidden entries keep their PTY + headless
+   * buffer alive so switching back is instant — no probe, no re-spawn. Map
+   * insertion order doubles as LRU recency (re-set on activate); bounded by
+   * {@link KEEP_ALIVE_MAX}. Reconnect-cheap providers never enter this map.
+   */
+  private readonly liveSessions = new Map<string, PtySession>();
   private placeholder: string[] | null = null;
   private menu: { boxName: string } | null = null;
   private lifecycleMenu: {
@@ -299,6 +319,23 @@ export class Compositor {
       /* keep last known list */
     }
     this.syncPromptSubscriptions();
+    this.reconcileLiveSessions();
+  }
+
+  /**
+   * Drop pooled (hidden) sessions whose box is gone or no longer running, so a
+   * paused/stopped/destroyed box can't keep its remote attach process alive.
+   * The *active* session is intentionally skipped — it's torn down on the next
+   * switch/re-resolve via {@link deactivateActive} (which checks box state),
+   * so evicting it here would blank the pane out from under the poll's
+   * re-resolve logic.
+   */
+  private reconcileLiveSessions(): void {
+    for (const boxId of [...this.liveSessions.keys()]) {
+      if (this.session && this.session.boxId === boxId) continue;
+      const running = this.boxes.some((b) => b.id === boxId && b.state === 'running');
+      if (!running) this.evictSession(boxId);
+    }
   }
 
   /**
@@ -425,14 +462,100 @@ export class Compositor {
     }
   }
 
-  private disposeSession(): void {
-    if (!this.session) return;
-    this.session.dispose();
+  /**
+   * Detach the active session from view. Keep-alive sessions (those in
+   * {@link liveSessions}) stay running in the background; everything else is
+   * disposed — matching the pre-pool dispose-on-switch behaviour for docker /
+   * hetzner / daytona.
+   */
+  private deactivateActive(): void {
+    const s = this.session;
+    if (!s) return;
+    s.active = false;
+    const pooled = this.liveSessions.get(s.boxId) === s;
+    const boxRunning = this.boxes.some((b) => b.id === s.boxId && b.state === 'running');
+    // Dispose unless it's a pooled session whose box is still running (then we
+    // keep it alive in the background for an instant switch-back). A pooled
+    // session whose box stopped/was destroyed is torn down here.
+    if (!pooled || !boxRunning) {
+      if (pooled) this.liveSessions.delete(s.boxId);
+      s.dispose();
+    }
     this.session = null;
   }
 
+  /** Dispose and drop the pooled session for `boxId` (box gone / stopped /
+   *  its attach died). Clears the active reference if it was the shown one. */
+  private evictSession(boxId: string): void {
+    const s = this.liveSessions.get(boxId);
+    if (s) {
+      this.liveSessions.delete(boxId);
+      s.dispose();
+    }
+    if (this.session && this.session.boxId === boxId) this.session = null;
+  }
+
+  /** Bound the pool: evict least-recently-used pooled sessions (Map insertion
+   *  order) until at most {@link KEEP_ALIVE_MAX} remain, never the active one. */
+  private evictLruIfNeeded(): void {
+    for (const boxId of this.liveSessions.keys()) {
+      if (this.liveSessions.size <= KEEP_ALIVE_MAX) break;
+      if (this.session && this.session.boxId === boxId) continue;
+      this.evictSession(boxId);
+    }
+  }
+
+  /** Dispose the active session plus every pooled one (teardown). */
+  private disposeAllSessions(): void {
+    const active = this.session;
+    if (active && this.liveSessions.get(active.boxId) !== active) active.dispose();
+    this.session = null;
+    for (const s of this.liveSessions.values()) s.dispose();
+    this.liveSessions.clear();
+  }
+
+  /**
+   * Show a pooled session in the right pane — the fast switch-back path: no
+   * probe, no re-spawn, instant repaint from its already-current headless
+   * buffer. Re-marks it most-recently-used and re-applies the current layout
+   * size (it may have changed while hidden).
+   */
+  private activateSession(sess: PtySession): void {
+    this.deactivateActive();
+    this.placeholder = null;
+    this.menu = null;
+    this.lifecycleMenu = null;
+    this.createMenu = null;
+    this.pendingConfirm = null;
+    this.session = sess;
+    sess.active = true;
+    this.activeMode = sess.mode;
+    sess.resize(Math.max(1, this.layout.right.w), Math.max(1, this.layout.right.h));
+    // Move to the MRU end so the LRU eviction in applyTarget picks idle boxes.
+    this.liveSessions.delete(sess.boxId);
+    this.liveSessions.set(sess.boxId, sess);
+    this.prevRows = null;
+    // The shown box may have a different alert-band height than the prior one;
+    // reflow if needed (matches applyTarget's tail).
+    if (!this.syncAlertLayout()) this.drawChrome();
+    this.scheduleRender();
+  }
+
+  /**
+   * Show the selected box. If a kept-alive session is pooled for it, re-show it
+   * synchronously (instant). Otherwise fall through to the async resolve+spawn.
+   */
+  private showSelected(): void {
+    const cached = this.liveSessions.get(this.selectedId);
+    if (cached) {
+      this.activateSession(cached);
+      return;
+    }
+    void this.spawnActive();
+  }
+
   private async spawnActive(): Promise<void> {
-    this.disposeSession();
+    this.deactivateActive();
     this.placeholder = null;
     this.menu = null;
     this.lifecycleMenu = null;
@@ -449,25 +572,38 @@ export class Compositor {
 
   /** Turn a resolved/started target into the right-pane state. */
   private applyTarget(target: RightTarget): void {
-    this.disposeSession();
+    this.deactivateActive();
     this.placeholder = null;
     this.menu = null;
     this.lifecycleMenu = null;
     this.createMenu = null;
     this.pendingConfirm = null;
     if (target.kind === 'attach') {
-      this.activeMode = target.mode ?? 'claude';
+      const boxId = this.selectedId;
+      const mode = target.mode ?? 'claude';
+      const keepAlive = target.keepAlive ?? false;
+      this.activeMode = mode;
       this.session = new PtySession(
         this.deps.ptySpawn,
         this.deps.termCtor,
+        boxId,
+        keepAlive,
+        mode,
         target.command,
         target.args,
         Math.max(1, this.layout.right.w),
         Math.max(1, this.layout.right.h),
         () => this.scheduleRender(),
-        () => this.onSessionExit(),
+        (id) => this.onSessionExit(id),
         target.cleanup,
       );
+      if (keepAlive) {
+        // A re-resolve can replace an existing pooled entry for this box.
+        const prev = this.liveSessions.get(boxId);
+        if (prev && prev !== this.session) prev.dispose();
+        this.liveSessions.set(boxId, this.session);
+        this.evictLruIfNeeded();
+      }
     } else if (target.kind === 'menu') {
       this.menu = { boxName: this.selectedBox()?.name ?? this.selectedId };
     } else if (target.kind === 'lifecycle-menu') {
@@ -861,10 +997,13 @@ export class Compositor {
     this.drawChrome();
   }
 
-  private onSessionExit(): void {
-    // Inner attach ended (container died / tmux session gone). Show a message;
-    // the next poll reconciles box state.
-    this.disposeSession();
+  private onSessionExit(boxId: string): void {
+    // Inner attach ended (container died / tmux session gone). Drop the pooled
+    // entry so a switch-back re-resolves instead of showing a dead session.
+    this.evictSession(boxId);
+    // Only repaint if the box that died is the one on screen — a hidden
+    // kept-alive box dying is silent; the next poll reconciles its state.
+    if (boxId !== this.selectedId) return;
     this.placeholder = ['', '  session ended — Ctrl-a ↑/↓ to switch boxes'];
     this.prevRows = null;
     this.scheduleRender();
@@ -881,7 +1020,7 @@ export class Compositor {
     const next = dir === 'prev' ? (i - 1 + n) % n : (i + 1) % n;
     this.selectedId = this.boxes[next]!.id;
     this.drawChrome();
-    void this.spawnActive();
+    this.showSelected();
   }
 
   /** Blank the right pane and drop the diff cache (next paint is full). */
@@ -1179,7 +1318,7 @@ export class Compositor {
     this.activePrompts.clear();
     this.activeNotices.clear();
     this.parser.dispose();
-    this.disposeSession();
+    this.disposeAllSessions();
     this.inp.off('data', this.onData);
     this.out.off('resize', this.onResize);
     if (this.inp.isTTY) this.inp.setRawMode(false);

--- a/apps/cli/src/dashboard/pty-session.ts
+++ b/apps/cli/src/dashboard/pty-session.ts
@@ -88,6 +88,21 @@ const BLANK: CellLike = {
  * cleanup so its 60-min ephemeral SSH token doesn't outlive the attach.
  */
 export class PtySession {
+  /** Box this session attaches to. Identifies it in the compositor's pool. */
+  readonly boxId: string;
+  /** When true, the compositor keeps this session alive (in its pool) across
+   *  box switches instead of disposing it — see {@link Compositor.liveSessions}. */
+  readonly keepAlive: boolean;
+  /** Agent/shell mode of this attach. The compositor restores `activeMode`
+   *  (drives the footer) from this when re-showing a pooled session. */
+  readonly mode: 'claude' | 'shell' | 'codex' | 'opencode';
+  /**
+   * Whether this session is the one currently shown in the right pane. A
+   * kept-alive hidden session (`active === false`) still consumes PTY output
+   * to keep its headless buffer current, but must NOT trigger right-pane
+   * repaints. The compositor flips this on show/hide.
+   */
+  active = true;
   private readonly term: XtermTerminal;
   private readonly pty: IPtyLike;
   private readonly cleanup?: () => Promise<void>;
@@ -99,14 +114,20 @@ export class PtySession {
   constructor(
     spawn: PtySpawn,
     TerminalClass: TerminalCtor,
+    boxId: string,
+    keepAlive: boolean,
+    mode: 'claude' | 'shell' | 'codex' | 'opencode',
     command: string,
     args: string[],
     cols: number,
     rows: number,
     onRenderable: () => void,
-    onExit: () => void,
+    onExit: (boxId: string) => void,
     cleanup?: () => Promise<void>,
   ) {
+    this.boxId = boxId;
+    this.keepAlive = keepAlive;
+    this.mode = mode;
     this.term = new TerminalClass({
       cols,
       rows,
@@ -122,8 +143,11 @@ export class PtySession {
       env: process.env,
     });
     this.pty.onData((d) => {
-      // Read the buffer only after the parser applied this chunk.
-      this.term.write(d, () => onRenderable());
+      // Always feed the parser so the headless buffer stays current even while
+      // hidden; only schedule a paint when this session is the shown one.
+      this.term.write(d, () => {
+        if (this.active) onRenderable();
+      });
     });
     this.term.onData((d) => {
       if (!this.disposed) this.pty.write(d);
@@ -131,8 +155,10 @@ export class PtySession {
     // Only surface *unexpected* exits. When we kill the pty ourselves (box
     // switch / teardown) `disposed` is already true; a stale exit from a
     // just-killed session must not tear down the session that replaced it.
+    // The boxId lets the compositor evict the right pool entry without
+    // assuming the dead session is the active one (a hidden box can die).
     this.pty.onExit(() => {
-      if (!this.disposed) onExit();
+      if (!this.disposed) onExit(this.boxId);
     });
   }
 

--- a/apps/cli/src/lib/doctor-checks.ts
+++ b/apps/cli/src/lib/doctor-checks.ts
@@ -369,9 +369,25 @@ function summaryToken(group: CheckGroup): string {
   return `${group.title} ready`;
 }
 
+// Raw ANSI escapes (the repo's established color path — see dashboard/sidebar.ts).
+const C_GREEN = '\x1b[32m';
+const C_YELLOW = '\x1b[33m';
+const C_RED = '\x1b[31m';
+const C_RESET = '\x1b[0m';
+const COLOR = !process.env.NO_COLOR; // install requires a TTY anyway; honor NO_COLOR for piped output
+
+function statusMarker(s: CheckStatus): string {
+  const glyph = s === 'ok' ? '✓' : s === 'warn' ? '⚠' : '✗';
+  if (!COLOR) return glyph;
+  const color = s === 'ok' ? C_GREEN : s === 'warn' ? C_YELLOW : C_RED;
+  return `${color}${glyph}${C_RESET}`;
+}
+
 /** One-line summary used by the `install` wizard. */
 export function formatCompact(groups: CheckGroup[]): string {
-  return groups.map(summaryToken).join(' · ');
+  return groups
+    .map((g) => `${statusMarker(worstInResults(g.results))} ${summaryToken(g)}`)
+    .join(' · ');
 }
 
 function pad(s: string, width: number): string {

--- a/apps/cli/src/provider/cloud-backend.ts
+++ b/apps/cli/src/provider/cloud-backend.ts
@@ -1,0 +1,21 @@
+/**
+ * Lazily resolve a cloud `CloudBackend` by provider name. Dynamic imports keep
+ * the heavy provider SDKs (Daytona/Hetzner/Vercel) off the docker hot path.
+ * Returns `null` for `docker` (no cloud backend) and any unknown name.
+ */
+import type { CloudBackend, ProviderName } from '@agentbox/core';
+
+export async function cloudBackendForProvider(
+  provider: ProviderName,
+): Promise<CloudBackend | null> {
+  switch (provider) {
+    case 'daytona':
+      return (await import('@agentbox/sandbox-daytona')).daytonaBackend;
+    case 'hetzner':
+      return (await import('@agentbox/sandbox-hetzner')).hetznerBackend;
+    case 'vercel':
+      return (await import('@agentbox/sandbox-vercel')).vercelBackend;
+    default:
+      return null;
+  }
+}

--- a/docs/vercel-backlog.md
+++ b/docs/vercel-backlog.md
@@ -199,6 +199,25 @@ Confirmed live 2026-05-28:
   resolves deleted/failed tombstones (`status: 'deleted'|'failed'`, `sizeBytes: 0`)
   instead of throwing, so "get didn't throw" wrongly meant "exists." The skip check
   now requires `status === 'created'` (`prepare.ts`).
+- **Per-box snapshot eviction nuked the shared base/checkpoint (410 on next create).**
+  Same root cause as the `destroy` bug but via the *automatic* retention policy: a box
+  boots from a shared snapshot (base or a `setup` checkpoint), which Vercel reports as
+  the box's `currentSnapshotId` until its first auto-snapshot — so it's the first member
+  of the box's `keepLastSnapshots` window. With `count: 1, deleteEvicted: true`, the box's
+  first stop/snapshot evicted **and deleted** that shared source, and every later `create`
+  hit `410 Snapshot expired or deleted.` Fixed by `deleteEvicted: false` + a sandbox-level
+  `snapshotExpiration: 0` so evicted snapshots are never deleted or re-stamped with a finite
+  expiry (`backend.ts`). Trade-off: a little snapshot accumulation across many pause cycles
+  instead of ever nuking a snapshot another box depends on.
+- **Stale checkpoint now self-heals instead of crashing create.** If a checkpoint snapshot
+  is gone anyway (reaped before this fix, or deleted from the dashboard), `create` no longer
+  dies with a raw 410. The wizard probes liveness (`backend.snapshotExists`) before announcing
+  "starting from checkpoint …", prunes the dangling local manifest, and re-asks the setup
+  wizard (`checkpoint-lookup.ts` → `probeCloudCheckpoint`). The non-interactive / `-y` path is
+  covered by a reactive fallback in `cloud-provider.ts`: a snapshot-gone error from
+  `provision()` prunes the manifest and re-provisions from the base image (start from scratch).
+  Detection is `isSnapshotGoneError` (`snapshot-error.ts`); covered by unit tests in
+  `packages/sandbox-cloud/test/checkpoint.test.ts` and `packages/sandbox-vercel/test/backend.test.ts`.
 
 The platform-side root causes (the AL2023 sudoers gap, the `Snapshot.get`
 tombstone behavior, the `currentSnapshotId === sourceSnapshotId` aliasing, the

--- a/packages/core/src/cloud-backend.ts
+++ b/packages/core/src/cloud-backend.ts
@@ -233,6 +233,17 @@ export interface CloudBackend {
   deleteSnapshot?(snapshotName: string): Promise<void>;
 
   /**
+   * Optional: report whether a named provider snapshot is still bootable.
+   * Used to detect a stale cloud-checkpoint (the snapshot expired or was
+   * deleted out-of-band) *before* a `provision()` would 410 on it — so the
+   * caller can prune the dangling local manifest and re-ask the setup wizard
+   * instead of crashing mid-create. Must return `false` (never throw) for a
+   * missing / deleted / failed snapshot, and `true` only for one that can
+   * actually boot a sandbox.
+   */
+  snapshotExists?(snapshotName: string): Promise<boolean>;
+
+  /**
    * Optional: bring up a `portless` proxy *inside the sandbox* that mirrors
    * the host's Portless setup, so `https://<boxName>.localhost` resolves to
    * the same content from both the host browser and the in-box browser.

--- a/packages/sandbox-cloud/src/checkpoint.ts
+++ b/packages/sandbox-cloud/src/checkpoint.ts
@@ -17,6 +17,7 @@
 import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
+import type { CloudBackend } from '@agentbox/core';
 import { hashProjectPath, projectDirSegment, sanitizeMnemonic } from '@agentbox/config';
 
 export const CLOUD_CHECKPOINTS_ROOT = join(homedir(), '.agentbox', 'cloud-checkpoints');
@@ -153,4 +154,29 @@ export async function removeCloudCheckpointDir(
   if (!existed) return false;
   await rm(dir, { recursive: true, force: true });
   return true;
+}
+
+/**
+ * Probe whether a cloud checkpoint's underlying provider snapshot is still
+ * bootable, pruning the dangling local manifest when it has expired or been
+ * deleted out-of-band. Lets the create / wizard paths recover gracefully —
+ * fall back to a from-scratch box and re-ask the setup wizard — instead of
+ * letting `provision()` 410 on a snapshot that no longer exists.
+ *
+ * Returns `{ live: false }` when there is no manifest for `ref`. When the
+ * backend can't probe (`snapshotExists` unimplemented) the snapshot is assumed
+ * live: we never prune on uncertainty.
+ */
+export async function probeCloudCheckpoint(
+  backend: Pick<CloudBackend, 'name' | 'snapshotExists'>,
+  projectRoot: string,
+  ref: string,
+): Promise<{ live: boolean; pruned: boolean }> {
+  const found = await resolveCloudCheckpoint(projectRoot, backend.name, ref);
+  if (!found) return { live: false, pruned: false };
+  if (!backend.snapshotExists) return { live: true, pruned: false };
+  const live = await backend.snapshotExists(found.manifest.snapshotName);
+  if (live) return { live: true, pruned: false };
+  await removeCloudCheckpointDir(projectRoot, backend.name, ref);
+  return { live: false, pruned: true };
 }

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -55,6 +55,7 @@ import {
   resolveCloudCheckpoint,
   writeCloudCheckpointManifest,
 } from './checkpoint.js';
+import { isSnapshotGoneError } from './snapshot-error.js';
 import { uploadEnvFiles } from './env-files.js';
 import { uploadCarryPaths } from './carry.js';
 import { readExposedServicePorts } from './expose-ports.js';
@@ -345,34 +346,67 @@ export function createCloudProvider(
       // the per-service preview-URL map. Best-effort: [] when there's no yaml.
       const exposeServicePorts = await readExposedServicePorts(req.workspacePath);
 
-      log(
-        snapshotName
-          ? `provisioning ${providerName} sandbox from snapshot`
-          : `provisioning ${providerName} sandbox`,
-      );
-      const handle = await backend.provision({
-        name,
-        image,
-        snapshot: snapshotName,
-        resources,
-        timeoutMs,
-        exposePorts: exposeServicePorts,
-        networkPolicy,
-        env: {
-          AGENTBOX_BOX_ID: id,
-          AGENTBOX_BOX_NAME: name,
-          AGENTBOX_BOX_KIND: 'cloud',
-          // In-sandbox relay is on the box's loopback at the in-box port.
-          // 8788 is distinct from the host relay's 8787 so a nested agentbox
-          // run inside the box can claim :8787 without colliding.
-          AGENTBOX_RELAY_URL: `http://127.0.0.1:${String(8788)}`,
-          AGENTBOX_RELAY_TOKEN: relayToken,
-          AGENTBOX_BRIDGE_TOKEN: bridgeToken,
-          ...agentVolumes.env,
-        },
-        volumes: agentVolumes.mounts,
-        onLog: log,
-      });
+      const provisionEnv = {
+        AGENTBOX_BOX_ID: id,
+        AGENTBOX_BOX_NAME: name,
+        AGENTBOX_BOX_KIND: 'cloud',
+        // In-sandbox relay is on the box's loopback at the in-box port.
+        // 8788 is distinct from the host relay's 8787 so a nested agentbox
+        // run inside the box can claim :8787 without colliding.
+        AGENTBOX_RELAY_URL: `http://127.0.0.1:${String(8788)}`,
+        AGENTBOX_RELAY_TOKEN: relayToken,
+        AGENTBOX_BRIDGE_TOKEN: bridgeToken,
+        ...agentVolumes.env,
+      };
+      const provisionFrom = async (snapshot: string | undefined): Promise<CloudHandle> => {
+        log(
+          snapshot
+            ? `provisioning ${providerName} sandbox from snapshot`
+            : `provisioning ${providerName} sandbox`,
+        );
+        return backend.provision({
+          name,
+          image,
+          snapshot,
+          resources,
+          timeoutMs,
+          exposePorts: exposeServicePorts,
+          networkPolicy,
+          env: provisionEnv,
+          volumes: agentVolumes.mounts,
+          onLog: log,
+        });
+      };
+
+      let handle: CloudHandle;
+      try {
+        handle = await provisionFrom(snapshotName);
+      } catch (err) {
+        // The checkpoint snapshot we tried to boot from is gone (expired or
+        // deleted out-of-band). Rather than crash, prune the dangling local
+        // manifest and fall back to a from-scratch box on the base image —
+        // the workspace seed below then runs as if no checkpoint existed.
+        // (No fallback for a base-image boot: there's nothing left to retry.)
+        if (snapshotName && isSnapshotGoneError(err)) {
+          log(
+            `checkpoint snapshot '${resolvedCheckpointRef ?? snapshotName}' has expired or been deleted; ` +
+              'starting a fresh box from the base image instead',
+          );
+          if (req.projectRoot && resolvedCheckpointRef) {
+            try {
+              await removeCloudCheckpointDir(req.projectRoot, backend.name, resolvedCheckpointRef);
+            } catch {
+              // best-effort: a stale manifest left behind only re-triggers this
+              // same fallback next time, which is still safe.
+            }
+          }
+          snapshotName = undefined;
+          resolvedCheckpointRef = undefined;
+          handle = await provisionFrom(undefined);
+        } else {
+          throw err;
+        }
+      }
 
       try {
         if (snapshotName) {

--- a/packages/sandbox-cloud/src/index.ts
+++ b/packages/sandbox-cloud/src/index.ts
@@ -51,6 +51,7 @@ export {
   CLOUD_SNAPSHOT_NAME_PREFIX,
   cloudSnapshotName,
   listCloudCheckpoints,
+  probeCloudCheckpoint,
   removeCloudCheckpointDir,
   resolveCloudCheckpoint,
   writeCloudCheckpointManifest,

--- a/packages/sandbox-cloud/src/snapshot-error.ts
+++ b/packages/sandbox-cloud/src/snapshot-error.ts
@@ -1,0 +1,28 @@
+/**
+ * Detect the "the snapshot I tried to boot from is gone" failure across cloud
+ * backends. Vercel surfaces it as an `APIError` with HTTP 410 ("Gone") and a
+ * body of `{ error: { message: 'Snapshot expired or deleted.' } }`; other
+ * backends phrase it differently. We match on the status code and a few
+ * message shapes so the create path can fall back to a from-scratch box
+ * instead of crashing when a base/checkpoint snapshot has been reaped.
+ */
+export function isSnapshotGoneError(err: unknown): boolean {
+  if (err === null || typeof err !== 'object') return false;
+  const e = err as {
+    status?: unknown;
+    response?: { status?: unknown };
+    json?: { error?: { message?: unknown } };
+    message?: unknown;
+  };
+  const status = e.response?.status ?? e.status;
+  if (status === 410) return true;
+  const parts = [
+    typeof e.json?.error?.message === 'string' ? e.json.error.message : '',
+    typeof e.message === 'string' ? e.message : '',
+  ];
+  const msg = parts.join(' ').toLowerCase();
+  return (
+    /snapshot[^.]*\b(expired|deleted|gone|not[ -]?found)\b/.test(msg) ||
+    msg.includes('expired or deleted')
+  );
+}

--- a/packages/sandbox-cloud/test/checkpoint.test.ts
+++ b/packages/sandbox-cloud/test/checkpoint.test.ts
@@ -6,10 +6,12 @@ import {
   cloudSnapshotName,
   CLOUD_SNAPSHOT_NAME_PREFIX,
   listCloudCheckpoints,
+  probeCloudCheckpoint,
   removeCloudCheckpointDir,
   resolveCloudCheckpoint,
   writeCloudCheckpointManifest,
 } from '../src/checkpoint.js';
+import { isSnapshotGoneError } from '../src/snapshot-error.js';
 
 // Override HOME so writeCloudCheckpointManifest writes under a tmp dir
 // instead of the real `~/.agentbox/`. Restored at the end.
@@ -104,5 +106,84 @@ describe('manifest lifecycle', () => {
     // A different backend with the same project + name finds nothing.
     expect(await resolveCloudCheckpoint(projectRoot, 'other-backend', 'setup')).toBeNull();
     await removeCloudCheckpointDir(projectRoot, 'daytona', 'setup');
+  });
+});
+
+describe('probeCloudCheckpoint', () => {
+  const projectRoot = '/projects/test-probe';
+
+  async function seed(name: string): Promise<void> {
+    await writeCloudCheckpointManifest(projectRoot, 'vercel', name, {
+      snapshotName: `snap_${name}`,
+      sourceBoxId: 'a',
+      sourceBoxName: 'x',
+    });
+  }
+
+  it('reports not-live with no prune when there is no manifest', async () => {
+    const backend = { name: 'vercel', snapshotExists: async () => true };
+    expect(await probeCloudCheckpoint(backend, projectRoot, 'absent')).toEqual({
+      live: false,
+      pruned: false,
+    });
+  });
+
+  it('keeps a live snapshot and leaves the manifest in place', async () => {
+    await seed('warm');
+    const backend = { name: 'vercel', snapshotExists: async () => true };
+    expect(await probeCloudCheckpoint(backend, projectRoot, 'warm')).toEqual({
+      live: true,
+      pruned: false,
+    });
+    expect(await resolveCloudCheckpoint(projectRoot, 'vercel', 'warm')).not.toBeNull();
+    await removeCloudCheckpointDir(projectRoot, 'vercel', 'warm');
+  });
+
+  it('prunes the manifest when the snapshot is gone', async () => {
+    await seed('stale');
+    const backend = { name: 'vercel', snapshotExists: async () => false };
+    expect(await probeCloudCheckpoint(backend, projectRoot, 'stale')).toEqual({
+      live: false,
+      pruned: true,
+    });
+    // The dangling manifest is gone so the next read provisions from base.
+    expect(await resolveCloudCheckpoint(projectRoot, 'vercel', 'stale')).toBeNull();
+  });
+
+  it('assumes live (no prune) when the backend cannot probe', async () => {
+    await seed('unprobable');
+    const backend = { name: 'vercel' };
+    expect(await probeCloudCheckpoint(backend, projectRoot, 'unprobable')).toEqual({
+      live: true,
+      pruned: false,
+    });
+    expect(await resolveCloudCheckpoint(projectRoot, 'vercel', 'unprobable')).not.toBeNull();
+    await removeCloudCheckpointDir(projectRoot, 'vercel', 'unprobable');
+  });
+});
+
+describe('isSnapshotGoneError', () => {
+  it('matches a Vercel 410 APIError by status code', () => {
+    expect(isSnapshotGoneError({ response: { status: 410 }, message: 'Status code 410 is not ok' })).toBe(
+      true,
+    );
+    expect(isSnapshotGoneError({ status: 410 })).toBe(true);
+  });
+
+  it('matches the "Snapshot expired or deleted." body message', () => {
+    expect(
+      isSnapshotGoneError({ json: { error: { message: 'Snapshot expired or deleted.' } } }),
+    ).toBe(true);
+  });
+
+  it('matches a "snapshot not found" message', () => {
+    expect(isSnapshotGoneError(new Error('snapshot not found'))).toBe(true);
+  });
+
+  it('does not match unrelated errors', () => {
+    expect(isSnapshotGoneError(new Error('network timeout'))).toBe(false);
+    expect(isSnapshotGoneError({ status: 500 })).toBe(false);
+    expect(isSnapshotGoneError(null)).toBe(false);
+    expect(isSnapshotGoneError('boom')).toBe(false);
   });
 });

--- a/packages/sandbox-vercel/src/backend.ts
+++ b/packages/sandbox-vercel/src/backend.ts
@@ -118,9 +118,23 @@ export function parseNetworkPolicy(raw: string | undefined): NetworkPolicy | und
  */
 const DEFAULT_TIMEOUT_MS = 45 * 60_000;
 
-/** Keep exactly one auto-snapshot per box, never expiring, so a paused box can
- * always resume and storage stays flat. `destroy` purges it explicitly. */
-const KEEP_LAST_SNAPSHOTS = { count: 1, expiration: 0, deleteEvicted: true } as const;
+/**
+ * Per-box snapshot retention. Keep one auto-snapshot, never expiring, so a
+ * paused box can always resume; `destroy` purges a box's own snapshot explicitly.
+ *
+ * `deleteEvicted: false` is load-bearing, NOT a tweak. A box boots from a shared
+ * snapshot (the prepared base, or a `setup` checkpoint), and Vercel reports that
+ * source as the box's `currentSnapshotId` until it takes its first auto-snapshot
+ * — i.e. the source is the first member of this box's retention window. With
+ * `deleteEvicted: true`, the box's first stop/snapshot evicts the source and
+ * DELETES it, nuking the shared base/checkpoint every other box depends on, so
+ * every later `create` 410s with "Snapshot expired or deleted." (Same hazard the
+ * `destroy` guard already dodges, but eviction is automatic and bypasses it.)
+ * `false` keeps evicted snapshots around (they fall back to `snapshotExpiration`,
+ * which we pin to 0 = never at create) — trading a little snapshot accumulation
+ * for never deleting a snapshot another box boots from.
+ */
+const KEEP_LAST_SNAPSHOTS = { count: 1, expiration: 0, deleteEvicted: false } as const;
 
 function creds(): Partial<{ token: string; teamId: string; projectId: string }> {
   return resolveCredentials();
@@ -288,6 +302,10 @@ export const vercelBackend: CloudBackend = {
           env: req.env,
           tags: { agentbox: 'true', 'agentbox.name': req.name },
           persistent: true,
+          // Pin the sandbox-default expiration to never. Evicted snapshots (see
+          // KEEP_LAST_SNAPSHOTS) fall back to this, so the shared base/checkpoint
+          // a box boots from is never re-stamped with a finite expiry on eviction.
+          snapshotExpiration: 0,
           keepLastSnapshots: { ...KEEP_LAST_SNAPSHOTS },
           ...(networkPolicy ? { networkPolicy } : {}),
           ...creds(),
@@ -489,6 +507,21 @@ export const vercelBackend: CloudBackend = {
   // lifetime, not a per-URL signature, so the expiry arg is irrelevant here).
   async signedPreviewUrl(h: CloudHandle, port: number): Promise<CloudPreviewUrl> {
     return this.previewUrl(h, port);
+  },
+
+  async snapshotExists(snapshotName: string): Promise<boolean> {
+    await ensureFreshCredentials();
+    return withVercelRetry({ method: 'snapshotExists', retryOnAmbiguous: true }, async () => {
+      try {
+        const snap = await Snapshot.get({ snapshotId: snapshotName, ...creds() });
+        // `Snapshot.get` resolves deleted/failed tombstones (status field) rather
+        // than throwing, so "didn't throw" wrongly passes a dead snapshot. Only a
+        // 'created' snapshot can actually boot a sandbox.
+        return snap.status === 'created';
+      } catch {
+        return false;
+      }
+    });
   },
 
   // NOTE: no `createSnapshot`/`deleteSnapshot` here. Vercel snapshots are

--- a/packages/sandbox-vercel/test/backend.test.ts
+++ b/packages/sandbox-vercel/test/backend.test.ts
@@ -151,6 +151,53 @@ describe('vercelBackend.destroy', () => {
   });
 });
 
+describe('vercelBackend.provision', () => {
+  it('pins snapshots to never-expire and never auto-deletes evicted ones', async () => {
+    mocks.create.mockResolvedValue(fakeSandbox());
+    // The post-create credential push resolves a sandbox; give it the methods
+    // it touches so a push failure doesn't mask the assertions below.
+    mocks.get.mockResolvedValue(
+      fakeSandbox({
+        writeFiles: vi.fn(async () => undefined),
+        runCommand: vi.fn(async () => ({ exitCode: 0, stdout: async () => '', stderr: async () => '' })),
+      }),
+    );
+
+    await vercelBackend.provision({
+      name: 'box-1',
+      image: 'agentbox/box:dev',
+      snapshot: 'snap_base',
+      env: {},
+    } as never);
+
+    const arg = mocks.create.mock.calls[0]![0] as {
+      source: unknown;
+      snapshotExpiration: number;
+      keepLastSnapshots: { count: number; expiration: number; deleteEvicted: boolean };
+    };
+    expect(arg.source).toEqual({ type: 'snapshot', snapshotId: 'snap_base' });
+    expect(arg.snapshotExpiration).toBe(0);
+    expect(arg.keepLastSnapshots).toMatchObject({ count: 1, expiration: 0, deleteEvicted: false });
+  });
+});
+
+describe('vercelBackend.snapshotExists', () => {
+  it('is true only for a created snapshot', async () => {
+    mocks.snapshotGet.mockResolvedValue({ status: 'created' });
+    expect(await vercelBackend.snapshotExists!('snap_x')).toBe(true);
+  });
+
+  it('is false for a deleted/failed tombstone (Snapshot.get resolves it)', async () => {
+    mocks.snapshotGet.mockResolvedValue({ status: 'deleted' });
+    expect(await vercelBackend.snapshotExists!('snap_x')).toBe(false);
+  });
+
+  it('is false when the snapshot lookup throws', async () => {
+    mocks.snapshotGet.mockRejectedValue(new Error('404 not found'));
+    expect(await vercelBackend.snapshotExists!('snap_gone')).toBe(false);
+  });
+});
+
 describe('buildExposedPorts', () => {
   it('returns just the base ports when no expose ports are given', () => {
     expect(buildExposedPorts(undefined)).toEqual([6080, 8788]);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes Vercel sandbox snapshot retention and cloud provisioning fallbacks that affect whether boxes boot at all; mistakes could break creates for all users on that provider, though behavior is covered by new unit tests.
> 
> **Overview**
> This PR hardens **Vercel (and cloud) snapshot/checkpoint lifecycle** so shared base and checkpoint images are not deleted when a box’s retention policy evicts its “current” snapshot, and so **stale checkpoints self-heal** instead of failing mid-create with HTTP 410.
> 
> **Vercel backend:** Per-box `keepLastSnapshots` now uses **`deleteEvicted: false`**, and new sandboxes set **`snapshotExpiration: 0`**, so evicted snapshots are not auto-deleted and do not re-expire the shared source other boxes boot from. **`snapshotExists`** treats only `status === 'created'` as bootable (tombstones count as gone).
> 
> **Cloud create / wizard:** **`probeCloudCheckpoint`** and wizard **`checkpointExistsForProvider`** verify the provider snapshot is still live and **prune dangling local manifests** when it is not. **`cloud-provider`** catches snapshot-gone errors via **`isSnapshotGoneError`**, removes the manifest, and **re-provisions from the base image**. CLI adds lazy **`cloudBackendForProvider`** for probes.
> 
> **Dashboard:** For **Vercel only**, attach sessions can **`keepAlive`** in an LRU pool (max 6) so switching boxes does not pay repeated `sbx exec` handshakes; **`PtySession`** tracks `boxId`, hidden sessions still update the headless buffer.
> 
> **UX / docs:** Install wizard gets an **animated logo** and clearer compact doctor output; README notes **Linux** support; **`docs/vercel-backlog.md`** documents the retention and stale-checkpoint fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aac2b900b72424d96503ef08642c0dd2cacdadd3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->