### PR TITLE
fix(cloud): record baseFingerprint in vercel + e2b checkpoints so staleness detection works across all clouds

### DIFF
--- a/docs/e2b_backlog.md
+++ b/docs/e2b_backlog.md
@@ -281,6 +281,14 @@ shipped.
   and the CLI's top-level catch renders it as a one-line message instead
   of a raw stack trace. Same treatment for the parallel vercel/hetzner
   gates.
+- **Checkpoint manifest records `baseFingerprint`** (2026-06-03). The custom
+  `e2bCheckpoint.create` (mirrors `vercelCheckpoint.create`) now passes
+  `baseProvider`, `baseFingerprint`, and `cliVersion` to
+  `writeCloudCheckpointManifest` — matching the scaffold default that
+  daytona/hetzner inherit. Before, every e2b/vercel default checkpoint
+  tripped the wizard's "captured before checkpoint versioning; base
+  snapshot unverifiable" branch and stale-prompted forever; now the
+  fresh-vs-stale verdict is real for all four clouds.
 
 ## Coordination notes (orchestrator)
 

--- a/packages/sandbox-e2b/src/index.ts
+++ b/packages/sandbox-e2b/src/index.ts
@@ -18,12 +18,13 @@
 import type { BoxRecord, Provider, ProviderCheckpoint } from '@agentbox/core';
 import {
   createCloudProvider,
+  currentCloudBaseFingerprint,
   listCloudCheckpoints,
   removeCloudCheckpointDir,
   resolveCloudCheckpoint,
   writeCloudCheckpointManifest,
 } from '@agentbox/sandbox-cloud';
-import { recordBox } from '@agentbox/sandbox-core';
+import { readCliStamp, recordBox } from '@agentbox/sandbox-core';
 import { e2bBackend, DEFAULT_BOX_IMAGE_REF } from './backend.js';
 import { Sandbox, resolveApiKey } from './sdk.js';
 import { withE2bRetry } from './retry.js';
@@ -119,6 +120,9 @@ const e2bCheckpoint: ProviderCheckpoint = {
       snapshotName: snapshotId,
       sourceBoxId: box.id,
       sourceBoxName: box.name,
+      baseProvider: BACKEND_NAME,
+      baseFingerprint: currentCloudBaseFingerprint(BACKEND_NAME),
+      cliVersion: readCliStamp().cliVersion,
     });
     return { ref: info.name };
   },

--- a/packages/sandbox-vercel/src/index.ts
+++ b/packages/sandbox-vercel/src/index.ts
@@ -15,6 +15,7 @@
 import type { BoxRecord, Provider, ProviderCheckpoint } from '@agentbox/core';
 import {
   createCloudProvider,
+  currentCloudBaseFingerprint,
   listCloudCheckpoints,
   removeCloudCheckpointDir,
   resolveCloudCheckpoint,
@@ -26,7 +27,7 @@ import {
   deleteVercelSnapshot,
   DEFAULT_BOX_IMAGE_REF,
 } from './backend.js';
-import { recordBox } from '@agentbox/sandbox-core';
+import { readCliStamp, recordBox } from '@agentbox/sandbox-core';
 import { prepareVercelProvider } from './prepare.js';
 import { buildVercelAttach } from './build-attach.js';
 
@@ -71,6 +72,9 @@ const vercelCheckpoint: ProviderCheckpoint = {
       snapshotName: snapshotId,
       sourceBoxId: box.id,
       sourceBoxName: box.name,
+      baseProvider: BACKEND_NAME,
+      baseFingerprint: currentCloudBaseFingerprint(BACKEND_NAME),
+      cliVersion: readCliStamp().cliVersion,
     });
     return { ref: info.name };
   },


### PR DESCRIPTION
## Summary

The wizard's stale-checkpoint detection (`apps/cli/src/checkpoint-lookup.ts → evaluateCloudCheckpoint`) compares `manifest.baseFingerprint` against the current `~/.agentbox/<provider>-prepared.json` `base.contextSha256`. The scaffold default checkpoint writer at `packages/sandbox-cloud/src/cloud-provider.ts:1273-1280` already records `baseProvider`, `baseFingerprint`, and `cliVersion`, so **daytona** and **hetzner** (which use the default unchanged) get a real fresh-vs-stale verdict.

