### PR TITLE
Cloud attach resilience: version-consistent relay, resume-on-attach, vercel checkpoint confirm + auto-reconnect

### DIFF
--- a/apps/cli/.gitignore
+++ b/apps/cli/.gitignore
@@ -1,0 +1,3 @@
+# Generated at build time by scripts/stage-runtime.mjs from the repo-root
+# README so the published package has a landing page. Not a source of truth.
+README.md

--- a/apps/cli/scripts/stage-runtime.mjs
+++ b/apps/cli/scripts/stage-runtime.mjs
@@ -14,7 +14,7 @@
 // needs zero changes. runtime/ sits next to dist/ in both the dev tree and the
 // published package, so the resolvers anchor on it uniformly.
 
-import { chmodSync, cpSync, existsSync, mkdirSync, rmSync } from 'node:fs';
+import { chmodSync, cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -139,6 +139,29 @@ const vercelFiles = [
 for (const [srcRel, destRel, exec] of vercelFiles) {
   copy(srcRel, join(vercelCtx, destRel), exec);
 }
+
+// README — npm reads the published package's README only from the package
+// root (apps/cli/), and there's no package.json field to point elsewhere.
+// Mirror the repo-root README here so npmjs.com has a landing page, rewriting
+// relative links to absolute GitHub URLs: the package's repository.directory
+// is apps/cli, so `./docs/cover.jpg` would resolve to a non-existent path.
+function stageReadme() {
+  const src = join(repoRoot, 'README.md');
+  if (!existsSync(src)) {
+    console.warn('[stage-runtime] WARN missing source (skipped): README.md');
+    missing++;
+    return;
+  }
+  const raw = 'https://raw.githubusercontent.com/madarco/agentbox/main/';
+  const blob = 'https://github.com/madarco/agentbox/blob/main/';
+  const isImage = (p) => /\.(png|jpe?g|gif|svg|webp)(#.*)?$/i.test(p);
+  const absolutize = (p) => (isImage(p) ? raw : blob) + p.replace(/^\.\//, '');
+  const rewritten = readFileSync(src, 'utf8')
+    .replace(/(\]\()(\.\/[^)]+)(\))/g, (_, a, p, b) => a + absolutize(p) + b)
+    .replace(/((?:src|href)=")(\.\/[^"]+)(")/g, (_, a, p, b) => a + absolutize(p) + b);
+  writeFileSync(join(cliRoot, 'README.md'), rewritten);
+}
+stageReadme();
 
 if (missing > 0) {
   console.warn(

--- a/apps/cli/src/commands/_cloud-attach.ts
+++ b/apps/cli/src/commands/_cloud-attach.ts
@@ -1,4 +1,7 @@
 import { spawn } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { spinner } from '@clack/prompts';
 import { DEFAULT_RELAY_PORT } from '@agentbox/sandbox-docker';
 import type { BoxRecord } from '@agentbox/core';
@@ -9,6 +12,27 @@ import { pasteHostClipboardImage } from '../lib/paste-image.js';
 import { clipboardCaptureAvailable } from '../lib/host-clipboard.js';
 
 const RELAY_HOST_URL = `http://127.0.0.1:${String(DEFAULT_RELAY_PORT)}`;
+/** Give up reconnecting a dropped attach after this long (box likely gone). */
+const RECONNECT_TIMEOUT_MS = 5 * 60_000;
+
+/** setTimeout that also resolves early if the signal aborts (no rejection). */
+function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const t = setTimeout(resolve, ms);
+    signal.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(t);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+}
 
 /**
  * Attach to (or create) a tmux session inside a cloud sandbox over SSH and
@@ -98,6 +122,9 @@ export async function cloudAgentAttach(args: CloudAgentAttachArgs): Promise<void
   if (!provider.buildAttach) {
     throw new Error(`provider '${provider.name}' does not support interactive attach`);
   }
+  // Captured for the reconnect closure (TS won't preserve the narrowing above
+  // inside a later-invoked callback).
+  const buildAttach = provider.buildAttach.bind(provider);
   // Ensure the box is running before we attach. A cloud box can be stopped
   // out from under an attach — most notably `checkpoint --set-default`, which
   // snapshots and stops the sandbox. Without this, buildAttach runs against a
@@ -144,7 +171,7 @@ export async function cloudAgentAttach(args: CloudAgentAttachArgs): Promise<void
     }
   }
 
-  const spec = await provider.buildAttach(box, 'agent', {
+  let spec = await provider.buildAttach(box, 'agent', {
     sessionName: args.sessionName,
     command,
   });
@@ -152,6 +179,46 @@ export async function cloudAgentAttach(args: CloudAgentAttachArgs): Promise<void
   // or a Linux desktop with xclip/wl-paste). Otherwise Ctrl+V forwards verbatim.
   const canPaste =
     args.mode === 'claude' && (await clipboardCaptureAvailable());
+
+  // Re-establish the attach after the wrapper decides the box dropped (a vercel
+  // checkpoint reboot, or a connection blip). Keep trying `provider.start` —
+  // which resumes a stopped box and no-ops a running one — until it succeeds or
+  // the deadline lapses. We deliberately DON'T bail on consecutive failures: a
+  // box mid-snapshot rejects `start` for the whole (multi-minute) capture, and
+  // that's indistinguishable from a destroyed box by error alone — so we lean on
+  // the time budget (and the user's Ctrl+C, which aborts the signal) instead. On
+  // a reboot this lands in a freshly-created tmux session (the snapshot is
+  // filesystem-only); a blip on a still-running box re-attaches the same live
+  // session. Returns null to give up (cancelled or timed out).
+  const reconnect = async (
+    signal: AbortSignal,
+  ): Promise<{ command: string; argv: string[]; env?: Record<string, string> } | null> => {
+    const deadline = Date.now() + RECONNECT_TIMEOUT_MS;
+    let backoff = 500;
+    for (;;) {
+      if (signal.aborted || Date.now() > deadline) return null;
+      try {
+        box = await provider.start(box);
+        break;
+      } catch {
+        await abortableSleep(backoff, signal);
+        backoff = Math.min(backoff * 2, 5000);
+      }
+    }
+    if (signal.aborted) return null;
+    // Release the previous attach's per-call resources (SSH tunnel / token)
+    // before minting fresh ones against the resumed box.
+    if (spec.cleanup) {
+      try {
+        await spec.cleanup();
+      } catch {
+        // best-effort
+      }
+    }
+    spec = await buildAttach(box, 'agent', { sessionName: args.sessionName, command });
+    return { command: spec.argv[0]!, argv: spec.argv.slice(1), env: spec.env };
+  };
+
   try {
     const code = await runWrappedAttach({
       container: box.name,
@@ -165,6 +232,19 @@ export async function cloudAgentAttach(args: CloudAgentAttachArgs): Promise<void
       mode: args.mode,
       detachable: true,
       openIn: safeOpenIn,
+      reconnect,
+      onError: (msg) => {
+        // Non-fatal wrapper diagnostics (reconnect failures, give-ups, etc.) —
+        // logged to a file because writing to stderr would corrupt the PTY.
+        try {
+          appendFileSync(
+            join(homedir(), '.agentbox', 'logs', 'attach.log'),
+            `${new Date().toISOString()} [${box.name}] ${msg}\n`,
+          );
+        } catch {
+          // best-effort
+        }
+      },
       onPasteImage: canPaste
         ? () => pasteHostClipboardImage(provider, box)
         : undefined,

--- a/apps/cli/src/commands/_cloud-attach.ts
+++ b/apps/cli/src/commands/_cloud-attach.ts
@@ -206,16 +206,20 @@ export async function cloudAgentAttach(args: CloudAgentAttachArgs): Promise<void
       }
     }
     if (signal.aborted) return null;
-    // Release the previous attach's per-call resources (SSH tunnel / token)
-    // before minting fresh ones against the resumed box.
-    if (spec.cleanup) {
+    // Mint the fresh attach FIRST, then release the previous one's per-call
+    // resources (SSH tunnel / token). Order matters: if buildAttach throws,
+    // `spec` still points at the old spec (uncleaned), so the outer `finally`
+    // cleans it exactly once — building-then-cleaning avoids the double-cleanup
+    // that the reverse order would cause on a buildAttach failure.
+    const prev = spec;
+    spec = await buildAttach(box, 'agent', { sessionName: args.sessionName, command });
+    if (prev.cleanup) {
       try {
-        await spec.cleanup();
+        await prev.cleanup();
       } catch {
         // best-effort
       }
     }
-    spec = await buildAttach(box, 'agent', { sessionName: args.sessionName, command });
     return { command: spec.argv[0]!, argv: spec.argv.slice(1), env: spec.env };
   };
 

--- a/apps/cli/src/commands/checkpoint.ts
+++ b/apps/cli/src/commands/checkpoint.ts
@@ -55,6 +55,7 @@ interface CreateOpts {
   merged?: boolean;
   setDefault?: boolean;
   replace?: boolean;
+  yes?: boolean;
 }
 
 async function projectRootFor(cwd: string, recordRoot?: string): Promise<string> {
@@ -74,6 +75,7 @@ const createSub = new Command('create')
     '--replace',
     "if a checkpoint with the same name exists, rm it first (idempotent recapture; safe to retry when the previous run's stdout was lost)",
   )
+  .option('-y, --yes', 'skip the vercel "box will reboot" confirmation prompt')
   .action(async (idOrName: string | undefined, opts: CreateOpts) => {
     try {
       const box = await resolveBoxOrExit(idOrName);
@@ -367,6 +369,23 @@ async function runCloudCheckpointCreate(box: BoxRecord, opts: CreateOpts): Promi
 
   if (!provider.checkpoint) {
     throw new Error(`provider '${box.provider ?? 'docker'}' doesn't support checkpoints`);
+  }
+
+  // Vercel snapshots stop + reboot the box (the live tmux/agent process doesn't
+  // survive; on-disk state does). Warn + confirm before yanking it. Only for a
+  // direct host invocation with a TTY — the relay spawns this same command
+  // headless for the in-box trigger (stdin ignored → isTTY false), and that
+  // path is already gated by a wrapper-visible prompt in the relay. Other
+  // providers snapshot without stopping, so they stay prompt-free.
+  if ((box.provider ?? 'docker') === 'vercel' && !opts.yes && process.stdin.isTTY) {
+    const ok = await confirm({
+      message: 'Create checkpoint? The vercel box will stop and reboot.',
+      initialValue: false,
+    });
+    if (isCancel(ok) || !ok) {
+      log.info('cancelled');
+      return;
+    }
   }
 
   // Daytona's snapshot capture pauses the sandbox while writing the image.

--- a/apps/cli/src/commands/list.ts
+++ b/apps/cli/src/commands/list.ts
@@ -4,6 +4,7 @@ import { listBoxes, type ListedBox } from '@agentbox/sandbox-docker';
 import { Command } from 'commander';
 import { pathToFileURL } from 'node:url';
 import { hyperlink } from '../hyperlink.js';
+import { applyLiveCloudStates } from '../lib/cloud-state.js';
 import { withWatchOptions, watchRender, type WatchableOptions } from '../watch.js';
 
 interface ListOptions extends WatchableOptions {
@@ -98,6 +99,10 @@ function workspaceCell(path: string, target: number, stream: NodeJS.WriteStream)
  * it would put a spurious `claude:unknown` on nearly every row.
  */
 function agentSummary(b: ListedBox): string {
+  // A non-running box can't have a live agent; its persisted status.json (the
+  // source of these fields) is just the last snapshot before it stopped, so
+  // showing `claude:idle` next to `paused`/`stopped` would be contradictory.
+  if (b.state !== 'running') return '-';
   const agents: string[] = [];
   if (b.claudeActivity && b.claudeActivity !== 'unknown') {
     agents.push(`claude:${b.claudeActivity}`);
@@ -180,9 +185,15 @@ async function scopedBoxes(
   all: boolean,
 ): Promise<{ boxes: ListedBox[]; projectRoot: string; scoped: boolean }> {
   const boxes = await listBoxes();
-  if (all) return { boxes, projectRoot: '', scoped: false };
+  if (all) {
+    await applyLiveCloudStates(boxes);
+    return { boxes, projectRoot: '', scoped: false };
+  }
   const { root } = await findProjectRoot(process.cwd());
-  return { boxes: boxes.filter((b) => b.projectRoot === root), projectRoot: root, scoped: true };
+  const scoped = boxes.filter((b) => b.projectRoot === root);
+  // Probe only the scoped boxes — don't round-trip every cloud box on the host.
+  await applyLiveCloudStates(scoped);
+  return { boxes: scoped, projectRoot: root, scoped: true };
 }
 
 async function buildListText(all: boolean): Promise<string> {

--- a/apps/cli/src/commands/list.ts
+++ b/apps/cli/src/commands/list.ts
@@ -10,6 +10,7 @@ import { withWatchOptions, watchRender, type WatchableOptions } from '../watch.j
 interface ListOptions extends WatchableOptions {
   json?: boolean;
   global?: boolean;
+  live?: boolean;
 }
 
 /** A table cell: the (possibly OSC-8-wrapped) text to print + its visible width. */
@@ -183,21 +184,24 @@ function renderTable(boxes: ListedBox[], stream: NodeJS.WriteStream): string {
  */
 async function scopedBoxes(
   all: boolean,
+  live: boolean,
 ): Promise<{ boxes: ListedBox[]; projectRoot: string; scoped: boolean }> {
   const boxes = await listBoxes();
   if (all) {
-    await applyLiveCloudStates(boxes);
+    // Default: cloud state is the fast persisted `cloud.lastState` from
+    // listBoxes. `--live` overrides it with an authoritative SDK probe.
+    if (live) await applyLiveCloudStates(boxes);
     return { boxes, projectRoot: '', scoped: false };
   }
   const { root } = await findProjectRoot(process.cwd());
   const scoped = boxes.filter((b) => b.projectRoot === root);
   // Probe only the scoped boxes — don't round-trip every cloud box on the host.
-  await applyLiveCloudStates(scoped);
+  if (live) await applyLiveCloudStates(scoped);
   return { boxes: scoped, projectRoot: root, scoped: true };
 }
 
-async function buildListText(all: boolean): Promise<string> {
-  const { boxes, projectRoot, scoped } = await scopedBoxes(all);
+async function buildListText(all: boolean, live: boolean): Promise<string> {
+  const { boxes, projectRoot, scoped } = await scopedBoxes(all, live);
   if (boxes.length === 0) {
     if (scoped) {
       return `no boxes in this project (${projectRoot}) — run \`agentbox create\`, or \`agentbox list --global\` to see all`;
@@ -216,21 +220,26 @@ export const listCommand = withWatchOptions(
     .alias('ls')
     .description('List agent boxes in the current project (-g for all)')
     .option('-j, --json', 'machine-readable JSON output')
-    .option('-g, --global', 'include boxes from all projects'),
+    .option('-g, --global', 'include boxes from all projects')
+    .option(
+      '--live',
+      'probe live cloud state via the provider SDK (slower; default: last host-known state)',
+    ),
 ).action(async (opts: ListOptions) => {
   if (opts.json && opts.watch) {
     log.error('cannot combine --json with --watch');
     process.exit(2);
   }
   const all = opts.global ?? false;
+  const live = opts.live ?? false;
   if (opts.watch) {
-    await watchRender(() => buildListText(all), opts.interval);
+    await watchRender(() => buildListText(all, live), opts.interval);
     return;
   }
   if (opts.json) {
-    const { boxes } = await scopedBoxes(all);
+    const { boxes } = await scopedBoxes(all, live);
     process.stdout.write(JSON.stringify(boxes, null, 2) + '\n');
     return;
   }
-  process.stdout.write((await buildListText(all)) + '\n');
+  process.stdout.write((await buildListText(all, live)) + '\n');
 });

--- a/apps/cli/src/commands/top.ts
+++ b/apps/cli/src/commands/top.ts
@@ -10,6 +10,7 @@ import {
 import type { BoxResourceStats } from '@agentbox/core';
 import { resolveBoxOrExit } from '../box-ref.js';
 import { fmtBytes, fmtPercent } from '../fmt.js';
+import { applyLiveCloudStates } from '../lib/cloud-state.js';
 import { watchRender } from '../watch.js';
 import { handleLifecycleError } from './_errors.js';
 
@@ -74,6 +75,8 @@ async function snapshot(
   opts: TopOptions,
 ): Promise<{ boxes: ListedBox[]; stats: BoxResourceStats[] }> {
   const boxes = await selectBoxes(idOrName, opts);
+  // listBoxes hardcodes cloud state to 'running'; replace it with a live probe.
+  await applyLiveCloudStates(boxes);
   const stats = await Promise.all(
     boxes.map((b) => {
       // Skip the docker-only `boxResourceStats` for cloud boxes — it would

--- a/apps/cli/src/commands/top.ts
+++ b/apps/cli/src/commands/top.ts
@@ -19,6 +19,7 @@ interface TopOptions {
   once?: boolean;
   json?: boolean;
   interval?: string;
+  live?: boolean;
 }
 
 const COLS = ['BOX', 'STATE', 'CPU%', 'MEM USAGE / LIMIT', 'MEM%', 'PIDS', 'DISK', 'NET I/O'];
@@ -75,8 +76,9 @@ async function snapshot(
   opts: TopOptions,
 ): Promise<{ boxes: ListedBox[]; stats: BoxResourceStats[] }> {
   const boxes = await selectBoxes(idOrName, opts);
-  // listBoxes hardcodes cloud state to 'running'; replace it with a live probe.
-  await applyLiveCloudStates(boxes);
+  // Default cloud state is the fast persisted value from listBoxes; `--live`
+  // overrides it with an authoritative SDK probe.
+  if (opts.live) await applyLiveCloudStates(boxes);
   const stats = await Promise.all(
     boxes.map((b) => {
       // Skip the docker-only `boxResourceStats` for cloud boxes — it would
@@ -136,6 +138,7 @@ export const topCommand = new Command('top')
   .option('--once', 'print a single snapshot instead of watching')
   .option('-j, --json', 'machine-readable JSON (implies --once)')
   .option('--interval <seconds>', 'refresh interval', '2')
+  .option('--live', 'probe live cloud state via the provider SDK (slower; default: last host-known)')
   .action(async (idOrName: string | undefined, opts: TopOptions) => {
     try {
       if (opts.json) {

--- a/apps/cli/src/lib/cloud-state.ts
+++ b/apps/cli/src/lib/cloud-state.ts
@@ -1,0 +1,49 @@
+import type { ListedBox } from '@agentbox/sandbox-docker';
+import { providerForBox } from '../provider/registry.js';
+
+/** Per-box probe budget. A hung cloud SDK call must not stall the whole list. */
+const PROBE_TIMEOUT_MS = 4000;
+
+/**
+ * Overwrite the optimistic `state` that `listBoxes()` hardcodes to `'running'`
+ * for cloud boxes (it skips the SDK round-trip — see lifecycle.ts) with a real
+ * `provider.probeState()`. Docker boxes already carry a live `docker inspect`
+ * state and are left untouched.
+ *
+ * Mutates `boxes` in place. Probes run in parallel; a probe that throws or
+ * exceeds {@link PROBE_TIMEOUT_MS} leaves that box's existing state as-is so the
+ * command stays responsive (e.g. missing/expired cloud creds, a wedged SDK call)
+ * rather than blocking or blanking every cloud row.
+ */
+export async function applyLiveCloudStates(boxes: ListedBox[]): Promise<void> {
+  await Promise.all(
+    boxes.map(async (b) => {
+      if (!b.provider || b.provider === 'docker') return;
+      try {
+        const provider = await providerForBox(b);
+        const state = await withTimeout(provider.probeState(b), PROBE_TIMEOUT_MS);
+        if (state !== null) b.state = state;
+      } catch {
+        // Leave b.state at the listBoxes literal — best-effort freshness.
+      }
+    }),
+  );
+}
+
+/** Resolve to the promise's value, or `null` if it doesn't settle within `ms`. */
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T | null> {
+  return new Promise<T | null>((resolve) => {
+    const t = setTimeout(() => resolve(null), ms);
+    if (typeof t.unref === 'function') t.unref();
+    p.then(
+      (v) => {
+        clearTimeout(t);
+        resolve(v);
+      },
+      () => {
+        clearTimeout(t);
+        resolve(null);
+      },
+    );
+  });
+}

--- a/apps/cli/src/wrapped-pty/run.ts
+++ b/apps/cli/src/wrapped-pty/run.ts
@@ -257,6 +257,11 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
   // `recomputeBand` derives the band visibility from prompt > notice > question.
   let capturingPrompt: PromptAskEvent | null = null;
   let activeNotice: BoxNoticeEvent | null = null;
+  // The "box rebooting — reconnecting…" banner, owned solely by reconnectFlow.
+  // Kept separate from `activeNotice` (which the SSE notice callbacks mutate) so
+  // a real notice-set/clear arriving mid-reconnect can't clobber or prematurely
+  // dismiss it. Takes precedence over everything while a reconnect is in flight.
+  let reconnectBanner: string | null = null;
   let noticeFrame = 0;
   let questionPayload: ClaudeQuestionPayload | null = null;
   let bandState: AlertBandState | null = null;
@@ -321,7 +326,9 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
   // question state has no one-line footer renderer — sidebar marker only).
   const recomputeFooter = (): void => {
     const collapsed = bandState !== null && bandReservedRows === 0;
-    if (collapsed && capturingPrompt) {
+    if (collapsed && reconnectBanner) {
+      footerState = { kind: 'notice', message: reconnectBanner, frame: noticeFrame };
+    } else if (collapsed && capturingPrompt) {
       footerState = { kind: 'prompt', prompt: capturingPrompt };
     } else if (collapsed && activeNotice) {
       footerState = { kind: 'notice', message: activeNotice.message, frame: noticeFrame };
@@ -338,7 +345,11 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
   // a question is the agent waiting for the user. When nothing is active the
   // band collapses entirely.
   const recomputeBand = (): void => {
-    if (capturingPrompt) {
+    if (reconnectBanner) {
+      // While reconnecting nothing else is actionable (stdin is swallowed, the
+      // box is down), so the banner outranks prompt/notice/question.
+      bandState = { kind: 'notice', message: reconnectBanner, frame: noticeFrame };
+    } else if (capturingPrompt) {
       bandState = { kind: 'prompt', prompt: capturingPrompt };
     } else if (activeNotice) {
       bandState = { kind: 'notice', message: activeNotice.message, frame: noticeFrame };
@@ -715,7 +726,7 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
     const controller = new AbortController();
     reconnecting = true; // swallow stdin (no live pty) while we re-establish
     reconnectAbort = controller;
-    activeNotice = { id: 'reconnect', kind: 'checkpoint', message: 'box rebooting — reconnecting…' };
+    reconnectBanner = 'box rebooting — reconnecting…';
     startSpinner();
     applyBandChange();
     let spec: { command: string; argv: string[]; env?: Record<string, string> } | null = null;
@@ -726,8 +737,10 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
     } finally {
       reconnecting = false;
       reconnectAbort = null;
-      activeNotice = null;
-      stopSpinner();
+      reconnectBanner = null;
+      // A real checkpoint notice may have arrived via SSE during the reconnect;
+      // keep the spinner running if so, only stop it when nothing animates.
+      if (!activeNotice) stopSpinner();
       applyBandChange();
     }
     if (spec) {

--- a/apps/cli/src/wrapped-pty/run.ts
+++ b/apps/cli/src/wrapped-pty/run.ts
@@ -106,9 +106,11 @@ const FLASH_DURATION_MS = 2000;
 const RAPID_RECONNECT_MS = 8000;
 /** Give up reconnecting after this many consecutive rapid failures (crash loop). */
 const MAX_RAPID_RECONNECTS = 3;
-/** A drop within this long of a checkpoint notice is treated as a reboot
- *  (the box snapshot stops it a beat before the host clears the notice). */
-const CHECKPOINT_DROP_GRACE_MS = 20_000;
+/** A drop within this long of a checkpoint notice clearing is still treated as
+ *  a reboot — only to bridge a tiny SSE-vs-pty event race (the box stops, and
+ *  thus the pty drops, while the notice is still active, so this rarely fires).
+ *  Kept short so a clean exit shortly after a checkpoint isn't misread. */
+const CHECKPOINT_DROP_GRACE_MS = 4000;
 
 /** Per-action confirmation text shown in the footer flash. */
 const ACTION_FLASH: Record<Exclude<LeaderAction, 'detach'>, string> = {
@@ -514,9 +516,11 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
   const router: InputRouter = createInputRouter({
     onForward: (b) => {
       // While reconnecting there's no live pty to write to. Swallow input, but
-      // let Ctrl+C (0x03) abort the reconnect wait so the user can bail out.
+      // let a bare Ctrl+C (a lone 0x03 byte) abort the reconnect wait so the
+      // user can bail out. Match exactly — a pasted/coalesced buffer that merely
+      // contains 0x03 must not trip the abort.
       if (reconnecting) {
-        if (b.includes(0x03)) reconnectAbort?.abort();
+        if (b.length === 1 && b[0] === 0x03) reconnectAbort?.abort();
         return;
       }
       // node-pty wants utf8 strings; stdin is binary safe via Buffer.
@@ -788,6 +792,11 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
     });
     wireOutput();
     lastSpawnAt = Date.now();
+    // The checkpoint that caused this drop is consumed — clear its tracking so a
+    // clean exit in the reconnected session isn't misclassified as another
+    // reboot (a fresh checkpoint sets these again via onNotice).
+    checkpointNoticeAt = 0;
+    checkpointNoticeClearedAt = 0;
     // Re-assert the scroll region (the fresh session repaints into it) and
     // repaint chrome so the footer/band survive the respawn.
     process.stdout.write(`\x1b[1;${String(innerNow)}r`);

--- a/apps/cli/src/wrapped-pty/run.ts
+++ b/apps/cli/src/wrapped-pty/run.ts
@@ -76,6 +76,20 @@ export interface WrappedAttachOptions {
    *  this settles, so Claude Code reads the now-loaded clipboard. Omitted →
    *  Ctrl+V forwards verbatim. */
   onPasteImage?: () => Promise<'pasted' | 'no-image' | 'error'>;
+  /**
+   * Re-establish the connection after the inner PTY drops. The wrapper decides
+   * *whether* to call this (a checkpoint reboot — signalled by an active
+   * `checkpoint` notice — or a non-zero exit; a clean exit-0 on a healthy box,
+   * or an explicit `agentbox stop`, ends the wrapper instead). The callback then
+   * resumes the box if needed and returns a fresh spawn spec to re-attach with,
+   * or `null` to give up (box destroyed, cancelled, or timed out). `signal`
+   * aborts if the user hits Ctrl+C while reconnecting. Only cloud attaches wire
+   * this; docker omits it (exit-on-drop, unchanged).
+   */
+  reconnect?: (
+    signal: AbortSignal,
+    exitCode: number,
+  ) => Promise<{ command: string; argv: string[]; env?: Record<string, string> } | null>;
 }
 
 const FOOTER_ROWS = 1;
@@ -88,6 +102,13 @@ const STATUS_POLL_INTERVAL_MS = 3000;
 const SPINNER_INTERVAL_MS = 120;
 /** How long the post-action confirmation flash stays in the footer. */
 const FLASH_DURATION_MS = 2000;
+/** A respawned session that dies within this window counts as a rapid failure. */
+const RAPID_RECONNECT_MS = 8000;
+/** Give up reconnecting after this many consecutive rapid failures (crash loop). */
+const MAX_RAPID_RECONNECTS = 3;
+/** A drop within this long of a checkpoint notice is treated as a reboot
+ *  (the box snapshot stops it a beat before the host clears the notice). */
+const CHECKPOINT_DROP_GRACE_MS = 20_000;
 
 /** Per-action confirmation text shown in the footer flash. */
 const ACTION_FLASH: Record<Exclude<LeaderAction, 'detach'>, string> = {
@@ -179,12 +200,26 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
   const rows = process.stdout.rows ?? 24;
   const innerRows = Math.max(1, rows - FOOTER_ROWS);
 
-  const pty = backend.ptySpawn(command, opts.dockerArgv, {
+  let pty = backend.ptySpawn(command, opts.dockerArgv, {
     name: 'xterm-256color',
     cols,
     rows: innerRows,
     env: opts.env ? { ...process.env, ...opts.env } : process.env,
   });
+  // When the current pty was (re)spawned — feeds the crash-loop guard below.
+  let lastSpawnAt = Date.now();
+  // Resize the current pty, tolerating a dead one: during a reconnect the old
+  // pty has exited and the new one isn't spawned yet, and node-pty throws on a
+  // closed pty. A throw here used to propagate out of the band-relayout in
+  // reconnectFlow's finally and silently kill the wrapper. The next spawn uses
+  // the correct size regardless.
+  const resizePty = (c: number, r: number): void => {
+    try {
+      pty.resize(c, r);
+    } catch {
+      // pty exited / mid-respawn
+    }
+  };
 
   // Mirror the agent's session title to the host terminal/tab title (iTerm2
   // etc.). tmux swallows the inner OSC title (set-titles off), so the host
@@ -228,6 +263,21 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
   // Transient confirmation shown after a Ctrl+a action fires.
   let flashMessage: string | null = null;
   let flashTimer: ReturnType<typeof setTimeout> | null = null;
+  // True while the inner pty has dropped and we're re-establishing it. Stdin is
+  // swallowed (no live pty to write to) except Ctrl+C, which aborts the wait.
+  let reconnecting = false;
+  let reconnectAbort: AbortController | null = null;
+  // Set when the user deliberately detaches (Ctrl+a d) — that exit must end the
+  // wrapper, never trigger a reconnect.
+  let userDetached = false;
+  // When a `checkpoint` notice last set / cleared (epoch ms; 0 = never). A pty
+  // drop while one is active, or within CHECKPOINT_DROP_GRACE_MS of it clearing,
+  // is a box reboot (snapshot stopped it) → reconnect; otherwise an exit-0 drop
+  // on a healthy box is a clean session end → exit. Plain numbers so the loop's
+  // check doesn't trip TS's null-narrowing on `activeNotice` (assigned only in a
+  // callback).
+  let checkpointNoticeAt = 0;
+  let checkpointNoticeClearedAt = 0;
 
   /** Reserved rows above the inner pty: footer (always 1) + band (3 or 0). */
   const reservedRows = (): number => FOOTER_ROWS + bandReservedRows;
@@ -305,7 +355,7 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
     const cs = process.stdout.columns ?? cols;
     const rs = process.stdout.rows ?? rows;
     const inner = Math.max(1, rs - reservedRows());
-    pty.resize(cs, inner);
+    resizePty(cs, inner);
     process.stdout.write(`\x1b[1;${String(inner)}r`);
     // Clear the chrome area (band + footer rows) so stale agent output left
     // over from the previous scroll region doesn't show through under the
@@ -367,10 +417,15 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
   // wrapped in synchronized output (DECSET 2026) so the user never sees a
   // half-painted frame on terminals that support it (iTerm2/WezTerm/kitty/
   // Apple Terminal/Ghostty).
-  pty.onData((d: string) => {
-    process.stdout.write(d);
-    redrawChrome();
-  });
+  // Wire the inner pty's output -> stdout. Factored out so a respawned pty
+  // (after a reconnect) can be re-wired the same way.
+  const wireOutput = (): void => {
+    pty.onData((d: string) => {
+      process.stdout.write(d);
+      redrawChrome();
+    });
+  };
+  wireOutput();
 
   // Ctrl+a leader chord map — keys mirror the dashboard's (`c`/`s`/`u`).
   // A detachable (tmux-backed) session also gets `d: detach`; a plain
@@ -386,7 +441,10 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
   // long-running open/launch never blocks (or corrupts) this terminal.
   const runAction = (name: LeaderAction): void => {
     if (name === 'detach') {
-      pty.write('\x02d');
+      if (!reconnecting) {
+        userDetached = true;
+        pty.write('\x02d');
+      }
       return;
     }
     const cliEntry = process.argv[1];
@@ -455,6 +513,12 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
   // Wire stdin -> pty (through the router so prompts + the leader can intercept).
   const router: InputRouter = createInputRouter({
     onForward: (b) => {
+      // While reconnecting there's no live pty to write to. Swallow input, but
+      // let Ctrl+C (0x03) abort the reconnect wait so the user can bail out.
+      if (reconnecting) {
+        if (b.includes(0x03)) reconnectAbort?.abort();
+        return;
+      }
       // node-pty wants utf8 strings; stdin is binary safe via Buffer.
       pty.write(b.toString('utf8'));
     },
@@ -498,7 +562,7 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
     // tracks the new reserve.
     bandReservedRows = bandState && bandFits() ? ALERT_BAND_ROWS : 0;
     const inner = Math.max(1, rs - reservedRows());
-    pty.resize(cs, inner);
+    resizePty(cs, inner);
     process.stdout.write(`\x1b[1;${String(inner)}r`);
     recomputeFooter();
     redrawChrome();
@@ -534,12 +598,14 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
       }
     },
     onNotice: (ev: BoxNoticeEvent) => {
+      if (ev.kind === 'checkpoint') checkpointNoticeAt = Date.now();
       activeNotice = ev;
       startSpinner();
       applyBandChange();
     },
     onNoticeCleared: (id: string) => {
       if (activeNotice && activeNotice.id === id) {
+        if (activeNotice.kind === 'checkpoint') checkpointNoticeClearedAt = Date.now();
         activeNotice = null;
         stopSpinner();
         applyBandChange();
@@ -633,10 +699,100 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
   // Initial paint so the idle footer appears immediately.
   redrawChrome();
 
-  // Wait for the pty to exit, then tear down everything.
-  const exitCode = await new Promise<number>((resolve) => {
-    pty.onExit(({ exitCode }) => resolve(exitCode));
-  });
+  /**
+   * Keep the wrapper open across a drop: show the "box rebooting — reconnecting…"
+   * band and let `opts.reconnect` resume the box + hand back a fresh spawn spec
+   * (or null to give up). Only called once the loop has decided the drop is a
+   * reboot/blip, so the band always shows here.
+   */
+  const reconnectFlow = async (
+    code: number,
+  ): Promise<{ command: string; argv: string[]; env?: Record<string, string> } | null> => {
+    const controller = new AbortController();
+    reconnecting = true; // swallow stdin (no live pty) while we re-establish
+    reconnectAbort = controller;
+    activeNotice = { id: 'reconnect', kind: 'checkpoint', message: 'box rebooting — reconnecting…' };
+    startSpinner();
+    applyBandChange();
+    let spec: { command: string; argv: string[]; env?: Record<string, string> } | null = null;
+    try {
+      spec = (await opts.reconnect?.(controller.signal, code)) ?? null;
+    } catch (e) {
+      logErr(`reconnect failed: ${(e as Error).message}`);
+    } finally {
+      reconnecting = false;
+      reconnectAbort = null;
+      activeNotice = null;
+      stopSpinner();
+      applyBandChange();
+    }
+    if (spec) {
+      flashMessage = 'reconnected';
+      if (flashTimer) clearTimeout(flashTimer);
+      flashTimer = setTimeout(() => {
+        flashTimer = null;
+        flashMessage = null;
+        recomputeFooter();
+        redrawChrome();
+      }, FLASH_DURATION_MS);
+      if (typeof flashTimer.unref === 'function') flashTimer.unref();
+      recomputeFooter();
+      redrawChrome();
+    }
+    return spec;
+  };
+
+  // Wait for the pty to exit. Reconnect only on a real drop: a checkpoint reboot
+  // (an active/just-cleared `checkpoint` notice — vercel's snapshot stops the
+  // box and its `sbx exec` exits 0, so the notice is the signal, not the code)
+  // or a non-zero exit (connection blip). A clean exit-0 on a healthy box (agent
+  // exited) or an explicit `agentbox stop` (no notice) ends the wrapper. A
+  // crash-loop guard bails if respawned sessions keep dying immediately.
+  let exitCode = 0;
+  let rapidFails = 0;
+  for (;;) {
+    const code = await new Promise<number>((resolve) => {
+      pty.onExit(({ exitCode }) => resolve(exitCode));
+    });
+    if (userDetached || !opts.reconnect) {
+      exitCode = code;
+      break;
+    }
+    // Checkpoint notice currently active (set more recently than cleared) or
+    // cleared within the grace window → this drop is a box reboot.
+    const checkpointing =
+      checkpointNoticeAt > checkpointNoticeClearedAt ||
+      Date.now() - checkpointNoticeClearedAt < CHECKPOINT_DROP_GRACE_MS;
+    if (!checkpointing && code === 0) {
+      exitCode = code; // clean session end on a healthy box
+      break;
+    }
+    rapidFails = Date.now() - lastSpawnAt < RAPID_RECONNECT_MS ? rapidFails + 1 : 0;
+    if (rapidFails >= MAX_RAPID_RECONNECTS) {
+      logErr('giving up reconnect after repeated rapid failures');
+      exitCode = code;
+      break;
+    }
+    const next = await reconnectFlow(code);
+    if (!next) {
+      exitCode = code;
+      break;
+    }
+    const rsNow = process.stdout.rows ?? rows;
+    const innerNow = Math.max(1, rsNow - reservedRows());
+    pty = backend.ptySpawn(next.command, next.argv, {
+      name: 'xterm-256color',
+      cols: process.stdout.columns ?? cols,
+      rows: innerNow,
+      env: next.env ? { ...process.env, ...next.env } : process.env,
+    });
+    wireOutput();
+    lastSpawnAt = Date.now();
+    // Re-assert the scroll region (the fresh session repaints into it) and
+    // repaint chrome so the footer/band survive the respawn.
+    process.stdout.write(`\x1b[1;${String(innerNow)}r`);
+    redrawChrome();
+  }
 
   // Teardown order: stop reading stdin, restore cooked mode, drop SSE,
   // dispose the router (rejects any in-flight capture), clear the footer

--- a/packages/core/src/box-record.ts
+++ b/packages/core/src/box-record.ts
@@ -5,6 +5,8 @@
  * live flat (Docker, for historical reasons) or under `cloud` (cloud backends).
  */
 
+import type { BoxRuntimeState } from './provider.js';
+
 /** Sandbox backend a box runs on. Open-ended so future providers need no core change. */
 export type ProviderName = 'docker' | 'daytona' | 'hetzner' | (string & {});
 
@@ -100,6 +102,15 @@ export interface CloudBoxFields {
    * checkpoint a box is currently running.
    */
   snapshotRef?: string;
+  /**
+   * Last lifecycle state agentbox itself drove this box to (running on
+   * create/start/resume, paused on pause/stop/vercel-checkpoint). `listBoxes`
+   * shows this for cloud boxes so `agentbox list` stays instant — no SDK probe.
+   * It reflects the last *host-initiated* op, not the authoritative live state
+   * (a platform-side stop won't update it); `agentbox list --live` probes for
+   * the real state. Absent on pre-feature records → treated as `running`.
+   */
+  lastState?: BoxRuntimeState;
 }
 
 export interface GitWorktreeRecord {

--- a/packages/relay/src/host-actions.ts
+++ b/packages/relay/src/host-actions.ts
@@ -550,6 +550,30 @@ async function runCheckpointRpc(
       stderr: 'relay: AGENTBOX_CLI_ENTRY not set; cannot run checkpoint host-side\n',
     };
   }
+  // Vercel checkpoints stop + reboot the box: `sb.snapshot()` powers off the
+  // microVM (resume is lazy on the next SDK call). When an interactive wrapper
+  // is attached, warn + require confirmation before we yank the box out from
+  // under it. Other backends snapshot without stopping (docker `docker commit`,
+  // hetzner no-pause, daytona), so they stay prompt-free. No attached wrapper →
+  // proceed (a headless caller already knows the box will reboot).
+  if (
+    deps.backendName === 'vercel' &&
+    deps.prompts &&
+    deps.subscribers &&
+    deps.subscribers.forBox(deps.boxId).length > 0
+  ) {
+    const verdict = await askPrompt(deps.prompts, deps.subscribers, deps.boxId, {
+      kind: 'confirm',
+      message: `Create checkpoint on ${deps.boxName ?? deps.boxId}? The vercel box will stop and reboot.`,
+      detail: params.name ? `checkpoint: ${params.name}` : '(auto-named)',
+      defaultAnswer: 'n',
+      context: { command: 'checkpoint create', argv: params.name ? [params.name] : [] },
+    });
+    if (verdict.answer !== 'y') {
+      return { exitCode: 10, stdout: '', stderr: 'checkpoint denied by user\n' };
+    }
+  }
+
   const argv = [process.execPath, entry, 'checkpoint', 'create', deps.boxId];
   if (params.name) argv.push('--name', params.name);
   // --merged is docker-image-layer specific (flatten). For cloud snapshots

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -270,6 +270,22 @@ export function createCloudProvider(
     }
   }
 
+  /**
+   * Persist the last host-driven lifecycle state so `agentbox list`/`top`/the
+   * dashboard can show it without a live SDK probe. `pause`/`stop` persist
+   * `paused` (matches vercel/hetzner's stopped→paused; daytona's authoritative
+   * `stopped` only shows under `--live`). Best-effort — a state-write failure
+   * must not fail the lifecycle op itself.
+   */
+  async function persistLastState(box: BoxRecord, lastState: BoxRuntimeState): Promise<void> {
+    if (!box.cloud) return;
+    try {
+      await recordBox({ ...box, cloud: { ...box.cloud, lastState } });
+    } catch {
+      // listBoxes falls back to the previous value; not worth failing stop/pause.
+    }
+  }
+
   // Re-ensure a freshly-woken cloud box. A resumed/restarted sandbox boots
   // fresh: its in-box processes are gone and (on some backends) preview URLs
   // rotate. Refresh the web/service/relay preview URLs, re-register host
@@ -380,6 +396,9 @@ export function createCloudProvider(
         previewUrls: Object.keys(mergedPreviews).length > 0 ? mergedPreviews : undefined,
         relayPreviewUrl: relayPreview?.url ?? box.cloud?.relayPreviewUrl,
         relayPreviewToken: relayPreview?.token ?? box.cloud?.relayPreviewToken,
+        // reEnsureCloudBox only runs on a freshly-woken box (start/resume), so
+        // the box is now running — persist it for the fast `agentbox list` path.
+        lastState: 'running',
       },
     };
     await recordBox(next);
@@ -868,6 +887,7 @@ export function createCloudProvider(
             relayPreviewToken: relayPreview?.token,
             bridgeToken,
             snapshotRef: resolvedCheckpointRef,
+            lastState: 'running',
           },
           createdAt: new Date().toISOString(),
         };
@@ -894,6 +914,7 @@ export function createCloudProvider(
 
     async pause(box: BoxRecord): Promise<void> {
       await backend.pause(handleFor(box));
+      await persistLastState(box, 'paused');
     },
 
     async resume(box: BoxRecord): Promise<void> {
@@ -909,6 +930,7 @@ export function createCloudProvider(
 
     async stop(box: BoxRecord): Promise<void> {
       await backend.stop(handleFor(box));
+      await persistLastState(box, 'paused');
     },
 
     async destroy(box: BoxRecord): Promise<void> {

--- a/packages/sandbox-docker/src/lifecycle.ts
+++ b/packages/sandbox-docker/src/lifecycle.ts
@@ -106,11 +106,14 @@ export async function listBoxes(): Promise<ListedBox[]> {
   return Promise.all(
     boxes.map(async (b): Promise<ListedBox> => {
       // Cloud boxes don't have a host Docker container — skip every Docker
-      // probe (inspect / exec / shell-session). Their state is optimistically
-      // 'running' (a real probe would round-trip the cloud SDK on every list;
-      // tracked for Phase 6); endpoints come from the cloud.previewUrls map
-      // populated at create/start; agent activity rides the persisted status
-      // snapshot the host poller mirrors from the in-sandbox relay.
+      // probe (inspect / exec / shell-session). State is the last host-driven
+      // lifecycle state persisted on `cloud.lastState` (create/start/resume ->
+      // running, pause/stop/checkpoint -> paused), so `list` stays instant with
+      // no SDK round-trip; `agentbox list --live` probes for the authoritative
+      // state. Pre-feature records (no lastState) fall back to 'running'.
+      // Endpoints come from the cloud.previewUrls map populated at create/start;
+      // agent activity rides the persisted status snapshot the host poller
+      // mirrors from the in-sandbox relay.
       if (b.provider && b.provider !== 'docker') {
         const persisted = await readBoxStatus(b);
         const webPort = b.cloud?.webPort ?? 0;
@@ -157,7 +160,7 @@ export async function listBoxes(): Promise<ListedBox[]> {
         };
         return {
           ...b,
-          state: 'running',
+          state: b.cloud?.lastState ?? 'running',
           endpoints,
           claudeActivity: persisted?.claude.state,
           claudeSessionTitle: persisted?.claude.sessionTitle,

--- a/packages/sandbox-docker/test/prune.test.ts
+++ b/packages/sandbox-docker/test/prune.test.ts
@@ -4,6 +4,12 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { BoxRecord, StateFile } from '../src/state.js';
 
+// Each test does `vi.resetModules()` then dynamic-imports lifecycle.js/state.js.
+// On a cold CI runner the first import transpiles the whole module graph, which
+// can exceed vitest's 5s default and flakily time out (passes in ~300ms locally).
+// The work is real one-time transpile cost, not a hang — give it headroom.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 // pruneBoxes reads/writes STATE_FILE, which is resolved against $HOME at module
 // load time. To isolate, we redirect HOME, vi.resetModules so the next import
 // re-evaluates state.ts with the new HOME, then dynamic-import everything.

--- a/packages/sandbox-vercel/src/index.ts
+++ b/packages/sandbox-vercel/src/index.ts
@@ -26,6 +26,7 @@ import {
   deleteVercelSnapshot,
   DEFAULT_BOX_IMAGE_REF,
 } from './backend.js';
+import { recordBox } from '@agentbox/sandbox-core';
 import { prepareVercelProvider } from './prepare.js';
 import { buildVercelAttach } from './build-attach.js';
 
@@ -59,6 +60,13 @@ const vercelCheckpoint: ProviderCheckpoint = {
     // NOTE: snapshotting stops the source sandbox; persistent mode resumes it
     // on the next call. Surfaced to the user in `agentbox checkpoint` docs.
     const snapshotId = await snapshotVercelSandbox(box.cloud.sandboxId);
+    // The box is now stopped — persist it so the fast `agentbox list` path
+    // doesn't show a stale `running` after a checkpoint. Best-effort.
+    try {
+      await recordBox({ ...box, cloud: { ...box.cloud, lastState: 'paused' } });
+    } catch {
+      // not worth failing the checkpoint over a state-record write
+    }
     const info = await writeCloudCheckpointManifest(box.projectRoot, BACKEND_NAME, name, {
       snapshotName: snapshotId,
       sourceBoxId: box.id,


### PR DESCRIPTION
Accumulated cloud/relay reliability work. Highlights:

## Relay: version-consistent global singleton (npx-robust)
- `/healthz` now reports version/commit; `ensureRelay` reclaims + respawns a relay spawned by a *different* agentbox version (stale npx-cache relay no longer silently serves a newer CLI). Matched on version only so dev rebuilds don't churn.
- Stages the relay's code into a stable `~/.agentbox/relay/<version>/` home (flat-tree installs only) so the long-lived relay and its `AGENTBOX_CLI_ENTRY` survive npx cache GC. `relay status` surfaces version/commit.

## Cloud attach: resume a stopped box before attaching
- `cloudAgentAttach` probes box state and resumes (vercel/daytona/hetzner) before building the attach, fixing the hang where `checkpoint --set-default` stopped the box and the relay poller 502'd forever at "Waiting for connection…".

## Vercel checkpoint: confirm before it reboots the box
A vercel checkpoint snapshots + **stops/reboots** the box (unlike docker/daytona/hetzner). Now, vercel-only:
- **In-box trigger** (`agentbox-ctl checkpoint`): the relay raises a wrapper-visible `[y/N]` prompt ("… the vercel box will stop and reboot") and blocks the RPC until answered.
- **Host-direct trigger**: a TTY confirm, bypassable with `-y/--yes`. The relay-spawned headless run self-skips (no TTY) → no double prompt.

## Attach: keep the wrapper open and auto-reconnect across a box reboot
- The inner PTY is respawnable; on a real drop (checkpoint reboot, or a non-zero-exit blip) the wrapper stays open, shows an animated "box rebooting — reconnecting…" band, resumes the box, and re-attaches **in place** — instead of dropping to the host shell. A clean exit-0 on a healthy box, an explicit `agentbox stop`, and `Ctrl+a d` detach all end the wrapper. Crash-loop guard + safe `pty.resize` (a resize on the dead pty during reconnect used to crash).
- Review-hardening: reset checkpoint-notice tracking after respawn, shrink the drop grace window, and abort reconnect only on a bare Ctrl+C.

## Plus
hetzner ssh-ready wait in `backend.start`, re-ensure daemons/services on `resume()`, dashboard PTY-exit cleanup, banner SIGINT handler fixes, hermetic cloud-cred backup path.

## Verification
- `feat(relay)` version gate + staging: unit-tested + live (faithful npm-pack flat install; relay survives simulated npx cache GC).
- Vercel checkpoint confirm + reconnect: verified live end-to-end on a vercel box — in-box `checkpoint --set-default` → wrapper `[y/N]` → `y` → reboot → "reconnecting…" → re-attached to the Claude session. Host-direct confirm + `--yes` verified.
- Full suites green (relay 120, sandbox-docker 256, cli 362); typecheck/lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes interactive attach lifecycle and checkpoint UX on Vercel (stop/reboot); reconnect heuristics could mis-classify rare exit patterns, but docker attach is unchanged when reconnect is omitted.
> 
> **Overview**
> **Cloud attach** now passes a **`reconnect`** hook into the wrapped PTY: after a real drop it retries **`provider.start`** with backoff (up to five minutes), refreshes attach spec/cleanup, and logs diagnostics to **`~/.agentbox/logs/attach.log`** via **`onError`** (no stderr on the PTY).
> 
> The **wrapper** can **respawn** the inner PTY instead of exiting on every disconnect. It reconnects when a **`checkpoint`** notice is active/recent or exit code is non-zero; it exits on clean **0**, **`Ctrl+a d`**, or no **`reconnect`**. While waiting it shows a **“box rebooting — reconnecting…”** band, swallows stdin (bare **Ctrl+C** aborts), uses safe **`resize`**, and stops after repeated rapid failures.
> 
> **Vercel checkpoints** that stop/reboot the box now require confirmation: **TTY** on **`checkpoint create`** (skippable with **`-y/--yes`**), and a **relay `[y/N]`** when an interactive wrapper is attached before **`checkpoint.create`** runs host-side. Other providers stay unprompted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 709037757bbb0db4c1b2ae14e92f279da31908bc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->