### PR TITLE
fix(checkpoint): re-prompt setup when the default snapshot is stale

### DIFF
--- a/apps/cli/src/checkpoint-lookup.ts
+++ b/apps/cli/src/checkpoint-lookup.ts
@@ -1,47 +1,123 @@
 /**
- * Provider-aware checkpoint existence check used by the wizard. The default
+ * Provider-aware checkpoint evaluation used by the wizard. The default
  * checkpoint name lives in a single config field (`box.defaultCheckpoint`),
- * but the actual artifact may exist for Docker, for Daytona, both, or
- * neither. The wizard consults this helper before announcing "starting from
- * checkpoint …" — if the named checkpoint doesn't exist for the active
- * provider, the wizard falls through to the normal setup flow instead of
- * misleadingly skipping it.
+ * but the actual artifact may exist for Docker, for a cloud backend, both, or
+ * neither — and even when it exists it may be *stale* (captured against a base
+ * image/snapshot that has since been rebuilt) or *orphaned* (its underlying
+ * Docker image / cloud snapshot is gone).
  *
- * For cloud providers the local manifest is only half the story: the provider
- * snapshot it points at can expire or be deleted out-of-band. We probe the
- * backend for liveness and prune the dangling manifest when it's gone, so the
- * wizard re-asks the setup wizard (start-from-scratch) rather than booting
- * from a snapshot that would 410 mid-create.
+ * `evaluateCheckpoint` collapses all of that into three states so the wizard
+ * can decide whether to silently skip setup (`fresh`), re-prompt the user to
+ * recreate it (`stale`), or fall through to normal setup (`missing`). Without
+ * this, a stale checkpoint would announce "starting from checkpoint …; skipping
+ * setup" and then quietly rebuild the base image while booting from the old
+ * layers — the exact confusion this module exists to prevent.
  */
 
 import type { ProviderName } from '@agentbox/core';
-import { resolveCheckpoint } from '@agentbox/sandbox-docker';
-import { probeCloudCheckpoint, resolveCloudCheckpoint } from '@agentbox/sandbox-cloud';
+import {
+  computeDockerContextFingerprint,
+  imageExists,
+  readPreparedDockerState,
+  resolveCheckpoint,
+} from '@agentbox/sandbox-docker';
+import {
+  currentCloudBaseFingerprint,
+  probeCloudCheckpoint,
+  resolveCloudCheckpoint,
+} from '@agentbox/sandbox-cloud';
 import { cloudBackendForProvider } from './provider/cloud-backend.js';
 
-export async function checkpointExistsForProvider(
+export type CheckpointStatus =
+  /** No manifest, a dead/expired cloud snapshot, or an orphaned Docker image — not bootable. */
+  | { state: 'missing' }
+  /** Bootable, but its base image/snapshot is older than the current one (or unverifiable). */
+  | { state: 'stale'; reason: string }
+  /** Bootable and captured against the current base. */
+  | { state: 'fresh' };
+
+function short(sha: string): string {
+  return sha.slice(0, 12);
+}
+
+async function evaluateDockerCheckpoint(
+  projectRoot: string,
+  ref: string,
+): Promise<CheckpointStatus> {
+  const head = await resolveCheckpoint(projectRoot, ref);
+  if (!head) return { state: 'missing' };
+  // The checkpoint *image* is the docker-run base. A manifest with no backing
+  // image (pruned out-of-band) can't boot — treat as missing so the wizard
+  // falls through to a fresh setup rather than offering "use it anyway".
+  if (!(await imageExists(head.manifest.image))) return { state: 'missing' };
+
+  const fp = head.manifest.baseFingerprint;
+  if (head.manifest.schema === 2 || !fp) {
+    return {
+      state: 'stale',
+      reason: 'captured before checkpoint versioning; base image unverifiable',
+    };
+  }
+  const current =
+    readPreparedDockerState()?.base?.contextSha256 ??
+    (await computeDockerContextFingerprint())?.contextSha256;
+  if (current && fp !== current) {
+    return {
+      state: 'stale',
+      reason: `base image updated since capture (captured ${short(fp)}, current ${short(current)})`,
+    };
+  }
+  return { state: 'fresh' };
+}
+
+async function evaluateCloudCheckpoint(
   provider: ProviderName,
   projectRoot: string,
   ref: string,
-): Promise<boolean> {
-  if (provider === 'docker') {
-    return (await resolveCheckpoint(projectRoot, ref)) !== null;
-  }
-  // v1: every cloud backend ships its checkpoints under the
-  // `~/.agentbox/cloud-checkpoints/<backend>/…` tree. The provider name is
-  // also the backend name so the lookup is a 1:1 mapping.
-  if ((await resolveCloudCheckpoint(projectRoot, provider, ref)) === null) return false;
-  // Manifest present — confirm the provider snapshot it points at is still
-  // bootable. A gone snapshot is pruned here so the next read sees nothing and
-  // the create path provisions from the base image. A probe failure (network /
-  // creds) is treated as "assume live": we never strand a usable checkpoint on
-  // a transient error.
+): Promise<CheckpointStatus> {
+  const found = await resolveCloudCheckpoint(projectRoot, provider, ref);
+  if (!found) return { state: 'missing' };
+  // Confirm the provider snapshot is still bootable. A gone snapshot is pruned
+  // here so the next read sees nothing. A probe failure (network / creds) is
+  // treated as "assume live": never strand a usable checkpoint on a transient
+  // error.
   try {
     const backend = await cloudBackendForProvider(provider);
-    if (!backend) return true;
-    const { live } = await probeCloudCheckpoint(backend, projectRoot, ref);
-    return live;
+    if (backend) {
+      const { live } = await probeCloudCheckpoint(backend, projectRoot, ref);
+      if (!live) return { state: 'missing' };
+    }
   } catch {
-    return true;
+    // assume live
   }
+
+  const fp = found.manifest.baseFingerprint;
+  if (found.manifest.schema < 2 || !fp) {
+    return {
+      state: 'stale',
+      reason: 'captured before checkpoint versioning; base snapshot unverifiable',
+    };
+  }
+  const current = currentCloudBaseFingerprint(provider);
+  if (current && fp !== current) {
+    return {
+      state: 'stale',
+      reason: `base snapshot updated since capture (captured ${short(fp)}, current ${short(current)})`,
+    };
+  }
+  return { state: 'fresh' };
+}
+
+/**
+ * Classify `ref` for the active provider. `docker` resolves against the local
+ * checkpoint store + image engine; cloud backends resolve the manifest, probe
+ * snapshot liveness, then compare base fingerprints.
+ */
+export async function evaluateCheckpoint(
+  provider: ProviderName,
+  projectRoot: string,
+  ref: string,
+): Promise<CheckpointStatus> {
+  if (provider === 'docker') return evaluateDockerCheckpoint(projectRoot, ref);
+  return evaluateCloudCheckpoint(provider, projectRoot, ref);
 }

--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -35,10 +35,7 @@ import {
 import { Command } from 'commander';
 import { resolveClaudeAuth, type ResolvedClaudeAuth } from '../auth.js';
 import { resolveBoxOrExit, resolveBoxOrShift } from '../box-ref.js';
-import {
-  assertAgentCredsAvailable,
-  MissingAgentCredsError,
-} from '../lib/queue/assert-creds.js';
+import { assertAgentCredsAvailable, MissingAgentCredsError } from '../lib/queue/assert-creds.js';
 import { buildPromptArgs } from '../lib/queue/build-prompt-args.js';
 import { maybeResyncWorkspace } from '../lib/resync-start.js';
 import { buildResyncWarning } from '../lib/resync-warning.js';
@@ -147,9 +144,7 @@ async function attachClaudeWrapped(
     detachNotice: formatDetachNotice(reattach),
     onError,
     openIn,
-    onPasteImage: canPaste
-      ? () => pasteHostClipboardImage(provider, box)
-      : undefined,
+    onPasteImage: canPaste ? () => pasteHostClipboardImage(provider, box) : undefined,
   });
   process.exit(code);
 }