Vercel and E2B override `Provider.checkpoint` with a custom `.create` because they store the SDK snapshot *id* in `manifest.snapshotName`. Both custom impls were omitting the three fingerprint fields, so every vercel/e2b default checkpoint short-circuited to `state: 'stale', reason: 'captured before checkpoint versioning; base snapshot unverifiable'` and the user got the stale-prompt forever.

This PR adds the three fields to both custom `checkpoint.create` impls, mirroring the scaffold default exactly. No change to the snapshot-id semantics; daytona + hetzner unchanged (already correct via the scaffold).

- `packages/sandbox-e2b/src/index.ts` — `e2bCheckpoint.create`
- `packages/sandbox-vercel/src/index.ts` — `vercelCheckpoint.create`
- `docs/e2b_backlog.md` — post-ship polish note

## Manifest before / after (live, captured against e2b)

**Before** (`~/.agentbox/cloud-checkpoints/e2b/<projectKey>/<name>/manifest.json`):
```json
{
  "schema": 2,
  "name": "cpdefault",
  "backend": "e2b",
  "snapshotName": "marco6/agentbox-cpsmoke-...:default",
  "sourceBoxId": "...",
  "sourceBoxName": "cpsmoke",
  "createdAt": "..."
}
```
→ `evaluateCloudCheckpoint` returns `state: 'stale', reason: 'captured before checkpoint versioning; base snapshot unverifiable'`.

**After** (live, this PR):
```json
{
  "schema": 2,
  "name": "cpdefault",
  "backend": "e2b",
  "snapshotName": "marco6/agentbox-cpsmoke-cpdefault-2026-06-03-10-56-26-394:default",
  "sourceBoxId": "ba79e2006",
  "sourceBoxName": "cpsmoke",
  "baseProvider": "e2b",
  "baseFingerprint": "244e09b10ec45164c71fd3768df59f5cac2f3f73a761fdb68d5c0af3cecf7138",
  "cliVersion": "0.13.0",
  "createdAt": "2026-06-03T10:56:28.138Z"
}
```
`baseFingerprint` matches `~/.agentbox/e2b-prepared.json` `base.contextSha256` exactly → `state: 'fresh'`. When the prepared base is rebuilt, the fingerprint will diverge and the wizard will correctly flip to `state: 'stale', reason: 'base snapshot updated since capture (captured ..., current ...)'`.

## Test plan

- [x] `pnpm build` — green
- [x] `pnpm lint` — green (12/12 packages)
- [x] `pnpm test` — green (23/23 packages, 0 failures)
- [x] Live e2e on e2b: `prepare --provider e2b` → `create --provider e2b -y` (from a tiny scratch repo) → `checkpoint create -y` → manifest fields populated as shown above
- [x] `agentbox checkpoint set-default --provider e2b cpdefault` + a second `create --provider e2b -y` boots from the snapshot with no stale verdict
- [ ] Vercel mirror-change: code path is identical (same imports, same three fields, same `BACKEND_NAME` substitution); verified by reading the diff and the package-level test suite passing. Not exercised live this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small manifest-field parity fix in two checkpoint writers; no auth, provisioning, or snapshot semantics changes.
> 
> **Overview**
> **Vercel and E2B** custom `checkpoint.create` paths now write **`baseProvider`**, **`baseFingerprint`**, and **`cliVersion`** on the cloud checkpoint manifest—the same trio the **`createCloudProvider`** scaffold already records for **Daytona** and **Hetzner**.
> 
> Without those fields, **`evaluateCloudCheckpoint`** treated every Vercel/E2B checkpoint as unversioned and always surfaced the stale “base snapshot unverifiable” wizard path. New checkpoints can be judged **fresh** vs **stale** when the prepared base fingerprint changes.
> 
> Snapshot-id checkpoint behavior is unchanged; **`docs/e2b_backlog.md`** notes the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68330dd4554d2b811e4f29d601ce4139150eaec2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->