### PR TITLE
fix(cli): clean actionable error when a cloud base template/snapshot is not prepared

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -38,6 +38,7 @@ import { forkCommand } from './commands/fork.js';
 import { installCommand, runInstallWizard } from './commands/install.js';
 import { doctorCommand } from './commands/doctor.js';
 import { isFirstRun } from './lib/first-run.js';
+import { printCliError } from './lib/print-cli-error.js';
 import { gitCommand } from './commands/git.js';
 import { listCommand } from './commands/list.js';
 import { logsCommand } from './commands/logs.js';
@@ -162,6 +163,6 @@ if (isFirstRun() && isFirstRunHookEligible(argv)) {
 }
 
 program.parseAsync(argv).catch((err: unknown) => {
-  console.error(err);
+  printCliError(err, process.stderr);
   process.exit(1);
 });

--- a/apps/cli/src/lib/print-cli-error.ts
+++ b/apps/cli/src/lib/print-cli-error.ts
@@ -1,0 +1,30 @@
+import { UserFacingError } from '@agentbox/core';
+
+/**
+ * Top-level CLI error renderer. `UserFacingError` (and anything that
+ * advertises itself as one via the `name` field — defends against bundling /
+ * dual-publish boundaries dropping the class identity) gets a clean one-line
+ * message. Anything else falls through to `console.error` so genuine bugs
+ * keep their stack trace for debugging.
+ */
+export function printCliError(err: unknown, stderr: NodeJS.WritableStream): void {
+  if (isUserFacingError(err)) {
+    stderr.write(`${err.message}\n`);
+    return;
+  }
+  // Mirror the original top-level catch: `console.error` writes to stderr
+  // and prints `.stack` for Error instances.
+  const writer = (chunk: string) => stderr.write(chunk);
+  writer(formatUnknown(err) + '\n');
+}
+
+function isUserFacingError(err: unknown): err is UserFacingError {
+  if (err instanceof UserFacingError) return true;
+  if (err instanceof Error && err.name === 'UserFacingError') return true;
+  return false;
+}
+
+function formatUnknown(err: unknown): string {
+  if (err instanceof Error) return err.stack ?? `${err.name}: ${err.message}`;
+  return String(err);
+}

--- a/apps/cli/test/print-cli-error.test.ts
+++ b/apps/cli/test/print-cli-error.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { Writable } from 'node:stream';
+import { UserFacingError } from '@agentbox/core';
+import { printCliError } from '../src/lib/print-cli-error.js';
+
+function makeSink(): { sink: Writable; readAll(): string } {
+  const chunks: Buffer[] = [];
+  const sink = new Writable({
+    write(chunk, _enc, cb) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      cb();
+    },
+  });
+  return { sink, readAll: () => Buffer.concat(chunks).toString('utf8') };
+}
+
+describe('printCliError', () => {
+  it('prints UserFacingError as a clean message with no stack frames', () => {
+    const { sink, readAll } = makeSink();
+    printCliError(new UserFacingError('no E2B base template found.\nRun `agentbox prepare`.'), sink);
+    const out = readAll();
+    expect(out).toBe('no E2B base template found.\nRun `agentbox prepare`.\n');
+    expect(out).not.toContain(' at ');
+  });
+
+  it('also picks up the name marker even if the class identity differs', () => {
+    const err = new Error('marker check');
+    err.name = 'UserFacingError';
+    const { sink, readAll } = makeSink();
+    printCliError(err, sink);
+    expect(readAll()).toBe('marker check\n');
+  });
+
+  it('prints the stack for unexpected errors so real bugs stay debuggable', () => {
+    const { sink, readAll } = makeSink();
+    printCliError(new Error('boom'), sink);
+    const out = readAll();
+    expect(out).toContain('boom');
+    expect(out).toContain(' at ');
+  });
+
+  it('handles non-Error throws by stringifying them', () => {
+    const { sink, readAll } = makeSink();
+    printCliError('plain string failure', sink);
+    expect(readAll()).toBe('plain string failure\n');
+  });
+});

--- a/docs/e2b_backlog.md
+++ b/docs/e2b_backlog.md
@@ -274,6 +274,14 @@ shipped.
 - **`box.image` cross-provider migration** was already handled in Task 2
   (per-provider `box.imageE2b` lives in `packages/config/src/types.ts`).
 