@@ -369,7 +364,10 @@ export const claudeCommand = new Command('claude')
   // Mirror create's surface so users can swap the verb without re-learning flags.
   .option('-w, --workspace <path>', 'host workspace to mount', process.cwd())
   .option('-n, --name <name>', 'friendly box name (default: <workspace-basename>-<id>)')
-  .option('--host-snapshot', 'APFS-clone the host workspace into a per-box scratch dir before seeding /workspace (stabilizes the tar-pipe source)')
+  .option(
+    '--host-snapshot',
+    'APFS-clone the host workspace into a per-box scratch dir before seeding /workspace (stabilizes the tar-pipe source)',
+  )
   .option('--no-host-snapshot', 'tar-pipe directly from the live host workspace at create time')
   .option(
     '--snapshot <ref>',
@@ -422,17 +420,14 @@ export const claudeCommand = new Command('claude')
   .option('--cpus <n>', 'CPU count cap (fractional ok, e.g. 1.5); unset = unlimited')
   .option('--pids-limit <n>', 'max process count (PIDs cgroup); unset = unlimited')
   .option('--disk <size>', 'best-effort writable-layer size (e.g. 10g); no-op on overlay2/macOS')
-  .option(
-    '--provider <name>',
-    "sandbox backend: 'docker' (default) or 'daytona' for a cloud box",
-  )
+  .option('--provider <name>', "sandbox backend: 'docker' (default) or 'daytona' for a cloud box")
   .option(
     '--from-branch <ref>',
     "base the box's per-box branch on this ref (branch / tag / SHA) instead of HEAD. Branch/tag names are fetched from origin first.",
   )
   .option(
     '-b, --use-branch <name>',
-    "reuse an existing branch directly instead of forking agentbox/<box-name>. Commits/pushes flow straight to it. Docker fails if the host already has it checked out. Mutually exclusive with --from-branch.",
+    'reuse an existing branch directly instead of forking agentbox/<box-name>. Commits/pushes flow straight to it. Docker fails if the host already has it checked out. Mutually exclusive with --from-branch.',
   )
   .option(
     '-v, --verbose',
@@ -443,7 +438,7 @@ export const claudeCommand = new Command('claude')
   .option('-d, --no-attach', NO_ATTACH_HELP)
   .option(
     '-i, --initial-prompt <text>',
-    'seed the claude session with this initial user turn and run in background (no attach). Jobs go through the host-wide queue (queue.maxConcurrent). NOTE: this is NOT claude\'s own `-p` headless print mode — for that, pass `-- -p ...`.',
+    "seed the claude session with this initial user turn and run in background (no attach). Jobs go through the host-wide queue (queue.maxConcurrent). NOTE: this is NOT claude's own `-p` headless print mode — for that, pass `-- -p ...`.",
   )
   .option(
     '--max-running <n>',
@@ -467,7 +462,7 @@ export const claudeCommand = new Command('claude')
   )
   .argument(
     '[claude-args...]',
-    "extra args passed to claude inside the box; place after `--`, e.g. `agentbox claude -- --model sonnet`",
+    'extra args passed to claude inside the box; place after `--`, e.g. `agentbox claude -- --model sonnet`',
   )
   .action(async (claudeArgs: string[], opts: ClaudeCreateOptions) => {
     const cmdLog = openCommandLog('claude');
@@ -486,14 +481,18 @@ export const claudeCommand = new Command('claude')
     if (opts.continue === true) resumeMode = { kind: 'continue' };
     else if (opts.resume) resumeMode = { kind: 'resume', id: opts.resume };
     if (resumeMode && opts.initialPrompt && opts.initialPrompt.length > 0) {
-      log.error('-i / --initial-prompt cannot be combined with -c / --resume (seeding a new turn into a resumed session is not supported).');
+      log.error(
+        '-i / --initial-prompt cannot be combined with -c / --resume (seeding a new turn into a resumed session is not supported).',
+      );
       cmdLog.close();
       process.exit(2);
     }
     // --plan seeds an interactive "resume the plan" turn, which is incompatible
     // with -i's background-queue mode (the same reason resume + -i is rejected).
     if (opts.plan && opts.initialPrompt && opts.initialPrompt.length > 0) {
-      log.error('--plan cannot be combined with -i / --initial-prompt (--plan already seeds an interactive "resume the plan" turn).');
+      log.error(
+        '--plan cannot be combined with -i / --initial-prompt (--plan already seeds an interactive "resume the plan" turn).',
+      );
       cmdLog.close();
       process.exit(2);
     }
@@ -672,9 +671,14 @@ export const claudeCommand = new Command('claude')
       yes: !!opts.yes,
       command: 'claude',
       checkpointRef,
+      checkpointFromDefault: !(opts.snapshot && opts.snapshot.length > 0),
       provider: providerName,
       withEnv: cfg.effective.box.withEnv,
     });
+    // The wizard may discard a stale/dead default checkpoint (recreate, or a
+    // non-interactive run): boot from the current base instead of the old
+    // artifact. An explicit `--snapshot` is never discarded.
+    const effectiveCheckpointRef = wiz.discardCheckpoint ? undefined : checkpointRef;
     let effectiveClaudeArgs = claudeArgs;
     // --plan: enter plan mode and seed a "resume the plan" turn. Adding
     // --permission-mode before applyClaudeSkipPermissions makes the latter treat
@@ -728,7 +732,7 @@ export const claudeCommand = new Command('claude')
         request: {
           workspacePath: opts.workspace,
           name: opts.name,
-          checkpointRef,
+          checkpointRef: effectiveCheckpointRef,
           image: cfg.effective.box.image,
           withPlaywright,
           withEnv: cfg.effective.box.withEnv,
@@ -805,7 +809,7 @@ export const claudeCommand = new Command('claude')
         workspacePath: opts.workspace,
         name: opts.name,
         useSnapshot,
-        checkpointRef,
+        checkpointRef: effectiveCheckpointRef,
         fromBranch,
         useBranch,
         resyncOnStart: opts.resync,
@@ -913,7 +917,12 @@ export const claudeCommand = new Command('claude')
           (wiz.action === 'launch-with-prompt' && Boolean(wiz.initialPrompt)) ||
           Boolean(resumePrepared);
         if (hasSeed) pendingCreateResyncWarn = createResyncWarning;
-        else effectiveClaudeArgs = buildPromptArgs('claude-code', createResyncWarning, effectiveClaudeArgs);
+        else
+          effectiveClaudeArgs = buildPromptArgs(
+            'claude-code',
+            createResyncWarning,
+            effectiveClaudeArgs,
+          );
       }
 
       s.message('starting claude session');
@@ -932,7 +941,9 @@ export const claudeCommand = new Command('claude')
       s.stop(`box ready${nSuffix}`);
       logPrune(rebuild);
       for (const f of rebuild.failed) {
-        log.warn(`plugin install failed for ${f.dir}; claude may still load it. stderr:\n${f.stderr.trim()}`);
+        log.warn(
+          `plugin install failed for ${f.dir}; claude may still load it. stderr:\n${f.stderr.trim()}`,
+        );
       }
       maybeShowInstallHint();
 
@@ -943,7 +954,7 @@ export const claudeCommand = new Command('claude')
         workspacePath: opts.workspace,
         fromBranch,
         useBranch,
-        checkpointRef,
+        checkpointRef: effectiveCheckpointRef,
         attaching: opts.attach !== false,
       });
       if (opts.attach === false) {
@@ -1168,7 +1179,9 @@ async function startOrAttachClaude(
   if (resyncWarning && resumePrepared) log.warn(resyncWarning);
   logPrune(rebuild);
   for (const f of rebuild.failed) {
-    log.warn(`plugin install failed for ${f.dir}; claude may still load it. stderr:\n${f.stderr.trim()}`);
+    log.warn(
+      `plugin install failed for ${f.dir}; claude may still load it. stderr:\n${f.stderr.trim()}`,
+    );
   }
 
   if (!wantAttach) {
@@ -1252,7 +1265,7 @@ const claudeStartCommand = new Command('start')
   )
   .argument(
     '[claude-args...]',
-    "extra args passed to claude when starting a new session; ignored if a session is already running. Place after `--`, e.g. `agentbox claude start 1 -- --model sonnet`",
+    'extra args passed to claude when starting a new session; ignored if a session is already running. Place after `--`, e.g. `agentbox claude start 1 -- --model sonnet`',
   )
   .action(async function (this: Command, idOrName: string | undefined, claudeArgs: string[]) {
     const opts = this.optsWithGlobals() as ClaudeStartOptions;

--- a/apps/cli/src/commands/create.ts
+++ b/apps/cli/src/commands/create.ts
@@ -89,10 +89,7 @@ function buildCliOverrides(opts: CreateOptions): Partial<UserConfig> {
   return out;
 }
 
-function resolveUseSnapshot(
-  opts: CreateOptions,
-  configDefault: boolean | undefined,
-): boolean {
+function resolveUseSnapshot(opts: CreateOptions, configDefault: boolean | undefined): boolean {
   // host-snapshot used to be on by default because the snapshot was the
   // overlay lower (the box read directly from it). With the new model the
   // snapshot is only the tar-pipe source for the no-git case, so default off:
@@ -108,10 +105,7 @@ function resolveUseSnapshot(
  * Checkpoint to start from: explicit `--snapshot <ref>` wins, else the
  * project's `box.defaultCheckpoint` (empty string = none).
  */
-function resolveCheckpointRef(
-  opts: CreateOptions,
-  configDefault: string,
-): string | undefined {
+function resolveCheckpointRef(opts: CreateOptions, configDefault: string): string | undefined {
   if (opts.snapshot && opts.snapshot.length > 0) return opts.snapshot;
   return configDefault.length > 0 ? configDefault : undefined;
 }
@@ -140,11 +134,16 @@ async function attachShell(record: BoxRecord): Promise<never> {
 }
 
 export const createCommand = new Command('create')
-  .description('Create and start a new agent box (Docker container with /workspace seeded via in-container git worktree)')
+  .description(
+    'Create and start a new agent box (Docker container with /workspace seeded via in-container git worktree)',
+  )
   .option('-w, --workspace <path>', 'host workspace to mount', process.cwd())
   .option('-n, --name <name>', 'friendly box name (default: <workspace-basename>-<id>)')
   .option('--provider <name>', "sandbox backend: 'docker' (default) or 'daytona' (cloud)")
-  .option('--host-snapshot', 'APFS-clone the host workspace into a per-box scratch dir before seeding /workspace (stabilizes the tar-pipe source)')
+  .option(
+    '--host-snapshot',
+    'APFS-clone the host workspace into a per-box scratch dir before seeding /workspace (stabilizes the tar-pipe source)',
+  )
   .option('--no-host-snapshot', 'bind the live workspace directly (host edits leak into reads)')
   .option(
     '--snapshot <ref>',
@@ -178,7 +177,10 @@ export const createCommand = new Command('create')
   .option('--memory <size>', 'memory ceiling (e.g. 512m, 2g); unset = unlimited')
   .option('--cpus <n>', 'CPU count cap (fractional ok, e.g. 1.5); unset = unlimited')
   .option('--pids-limit <n>', 'max process count (PIDs cgroup); unset = unlimited')
-  .option('--disk <size>', 'best-effort container writable-layer size (e.g. 10g); no-op on overlay2/macOS')
+  .option(
+    '--disk <size>',
+    'best-effort container writable-layer size (e.g. 10g); no-op on overlay2/macOS',
+  )
   .option(
     '--size <spec>',
     'VM size for cloud providers. Hetzner: server type (e.g. cx33). Daytona: cpu-mem-disk GB (e.g. 4-8-20). Overrides box.size / box.size<Provider>.',
@@ -188,7 +190,8 @@ export const createCommand = new Command('create')
     'cap commits shipped in the cloud-seed git bundle (daytona, hetzner). 0 = full history. Unset = adaptive (200 commits, re-bundle at 100 if >20 MB). Ignored for docker.',
     (v) => {
       const n = Number.parseInt(v, 10);
-      if (!Number.isInteger(n) || n < 0) throw new Error(`--bundle-depth: expected a non-negative integer, got "${v}"`);
+      if (!Number.isInteger(n) || n < 0)
+        throw new Error(`--bundle-depth: expected a non-negative integer, got "${v}"`);
       return n;
     },
   )
@@ -198,7 +201,7 @@ export const createCommand = new Command('create')
   )
   .option(
     '-b, --use-branch <name>',
-    "reuse an existing branch directly instead of forking agentbox/<box-name>. Commits/pushes flow straight to it. Docker fails if the host already has it checked out. Mutually exclusive with --from-branch.",
+    'reuse an existing branch directly instead of forking agentbox/<box-name>. Commits/pushes flow straight to it. Docker fails if the host already has it checked out. Mutually exclusive with --from-branch.',
   )
   .option('-y, --yes', 'skip prompts, accept defaults')
   .option(
@@ -226,7 +229,10 @@ export const createCommand = new Command('create')
     const providerName = opts.provider ?? cfg.effective.box.provider ?? 'docker';
     const checkpointRef = resolveCheckpointRef(
       opts,
-      resolveDefaultCheckpoint(cfg.effective, providerName as 'docker' | 'daytona' | 'hetzner' | 'vercel'),
+      resolveDefaultCheckpoint(
+        cfg.effective,
+        providerName as 'docker' | 'daytona' | 'hetzner' | 'vercel',
+      ),
     );
     // VM size: `--size` flag wins; otherwise the cascaded box.size /
     // box.size<Provider>. Resolved here (not in buildCliOverrides) so a CLI
@@ -235,8 +241,7 @@ export const createCommand = new Command('create')
       cfg.effective,
       providerName as 'docker' | 'daytona' | 'hetzner' | 'vercel',
     );
-    const effectiveSize =
-      opts.size && opts.size.length > 0 ? opts.size : sizeDefault;
+    const effectiveSize = opts.size && opts.size.length > 0 ? opts.size : sizeDefault;
     // Box image: same precedence pattern as --size. `--image` wins; otherwise
     // the cascaded box.image / box.image<Provider> (written by `agentbox
     // prepare --provider X`).
@@ -244,8 +249,7 @@ export const createCommand = new Command('create')
       cfg.effective,
       providerName as 'docker' | 'daytona' | 'hetzner' | 'vercel',
     );
-    const effectiveImage =
-      opts.image && opts.image.length > 0 ? opts.image : imageDefault;
+    const effectiveImage = opts.image && opts.image.length > 0 ? opts.image : imageDefault;
 
     // Cloud providers that use the Daytona public-URL path don't need
     // Portless; the URL is already reachable from anywhere. The wizard's
@@ -305,9 +309,15 @@ export const createCommand = new Command('create')
       yes: !!opts.yes,
       command: 'create',
       checkpointRef,
+      checkpointFromDefault: !(opts.snapshot && opts.snapshot.length > 0),
       provider: providerName,
       withEnv: cfg.effective.box.withEnv,
     });
+    // Drop a stale/dead default checkpoint so the box provisions from the
+    // current base. On the docker switch-to-claude re-dispatch below the
+    // default isn't forwarded as `--snapshot`, so the inner `agentbox claude`
+    // re-evaluates and discards it too — no extra signal needed.
+    const effectiveCheckpointRef = wiz.discardCheckpoint ? undefined : checkpointRef;
     if (wiz.action === 'switch-to-claude' && isDocker) {
       // Docker: hand off to `agentbox claude` whose default action creates +
       // attaches in one go. For non-docker providers we fall through to the
@@ -372,7 +382,7 @@ export const createCommand = new Command('create')
       const result = await provider.create({
         workspacePath: opts.workspace,
         name: opts.name,
-        checkpointRef,
+        checkpointRef: effectiveCheckpointRef,
         image: effectiveImage,
         allowPull: opts.build ? false : undefined,
         imageRegistry: cfg.effective.box.imageRegistry,

--- a/apps/cli/src/wizard.ts
+++ b/apps/cli/src/wizard.ts
@@ -3,7 +3,7 @@ import { findProjectRoot } from '@agentbox/config';
 import type { ProviderName } from '@agentbox/core';
 import { DEFAULT_ENV_PATTERNS, scanHostEnvFiles } from '@agentbox/sandbox-docker';
 import { basename } from 'node:path';
-import { checkpointExistsForProvider } from './checkpoint-lookup.js';
+import { type CheckpointStatus, evaluateCheckpoint } from './checkpoint-lookup.js';
 
 /**
  * In-box absolute path to the setup guide markdown (baked into the box image
@@ -43,6 +43,14 @@ export interface WizardOutcome {
    * selection. Independent of `withEnv` / the wizard's yes/no answer.
    */
   envFilesToImport?: string[];
+  /**
+   * Set when the resolved default checkpoint must NOT be used to boot the box
+   * — it's stale (and the user chose to recreate, or the run is
+   * non-interactive) or its underlying image/snapshot is gone. The caller
+   * drops `checkpointRef` before `createBox`/`provider.create` so the box
+   * provisions from the current base instead of a dead/outdated artifact.
+   */
+  discardCheckpoint?: boolean;
 }
 
 interface WizardArgs {
@@ -51,15 +59,22 @@ interface WizardArgs {
   command: 'create' | 'claude';
   /**
    * Resolved checkpoint ref this box will start from (explicit `--snapshot`
-   * or the project's `box.defaultCheckpoint`), if any. When set AND the
-   * checkpoint exists for the active provider, the project is already
-   * configured: the checkpoint carries the warm state *and* the agentbox.yaml
-   * that was present when it was captured, so we skip the "generate one?"
-   * prompt entirely. When the checkpoint doesn't exist for the active
-   * provider (e.g. a Docker `setup` checkpoint and the user is creating a
-   * cloud box), the wizard falls through silently to normal setup.
+   * or the project's `box.defaultCheckpoint`), if any. Classified via
+   * `evaluateCheckpoint`: a `fresh` one carries the warm state *and* the
+   * agentbox.yaml from capture, so we skip the "generate one?" prompt; a
+   * `stale` default is re-prompted (recreate vs use-anyway); a `missing` one
+   * (wrong provider, pruned image, or dead snapshot) falls through to normal
+   * setup and is discarded so create provisions from the base.
    */
   checkpointRef?: string;
+  /**
+   * True when `checkpointRef` came from the project default
+   * (`box.defaultCheckpoint`) rather than an explicit `--snapshot`. A stale or
+   * missing *default* is re-prompted/discarded; an explicit `--snapshot` is a
+   * deliberate restore and is kept as-is (the create path still warns on
+   * staleness). Defaults to treating the ref as a default when unset.
+   */
+  checkpointFromDefault?: boolean;
   /**
    * The provider this box will be created on. Used to scope the
    * `checkpointRef` lookup so the wizard only announces "starting from
@@ -98,44 +113,68 @@ export const WIZARD_ENV_FILES_ENV = 'AGENTBOX_WIZARD_ENV_FILES';
 const WIZARD_ENV_SCAN_PATTERNS = DEFAULT_ENV_PATTERNS.filter((p) => p !== 'agentbox.yaml');
 
 export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutcome> {
-  // Re-entry from agentbox create → claude: outer pass already prompted;
-  // just inject the initial prompt for claude. Env-file picks were stashed by
-  // the outer pass in WIZARD_ENV_FILES_ENV and need to flow through this
-  // outcome so claude's action handler can pass them to createBox.
+  // Re-entry from agentbox create → claude: outer pass already prompted; this
+  // pass is non-interactive. Env-file picks were stashed by the outer pass in
+  // WIZARD_ENV_FILES_ENV and flow through so claude's action handler can pass
+  // them to createBox.
   if (process.env[WIZARD_AUTOLAUNCH_ENV] === '1') {
     if (args.command !== 'claude') return { action: 'proceed' };
     const envFiles = parseEnvFilesFromEnv(process.env[WIZARD_ENV_FILES_ENV]);
-    if (args.checkpointRef && (await checkpointAppliesHere(args))) {
-      return { action: 'proceed', envFilesToImport: envFiles };
-    }
     const proj = await findProjectRoot(args.workspace);
-    if (proj.hasAgentboxYaml) return { action: 'proceed', envFilesToImport: envFiles };
-    return {
-      action: 'launch-with-prompt',
-      initialPrompt: buildSetupInitialPrompt(proj.root),
-      envFilesToImport: envFiles,
-    };
+    return nonInteractiveOutcome(args, proj, await checkpointStatus(args, proj.root), envFiles);
   }
 
-  if (args.yes) return { action: 'proceed' };
-  if (!process.stdin.isTTY) return { action: 'proceed' };
-
   const proj = await findProjectRoot(args.workspace);
-  if (proj.hasAgentboxYaml) return { action: 'proceed' };
+  const status = await checkpointStatus(args, proj.root);
 
-  // A configured default checkpoint means the project is already set up — the
-  // checkpoint carries node_modules/env *and* the agentbox.yaml from when it
-  // was captured. Don't nag to regenerate one. Skip env-file picker too: the
-  // checkpoint already has whatever was on disk when it was captured.
-  //
-  // …but only if the checkpoint exists for the ACTIVE provider. A
-  // `box.defaultCheckpoint` resolved against the wrong provider's store would
-  // mislead the user — wizard announces the skip, then the cloud-provider
-  // create silently drops the ref because the snapshot doesn't exist for
-  // daytona. Silently fall through to normal setup instead.
-  if (args.checkpointRef && (await checkpointAppliesHere(args))) {
+  // Non-interactive (-y / piped): treat `-y` as "yes to the setup wizard"
+  // rather than "skip it". A stale/missing default checkpoint is discarded
+  // (provision from the current base); when there's no usable snapshot and no
+  // agentbox.yaml, `claude` seeds the setup prompt while `create` just makes a
+  // bare box. The env-file multiselect can't run without a TTY.
+  if (args.yes || !process.stdin.isTTY) {
+    return nonInteractiveOutcome(args, proj, status, undefined);
+  }
+
+  const fromDefault = args.checkpointFromDefault !== false;
+
+  // An existing agentbox.yaml means the project is already configured; don't
+  // nag. Still drop a dead *default* checkpoint so create doesn't try to boot
+  // a pruned image/snapshot (a stale-but-bootable one is kept — the create
+  // path warns about it).
+  if (proj.hasAgentboxYaml) {
+    return { action: 'proceed', discardCheckpoint: discardOnMissing(status, fromDefault) };
+  }
+
+  // A usable checkpoint carries node_modules/env *and* the agentbox.yaml from
+  // when it was captured — skip the "generate one?" prompt entirely. "Usable"
+  // = fresh, or a stale snapshot the user pinned explicitly via `--snapshot`
+  // (kept as-is; the create path warns). A stale *default* is re-prompted
+  // below; a missing one falls through to normal setup.
+  if (status.state === 'fresh' || (status.state === 'stale' && !fromDefault)) {
     log.info(`starting from checkpoint "${args.checkpointRef}"; skipping agentbox.yaml setup`);
     return { action: 'proceed' };
+  }
+
+  // Stale default checkpoint: don't silently boot the old base layers. Offer
+  // to recreate (re-run setup on the current base) or use it anyway.
+  let discardCheckpoint = false;
+  let recreateChosen = false;
+  if (status.state === 'stale' && fromDefault) {
+    const recreate = await confirm({
+      message: `Snapshot "${args.checkpointRef}" is stale (${status.reason}). Recreate it now? (No = use it anyway)`,
+      initialValue: true,
+    });
+    if (isCancel(recreate) || !recreate) {
+      // Use it anyway — keep the checkpoint, skip setup (create path warns).
+      return { action: 'proceed' };
+    }
+    discardCheckpoint = true;
+    recreateChosen = true;
+  } else if (status.state === 'missing') {
+    // No bootable artifact for this provider — drop a dead default ref so
+    // create provisions fresh, then fall through to normal setup.
+    discardCheckpoint = discardOnMissing(status, fromDefault) ?? false;
   }
 
   // Env-file multiselect — runs *before* the "run setup wizard?" confirm so
@@ -158,11 +197,21 @@ export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutco
     }
   }
 
-  const go = await confirm({
-    message: 'New project: run setup wizard? Will install dependencies and setup agentbox.yaml',
-    initialValue: true,
-  });
-  if (isCancel(go) || !go) return { action: 'proceed', envFilesToImport };
+  // Recreating already implies "yes, set up"; only ask the generic confirm on
+  // the from-scratch (missing/no-checkpoint) path.
+  if (!recreateChosen) {
+    const go = await confirm({
+      message: 'New project: run setup wizard? Will install dependencies and setup agentbox.yaml',
+      initialValue: true,
+    });
+    if (isCancel(go) || !go) {
+      return {
+        action: 'proceed',
+        envFilesToImport,
+        discardCheckpoint: discardCheckpoint || undefined,
+      };
+    }
+  }
 
   // The /agentbox-setup skill is seeded into the box's claude-config volume
   // by seedSetupSkillIntoVolume() (sandbox-docker) — box-only, never written
@@ -171,27 +220,76 @@ export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutco
   // For `agentbox create`, the only sensible yes-path is to hand off to
   // `agentbox claude` (that's where the agent runs). No second prompt — the
   // first confirm already captured the user's intent.
-  if (args.command === 'create') return { action: 'switch-to-claude', envFilesToImport };
+  if (args.command === 'create') {
+    return {
+      action: 'switch-to-claude',
+      envFilesToImport,
+      discardCheckpoint: discardCheckpoint || undefined,
+    };
+  }
 
   return {
     action: 'launch-with-prompt',
     initialPrompt: buildSetupInitialPrompt(proj.root),
     envFilesToImport,
+    discardCheckpoint: discardCheckpoint || undefined,
   };
 }
 
 /**
- * True when `args.checkpointRef` resolves to an artifact in the active
- * provider's checkpoint store. Falls back to `true` only when no `checkpointRef`
- * is set (caller checked already). Resolves the project root from the workspace
- * so the lookup uses the same hash the `agentbox checkpoint create` flow
- * persists under.
+ * Classify `args.checkpointRef` for the active provider, or `missing` when no
+ * ref is set. Resolves the project root from the workspace so the lookup uses
+ * the same hash the `agentbox checkpoint create` flow persists under.
  */
-async function checkpointAppliesHere(args: WizardArgs): Promise<boolean> {
-  if (!args.checkpointRef) return false;
-  const proj = await findProjectRoot(args.workspace);
+async function checkpointStatus(args: WizardArgs, projectRoot: string): Promise<CheckpointStatus> {
+  if (!args.checkpointRef) return { state: 'missing' };
   const provider = args.provider ?? 'docker';
-  return checkpointExistsForProvider(provider, proj.root, args.checkpointRef);
+  return evaluateCheckpoint(provider, projectRoot, args.checkpointRef);
+}
+
+/** Drop a *default* checkpoint ref when its artifact is gone (orphaned image / dead snapshot). */
+function discardOnMissing(status: CheckpointStatus, fromDefault: boolean): boolean | undefined {
+  return status.state === 'missing' && fromDefault ? true : undefined;
+}
+
+/**
+ * Decide the outcome without prompting (autolaunch, `-y`, or non-TTY). A
+ * `fresh` checkpoint (or an explicitly-pinned stale one) is used as-is; a
+ * stale/missing *default* is discarded. With no usable snapshot and no
+ * agentbox.yaml, `claude` runs setup (`launch-with-prompt`) while `create`
+ * makes a bare box (`proceed`).
+ */
+function nonInteractiveOutcome(
+  args: WizardArgs,
+  proj: { root: string; hasAgentboxYaml: boolean },
+  status: CheckpointStatus,
+  envFilesToImport: string[] | undefined,
+): WizardOutcome {
+  const fromDefault = args.checkpointFromDefault !== false;
+  const usableAsIs = status.state === 'fresh' || (status.state === 'stale' && !fromDefault);
+  // Drop a dead default ref always (it can't boot). Drop a stale default only
+  // when there's no agentbox.yaml — i.e. the checkpoint *was* the config source
+  // and we're recreating it. With a yaml present the checkpoint is just a warm
+  // start, so keep it (the create path warns it's stale) rather than forcing a
+  // cold rebuild on every base bump.
+  const discardCheckpoint =
+    fromDefault &&
+    (status.state === 'missing' || (status.state === 'stale' && !proj.hasAgentboxYaml))
+      ? true
+      : undefined;
+
+  if (usableAsIs || proj.hasAgentboxYaml) {
+    return { action: 'proceed', envFilesToImport, discardCheckpoint };
+  }
+  if (args.command === 'claude') {
+    return {
+      action: 'launch-with-prompt',
+      initialPrompt: buildSetupInitialPrompt(proj.root),
+      envFilesToImport,
+      discardCheckpoint,
+    };
+  }
+  return { action: 'proceed', envFilesToImport, discardCheckpoint };
 }
 
 /** Serialize the multiselect picks for the create→claude re-dispatch. */

--- a/apps/cli/src/wizard.ts
+++ b/apps/cli/src/wizard.ts
@@ -162,7 +162,7 @@ export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutco
   let recreateChosen = false;
   if (status.state === 'stale' && fromDefault) {
     const recreate = await confirm({
-      message: `Snapshot "${args.checkpointRef}" is stale (${status.reason}). Recreate it now? (No = use it anyway)`,
+      message: `Snapshot "${args.checkpointRef}" is stale (${status.reason}). Start from base and run Setup Wizard? (No = use it anyway)`,
       initialValue: true,
     });
     if (isCancel(recreate) || !recreate) {

--- a/packages/sandbox-cloud/src/checkpoint.ts
+++ b/packages/sandbox-cloud/src/checkpoint.ts
@@ -19,6 +19,7 @@ import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
 import type { CloudBackend } from '@agentbox/core';
 import { hashProjectPath, projectDirSegment, sanitizeMnemonic } from '@agentbox/config';
+import { type PreparedProviderKind, readPreparedStateRaw } from '@agentbox/sandbox-core';
 
 export const CLOUD_CHECKPOINTS_ROOT = join(homedir(), '.agentbox', 'cloud-checkpoints');
 
@@ -30,7 +31,15 @@ export const CLOUD_CHECKPOINTS_ROOT = join(homedir(), '.agentbox', 'cloud-checkp
 export const CLOUD_SNAPSHOT_NAME_PREFIX = 'agentbox-ckpt-';
 
 export interface CloudCheckpointManifest {
-  schema: 1;
+  /**
+   * Schema history:
+   *   1 — original fields (no base fingerprint; staleness unverifiable)
+   *   2 — adds `baseProvider`, `baseFingerprint`, `cliVersion` so the wizard
+   *       can tell a checkpoint captured against a now-rebuilt base snapshot
+   *       from a fresh one. A legacy schema-1 manifest has no fingerprint and
+   *       is treated as "stale / unverifiable" by `evaluateCheckpoint`.
+   */
+  schema: 1 | 2;
   /** User-facing, project-scoped name (e.g. "setup"). */
   name: string;
   /** Cloud backend the snapshot lives in (e.g. "daytona"). */
@@ -42,6 +51,19 @@ export interface CloudCheckpointManifest {
   snapshotName: string;
   sourceBoxId: string;
   sourceBoxName: string;
+  /**
+   * Cloud provider whose base-snapshot fingerprint this checkpoint was
+   * captured against. Schema-2+ only.
+   */
+  baseProvider?: string;
+  /**
+   * Build-context fingerprint of the base snapshot at capture time (the
+   * provider's `prepared-state` `contextSha256`). Schema-2+ only; missing →
+   * legacy schema-1 → "unverifiable / stale".
+   */
+  baseFingerprint?: string;
+  /** CLI version that captured the checkpoint. Schema-2+ only. */
+  cliVersion?: string;
   createdAt: string;
 }
 
@@ -76,7 +98,7 @@ async function readManifest(dir: string): Promise<CloudCheckpointManifest | null
   try {
     const raw = await readFile(join(dir, 'manifest.json'), 'utf8');
     const m = JSON.parse(raw) as CloudCheckpointManifest;
-    if (m.schema !== 1) return null;
+    if (m.schema !== 1 && m.schema !== 2) return null;
     return m;
   } catch {
     return null;
@@ -121,6 +143,9 @@ export interface WriteCloudManifestFields {
   snapshotName: string;
   sourceBoxId: string;
   sourceBoxName: string;
+  baseProvider?: string;
+  baseFingerprint?: string;
+  cliVersion?: string;
 }
 
 export async function writeCloudCheckpointManifest(
@@ -132,16 +157,36 @@ export async function writeCloudCheckpointManifest(
   const dir = checkpointDir(backend, projectRoot, name);
   await mkdir(dir, { recursive: true });
   const manifest: CloudCheckpointManifest = {
-    schema: 1,
+    schema: 2,
     name,
     backend,
     snapshotName: fields.snapshotName,
     sourceBoxId: fields.sourceBoxId,
     sourceBoxName: fields.sourceBoxName,
+    baseProvider: fields.baseProvider,
+    baseFingerprint: fields.baseFingerprint,
+    cliVersion: fields.cliVersion,
     createdAt: new Date().toISOString(),
   };
   await writeFile(join(dir, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n', 'utf8');
   return { name, dir, manifest };
+}
+
+/**
+ * Current base-snapshot build-context fingerprint for a cloud provider, read
+ * from its `~/.agentbox/<provider>-prepared.json`. Returns `undefined` when no
+ * prepared state exists or it predates fingerprinting — callers then can't
+ * verify staleness and must not falsely flag a checkpoint as stale.
+ */
+export function currentCloudBaseFingerprint(provider: string): string | undefined {
+  try {
+    const raw = readPreparedStateRaw(provider as PreparedProviderKind) as {
+      base?: { contextSha256?: string };
+    } | null;
+    return raw?.base?.contextSha256;
+  } catch {
+    return undefined;
+  }
 }
 
 export async function removeCloudCheckpointDir(

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -30,7 +30,13 @@ import type {
   Provider,
   ProviderCheckpoint,
 } from '@agentbox/core';
-import { allocateProjectIndex, readState, recordBox, removeBoxRecord } from '@agentbox/sandbox-core';
+import {
+  allocateProjectIndex,
+  readCliStamp,
+  readState,
+  recordBox,
+  removeBoxRecord,
+} from '@agentbox/sandbox-core';
 import {
   buildTmuxConfigShellSnippet,
   ensureRelay,
@@ -52,6 +58,7 @@ import { seedDynamicConfig } from './dynamic-sync.js';
 import { seedGitIdentity } from './git-identity.js';
 import {
   cloudSnapshotName,
+  currentCloudBaseFingerprint,
   listCloudCheckpoints,
   removeCloudCheckpointDir,
   resolveCloudCheckpoint,
@@ -61,11 +68,7 @@ import { isSnapshotGoneError } from './snapshot-error.js';
 import { uploadEnvFiles } from './env-files.js';
 import { uploadCarryPaths } from './carry.js';
 import { readExposedServicePorts } from './expose-ports.js';
-import {
-  downloadFromCloudBox,
-  pullCloudDirContents,
-  uploadToCloudBox,
-} from './cloud-cp.js';
+import { downloadFromCloudBox, pullCloudDirContents, uploadToCloudBox } from './cloud-cp.js';
 import { launchCloudCtlDaemon } from './ctl-launch.js';
 import { launchCloudDockerdDaemon } from './dockerd-launch.js';
 import { quoteShellArgv } from './shell.js';
@@ -134,11 +137,7 @@ function parsePortlessUrl(url: string): { proxyPort: number; tls: boolean } | un
     const u = new URL(url);
     if (!u.hostname.endsWith('.localhost')) return undefined;
     const tls = u.protocol === 'https:';
-    const proxyPort = u.port
-      ? Number.parseInt(u.port, 10)
-      : tls
-        ? 443
-        : 80;
+    const proxyPort = u.port ? Number.parseInt(u.port, 10) : tls ? 443 : 80;
     if (!Number.isFinite(proxyPort)) return undefined;
     return { proxyPort, tls };
   } catch {
@@ -468,7 +467,9 @@ export function createCloudProvider(
     async create(req: CreateBoxRequest): Promise<CreatedBox> {
       const log = req.onLog ?? (() => {});
       const { id, name, branch } = mintBox(req);
-      const image = opts.provisionImage ? await opts.provisionImage(req) : (req.image ?? FALLBACK_IMAGE);
+      const image = opts.provisionImage
+        ? await opts.provisionImage(req)
+        : (req.image ?? FALLBACK_IMAGE);
       // Per-create overrides (currently vercel's box.vercelVcpus / vercelTimeoutMs,
       // threaded through providerOptions). Fall back to the provider's static
       // defaults so daytona/hetzner are unaffected.
@@ -507,7 +508,9 @@ export function createCloudProvider(
       try {
         await ensureRelay({ onLog: log });
       } catch (err) {
-        log(`relay ensure failed (continuing): ${err instanceof Error ? err.message : String(err)}`);
+        log(
+          `relay ensure failed (continuing): ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
 
       // Resolve any cloud checkpoint the caller requested. When found, we
@@ -520,7 +523,11 @@ export function createCloudProvider(
       let snapshotName: string | undefined;
       let resolvedCheckpointRef: string | undefined;
       if (req.checkpointRef && req.projectRoot) {
-        const found = await resolveCloudCheckpoint(req.projectRoot, backend.name, req.checkpointRef);
+        const found = await resolveCloudCheckpoint(
+          req.projectRoot,
+          backend.name,
+          req.checkpointRef,
+        );
         if (found) {
           snapshotName = found.manifest.snapshotName;
           resolvedCheckpointRef = found.name;
@@ -684,7 +691,9 @@ export function createCloudProvider(
         // before the supervisor launches, mirroring the docker provider.
         // The host CLI already resolved + got user approval before threading
         // entries into req.carry.
-        let carrySummary: { count: number; entries: Array<{ src: string; dest: string; bytes: number }> } | undefined;
+        let carrySummary:
+          | { count: number; entries: Array<{ src: string; dest: string; bytes: number }> }
+          | undefined;
         if (req.carry && req.carry.length > 0) {
           log(`carry: copying ${String(req.carry.length)} host path(s) into the box`);
           const result = await uploadCarryPaths({
@@ -723,9 +732,12 @@ export function createCloudProvider(
           log('launching in-box dockerd');
           try {
             const dockerd = await launchCloudDockerdDaemon({ backend, handle, timeoutMs: 60_000 });
-            if (!dockerd.up) log(`dockerd did not become ready (continuing): ${dockerd.reason ?? 'unknown'}`);
+            if (!dockerd.up)
+              log(`dockerd did not become ready (continuing): ${dockerd.reason ?? 'unknown'}`);
           } catch (err) {
-            log(`dockerd daemon launch failed (continuing): ${err instanceof Error ? err.message : String(err)}`);
+            log(
+              `dockerd daemon launch failed (continuing): ${err instanceof Error ? err.message : String(err)}`,
+            );
           }
         }
 
@@ -1216,8 +1228,7 @@ const RESERVED_CLOUD_PORTS = new Set<number>([CLOUD_WEB_PROXY_PORT, CLOUD_VNC_PO
 async function firstExposedServicePort(box: BoxRecord): Promise<number | undefined> {
   // The box's own WebProxy port (e.g. Vercel's 8080) is reserved too — it's the
   // web aggregator, not a user service port.
-  const reserved = (p: number): boolean =>
-    RESERVED_CLOUD_PORTS.has(p) || p === box.cloud?.webPort;
+  const reserved = (p: number): boolean => RESERVED_CLOUD_PORTS.has(p) || p === box.cloud?.webPort;
   const fromRecord = Object.keys(box.cloud?.previewUrls ?? {})
     .map(Number)
     .filter((p) => Number.isInteger(p) && !reserved(p));
@@ -1263,6 +1274,9 @@ function makeCloudCheckpoint(backend: CloudBackend): ProviderCheckpoint {
         snapshotName,
         sourceBoxId: box.id,
         sourceBoxName: box.name,
+        baseProvider: backend.name,
+        baseFingerprint: currentCloudBaseFingerprint(backend.name),
+        cliVersion: readCliStamp().cliVersion,
       });
       return { ref: info.name };
     },

--- a/packages/sandbox-cloud/src/index.ts
+++ b/packages/sandbox-cloud/src/index.ts
@@ -6,14 +6,8 @@ export {
   renderInnerCommand,
   type CreateCloudProviderOptions,
 } from './cloud-provider.js';
-export {
-  launchCloudCtlDaemon,
-  type LaunchCloudCtlArgs,
-} from './ctl-launch.js';
-export {
-  launchCloudDockerdDaemon,
-  type CloudDockerdLaunchResult,
-} from './dockerd-launch.js';
+export { launchCloudCtlDaemon, type LaunchCloudCtlArgs } from './ctl-launch.js';
+export { launchCloudDockerdDaemon, type CloudDockerdLaunchResult } from './dockerd-launch.js';
 export {
   seedCloudWorkspace,
   type SeedCloudWorkspaceArgs,
@@ -29,11 +23,7 @@ export {
   type EnsureAgentVolumesResult,
   type SeedAgentVolumesOptions,
 } from './agent-credentials.js';
-export {
-  uploadEnvFiles,
-  type UploadEnvFilesArgs,
-  type UploadEnvFilesResult,
-} from './env-files.js';
+export { uploadEnvFiles, type UploadEnvFilesArgs, type UploadEnvFilesResult } from './env-files.js';
 export { seedDynamicConfig, type SeedDynamicConfigOptions } from './dynamic-sync.js';
 export { seedGitIdentity, type SeedGitIdentityOptions } from './git-identity.js';
 export { bashScript, quoteShellArg, quoteShellArgv } from './shell.js';
@@ -52,6 +42,7 @@ export {
   CLOUD_CHECKPOINTS_ROOT,
   CLOUD_SNAPSHOT_NAME_PREFIX,
   cloudSnapshotName,
+  currentCloudBaseFingerprint,
   listCloudCheckpoints,
   probeCloudCheckpoint,
   removeCloudCheckpointDir,

--- a/packages/sandbox-cloud/test/checkpoint.test.ts
+++ b/packages/sandbox-cloud/test/checkpoint.test.ts
@@ -72,14 +72,19 @@ describe('manifest lifecycle', () => {
       snapshotName: cloudSnapshotName(projectRoot, 'setup'),
       sourceBoxId: 'abc123',
       sourceBoxName: 'test-cloud-ckpt-abc123',
+      baseProvider: backend,
+      baseFingerprint: 'deadbeefcafef00d',
+      cliVersion: '9.9.9',
     });
-    expect(info.manifest.schema).toBe(1);
+    // Schema 2 carries the base fingerprint so staleness is verifiable.
+    expect(info.manifest.schema).toBe(2);
     expect(info.manifest.name).toBe('setup');
     expect(info.manifest.backend).toBe(backend);
+    expect(info.manifest.baseFingerprint).toBe('deadbeefcafef00d');
     expect(info.manifest.snapshotName).toContain('test_cloud_ckpt');
     // Manifest file lives on disk and is valid JSON.
     const raw = await readFile(join(info.dir, 'manifest.json'), 'utf8');
-    expect(JSON.parse(raw)).toMatchObject({ schema: 1, name: 'setup', backend });
+    expect(JSON.parse(raw)).toMatchObject({ schema: 2, name: 'setup', backend });
 
     // resolve after write → populated
     const resolved = await resolveCloudCheckpoint(projectRoot, backend, 'setup');


### PR DESCRIPTION
## Problem

Running `agentbox claude` in a project whose `box.defaultCheckpoint` points at a **stale** snapshot announced:

```
●  starting from checkpoint "setup"; skipping agentbox.yaml setup
◐  [image] #22 RUN curl -fsSL https://claude.ai/install.sh | bash -s stable
```

i.e. it skipped setup *and* rebuilt the base image — then booted from the old checkpoint layers anyway. The wizard's skip decision only checked that the manifest **existed**, ignoring whether the checkpoint was still valid.

Repro case: a schema-2 (pre-versioning) `setup` checkpoint while the base image had been re-prepared since.

## Fix

- **`evaluateCheckpoint` (`apps/cli/src/checkpoint-lookup.ts`)** — classifies a ref as `fresh` / `stale` / `missing`:
  - docker: orphaned image → missing; schema-2/no-fingerprint or fingerprint mismatch → stale
  - cloud: dead snapshot → missing; legacy schema-1 or fingerprint mismatch → stale
- **Wizard (`apps/cli/src/wizard.ts`)** now branches on that:
  - **interactive + stale default** → re-prompt "snapshot is stale — recreate or use anyway?"; recreate discards the ref and re-runs setup
  - **`-y` / non-TTY / autolaunch** → treat `-y` as *yes to the wizard*: `claude -y` runs setup, `create -y` makes a bare box; a stale/dead default is discarded so the box provisions from the current base (a warm checkpoint behind an existing `agentbox.yaml` is kept, not cold-rebuilt)
  - **explicit `--snapshot`** is always honored as-is (the create path still logs its loud staleness warning)
- **`discardCheckpoint`** signal threads through `claude.ts` / `create.ts` so the ref is dropped before `createBox` / `provider.create`.
- **Cloud parity** — `CloudCheckpointManifest` bumped to schema 2 with `baseProvider` / `baseFingerprint` / `cliVersion`, captured at checkpoint-create time, so cloud staleness is verifiable going forward.

## Verification

- `pnpm typecheck` 21/21, `pnpm lint` clean, build green.
- Evaluator checked against real on-disk data: stale-by-schema-2, stale-by-fingerprint-mismatch, and missing-manifest all classified correctly.
- `claude -y` end-to-end on the stale project: no "starting from checkpoint", discarded → built base → provisioned a fresh git-worktree box, came up clean.

## Note

The interactive recreate path re-runs setup but does not auto-recapture the `setup` checkpoint (recapturing stays a manual `agentbox checkpoint create setup`, same as today).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-run and default-checkpoint boot behavior for create/claude across Docker and cloud; explicit `--snapshot` is preserved but default-checkpoint and non-interactive paths now drop or re-prompt on staleness.
> 
> **Overview**
> Fixes misleading **“starting from checkpoint …; skipping setup”** when `box.defaultCheckpoint` still exists but is **orphaned**, **dead on the cloud backend**, or **captured against an older base** than the current prepared image/snapshot.
> 
> **`evaluateCheckpoint`** replaces the old existence-only check with **`fresh` / `stale` / `missing`**: Docker verifies the backing image and compares `baseFingerprint` to prepared context; cloud probes snapshot liveness (pruning dead manifests) and compares fingerprints via new **`currentCloudBaseFingerprint`**.
> 
> The **setup wizard** uses that classification: **fresh** (or explicit **`--snapshot`**) skips setup as before; **stale defaults** get an interactive **recreate vs use anyway** prompt; **missing/orphaned defaults** are dropped. **`discardCheckpoint`** flows into **`agentbox create`** / **`agentbox claude`** so provisioning uses the current base instead of the bad ref. **`-y` / non-TTY** paths discard stale/missing defaults when there is no `agentbox.yaml`, while keeping a stale warm start when config already exists.
> 
> **Cloud checkpoints** bump manifests to **schema 2** with `baseProvider`, `baseFingerprint`, and `cliVersion` at capture time so staleness is verifiable going forward (legacy schema 1 treated as unverifiable/stale).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f299d0131d818d184629feeceada3b1a9cfde935. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->