### PR TITLE
fix(cloud): seed a git committer identity into cloud boxes

### DIFF
--- a/packages/ctl/src/commands/git.ts
+++ b/packages/ctl/src/commands/git.ts
@@ -65,6 +65,25 @@ function runLocalGit(args: string[], cwd: string): Promise<number> {
   });
 }
 
+/**
+ * True when the box has a git committer identity configured (`user.email`).
+ * Docker boxes bind-mount the host `~/.gitconfig`, so they do; cloud boxes
+ * (e.g. Vercel's `vscode` user on fresh AL2023) often don't, which makes a
+ * non-fast-forward `git pull` merge fail with "Committer identity unknown".
+ */
+function hasGitIdentity(cwd: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const child = spawn('git', ['config', 'user.email'], {
+      cwd,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    let out = '';
+    child.stdout.on('data', (c: Buffer) => (out += c.toString('utf8')));
+    child.on('close', (code) => resolve(code === 0 && out.trim().length > 0));
+    child.on('error', () => resolve(false));
+  });
+}
+
 export const gitCommand = new Command('git')
   .description('Git operations that need host credentials (routed through the agentbox relay)')
   .addCommand(
@@ -135,7 +154,21 @@ export const gitCommand = new Command('git')
           // Resolve branch via the current HEAD's upstream, falling back to
           // `<remote>/HEAD` so a freshly cloned worktree still pulls.
           const cwd = opts.cwd ?? process.cwd();
-          const mergeArgs = ['merge'];
+          // A non-fast-forward merge writes a merge commit, which needs a
+          // committer identity. Fall back to a generic agentbox identity only
+          // when the box has none of its own — docker boxes inherit the user's
+          // bind-mounted ~/.gitconfig and should keep authoring as the user.
+          // Mirrors the resync merge in sandbox-docker/src/in-box-git.ts.
+          const mergeArgs: string[] = [];
+          if (!(await hasGitIdentity(cwd))) {
+            mergeArgs.push(
+              '-c',
+              'user.name=agentbox',
+              '-c',
+              'user.email=agentbox@users.noreply.github.com',
+            );
+          }
+          mergeArgs.push('merge');
           if (opts.ffOnly) mergeArgs.push('--ff-only');
           mergeArgs.push(`${remote}/HEAD`);
           const mergeCode = await runLocalGit(mergeArgs, cwd);

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -49,6 +49,7 @@ import {
   seedOpencodeModelState,
 } from './agent-credentials.js';
 import { seedDynamicConfig } from './dynamic-sync.js';
+import { seedGitIdentity } from './git-identity.js';
 import {
   cloudSnapshotName,
   listCloudCheckpoints,
@@ -653,6 +654,15 @@ export function createCloudProvider(
         // Static config (plugins/skills/settings) is baked into the snapshot;
         // these two trees change between runs and ship per-box, like credentials.
         await seedDynamicConfig(backend, handle, { workspacePath: req.workspacePath, onLog: log });
+
+        // Configure a git committer identity in the box. Docker inherits the
+        // host's via a bind-mounted ~/.gitconfig; cloud boxes have none, so the
+        // agent's `git commit` and `agentbox git pull`'s merge commit would
+        // fail with "Committer identity unknown". Author as the host user when
+        // resolvable, else a generic agentbox identity. Runs on both fresh and
+        // snapshot boots (idempotent `git config --global`) so a snapshot that
+        // didn't capture ~/.gitconfig can't leave the box identity-less.
+        await seedGitIdentity(backend, handle, { hostRepo: req.workspacePath, onLog: log });
 
         // Copy the env/config files the setup wizard collected (`.env`,
         // `secrets.toml`, `agentbox.yaml`, …) into `/workspace`. The Docker

--- a/packages/sandbox-cloud/src/git-identity.ts
+++ b/packages/sandbox-cloud/src/git-identity.ts
@@ -1,0 +1,60 @@
+import { execa } from 'execa';
+import type { CloudBackend, CloudHandle } from '@agentbox/core';
+import { bashScript, quoteShellArg } from './shell.js';
+
+export interface SeedGitIdentityOptions {
+  /** Host repo dir to read the effective `user.name`/`user.email` from. */
+  hostRepo?: string;
+  onLog?: (line: string) => void;
+}
+
+/** Generic fallback so a box always has a usable committer identity. */
+const FALLBACK_NAME = 'agentbox';
+const FALLBACK_EMAIL = 'agentbox@users.noreply.github.com';
+
+/**
+ * Configure a git committer identity inside a cloud box.
+ *
+ * Docker boxes bind-mount the host `~/.gitconfig`, so they inherit the user's
+ * identity for free. Cloud boxes (vercel/hetzner/daytona) can't bind-mount and
+ * otherwise have *no* identity — which breaks any in-box commit: the agent's
+ * own `git commit`, and the merge commit `agentbox git pull` writes. We mirror
+ * the Docker behavior here: author as the host user when their identity is
+ * resolvable, and fall back to a generic agentbox identity so commits never
+ * fail with "Committer identity unknown".
+ *
+ * Reads the *effective* identity from the host repo (`git -C <repo> config
+ * user.name`), so a repo-local override is honored just like a normal local
+ * commit would. Sets `--global` for the box's agent user (cloud `exec` runs as
+ * that user), which is where the in-box merge / agent commits look it up.
+ */
+export async function seedGitIdentity(
+  backend: CloudBackend,
+  handle: CloudHandle,
+  opts: SeedGitIdentityOptions = {},
+): Promise<void> {
+  const log = opts.onLog ?? (() => {});
+  const name = (await readHostGitConfig('user.name', opts.hostRepo)) ?? FALLBACK_NAME;
+  const email = (await readHostGitConfig('user.email', opts.hostRepo)) ?? FALLBACK_EMAIL;
+
+  const script =
+    `git config --global user.name ${quoteShellArg(name)} && ` +
+    `git config --global user.email ${quoteShellArg(email)}`;
+  const r = await backend.exec(handle, bashScript(script));
+  if (r.exitCode !== 0) {
+    // Non-fatal: the box still boots; the user just sees the identity error on
+    // the next commit, same as before this step existed.
+    log(`git: identity config failed (exit ${String(r.exitCode)}): ${(r.stderr || r.stdout).trim()}`);
+    return;
+  }
+  log(`git: configured committer identity ${name} <${email}>`);
+}
+
+/** Read a host git config value (effective: system + global + repo-local). */
+async function readHostGitConfig(key: string, hostRepo?: string): Promise<string | null> {
+  const args = hostRepo ? ['-C', hostRepo, 'config', key] : ['config', key];
+  const r = await execa('git', args, { reject: false });
+  if (r.exitCode !== 0) return null;
+  const value = (r.stdout ?? '').trim();
+  return value.length > 0 ? value : null;
+}

--- a/packages/sandbox-cloud/src/index.ts
+++ b/packages/sandbox-cloud/src/index.ts
@@ -35,6 +35,7 @@ export {
   type UploadEnvFilesResult,
 } from './env-files.js';
 export { seedDynamicConfig, type SeedDynamicConfigOptions } from './dynamic-sync.js';
+export { seedGitIdentity, type SeedGitIdentityOptions } from './git-identity.js';
 export { bashScript, quoteShellArg, quoteShellArgv } from './shell.js';
 export {
   makeMockCloudBackend,

--- a/packages/sandbox-cloud/test/git-identity.test.ts
+++ b/packages/sandbox-cloud/test/git-identity.test.ts
@@ -1,0 +1,71 @@
+import { execa } from 'execa';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { CloudHandle } from '@agentbox/core';
+import { makeMockCloudBackend, type MockCloudBackend } from '../src/mock-backend.js';
+import { seedGitIdentity } from '../src/git-identity.js';
+
+const HANDLE: CloudHandle = { sandboxId: 'box1' };
+
+function lastExecCmd(backend: MockCloudBackend): string {
+  const execCalls = backend.calls.filter((c) => c.method === 'exec');
+  const last = execCalls[execCalls.length - 1];
+  return (last?.args[1] as string) ?? '';
+}
+
+describe('seedGitIdentity', () => {
+  let repo: string;
+
+  beforeEach(async () => {
+    repo = await mkdtemp(join(tmpdir(), 'agentbox-gitid-'));
+    await execa('git', ['init', '-q', repo]);
+  });
+
+  afterEach(async () => {
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  it("configures the box with the host repo's effective identity", async () => {
+    // Local config wins over any global/system identity, so this is
+    // deterministic regardless of the CI host's git setup.
+    await execa('git', ['-C', repo, 'config', 'user.name', 'test-user']);
+    await execa('git', ['-C', repo, 'config', 'user.email', 'test@example.com']);
+
+    const backend = makeMockCloudBackend({ preloaded: [{ id: 'box1' }] });
+    await seedGitIdentity(backend, HANDLE, { hostRepo: repo });
+
+    const cmd = lastExecCmd(backend);
+    expect(cmd).toContain('git config --global user.name test-user');
+    expect(cmd).toContain('git config --global user.email test@example.com');
+  });
+
+  it('falls back to a generic agentbox identity when the host has none', async () => {
+    // Isolate from any real global/system identity on the test host so the
+    // non-configured temp repo resolves to nothing → fallback path.
+    const prevGlobal = process.env['GIT_CONFIG_GLOBAL'];
+    const prevSystem = process.env['GIT_CONFIG_SYSTEM'];
+    process.env['GIT_CONFIG_GLOBAL'] = '/dev/null';
+    process.env['GIT_CONFIG_SYSTEM'] = '/dev/null';
+    try {
+      const backend = makeMockCloudBackend({ preloaded: [{ id: 'box1' }] });
+      await seedGitIdentity(backend, HANDLE, { hostRepo: repo });
+
+      const cmd = lastExecCmd(backend);
+      expect(cmd).toContain('git config --global user.name agentbox');
+      expect(cmd).toContain('git config --global user.email agentbox@users.noreply.github.com');
+    } finally {
+      if (prevGlobal === undefined) delete process.env['GIT_CONFIG_GLOBAL'];
+      else process.env['GIT_CONFIG_GLOBAL'] = prevGlobal;
+      if (prevSystem === undefined) delete process.env['GIT_CONFIG_SYSTEM'];
+      else process.env['GIT_CONFIG_SYSTEM'] = prevSystem;
+    }
+  });
+
+  it('issues exactly one identity exec (both keys in one command)', async () => {
+    const backend = makeMockCloudBackend({ preloaded: [{ id: 'box1' }] });
+    await seedGitIdentity(backend, HANDLE, { hostRepo: repo });
+    expect(backend.calls.filter((c) => c.method === 'exec')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Problem

Cloud boxes (vercel/hetzner/daytona) bind-mount no host `~/.gitconfig`, so they had **no git committer identity at all**. Any in-box commit failed with:

```
*** Please tell me who you are.
fatal: unable to auto-detect email address (got 'vscode@...(none)')
```

This broke both:
- the agent's own `git commit` inside a cloud box, and
- the merge commit that `agentbox git pull` writes (the reported symptom).

Docker boxes never hit this because `create.ts` bind-mounts the host `~/.gitconfig`. The "no host gitconfig identity" state was even documented in `custom-system-CLAUDE.md`, but nothing supplied a fallback.

## Fix

Mirror the docker behavior on the cloud path. New `seedGitIdentity()` (`packages/sandbox-cloud/src/git-identity.ts`) reads the host repo's **effective** identity (`git -C <repo> config user.name/email`, so a repo-local override is honored like a normal commit) and falls back to a generic `agentbox <agentbox@users.noreply.github.com>` so commits never fail.

Wired into the **shared** cloud create flow (`cloud-provider.ts`, right after `seedDynamicConfig`), so it covers all three cloud providers. Runs on fresh **and** snapshot boots (idempotent `git config --global`), so a snapshot that didn't capture `~/.gitconfig` can't leave the box identity-less.

Also hardened ctl's `git pull` in-box merge with the same fallback — injected **only** when the box has no identity of its own, so docker boxes keep authoring as the real user. Mirrors the existing resync merge in `sandbox-docker/src/in-box-git.ts`.

### Why the merge stays in-box
`git push`/`git fetch` already run host-side through the relay (creds never enter the box — bundle round-trip in `runGitRpc`). But `git pull`'s merge integrates `origin/HEAD` into the box's **working tree**, which only the box has. So it's correctly a local, non-credentialed op; it just needed an identity.

## Test plan
- [x] `pnpm build` green; lint clean.
- [x] New `git-identity.test.ts` (3): host-identity path, generic-fallback path, single-exec. Cloud suite 60/60 (create-ordering tests intact); ctl 183/183.
- [ ] Live: on a Vercel box, `agentbox git pull <box>` merges without the identity error, and an in-box `git commit` succeeds — not yet run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to git identity seeding and optional merge-time `-c` overrides; failures during seed are non-fatal and Docker behavior is preserved when identity exists.
> 
> **Overview**
> Cloud sandboxes no longer ship without a git committer identity, which previously broke in-box **`git commit`** and the merge step of **`agentbox git pull`** with “Committer identity unknown” (Docker already got identity from a bind-mounted **`~/.gitconfig`**).
> 
> **`seedGitIdentity`** runs in the shared cloud create path after dynamic config seeding: it reads the host repo’s effective **`user.name`** / **`user.email`**, sets them **`git config --global`** in the box, or falls back to **`agentbox <agentbox@users.noreply.github.com>`**. It runs on fresh and snapshot boots (idempotent) so snapshots that lack gitconfig still get an identity.
> 
> **`agentbox-ctl git pull`** now checks for **`user.email`** in the box before the local merge; only when missing does it inject the same generic **`-c`** identity (Docker boxes with a real config are unchanged), aligned with the Docker resync merge in **`in-box-git.ts`**.
> 
> New unit tests cover host identity, fallback, and a single exec for both config keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aeb8ac84ed6c7dcaf13e9f7348faa89b6628ce3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->