+#### Post-ship polish
+
+- **Clean prepare-gate error output** (2026-06-03). The "no E2B base
+  template found" gate now throws `UserFacingError` (from `@agentbox/core`)
+  and the CLI's top-level catch renders it as a one-line message instead
+  of a raw stack trace. Same treatment for the parallel vercel/hetzner
+  gates.
+
 ## Coordination notes (orchestrator)
 
 - Each task is assigned to an agent via

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -7,6 +7,20 @@
 
 import type { BoxRecord } from './box-record.js';
 
+/**
+ * Marker class for expected, actionable failures that the CLI should render
+ * to the user as a clean message (no stack trace) — e.g. "you skipped a
+ * required `agentbox prepare` step". The top-level CLI catch in
+ * `apps/cli/src/index.ts` detects this via `instanceof` and falls back to the
+ * `name` field so bundling / dual-publish boundaries can't lose the marker.
+ */
+export class UserFacingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UserFacingError';
+  }
+}
+
 export class BoxNotFoundError extends Error {
   constructor(public readonly query: string) {
     super(`no agentbox matches "${query}"`);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,5 +51,5 @@ export type {
   CloudState,
   CloudVolumeMount,
 } from './cloud-backend.js';
-export { AmbiguousBoxError, BoxNotFoundError } from './errors.js';
+export { AmbiguousBoxError, BoxNotFoundError, UserFacingError } from './errors.js';
 export { BOX_ID_PREFIX, generateBoxId } from './identity.js';

--- a/packages/sandbox-e2b/src/prepared-state.ts
+++ b/packages/sandbox-e2b/src/prepared-state.ts
@@ -14,6 +14,7 @@
  */
 
 import { readPreparedStateRaw, writePreparedStateRaw, preparedStatePathFor } from '@agentbox/sandbox-core';
+import { UserFacingError } from '@agentbox/core';
 
 const SCHEMA = 1 as const;
 
@@ -73,7 +74,7 @@ export function updatePreparedState(mutate: (s: PreparedE2bState) => void): void
 export function ensureE2bBaseTemplate(): void {
   const state = readPreparedState();
   if (state.base !== undefined) return;
-  throw new Error(
+  throw new UserFacingError(
     'no E2B base template found.\n' +
       'Run `agentbox prepare --provider e2b` first — it bakes a custom template ' +
       'with the agentbox runtime (agentbox-ctl, vscode user, claude/codex/opencode, tmux) ' +

--- a/packages/sandbox-hetzner/src/prepare.ts
+++ b/packages/sandbox-hetzner/src/prepare.ts
@@ -31,6 +31,7 @@
 
 import { join } from 'node:path';
 import type { Provider } from '@agentbox/core';
+import { UserFacingError } from '@agentbox/core';
 import { computeContextSha256, readCliStamp } from '@agentbox/sandbox-core';
 import {
   stageClaudeStaticForUpload,
@@ -408,7 +409,7 @@ export const prepareHetznerProvider: NonNullable<Provider['prepare']> = (req) =>
 export async function ensureHetznerBaseSnapshot(): Promise<void> {
   const state = readPreparedState();
   if (state.base !== undefined) return;
-  throw new Error(
+  throw new UserFacingError(
     'no Hetzner base snapshot found.\n' +
       'Run `agentbox prepare --provider hetzner` first (Hetzner cannot build images from a Dockerfile,\n' +
       'so the base snapshot is a one-time prerequisite for cloud boxes on this backend).',

--- a/packages/sandbox-vercel/src/prepared-state.ts
+++ b/packages/sandbox-vercel/src/prepared-state.ts
@@ -13,6 +13,7 @@
  */
 
 import { readPreparedStateRaw, writePreparedStateRaw, preparedStatePathFor } from '@agentbox/sandbox-core';
+import { UserFacingError } from '@agentbox/core';
 
 const SCHEMA = 1 as const;
 
@@ -69,7 +70,7 @@ export function updatePreparedState(mutate: (s: PreparedVercelState) => void): v
 export function ensureVercelBaseSnapshot(): void {
   const state = readPreparedState();
   if (state.base !== undefined) return;
-  throw new Error(
+  throw new UserFacingError(
     'no Vercel base snapshot found.\n' +
       'Run `agentbox prepare --provider vercel` first — Vercel cannot build images ' +
       'from a Dockerfile, so the base snapshot is a one-time prerequisite for cloud boxes.',


### PR DESCRIPTION
## Summary

When a user runs e.g. \`agentbox e2b claude\` without having first run \`agentbox prepare --provider e2b\`, the CLI surfaced the prepare-gate \`Error\` through the top-level \`parseAsync(...).catch(err => console.error(err))\` — printing the full stack trace, which makes a missing prerequisite look like a crash.

This PR introduces a small \`UserFacingError\` marker in \`@agentbox/core\` (mirrors the local \`BoxNotFoundError\` / \`AmbiguousBoxError\` pattern) and:

- Routes the three "not prepared" gates through it:
  - \`ensureE2bBaseTemplate\` (\`packages/sandbox-e2b/src/prepared-state.ts\`)
  - \`ensureVercelBaseSnapshot\` (\`packages/sandbox-vercel/src/prepared-state.ts\`)
  - \`ensureHetznerBaseSnapshot\` (\`packages/sandbox-hetzner/src/prepare.ts\`)
- Replaces the CLI's top-level catch with a tiny \`printCliError\` helper that renders \`UserFacingError\`s as a clean one-line message (no stack) while keeping the full stack output for genuinely unexpected errors so real bugs stay debuggable. Exit code 1 is preserved. Detection falls back to \`err.name === 'UserFacingError'\` so bundling/dual-publish boundaries can't strip the marker.
- Adds a vitest unit test covering both branches (clean for \`UserFacingError\`, stack for plain \`Error\`).
- Notes the polish under \`docs/e2b_backlog.md\` → Post-ship polish.

Scope discipline: no auto-prepare, no provider lifecycle changes, no message rewording — just the marker + printer.

### Before (this branch, with the fix temporarily reverted)

\`\`\`
┌  Starting Claude in a box...
│
◇  cloud box create failed
Error: no E2B base template found.
Run \`agentbox prepare --provider e2b\` first — it bakes a custom template with the agentbox runtime (agentbox-ctl, vscode user, claude/codex/opencode, tmux) so per-box \`create\` boots ready in seconds.
    at ensureE2bBaseTemplate (file:///workspace/apps/cli/dist/dist-K3OMMEAX.js:159:9)
    at Object.provision (file:///workspace/apps/cli/dist/dist-K3OMMEAX.js:210:7)
    at provisionFrom (file:///workspace/apps/cli/dist/chunk-EVVRX527.js:1403:24)
    at Object.create (file:///workspace/apps/cli/dist/chunk-EVVRX527.js:1419:24)
    at async cloudAgentCreate (file:///workspace/apps/cli/dist/index.js:1316:20)
    at async Command.<anonymous> (file:///workspace/apps/cli/dist/index.js:2670:5)
    at async Command.parseAsync (.../commander/lib/command.js:1092:5)
\`\`\`

### After

\`\`\`
┌  Starting Claude in a box...
│
◇  cloud box create failed
no E2B base template found.
Run \`agentbox prepare --provider e2b\` first — it bakes a custom template with the agentbox runtime (agentbox-ctl, vscode user, claude/codex/opencode, tmux) so per-box \`create\` boots ready in seconds.
\`\`\`

(Exit code 1 in both cases.)

## Test plan

- [x] \`pnpm build\` green
- [x] \`pnpm lint\` green
- [x] \`pnpm test\` green (incl. new \`apps/cli/test/print-cli-error.test.ts\`, 4 tests)
- [x] Live smoke: with no E2B template prepared on the box, \`node apps/cli/dist/index.js e2b claude -y -n cleanerr -w /tmp/cleanerr-repo\` prints the clean one-liner, exit 1, no \`at …\` frames
- [ ] Vercel and Hetzner share the exact same code path and are covered by the unit test (no live snapshot available on this box)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX/error-handling change on the CLI top-level catch and three prepare gates; no auth, provisioning, or lifecycle behavior changes beyond error type and rendering.
> 
> **Overview**
> Introduces **`UserFacingError`** in `@agentbox/core` for expected, actionable CLI failures (same pattern as box-resolution errors) and wires the **E2B, Vercel, and Hetzner** “no base template/snapshot” prepare gates to throw it instead of a plain `Error`.
> 
> The CLI’s top-level **`parseAsync` catch** now uses **`printCliError`**, which prints only the message (no stack) for `UserFacingError`, with a **`name === 'UserFacingError'`** fallback when `instanceof` breaks across bundles; unexpected errors still get stack traces. **Vitest** covers both paths; **e2b backlog** notes the polish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c5eeee3ba640e7057cd05cf436603f4b4264443. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->