### PR TITLE
fix(vercel): bake Chromium into the base snapshot for agent-browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Uses `portless` to give box web apps the same URL from inside the box and on the
 - `agentbox config` — Read / write layered config (global, per-project, workspace `defaults:`)
 - `agentbox relay` — Manage the host relay process (`status` / `stop` / `start` / `restart`)
 
-Run `agentbox <command> --help` for command-specific options, or see the full [guide](./docs/guide.md).
+Run `agentbox <command> --help` for command-specific options.
 
 ## Development
 
@@ -150,7 +150,7 @@ pnpm install && pnpm build
 node apps/cli/dist/index.js --help
 ```
 
-The full development workflow, stack, end-to-end smoke tests, and teardown live in the [guide](./docs/guide.md#development).
+The full development workflow, stack, end-to-end smoke tests, and teardown live in [`docs/development.md`](./docs/development.md).
 
 # Author
 

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -34,6 +34,14 @@ CLI, not the raw commits.
 - Cloud boxes now offer to sign you in before the box starts when agent
   credentials are missing or expired, seeding the login into this box and every
   future one (Claude, Codex, OpenCode).
+- Attach now survives a box reboot: the wrapper stays open and auto-reconnects
+  once the box is back, so a Vercel checkpoint or restart no longer drops your
+  session.
+- `agentbox url` and `agentbox screen` reach an in-box web service on Vercel —
+  the in-box proxy binds to the always-exposed port 8080, and `url` falls back to
+  the first exposed service port when no proxy is configured.
+- `agentbox list --live` forces a real state probe of cloud boxes; by default
+  `list` now reads persisted box state, so it's fast even with several boxes.
 - A 3-line alert band above the footer surfaces relay confirm prompts,
   checkpoint notices, and the agent's questions without hiding the status bar —
   in both the single-attach TUI and the dashboard.
@@ -48,6 +56,13 @@ CLI, not the raw commits.
   footers and the dashboard: `s` opens the noVNC screen, `u` opens the web-app
   URL, `d` detaches. The dashboard keeps `Ctrl+a q` to quit and moves "stop the
   box" to `Ctrl+a t`.
+- A Vercel checkpoint reboots the box, so it now asks for confirmation first
+  (skip with `-y`).
+- Chromium is baked into the Vercel base snapshot at `prepare` time, so
+  agent-browser is ready immediately on every box instead of installing on each
+  create.
+- The host relay is now a version-consistent global singleton shared by all
+  boxes, robust to mismatched `npx` caches.
 - Faster dashboard switching on the Vercel provider; install-wizard copy and
   progress animation polished.
 
@@ -55,6 +70,14 @@ CLI, not the raw commits.
 
 - The cloud login offer runs in the default docker image instead of a cloud
   snapshot ref, fixing a `docker build` failure on `snap_…` image names.
+- `agentbox list` shows the real state of cloud boxes (stopped/paused) instead
+  of always reporting `running`.
+- Resuming a cloud box re-ensures its daemons and declared services, and a
+  stopped cloud box is resumed before attach instead of failing.
+- Hetzner box creation waits for SSH to be ready before returning, so the next
+  command no longer races a not-yet-reachable VPS.
+- The published npm package now includes the repo README.
+- `Ctrl+c` during the startup banner animation exits cleanly.
 - Skip-permissions conflict detection now also matches inline `--flag=value`
   syntax, so an explicit user choice always wins; background-queue jobs honor
   `--no-dangerously-skip-permissions`.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madarco/agentbox",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Launch Claude Code, Codex, and other coding agents in isolated sandboxes",
   "license": "MIT",
   "author": "Marco D'Alia",

--- a/apps/cli/share/agentbox-setup/SKILL.md
+++ b/apps/cli/share/agentbox-setup/SKILL.md
@@ -164,14 +164,7 @@ services:
 - A service with `restart: never` and an autostart dependency will block the dependent forever after one failed run — usually a mistake.
 - `command:` is either a shell string (run via `bash -c`) or an argv array. Use the argv form if you need to avoid shell quoting.
 
-## 8. Checkpoint the warm state (do this at the very end)
-
-Checkpoint (snapshot) this box writable layer: once the box is warmed up (deps installed, services ready), checkpoint it with `agentbox-ctl checkpoint --name setup --replace --set-default` so future boxes start ready.
-Run this command exactly once. The `--name setup --replace` makes it idempotent — if it ever needs to run again it overwrites the existing `setup` checkpoint instead of stacking duplicates.
-On all providers except Vercel, this doesn't need to be confirmed by the user. It will pause the container for several seconds so warn the user about it and write Done when it's done.
-On Vercel: this actually STOPS the sandbox, so warn the user about it and ask if they want to continue.
-
-## 9. Hand-off
+## 8. Hand-off
 
 Tell the user (verbatim):
 
@@ -186,6 +179,14 @@ Tell the user (verbatim):
 
    your box is ready, you can start more sessions with `agentbox claude`
    you can access the web app at https://<boxname>.localhost
+
+
+## 9. Checkpoint the warm state - DON't SKIP THIS STEP
+
+Checkpoint (snapshot) this box writable layer: once the box is warmed up (deps installed, services ready), checkpoint it with `agentbox-ctl checkpoint --name setup --replace --set-default` so future boxes start ready.
+Run this command exactly once. The `--name setup --replace` makes it idempotent — if it ever needs to run again it overwrites the existing `setup` checkpoint instead of stacking duplicates.
+On all providers except Vercel, this doesn't need to be confirmed by the user. It will pause the container for several seconds so warn the user about it and write Done when it's done.
+On Vercel: this actually STOPS the sandbox, so warn the user about it. Also the system will ask confirmation.
 
 ## 10. Known issues
 

--- a/apps/cli/src/commands/screen.ts
+++ b/apps/cli/src/commands/screen.ts
@@ -131,6 +131,35 @@ export const screenCommand = new Command('screen')
         } else if (state === 'missing') {
           throw new Error(`cloud sandbox for ${box.name} is missing; was it deleted?`);
         }
+
+        // Open the box's web app *inside* the VNC desktop (the host browser only
+        // gets the noVNC viewer), mirroring the docker path. The in-box Chromium
+        // loads the same public preview URL the host uses — the box can reach its
+        // own `*.vercel.run` domain (verified), so it's one origin both sides.
+        // Only when a web service is declared; best-effort, never fails `screen`.
+        const persisted = await readBoxStatus(box);
+        const hasWebService = persisted?.services.some((s) => s.expose) ?? false;
+        if (hasWebService) {
+          try {
+            const webUrl = await p.resolveUrl(box, { kind: 'web' });
+            const q = `'${webUrl.replace(/'/g, "'\\''")}'`;
+            const br = await p.exec(box, ['bash', '-lc', `agent-browser open --headed ${q}`], {
+              user: 'vscode',
+            });
+            if (br.exitCode === 0) {
+              log.info(`opened ${webUrl} in the in-box browser (visible in the VNC view)`);
+            } else {
+              log.warn(
+                `could not open in-box browser (continuing): ${br.stderr.trim() || br.stdout.trim() || `exit ${String(br.exitCode)}`}`,
+              );
+            }
+          } catch (err) {
+            log.warn(
+              `in-box browser skipped: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
+
         const base = await p.resolveUrl(box, { kind: 'vnc', ttl });
         // Append noVNC's auto-connect query so the browser jumps straight to
         // the desktop without prompting for a password — same shape Docker's

--- a/apps/cli/src/wrapped-pty/footer.ts
+++ b/apps/cli/src/wrapped-pty/footer.ts
@@ -52,9 +52,12 @@ export type FooterState =
 export const SPINNER_FRAMES = ['◐', '◓', '◑', '◒'] as const;
 
 const URGENT = '\x1b[38;5;220m\x1b[1m'; // bright yellow + bold (active prompt)
+const TITLE = '\x1b[1m\x1b[38;5;253m'; // bold near-white (prompt band title)
 const TXT = '\x1b[38;5;250m'; // dim gray body text
-const SUBTLE = '\x1b[38;5;245m'; // very dim (Y/N hint)
+const SUBTLE = '\x1b[38;5;245m'; // very dim (detail / Y/N hint)
 const RESET = '\x1b[0m';
+const UNDERLINE = '\x1b[4m'; // emphasizes the default answer inside the chip
+const NO_UNDERLINE = '\x1b[24m'; // ends underline without dropping the chip bg
 // Agent-question accent: cyan + bold, matching the dashboard sidebar's
 // "awaiting" hue — distinct from URGENT (relay prompt) so the two readings
 // don't collide when both could in principle stack.
@@ -112,6 +115,27 @@ function padTo(visible: string, width: number): string {
 }
 
 /**
+ * High-contrast answer chip for a confirm prompt: the keys spelled out on a
+ * bright-yellow background (the same NOTICE treatment used for the "box
+ * frozen" banner) so the y/N choice is unmissable. The default answer is
+ * underlined. Returns the styled string plus its visible column width — the
+ * ANSI codes don't count toward layout, so callers need the plain width.
+ */
+function answerChip(defaultAnswer: 'y' | 'n' | undefined): { ansi: string; width: number } {
+  const yesKey = 'y Yes';
+  const noKey = 'n No';
+  const sep = ' · ';
+  const yesIsDefault = defaultAnswer === 'y';
+  const yes = yesIsDefault ? `${UNDERLINE}${yesKey}${NO_UNDERLINE}` : yesKey;
+  const no = yesIsDefault ? noKey : `${UNDERLINE}${noKey}${NO_UNDERLINE}`;
+  const ansi = `${NOTICE_BG}${NOTICE_FG} ${yes}${sep}${no} ${RESET}`;
+  // Width derived from the plain (underline-free) shape so it stays correct
+  // if the wording changes.
+  const width = ` ${yesKey}${sep}${noKey} `.length;
+  return { ansi, width };
+}
+
+/**
  * Render the footer row as a single ANSI string. Caller positions the
  * cursor at the last row, col 0 before writing, and restores it afterwards.
  * Always ends with SGR reset so the inner pty's next byte starts clean.
@@ -160,15 +184,13 @@ export function renderFooter(state: FooterState, cols: number): string {
     const message = padTo(state.message, inner);
     return `${NOTICE_BG}${NOTICE_FG}${prefix}${message}${RESET}`;
   }
-  // Prompt state: "[!] <message> [detail]  [y/N]"
-  // The y/N hint is suffixed; we squeeze the message+detail into the space
+  // Prompt state (narrow-terminal fallback): "[!] <message> [detail] <chip>".
+  // The answer chip is suffixed; we squeeze the message+detail into the space
   // left over (truncating message first, then detail).
-  const def = state.prompt.defaultAnswer ?? 'n';
-  const yn = def === 'y' ? '[Y/n]' : '[y/N]';
+  const chip = answerChip(state.prompt.defaultAnswer);
   const tag = ' [!] ';
   const sep = '  ';
-  const hintW = ` ${yn} `.length;
-  const inner = Math.max(0, cols - tag.length - hintW);
+  const inner = Math.max(0, cols - tag.length - chip.width);
   const detailRaw = state.prompt.detail ?? '';
   let message = state.prompt.message;
   let detail = detailRaw;
@@ -183,7 +205,7 @@ export function renderFooter(state: FooterState, cols: number): string {
   }
   const middlePlain = detail.length > 0 ? `${message}${sep}${detail}` : message;
   const padded = padTo(middlePlain, inner);
-  return `${BAR_BG}${URGENT}${tag}${TXT}${padded}${SUBTLE} ${yn} ${RESET}`;
+  return `${BAR_BG}${URGENT}${tag}${TXT}${padded}${RESET}${chip.ansi}`;
 }
 
 /**
@@ -227,24 +249,25 @@ function blankBar(cols: number, bg: string): string {
 }
 
 function renderPromptBand(prompt: PromptAskEvent, cols: number, rows: number): string[] {
-  const def = prompt.defaultAnswer ?? 'n';
-  const yn = def === 'y' ? '[Y/n]' : '[y/N]';
   const tag = ' [!] ';
   const indent = ' '.repeat(tag.length);
-  const innerW = Math.max(0, cols - tag.length);
   const contW = Math.max(0, cols - indent.length);
 
-  const msg = padTo(prompt.message, innerW);
-  const line1 = `${BAR_BG}${URGENT}${tag}${TXT}${msg}${RESET}`;
+  // Row 1: "[!] TITLE ............ <chip>". The bold title (the relay action,
+  // e.g. GIT PUSH) flags what needs approval; the high-contrast answer chip
+  // sits right next to it so the keys are spotted immediately — not stranded
+  // dim in the bottom-right corner.
+  const chip = answerChip(prompt.defaultAnswer);
+  const title = (prompt.context?.command ?? 'confirm').toUpperCase();
+  const titleW = Math.max(0, cols - tag.length - chip.width);
+  const titlePadded = padTo(title, titleW);
+  const line1 = `${BAR_BG}${URGENT}${tag}${TITLE}${titlePadded}${RESET}${chip.ansi}`;
 
-  const detail = prompt.detail ?? '';
-  const detailPadded = padTo(detail, contW);
-  const line2 = `${BAR_BG}${TXT}${indent}${detailPadded}${RESET}`;
+  // Row 2: the question itself, full width.
+  const line2 = `${BAR_BG}${TXT}${indent}${padTo(prompt.message, contW)}${RESET}`;
 
-  const hint = ` ${yn} `;
-  const leftW = Math.max(0, cols - hint.length);
-  const left = ' '.repeat(leftW);
-  const line3 = `${BAR_BG}${left}${SUBTLE}${hint}${RESET}`;
+  // Row 3: optional detail/sub-message, dimmer.
+  const line3 = `${BAR_BG}${SUBTLE}${indent}${padTo(prompt.detail ?? '', contW)}${RESET}`;
 
   return [line1, line2, line3].slice(0, rows);
 }

--- a/apps/cli/test/wrapped-pty/footer.test.ts
+++ b/apps/cli/test/wrapped-pty/footer.test.ts
@@ -153,21 +153,28 @@ describe('renderFooter — prompt', () => {
     },
   };
 
-  it('shows the message + Y/N hint', () => {
+  it('shows the message + spelled-out answer chip', () => {
     const out = visible(renderFooter(prompt, 80));
     expect(out).toContain('Allow git push to origin?');
-    expect(out).toContain('[y/N]');
+    expect(out).toContain('y Yes');
+    expect(out).toContain('n No');
     expect(out.startsWith(' [!] ')).toBe(true);
   });
 
-  it('prompt with defaultAnswer "y" shows [Y/n]', () => {
+  it('underlines No (the safe default) when defaultAnswer is absent', () => {
+    // The default is conveyed via the underline SGR, not the chip text, so
+    // assert on the raw (un-stripped) string.
+    const raw = renderFooter(prompt, 80);
+    expect(raw).toContain('\x1b[4mn No');
+  });
+
+  it('underlines Yes when defaultAnswer is "y"', () => {
     const p: FooterState = {
       kind: 'prompt',
       prompt: { ...prompt.prompt, defaultAnswer: 'y' } as never,
     };
-    const out = visible(renderFooter(p, 80));
-    expect(out).toContain('[Y/n]');
-    expect(out).not.toContain('[y/N]');
+    const raw = renderFooter(p, 80);
+    expect(raw).toContain('\x1b[4my Yes');
   });
 
   it('truncates long messages with an ellipsis when cols is narrow', () => {
@@ -181,7 +188,7 @@ describe('renderFooter — prompt', () => {
     };
     const out = visible(renderFooter(long, 30));
     expect(out).toContain('…');
-    expect(out).toContain('[y/N]');
+    expect(out).toContain('n No');
   });
 });
 
@@ -235,7 +242,7 @@ describe('renderFooter — edge cases', () => {
 });
 
 describe('renderAlertBand', () => {
-  it('renders a prompt band as 3 rows with [!] tag, detail row, and right-aligned [y/N] hint', () => {
+  it('renders a prompt band as 3 rows: title + answer chip, then message, then detail', () => {
     const state: AlertBandState = {
       kind: 'prompt',
       prompt: {
@@ -243,15 +250,30 @@ describe('renderAlertBand', () => {
         kind: 'confirm',
         message: 'git push to origin',
         detail: 'branch: agentbox/foo',
+        context: { command: 'git push' },
       },
     };
     const lines = renderAlertBand(state, 80);
     expect(lines).toHaveLength(ALERT_BAND_ROWS);
     const visibleLines = lines.map(visible);
+    // Row 1: marker + bold title (the command, uppercased) + spelled-out chip.
     expect(visibleLines[0]).toContain('[!]');
-    expect(visibleLines[0]).toContain('git push to origin');
-    expect(visibleLines[1]).toContain('branch: agentbox/foo');
-    expect(visibleLines[2]).toContain('[y/N]');
+    expect(visibleLines[0]).toContain('GIT PUSH');
+    expect(visibleLines[0]).toContain('y Yes');
+    expect(visibleLines[0]).toContain('n No');
+    // Row 2: the question; Row 3: the sub-message.
+    expect(visibleLines[1]).toContain('git push to origin');
+    expect(visibleLines[2]).toContain('branch: agentbox/foo');
+  });
+
+  it('falls back to a CONFIRM title when the prompt carries no command', () => {
+    const state: AlertBandState = {
+      kind: 'prompt',
+      prompt: { id: '1', kind: 'confirm', message: 'do the thing?' },
+    };
+    const visibleLines = renderAlertBand(state, 80).map(visible);
+    expect(visibleLines[0]).toContain('CONFIRM');
+    expect(visibleLines[1]).toContain('do the thing?');
   });
 
   it('renders a notice band with a spinner glyph + message, all rows on the yellow banner', () => {

--- a/docs/vercel-backlog.md
+++ b/docs/vercel-backlog.md
@@ -316,6 +316,21 @@ agentbox/<box>` shows the commit, then try `agentbox-ctl git pull` and a `gh pr`
     every create (renewable tokens), best-effort (a failure logs + falls back to
     interactive login). Closes the agent-credential gap from the no-volume
     short-circuit. Unit-tested in `test/push-credentials.test.ts`.
+14b. [ ] **Chromium baked for `agent-browser`.** The login-shell shim exported
+    `AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium` and `provision.sh`
+    installed the `agent-browser` CLI, but never installed Chromium nor created
+    that symlink — so `agent-browser open` failed with `Failed to launch Chrome
+    at "/usr/local/bin/chromium": No such file or directory`. `provision.sh` now
+    mirrors docker/hetzner: installs the AL2023 (dnf) Chrome runtime libs —
+    `nss nspr atk at-spi2-atk at-spi2-core cups-libs libdrm libxkbcommon
+    libX{composite,damage,fixes,randr,ext,11} libxcb mesa-libgbm pango cairo
+    alsa-lib liberation-fonts` (the dnf equivalents of the Ubuntu `t64` deps; the
+    Ubuntu names don't exist on AL2023) — then `playwright install chromium` as
+    vscode and symlinks the resolved binary to `/usr/local/bin/chromium`. The bake
+    fails loud (`exit 70` if the binary doesn't resolve, `exit 71` if `ldd` shows
+    unresolved libs) so an incomplete AL2023 dep set surfaces at prepare time, not
+    at first launch. Headless launch is the success bar; `--headed` still needs the
+    VNC X server on `:1`. **Live-verify pending: re-bake + `ldd`/headless smoke.**
 
 ### P2 — deferred (parity niceties, not blocking)
 

--- a/docs/vercel-backlog.md
+++ b/docs/vercel-backlog.md
@@ -342,7 +342,33 @@ agentbox/<box>` shows the commit, then try `agentbox-ctl git pull` and a `gh pr`
     `agentbox.yaml`). Daytona/Hetzner expose `:80` directly so the branch never
     runs for them. **Live-verified 2026-05-30:** `agentbox url --print` on the
     express-ready box returns the service preview URL and curls `HTTP/2 200`
-    (Express) instead of erroring.
+    (Express) instead of erroring. *(Superseded as the primary path by 14d — kept
+    as a harmless safety net.)*
+14d. [x] **WebProxy on a non-privileged port (8080) so `url`/`screen` work for an
+    in-box-only `agentbox.yaml`.** When the web service is declared by an
+    `agentbox.yaml` that lives only inside the box (host workspace has none), no
+    app port is exposed at create, so `agentbox url` had nothing to reach.
+    **Empirically established (PoC, 2026-05-30):** Vercel rejects privileged ports
+    (`update({ports:[...,80]})` → 400) **and** `sandbox.update` can't add a routable
+    port to a running box (create-time `domain(6080)`=200 vs update-added
+    `domain(3000)`=502, same instant, both with live listeners; docs confirm
+    `domain()` is for "a port you exposed during creation"). So ports must be in
+    `Sandbox.create({ ports })`. Fix: run the in-box WebProxy on **8080** and expose
+    it at create. The WebProxy (owned by the supervisor) forwards `8080 → 127.0.0.1:
+    <expose.port>` from the *in-box* yaml, so it works regardless of where the yaml
+    lives. Changes: ctl WebProxy listen port is configurable via
+    `AGENTBOX_WEB_PROXY_PORT` (`supervisor.ts`/`daemon.ts`); `CloudBackend.webProxyPort`
+    (default 80) — vercel sets 8080; `VERCEL_EXPOSED_PORTS = [8080, 6080, 8788]`;
+    `cloud-provider` uses `backend.webProxyPort` for the web preview / recorded
+    `webPort` / `resolveUrl`, and threads it to the box via `ctl-launch`. Also
+    `agentbox screen` now opens the in-box Chromium onto the VNC desktop at the same
+    `domain(8080)` URL the host uses (the box reaches its own `*.vercel.run` —
+    hairpin verified 200 host + in-box). **Requires a re-bake** (ctl is baked into
+    the snapshot) and applies to **newly-created** boxes (ports are fixed at create).
+    **Live-verified 2026-05-30:** WebProxy logs `:8080 -> 127.0.0.1:3000`,
+    `agentbox url` → `domain(8080)` curls `HTTP/2 200` (Express), and the noVNC
+    screenshot shows the in-box Chromium on the same URL rendering the app.
+    Out of scope: multiple exposed service ports; docker/hetzner/daytona stay on `:80`.
 
 ### P2 — deferred (parity niceties, not blocking)
 

--- a/docs/vercel-backlog.md
+++ b/docs/vercel-backlog.md
@@ -316,7 +316,7 @@ agentbox/<box>` shows the commit, then try `agentbox-ctl git pull` and a `gh pr`
     every create (renewable tokens), best-effort (a failure logs + falls back to
     interactive login). Closes the agent-credential gap from the no-volume
     short-circuit. Unit-tested in `test/push-credentials.test.ts`.
-14b. [ ] **Chromium baked for `agent-browser`.** The login-shell shim exported
+14b. [x] **Chromium baked for `agent-browser`.** The login-shell shim exported
     `AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium` and `provision.sh`
     installed the `agent-browser` CLI, but never installed Chromium nor created
     that symlink — so `agent-browser open` failed with `Failed to launch Chrome
@@ -330,7 +330,19 @@ agentbox/<box>` shows the commit, then try `agentbox-ctl git pull` and a `gh pr`
     fails loud (`exit 70` if the binary doesn't resolve, `exit 71` if `ldd` shows
     unresolved libs) so an incomplete AL2023 dep set surfaces at prepare time, not
     at first launch. Headless launch is the success bar; `--headed` still needs the
-    VNC X server on `:1`. **Live-verify pending: re-bake + `ldd`/headless smoke.**
+    VNC X server on `:1`. **Live-verified 2026-05-30:** re-baked snapshot, `ldd`
+    clean, headless `--dump-dom https://example.com` works, `agent-browser open`
+    returns ok, and a headed Chromium renders over the noVNC desktop.
+14c. [x] **`agentbox url` fallback when :80 isn't exposable.** Vercel rejects
+    privileged ports, so the WebProxy `:80` is never exposed and `sb.domain(80)`
+    throws "No route for port 80" — `agentbox url` errored instead of opening the
+    app. The shared cloud `resolveUrl` (`packages/sandbox-cloud/src/cloud-provider.ts`)
+    now catches a failed `kind:'web'` resolve and falls back to the first exposed
+    `expose:` service port (from the box record's `previewUrls`, else re-read from
+    `agentbox.yaml`). Daytona/Hetzner expose `:80` directly so the branch never
+    runs for them. **Live-verified 2026-05-30:** `agentbox url --print` on the
+    express-ready box returns the service preview URL and curls `HTTP/2 200`
+    (Express) instead of erroring.
 
 ### P2 — deferred (parity niceties, not blocking)
 

--- a/packages/core/src/cloud-backend.ts
+++ b/packages/core/src/cloud-backend.ts
@@ -131,6 +131,17 @@ export interface CloudSandboxSummary {
 export interface CloudBackend {
   readonly name: string;
 
+  /**
+   * Port the in-box WebProxy binds and that the provider exposes + treats as the
+   * box's "web" port (what `resolveUrl(kind:'web')` resolves and `agentbox url`
+   * opens). Defaults to `CLOUD_WEB_PROXY_PORT` (80) when absent — docker/hetzner/
+   * daytona reach the WebProxy on :80. Vercel rejects privileged ports (<1024)
+   * and can't add ports to a running sandbox, so it sets this to a non-privileged
+   * port (8080) that is exposed at create; the value is also wired to the in-box
+   * ctl via AGENTBOX_WEB_PROXY_PORT so the WebProxy binds the same port.
+   */
+  readonly webProxyPort?: number;
+
   provision(req: CloudProvisionRequest): Promise<CloudHandle>;
   /** Resolve an existing sandbox by id; null when it no longer exists. */
   get(sandboxId: string): Promise<CloudHandle | null>;

--- a/packages/ctl/src/commands/daemon.ts
+++ b/packages/ctl/src/commands/daemon.ts
@@ -48,7 +48,10 @@ export const daemonCommand = new Command('daemon')
   .option('--workspace <path>', 'cwd for service processes', '/workspace')
   .action(async (opts: DaemonOptions) => {
     const cfg = await loadConfig(opts.config);
-    const sup = new Supervisor({ workspace: opts.workspace, logDir: opts.logDir });
+    // Cloud backends that can't expose port 80 (Vercel) set AGENTBOX_WEB_PROXY_PORT
+    // so the WebProxy binds a reachable non-privileged port. Unset → default 80.
+    const webProxyPort = Number(process.env.AGENTBOX_WEB_PROXY_PORT) || undefined;
+    const sup = new Supervisor({ workspace: opts.workspace, logDir: opts.logDir, webProxyPort });
     await sup.init(cfg);
     const reporter = new StatusReporter({
       supervisor: sup,

--- a/packages/ctl/src/supervisor.ts
+++ b/packages/ctl/src/supervisor.ts
@@ -515,6 +515,13 @@ export interface SupervisorOptions {
   workspace: string;
   logDir: string;
   spawn?: typeof spawn;
+  /**
+   * Port the in-box WebProxy binds (forwarding to the `expose:` service).
+   * Defaults to 80 (docker/hetzner/daytona). Cloud backends that can't expose a
+   * privileged port — Vercel rejects <1024 — set this to a non-privileged port
+   * (8080) via AGENTBOX_WEB_PROXY_PORT so the WebProxy is reachable at all.
+   */
+  webProxyPort?: number;
 }
 
 interface SupervisorEvents {
@@ -548,11 +555,12 @@ export class Supervisor extends EventEmitter<SupervisorEvents> {
   private scheduling = false;
   private rescheduleDirty = false;
   private readonly relay: RelayClient;
-  private readonly webProxy = new WebProxy();
+  private readonly webProxy: WebProxy;
 
   constructor(private readonly opts: SupervisorOptions) {
     super();
     this.relay = new RelayClient();
+    this.webProxy = new WebProxy(opts.webProxyPort);
   }
 
   /** The relay client the supervisor pushes state events on. Shared with the

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -1117,8 +1117,24 @@ export function createCloudProvider(
       // attach an `x-daytona-preview-token` header from a click).
       if (backend.signedPreviewUrl) {
         const ttl = opts?.ttl ?? DEFAULT_SIGNED_URL_TTL_SECONDS;
-        const signed = await backend.signedPreviewUrl(h, port, ttl);
-        return signed.url;
+        try {
+          const signed = await backend.signedPreviewUrl(h, port, ttl);
+          return signed.url;
+        } catch (err) {
+          // Web fallback: some backends (Vercel) can't expose the privileged
+          // WebProxy port (<1024), so resolving :80 throws "no route". Fall back
+          // to the first exposed `expose:` service port so `agentbox url` still
+          // reaches the app the user actually published. Daytona/Hetzner expose
+          // :80 directly, so this branch never runs for them.
+          if (kind === 'web') {
+            const fallbackPort = await firstExposedServicePort(box);
+            if (fallbackPort !== undefined && fallbackPort !== port) {
+              const signed = await backend.signedPreviewUrl(h, fallbackPort, ttl);
+              return signed.url;
+            }
+          }
+          throw err;
+        }
       }
       // No signed-URL primitive: fall back to the header-token URL, but fail
       // loudly so the caller sees this isn't usable in a browser as-is.
@@ -1149,6 +1165,32 @@ export function createCloudProvider(
     // stats is provider-optional; cloud backends without a metrics API just
     // omit it. Backends that have one can decorate the returned provider.
   };
+}
+
+/** Reserved cloud ports that are never a user-facing web service. */
+const RESERVED_CLOUD_PORTS = new Set<number>([CLOUD_WEB_PROXY_PORT, CLOUD_VNC_PORT, 8788]);
+
+/**
+ * The lowest exposed `expose:` service port for a box, used as the web URL
+ * fallback when the WebProxy port itself can't be exposed (Vercel). Prefers the
+ * box record's `previewUrls` map (only ports that actually got a preview URL
+ * land there), then falls back to re-reading `agentbox.yaml`. Returns undefined
+ * when the box exposes no non-reserved service port.
+ */
+async function firstExposedServicePort(box: BoxRecord): Promise<number | undefined> {
+  const fromRecord = Object.keys(box.cloud?.previewUrls ?? {})
+    .map(Number)
+    .filter((p) => Number.isInteger(p) && !RESERVED_CLOUD_PORTS.has(p));
+  if (fromRecord.length > 0) return Math.min(...fromRecord);
+  try {
+    const fromYaml = (await readExposedServicePorts(box.workspacePath)).filter(
+      (p) => !RESERVED_CLOUD_PORTS.has(p),
+    );
+    if (fromYaml.length > 0) return Math.min(...fromYaml);
+  } catch {
+    // workspace path missing / yaml unreadable — no fallback available
+  }
+  return undefined;
 }
 
 /**

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -299,7 +299,7 @@ export function createCloudProvider(
     // Preview URLs (and their tokens) can rotate across stop/start — refresh
     // the web + relay preview URLs and persist so `agentbox url` and the
     // host poller see the live values.
-    const webPort = box.cloud?.webPort ?? CLOUD_WEB_PROXY_PORT;
+    const webPort = box.cloud?.webPort ?? backend.webProxyPort ?? CLOUD_WEB_PROXY_PORT;
     let webPreview: { url: string; token?: string } | undefined;
     try {
       webPreview = await backend.previewUrl(h, webPort);
@@ -411,6 +411,7 @@ export function createCloudProvider(
       relayUrl: `http://127.0.0.1:${String(8788)}`,
       relayToken: box.relayToken ?? '',
       bridgeToken: box.cloud?.bridgeToken,
+      webProxyPort: backend.webProxyPort,
     });
     // Re-launch in-box dockerd — also dies with the sandbox. Best-effort,
     // mirrors the docker provider's lifecycle.ts:276 relaunch. Skipped for
@@ -681,6 +682,7 @@ export function createCloudProvider(
           relayUrl: `http://127.0.0.1:${String(8788)}`,
           relayToken,
           bridgeToken,
+          webProxyPort: backend.webProxyPort,
         });
 
         // Always-on in-box dockerd, matching the Docker provider
@@ -717,12 +719,16 @@ export function createCloudProvider(
           }
         }
 
+        // The box's "web" port: the in-box WebProxy port the provider exposes.
+        // Defaults to 80; Vercel uses 8080 (it can't expose privileged ports).
+        const wp = backend.webProxyPort ?? CLOUD_WEB_PROXY_PORT;
+
         // The web preview URL is best-effort at create — most boxes won't
-        // have a service on CLOUD_WEB_PROXY_PORT until the supervisor schedules
+        // have a service on the WebProxy port until the supervisor schedules
         // the `expose:` service. `agentbox url` re-resolves on demand.
         let webPreview: { url: string; token?: string } | undefined;
         try {
-          webPreview = await backend.previewUrl(handle, CLOUD_WEB_PROXY_PORT);
+          webPreview = await backend.previewUrl(handle, wp);
         } catch {
           webPreview = undefined;
         }
@@ -739,7 +745,7 @@ export function createCloudProvider(
           const r = await bootstrapPortlessForCloudBox(backend, handle, {
             boxName: name,
             webPreviewUrl: webPreview.url,
-            webPort: CLOUD_WEB_PROXY_PORT,
+            webPort: wp,
             onLog: log,
           });
           if (r) {
@@ -782,7 +788,7 @@ export function createCloudProvider(
         const servicePorts = exposeServicePorts;
         const servicePreviews: Record<number, string> = {};
         for (const port of servicePorts) {
-          if (port === CLOUD_WEB_PROXY_PORT) continue;
+          if (port === wp) continue;
           try {
             const p = await backend.previewUrl(handle, port);
             servicePreviews[port] = p.url;
@@ -877,10 +883,10 @@ export function createCloudProvider(
             backend: backend.name,
             sandboxId: handle.sandboxId,
             image,
-            webPort: CLOUD_WEB_PROXY_PORT,
+            webPort: wp,
             previewUrls: ((): Record<number, string> | undefined => {
               const m: Record<number, string> = { ...servicePreviews };
-              if (webPreview) m[CLOUD_WEB_PROXY_PORT] = webPreview.url;
+              if (webPreview) m[wp] = webPreview.url;
               return Object.keys(m).length > 0 ? m : undefined;
             })(),
             relayPreviewUrl: relayPreview?.url,
@@ -974,7 +980,7 @@ export function createCloudProvider(
 
     async inspect(box: BoxRecord): Promise<InspectedBox> {
       const state = await probe(box);
-      const webPort = box.cloud?.webPort ?? CLOUD_WEB_PROXY_PORT;
+      const webPort = box.cloud?.webPort ?? backend.webProxyPort ?? CLOUD_WEB_PROXY_PORT;
       // Prefer the stable Portless URL for the `web` endpoint when one was
       // registered — matches Docker's endpoint shape (sandbox-docker/src/
       // endpoints.ts:108-117) so `<name>.localhost` shows up uniformly in
@@ -1110,7 +1116,10 @@ export function createCloudProvider(
         }
       }
       // VNC port is fixed by Dockerfile.box (websockify serves noVNC on :6080).
-      const port = kind === 'vnc' ? CLOUD_VNC_PORT : (box.cloud?.webPort ?? CLOUD_WEB_PROXY_PORT);
+      const port =
+        kind === 'vnc'
+          ? CLOUD_VNC_PORT
+          : (box.cloud?.webPort ?? backend.webProxyPort ?? CLOUD_WEB_PROXY_PORT);
       // Always re-resolve through the SDK — cached URLs on the record may be
       // from a previous start whose token has rotated. Prefer signed URLs
       // because the user is about to hand the URL to a browser (no way to
@@ -1178,14 +1187,16 @@ const RESERVED_CLOUD_PORTS = new Set<number>([CLOUD_WEB_PROXY_PORT, CLOUD_VNC_PO
  * when the box exposes no non-reserved service port.
  */
 async function firstExposedServicePort(box: BoxRecord): Promise<number | undefined> {
+  // The box's own WebProxy port (e.g. Vercel's 8080) is reserved too — it's the
+  // web aggregator, not a user service port.
+  const reserved = (p: number): boolean =>
+    RESERVED_CLOUD_PORTS.has(p) || p === box.cloud?.webPort;
   const fromRecord = Object.keys(box.cloud?.previewUrls ?? {})
     .map(Number)
-    .filter((p) => Number.isInteger(p) && !RESERVED_CLOUD_PORTS.has(p));
+    .filter((p) => Number.isInteger(p) && !reserved(p));
   if (fromRecord.length > 0) return Math.min(...fromRecord);
   try {
-    const fromYaml = (await readExposedServicePorts(box.workspacePath)).filter(
-      (p) => !RESERVED_CLOUD_PORTS.has(p),
-    );
+    const fromYaml = (await readExposedServicePorts(box.workspacePath)).filter((p) => !reserved(p));
     if (fromYaml.length > 0) return Math.min(...fromYaml);
   } catch {
     // workspace path missing / yaml unreadable — no fallback available

--- a/packages/sandbox-cloud/src/ctl-launch.ts
+++ b/packages/sandbox-cloud/src/ctl-launch.ts
@@ -23,6 +23,12 @@ export interface LaunchCloudCtlArgs {
   relayToken?: string;
   /** When set, exported as AGENTBOX_BRIDGE_TOKEN inside the box. v0 leaves unset. */
   bridgeToken?: string;
+  /**
+   * When set, exported as AGENTBOX_WEB_PROXY_PORT so the in-box ctl binds its
+   * WebProxy on this port instead of the default 80. Vercel uses 8080 because it
+   * can't expose privileged ports.
+   */
+  webProxyPort?: number;
 }
 
 export async function launchCloudCtlDaemon(args: LaunchCloudCtlArgs): Promise<void> {
@@ -34,6 +40,8 @@ export async function launchCloudCtlDaemon(args: LaunchCloudCtlArgs): Promise<vo
   if (args.relayUrl) env.push(`AGENTBOX_RELAY_URL=${quoteShellArgv([args.relayUrl])}`);
   if (args.relayToken) env.push(`AGENTBOX_RELAY_TOKEN=${quoteShellArgv([args.relayToken])}`);
   if (args.bridgeToken) env.push(`AGENTBOX_BRIDGE_TOKEN=${quoteShellArgv([args.bridgeToken])}`);
+  if (args.webProxyPort !== undefined)
+    env.push(`AGENTBOX_WEB_PROXY_PORT=${quoteShellArgv([String(args.webProxyPort)])}`);
 
   // nohup + & detaches the daemon from the exec channel; logs go to the file
   // the daemon already uses for Docker boxes so debugging is uniform.

--- a/packages/sandbox-vercel/scripts/custom-system-CLAUDE.md
+++ b/packages/sandbox-vercel/scripts/custom-system-CLAUDE.md
@@ -15,10 +15,7 @@ This box is **persistent**: stopping it captures a snapshot and resuming
 restarts from that snapshot, so the filesystem survives a pause. You can also
 save the current filesystem state for future boxes with
 `agentbox-ctl checkpoint --set-default`, but a checkpoint/snapshot STOPS the
-box, so use it only at the end of the setup wizard — otherwise rely on
-idempotent tasks in `agentbox.yaml`. NB: this `agentbox-ctl` command normally
-doesn't need user confirmation, but since it stops the box, ask for
-confirmation before running it.
+box, so use it only at the end of the setup wizard.
 
 `/workspace` is a normal git checkout seeded from the host repo at create time.
 Because there is no host bind-mount, plain `git` inside the box only affects

--- a/packages/sandbox-vercel/scripts/provision.sh
+++ b/packages/sandbox-vercel/scripts/provision.sh
@@ -245,6 +245,42 @@ step "Claude Code (native installer, run as vscode)"
 sudo -u vscode -H bash -lc 'curl -fsSL https://claude.ai/install.sh | bash -s stable'
 done_ "Claude Code (native installer, run as vscode)"
 
+step "Chrome runtime libs (dnf)"
+# agent-browser launches Chromium at AGENT_BROWSER_EXECUTABLE_PATH
+# (/usr/local/bin/chromium, set in the login-shell shim above). Docker + hetzner
+# bake that binary in; do the same here. These are the AL2023 (dnf) equivalents
+# of the Ubuntu `t64` Chrome deps the other two providers apt-install — the
+# Ubuntu package names don't exist on Amazon Linux 2023. Fail loud: a missing lib
+# means a silently broken browser, not a convenience we can skip.
+dnf install -y -q --allowerasing \
+  nss nspr atk at-spi2-atk at-spi2-core cups-libs \
+  libdrm libxkbcommon libXcomposite libXdamage libXfixes libXrandr \
+  libXext libX11 libxcb mesa-libgbm pango cairo alsa-lib \
+  liberation-fonts
+done_ "Chrome runtime libs (dnf)"
+
+step "playwright + Chromium download (as vscode)"
+# Run the download as vscode so the cache lands under
+# /home/vscode/.cache/ms-playwright. Resolve a stable symlink at
+# /usr/local/bin/chromium so AGENT_BROWSER_EXECUTABLE_PATH stays predictable
+# across Chromium revision bumps (mirrors hetzner install-box.sh).
+npm install -g playwright 2>&1 | tail -3
+sudo -u vscode -H bash -lc 'playwright install chromium'
+CHROME_BIN="$(sudo -u vscode -H bash -lc 'ls /home/vscode/.cache/ms-playwright/chromium-*/chrome-linux*/chrome 2>/dev/null | sort | tail -1')"
+if [ -z "$CHROME_BIN" ] || [ ! -x "$CHROME_BIN" ]; then
+  echo "provision.sh: could not resolve Playwright Chromium binary" >&2
+  exit 70
+fi
+# Fail loud if a shared lib is missing — this is where an incomplete AL2023 dep
+# set surfaces at bake time instead of at first agent-browser launch.
+if ldd "$CHROME_BIN" | grep -q 'not found'; then
+  echo "provision.sh: Chromium has unresolved shared libs:" >&2
+  ldd "$CHROME_BIN" | grep 'not found' >&2
+  exit 71
+fi
+ln -sf "$CHROME_BIN" /usr/local/bin/chromium
+done_ "playwright + Chromium download (as vscode)"
+
 step "dnf cleanup"
 dnf clean all 2>/dev/null || true
 done_ "dnf cleanup"

--- a/packages/sandbox-vercel/scripts/provision.sh
+++ b/packages/sandbox-vercel/scripts/provision.sh
@@ -272,10 +272,14 @@ if [ -z "$CHROME_BIN" ] || [ ! -x "$CHROME_BIN" ]; then
   exit 70
 fi
 # Fail loud if a shared lib is missing — this is where an incomplete AL2023 dep
-# set surfaces at bake time instead of at first agent-browser launch.
-if ldd "$CHROME_BIN" | grep -q 'not found'; then
+# set surfaces at bake time instead of at first agent-browser launch. Capture
+# ldd's output first (|| true): under `set -euo pipefail` a non-zero ldd exit
+# would otherwise dominate the `ldd | grep` pipeline and make the missing-libs
+# check a silent no-op even when 'not found' lines are present.
+LDD_OUT="$(ldd "$CHROME_BIN" 2>&1 || true)"
+if printf '%s\n' "$LDD_OUT" | grep -q 'not found'; then
   echo "provision.sh: Chromium has unresolved shared libs:" >&2
-  ldd "$CHROME_BIN" | grep 'not found' >&2
+  printf '%s\n' "$LDD_OUT" | grep 'not found' >&2
   exit 71
 fi
 ln -sf "$CHROME_BIN" /usr/local/bin/chromium

--- a/packages/sandbox-vercel/src/backend.ts
+++ b/packages/sandbox-vercel/src/backend.ts
@@ -61,16 +61,16 @@ const BOX_OWNER = 'vscode:vscode';
 
 /**
  * Base ports exposed at create. Vercel REJECTS privileged ports (<1024) with a
- * 400, so we cannot expose the scaffold's WebProxy port 80 — the two base ports
- * are 6080 (noVNC) and 8788 (the relay/ctl bridge the host poller reaches via
- * `sandbox.domain(8788)`). The in-box WebProxy still binds 80, but it isn't
- * externally reachable on Vercel — so `agentbox url` can't resolve :80 and the
- * shared cloud `resolveUrl` falls back to the first exposed `expose:` service
- * port instead. The remaining slots (up to VERCEL_MAX_PORTS) are filled at create
- * from `agentbox.yaml` `expose:` ports so those per-service preview URLs actually
- * route (see buildExposedPorts).
+ * 400, so we cannot expose the scaffold's WebProxy on :80. Instead the in-box
+ * WebProxy binds 8080 (set via `webProxyPort` → AGENTBOX_WEB_PROXY_PORT) and we
+ * expose 8080 here so `sandbox.domain(8080)` routes to it → the in-box `expose:`
+ * service. Ports are fixed at create (update can't add a routable port to a
+ * running sandbox — verified), so 8080 must be in this base set. The other two
+ * base ports are 6080 (noVNC) and 8788 (the relay/ctl bridge the host poller
+ * reaches via `sandbox.domain(8788)`). Remaining slots (up to VERCEL_MAX_PORTS)
+ * are filled at create from `agentbox.yaml` `expose:` ports (see buildExposedPorts).
  */
-export const VERCEL_EXPOSED_PORTS = [6080, 8788] as const;
+export const VERCEL_EXPOSED_PORTS = [8080, 6080, 8788] as const;
 
 /** Vercel's hard per-sandbox exposed-port cap. */
 export const VERCEL_MAX_PORTS = 4;
@@ -272,6 +272,12 @@ async function pushVercelAgentCredentials(
 
 export const vercelBackend: CloudBackend = {
   name: 'vercel',
+
+  // Vercel rejects privileged ports (<1024) and can't add a routable port to a
+  // running sandbox (update registers a route that 502s — verified). So the
+  // in-box WebProxy binds 8080 (exposed at create via VERCEL_EXPOSED_PORTS) and
+  // `agentbox url` resolves sandbox.domain(8080) → WebProxy → the in-box service.
+  webProxyPort: 8080,
 
   async provision(req: CloudProvisionRequest): Promise<CloudHandle> {
     await ensureFreshCredentials();

--- a/packages/sandbox-vercel/src/backend.ts
+++ b/packages/sandbox-vercel/src/backend.ts
@@ -64,10 +64,11 @@ const BOX_OWNER = 'vscode:vscode';
  * 400, so we cannot expose the scaffold's WebProxy port 80 — the two base ports
  * are 6080 (noVNC) and 8788 (the relay/ctl bridge the host poller reaches via
  * `sandbox.domain(8788)`). The in-box WebProxy still binds 80, but it isn't
- * externally reachable on Vercel, so `agentbox url` for a web app on :80 stays a
- * documented limitation. The remaining slots (up to VERCEL_MAX_PORTS) are filled
- * at create from `agentbox.yaml` `expose:` ports so per-service preview URLs
- * actually route (see buildExposedPorts).
+ * externally reachable on Vercel — so `agentbox url` can't resolve :80 and the
+ * shared cloud `resolveUrl` falls back to the first exposed `expose:` service
+ * port instead. The remaining slots (up to VERCEL_MAX_PORTS) are filled at create
+ * from `agentbox.yaml` `expose:` ports so those per-service preview URLs actually
+ * route (see buildExposedPorts).
  */
 export const VERCEL_EXPOSED_PORTS = [6080, 8788] as const;
 

--- a/packages/sandbox-vercel/test/backend.test.ts
+++ b/packages/sandbox-vercel/test/backend.test.ts
@@ -200,26 +200,27 @@ describe('vercelBackend.snapshotExists', () => {
 
 describe('buildExposedPorts', () => {
   it('returns just the base ports when no expose ports are given', () => {
-    expect(buildExposedPorts(undefined)).toEqual([6080, 8788]);
-    expect(buildExposedPorts([])).toEqual([6080, 8788]);
+    expect(buildExposedPorts(undefined)).toEqual([8080, 6080, 8788]);
+    expect(buildExposedPorts([])).toEqual([8080, 6080, 8788]);
   });
 
   it('appends non-privileged expose ports after the base set', () => {
-    expect(buildExposedPorts([3000])).toEqual([6080, 8788, 3000]);
+    expect(buildExposedPorts([3000])).toEqual([8080, 6080, 8788, 3000]);
   });
 
   it('drops privileged ports (<1024, which Vercel 400s) and out-of-range', () => {
-    expect(buildExposedPorts([80, 443, 3000, 70000])).toEqual([6080, 8788, 3000]);
+    expect(buildExposedPorts([80, 443, 3000, 70000])).toEqual([8080, 6080, 8788, 3000]);
   });
 
   it('dedupes against the base set and itself', () => {
-    expect(buildExposedPorts([6080, 3000, 3000])).toEqual([6080, 8788, 3000]);
+    expect(buildExposedPorts([8080, 6080, 3000, 3000])).toEqual([8080, 6080, 8788, 3000]);
   });
 
   it('never exceeds the Vercel 4-port cap', () => {
+    // Base set is now [8080, 6080, 8788] (3 ports), so only one expose slot is left.
     const out = buildExposedPorts([3000, 3001, 3002, 3003]);
     expect(out.length).toBe(VERCEL_MAX_PORTS);
-    expect(out).toEqual([6080, 8788, 3000, 3001]);
+    expect(out).toEqual([8080, 6080, 8788, 3000]);
   });
 });
 


### PR DESCRIPTION
## Problem

Inside a Vercel box, `agent-browser open ...` failed with:

```
✗ Failed to launch Chrome at "/usr/local/bin/chromium": No such file or directory (os error 2)
```

`provision.sh` installed the `agent-browser` CLI and exported `AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium` in the login-shell shim, but — unlike the **docker** (`Dockerfile.box`) and **hetzner** (`install-box.sh`) providers — never installed Chromium nor created that symlink.

## Fix

`packages/sandbox-vercel/scripts/provision.sh` now mirrors docker/hetzner, adapted for Amazon Linux 2023:

- Install Chrome runtime libs via `dnf` (the AL2023 equivalents of the Ubuntu `t64` deps; the Ubuntu names don't exist on AL2023).
- `playwright install chromium` as `vscode`, then symlink the resolved binary to `/usr/local/bin/chromium`.
- Fail loud: `exit 70` if the binary can't resolve, `exit 71` if `ldd` reports unresolved libs — so an incomplete AL2023 dep set surfaces at bake time, not at first launch.

## Verified live

Re-baked the snapshot and created a fresh box:
- Symlink resolves to the real `chrome` binary; `ldd` shows no missing libs.
- Headless Chromium launches in the Firecracker microVM: `--dump-dom https://example.com` → `<title>Example Domain</title>`.
- `agent-browser open http://localhost:3000` → `✓ Directory listing for /`, exit 0 (the originally-failing command).

`--headed`/VNC display wiring is out of scope (separate concern — needs the X server on `:1`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cloud create URLs, exposed ports, and snapshot bake paths on Vercel; incorrect port wiring would break `agentbox url`/`screen` until re-bake and new boxes.
> 
> **Overview**
> This PR extends **Vercel** sandbox parity beyond the titled Chromium fix: it bakes **Chromium** into `provision.sh` (AL2023 `dnf` libs, Playwright install, `/usr/local/bin/chromium`, bake-time `ldd` failures), moves the in-box **WebProxy to port 8080** (`CloudBackend.webProxyPort`, `AGENTBOX_WEB_PROXY_PORT`, expose `8080` at create), and threads that through **cloud-provider** URL resolution plus a **fallback** to the first exposed `expose:` service port when the web proxy port cannot be signed.
> 
> **CLI/UX:** `agentbox screen` on cloud boxes best-effort opens the web app in headed **agent-browser** inside the VNC desktop using the same preview URL as the host. Confirm prompts in the wrapped PTY use a high-contrast **y Yes · n No** chip (default underlined) and a 3-row alert band with an uppercased command title. The **agentbox-setup** skill moves checkpoint instructions after hand-off and stresses not skipping them on Vercel.
> 
> Docs record live verification for Chromium, `url`, and WebProxy behavior. **Re-bake** the Vercel snapshot and **new creates** are required for ctl/WebProxy and Chromium changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c66e3e832e80055005312902cabad742c1385d6a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->