### PR TITLE
feat(cloud): build base on setup + detect stale base at create (checksum-based, merged with checkpoint-staleness prompt)

### DIFF
--- a/apps/cli/src/checkpoint-lookup.ts
+++ b/apps/cli/src/checkpoint-lookup.ts
@@ -26,7 +26,7 @@ import {
   probeCloudCheckpoint,
   resolveCloudCheckpoint,
 } from '@agentbox/sandbox-cloud';
-import { cloudBackendForProvider } from './provider/cloud-backend.js';
+import { cloudBackendForProvider, currentCloudBaseFingerprintLive } from './provider/cloud-backend.js';
 
 export type CheckpointStatus =
   /** No manifest, a dead/expired cloud snapshot, or an orphaned Docker image — not bootable. */
@@ -120,4 +120,52 @@ export async function evaluateCheckpoint(
 ): Promise<CheckpointStatus> {
   if (provider === 'docker') return evaluateDockerCheckpoint(projectRoot, ref);
   return evaluateCloudCheckpoint(provider, projectRoot, ref);
+}
+
+/**
+ * Cloud base-image / base-snapshot freshness, derived purely from the
+ * `contextSha256` of the baked runtime files. The CLI re-prompts at
+ * `create`/`claude` time so a stale base (a CLI upgrade that altered any
+ * baked file) doesn't silently boot incompatible boxes on an old snapshot.
+ *
+ * **Checksum-only.** CLI version strings stored alongside the fingerprint
+ * are informational and MUST NOT influence the decision: a CLI bump that
+ * doesn't change any baked file produces an identical hash → `fresh`.
+ */
+export type BaseStatus =
+  /** No prepared base on disk — the ensure-gate inside `provision` raises the hard error. */
+  | { state: 'unprepared' }
+  /**
+   * Can't compute the live fingerprint (e.g. a dev tree with no built ctl
+   * bundle). Inert: callers must not prompt for a rebuild they can't verify.
+   */
+  | { state: 'unknown' }
+  /** Stored fingerprint differs from current — the baked runtime is out of date. */
+  | { state: 'stale'; reason: string }
+  /** Stored fingerprint matches current. */
+  | { state: 'fresh' };
+
+/**
+ * Decide whether the provider's base image / snapshot is still up to date
+ * with the CURRENT runtime context. Docker self-heals via `ensureImage` and
+ * is always `fresh` here. Cloud providers compare the stored
+ * `<provider>-prepared.json.base.contextSha256` (via
+ * `currentCloudBaseFingerprint`) against a freshly-computed one (via
+ * `currentCloudBaseFingerprintLive`), which the provider package builds the
+ * same way `prepare` does — so both values are byte-identical when nothing
+ * has changed.
+ */
+export async function evaluateBaseFreshness(provider: ProviderName): Promise<BaseStatus> {
+  if (provider === 'docker') return { state: 'fresh' };
+  const stored = currentCloudBaseFingerprint(provider);
+  if (!stored) return { state: 'unprepared' };
+  const current = await currentCloudBaseFingerprintLive(provider).catch(() => undefined);
+  if (!current) return { state: 'unknown' };
+  if (stored !== current) {
+    return {
+      state: 'stale',
+      reason: `baked runtime differs (base ${short(stored)}, current ${short(current)})`,
+    };
+  }
+  return { state: 'fresh' };
 }

--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -69,6 +69,8 @@ import { openCommandLog } from '../lib/log-file.js';
 import { resolveLimits } from '../limits.js';
 import { maybePromptPortless } from '../portless-prompt.js';
 import { maybeRunSetupWizard } from '../wizard.js';
+import { evaluateBaseFreshness } from '../checkpoint-lookup.js';
+import { runPrepare } from './prepare.js';
 import { runWrappedAttach } from '../wrapped-pty/index.js';
 import { pasteHostClipboardImage } from '../lib/paste-image.js';
 import { clipboardCaptureAvailable } from '../lib/host-clipboard.js';
@@ -666,6 +668,12 @@ export const claudeCommand = new Command('claude')
     // First-run wizard: when no agentbox.yaml exists, offer to inject an
     // initial user-message so claude reads /agentbox-setup and writes one.
     // Skipped when starting from a checkpoint (it already carries the config).
+    //
+    // Base freshness: cloud providers store a fingerprint of the baked
+    // runtime; if the local install no longer matches, the wizard offers to
+    // rebuild before creating. Docker self-heals via `ensureImage`, so its
+    // baseStatus is always `fresh` and the wizard is a no-op here.
+    const baseStatus = await evaluateBaseFreshness(providerName);
     const wiz = await maybeRunSetupWizard({
       workspace: opts.workspace,
       yes: !!opts.yes,
@@ -674,7 +682,21 @@ export const claudeCommand = new Command('claude')
       checkpointFromDefault: !(opts.snapshot && opts.snapshot.length > 0),
       provider: providerName,
       withEnv: cfg.effective.box.withEnv,
+      baseStatus,
     });
+    // Stale base: user opted in to rebuilding it. Re-bakes the snapshot /
+    // template and refreshes its stored fingerprint, so the subsequent box
+    // boots from the fresh base. Runs *before* checkpoint discard so a
+    // failure aborts cleanly without leaving a half-created box.
+    if (wiz.rebuildBase) {
+      log.warn(`${providerName} base image is outdated; rebuilding before create…`);
+      await runPrepare(providerName, {
+        force: true,
+        cwd: opts.workspace,
+        suppressTip: true,
+        suppressStatus: true,
+      });
+    }
     // The wizard may discard a stale/dead default checkpoint (recreate, or a
     // non-interactive run): boot from the current base instead of the old
     // artifact. An explicit `--snapshot` is never discarded.

--- a/apps/cli/src/commands/create.ts
+++ b/apps/cli/src/commands/create.ts
@@ -33,6 +33,8 @@ import {
   WIZARD_AUTOLAUNCH_ENV,
   WIZARD_ENV_FILES_ENV,
 } from '../wizard.js';
+import { evaluateBaseFreshness } from '../checkpoint-lookup.js';
+import { runPrepare } from './prepare.js';
 import { claudeCommand } from './claude.js';
 
 interface CreateOptions {
@@ -304,6 +306,12 @@ export const createCommand = new Command('create')
     // `agentbox claude` so the agent can interactively generate one. The
     // wizard runs for every provider — it's the env-file picker + first-run
     // claude offer, both of which are useful for cloud boxes too.
+    //
+    // Base freshness: cloud providers store a fingerprint of the baked
+    // runtime; if the local install no longer matches, the wizard offers to
+    // rebuild before creating. Docker self-heals via `ensureImage`, so its
+    // baseStatus is always `fresh` and the wizard is a no-op here.
+    const baseStatus = await evaluateBaseFreshness(providerName);
     const wiz = await maybeRunSetupWizard({
       workspace: opts.workspace,
       yes: !!opts.yes,
@@ -312,7 +320,21 @@ export const createCommand = new Command('create')
       checkpointFromDefault: !(opts.snapshot && opts.snapshot.length > 0),
       provider: providerName,
       withEnv: cfg.effective.box.withEnv,
+      baseStatus,
     });
+    // Stale base: user opted in to rebuilding it. Re-bakes the snapshot /
+    // template and refreshes its stored fingerprint, so the subsequent
+    // create boots from the fresh base. Runs *before* checkpoint discard so
+    // a failure aborts cleanly without leaving a half-created box.
+    if (wiz.rebuildBase) {
+      log.warn(`${providerName} base image is outdated; rebuilding before create…`);
+      await runPrepare(providerName, {
+        force: true,
+        cwd: opts.workspace,
+        suppressTip: true,
+        suppressStatus: true,
+      });
+    }
     // Drop a stale/dead default checkpoint so the box provisions from the
     // current base. On the docker switch-to-claude re-dispatch below the
     // default isn't forwarded as `--snapshot`, so the inner `agentbox claude`

--- a/apps/cli/src/provider/cloud-backend.ts
+++ b/apps/cli/src/provider/cloud-backend.ts
@@ -21,3 +21,30 @@ export async function cloudBackendForProvider(
       return null;
   }
 }
+
+/**
+ * Compute the CURRENT build-context fingerprint for a cloud provider's base
+ * image / snapshot — same shape as `cloudBackendForProvider` but resolves the
+ * provider package's `*BaseFingerprintLive()` helper instead of the backend.
+ * Dynamic imports keep the cloud SDKs off the docker hot path.
+ *
+ * Returns `undefined` for docker (its base self-heals via `ensureImage`) and
+ * any provider whose live computation fails (typically a dev tree without
+ * `pnpm -w build` — callers degrade to "can't tell, don't nag").
+ */
+export async function currentCloudBaseFingerprintLive(
+  provider: ProviderName,
+): Promise<string | undefined> {
+  switch (provider) {
+    case 'daytona':
+      return (await import('@agentbox/sandbox-daytona')).currentDaytonaBaseFingerprintLive();
+    case 'hetzner':
+      return (await import('@agentbox/sandbox-hetzner')).currentHetznerBaseFingerprintLive();
+    case 'vercel':
+      return (await import('@agentbox/sandbox-vercel')).currentVercelBaseFingerprintLive();
+    case 'e2b':
+      return (await import('@agentbox/sandbox-e2b')).currentE2bBaseFingerprintLive();
+    default:
+      return undefined;
+  }
+}

--- a/apps/cli/src/wizard.ts
+++ b/apps/cli/src/wizard.ts
@@ -3,7 +3,7 @@ import { findProjectRoot } from '@agentbox/config';
 import type { ProviderName } from '@agentbox/core';
 import { DEFAULT_ENV_PATTERNS, scanHostEnvFiles } from '@agentbox/sandbox-docker';
 import { basename } from 'node:path';
-import { type CheckpointStatus, evaluateCheckpoint } from './checkpoint-lookup.js';
+import { type BaseStatus, type CheckpointStatus, evaluateCheckpoint } from './checkpoint-lookup.js';
 
 /**
  * In-box absolute path to the setup guide markdown (baked into the box image
@@ -51,6 +51,14 @@ export interface WizardOutcome {
    * provisions from the current base instead of a dead/outdated artifact.
    */
   discardCheckpoint?: boolean;
+  /**
+   * Set when the provider's base image / snapshot is out of date and the
+   * user opted in to recreating it. The caller runs `runPrepare(provider, {
+   * force: true })` BEFORE `createBox`/`provider.create` so the box boots
+   * from the fresh base. Implies `discardCheckpoint`: a stale base
+   * invalidates any artifact captured against it.
+   */
+  rebuildBase?: boolean;
 }
 
 interface WizardArgs {
@@ -87,6 +95,15 @@ interface WizardArgs {
    * env-file multiselect is suppressed in that case — the user pre-decided.
    */
   withEnv?: boolean;
+  /**
+   * Freshness of the target provider's base image / snapshot
+   * (`evaluateBaseFreshness(provider)`). A `stale` base must be re-prompted
+   * to rebuild before booting any box — outranks even a fresh checkpoint and
+   * an existing agentbox.yaml, since they all share the same base. `unknown`
+   * / `unprepared` / `fresh` (or omitted) → silent no-op. Non-interactive
+   * runs warn loudly and proceed on the existing base — never auto-bake.
+   */
+  baseStatus?: BaseStatus;
 }
 
 /**
@@ -138,10 +155,47 @@ export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutco
 
   const fromDefault = args.checkpointFromDefault !== false;
 
+  // Stale CLOUD base: every box on this provider boots from it, so re-prompt
+  // BEFORE the agentbox.yaml early-return AND before the fresh-checkpoint
+  // short-circuit (both would silently boot incompatible boxes on an old base).
+  // `fromDefault === false` (explicit `--snapshot`) is a deliberate restore —
+  // no base-rebuild hijack; create-time warning only.
+  const baseStale = args.baseStatus?.state === 'stale' && fromDefault;
+  let rebuildBase = false;
+  if (baseStale) {
+    const provider = args.provider ?? 'docker';
+    const mins = rebuildMinutesFor(provider);
+    const yamlSuffix = proj.hasAgentboxYaml ? '' : ' and run Setup Wizard';
+    const rebuild = await confirm({
+      message:
+        `The ${provider} base image is out of date — its baked runtime no longer matches your current install. ` +
+        `Recreate the base${yamlSuffix}? (rebuilds the base — ~${mins} min — then starts fresh)`,
+      initialValue: true,
+    });
+    if (isCancel(rebuild) || !rebuild) {
+      // Boot on the old base — keep any checkpoint as-is (the user opted in
+      // to the existing artifact). Mirrors the "use it anyway" arm below.
+      return {
+        action: 'proceed',
+        discardCheckpoint: discardOnMissing(status, fromDefault),
+      };
+    }
+    rebuildBase = true;
+    // hasAgentboxYaml + base rebuild: the project's already configured, so
+    // skip the setup wizard branch and just rebuild + proceed.
+    if (proj.hasAgentboxYaml) {
+      return {
+        action: 'proceed',
+        rebuildBase: true,
+        discardCheckpoint: true,
+      };
+    }
+  }
+
   // An existing agentbox.yaml means the project is already configured; don't
   // nag. Still drop a dead *default* checkpoint so create doesn't try to boot
   // a pruned image/snapshot (a stale-but-bootable one is kept — the create
-  // path warns about it).
+  // path warns about it). A stale base was handled above (early-returned).
   if (proj.hasAgentboxYaml) {
     return { action: 'proceed', discardCheckpoint: discardOnMissing(status, fromDefault) };
   }
@@ -150,17 +204,20 @@ export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutco
   // when it was captured — skip the "generate one?" prompt entirely. "Usable"
   // = fresh, or a stale snapshot the user pinned explicitly via `--snapshot`
   // (kept as-is; the create path warns). A stale *default* is re-prompted
-  // below; a missing one falls through to normal setup.
-  if (status.state === 'fresh' || (status.state === 'stale' && !fromDefault)) {
+  // below; a missing one falls through to normal setup. Skipped when the user
+  // already opted in to rebuilding the base — the old checkpoint's gone with it.
+  if (!rebuildBase && (status.state === 'fresh' || (status.state === 'stale' && !fromDefault))) {
     log.info(`starting from checkpoint "${args.checkpointRef}"; skipping agentbox.yaml setup`);
     return { action: 'proceed' };
   }
 
   // Stale default checkpoint: don't silently boot the old base layers. Offer
-  // to recreate (re-run setup on the current base) or use it anyway.
-  let discardCheckpoint = false;
-  let recreateChosen = false;
-  if (status.state === 'stale' && fromDefault) {
+  // to recreate (re-run setup on the current base) or use it anyway. Skipped
+  // when `rebuildBase` is already true — the base rebuild implies a discard,
+  // and recreateChosen below short-circuits the second "set up?" confirm.
+  let discardCheckpoint = rebuildBase;
+  let recreateChosen = rebuildBase;
+  if (!rebuildBase && status.state === 'stale' && fromDefault) {
     const recreate = await confirm({
       message: `Snapshot "${args.checkpointRef}" is stale (${status.reason}). Start from base and run Setup Wizard? (No = use it anyway)`,
       initialValue: true,
@@ -171,7 +228,7 @@ export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutco
     }
     discardCheckpoint = true;
     recreateChosen = true;
-  } else if (status.state === 'missing') {
+  } else if (!rebuildBase && status.state === 'missing') {
     // No bootable artifact for this provider — drop a dead default ref so
     // create provisions fresh, then fall through to normal setup.
     discardCheckpoint = discardOnMissing(status, fromDefault) ?? false;
@@ -209,6 +266,7 @@ export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutco
         action: 'proceed',
         envFilesToImport,
         discardCheckpoint: discardCheckpoint || undefined,
+        rebuildBase: rebuildBase || undefined,
       };
     }
   }
@@ -225,6 +283,7 @@ export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutco
       action: 'switch-to-claude',
       envFilesToImport,
       discardCheckpoint: discardCheckpoint || undefined,
+      rebuildBase: rebuildBase || undefined,
     };
   }
 
@@ -233,7 +292,31 @@ export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutco
     initialPrompt: buildSetupInitialPrompt(proj.root),
     envFilesToImport,
     discardCheckpoint: discardCheckpoint || undefined,
+    rebuildBase: rebuildBase || undefined,
   };
+}
+
+/**
+ * Rough rebuild-time estimate per provider, shown in the merged stale-base
+ * prompt. Order-of-magnitude only — the user just needs to know if this is
+ * "a couple minutes" or "go grab coffee". Numbers come from the
+ * provider backlog docs and live verification (e2b: SDK Template.build of
+ * the agentbox base; vercel: AL2023 provision.sh; hetzner: cloud-init + scp;
+ * daytona: docker Image.build).
+ */
+function rebuildMinutesFor(provider: ProviderName): string {
+  switch (provider) {
+    case 'e2b':
+      return '2';
+    case 'daytona':
+      return '7';
+    case 'vercel':
+      return '25';
+    case 'hetzner':
+      return '35–50';
+    default:
+      return '1';
+  }
 }
 
 /**
@@ -258,6 +341,12 @@ function discardOnMissing(status: CheckpointStatus, fromDefault: boolean): boole
  * stale/missing *default* is discarded. With no usable snapshot and no
  * agentbox.yaml, `claude` runs setup (`launch-with-prompt`) while `create`
  * makes a bare box (`proceed`).
+ *
+ * Stale CLOUD base in -y / non-TTY: warn loudly and PROCEED on the existing
+ * base. Never auto-bake an expensive snapshot in a scripted run; tell the
+ * user to run `agentbox prepare --provider X --force`. Do not discard the
+ * checkpoint solely for base staleness either — the checkpoint's still
+ * bootable; the user can deal with it during their next interactive session.
  */
 function nonInteractiveOutcome(
   args: WizardArgs,
@@ -265,6 +354,13 @@ function nonInteractiveOutcome(
   status: CheckpointStatus,
   envFilesToImport: string[] | undefined,
 ): WizardOutcome {
+  if (args.baseStatus?.state === 'stale') {
+    const provider = args.provider ?? 'docker';
+    log.warn(
+      `${provider} base image is out of date (${args.baseStatus.reason}); booting on the existing base. ` +
+        `Run \`agentbox prepare --provider ${provider} --force\` to rebuild.`,
+    );
+  }
   const fromDefault = args.checkpointFromDefault !== false;
   const usableAsIs = status.state === 'fresh' || (status.state === 'stale' && !fromDefault);
   // Drop a dead default ref always (it can't boot). Drop a stale default only

--- a/apps/cli/test/evaluate-base-freshness.test.ts
+++ b/apps/cli/test/evaluate-base-freshness.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Mock the two modules `evaluateBaseFreshness` reaches into so the test is
+// pure: no fs, no SDKs, no network. We swap implementations per-test via
+// vi.mocked().
+vi.mock('@agentbox/sandbox-cloud', () => ({
+  currentCloudBaseFingerprint: vi.fn(),
+  // The other named imports of checkpoint-lookup.ts are unused by
+  // evaluateBaseFreshness but must still be present so the module loads.
+  probeCloudCheckpoint: vi.fn(),
+  resolveCloudCheckpoint: vi.fn(),
+}));
+vi.mock('../src/provider/cloud-backend.js', () => ({
+  cloudBackendForProvider: vi.fn(),
+  currentCloudBaseFingerprintLive: vi.fn(),
+}));
+// checkpoint-lookup also pulls these in for evaluateCheckpoint (a sibling we
+// don't test here); stub them so the import graph resolves.
+vi.mock('@agentbox/sandbox-docker', () => ({
+  computeDockerContextFingerprint: vi.fn(),
+  imageExists: vi.fn(),
+  readPreparedDockerState: vi.fn(),
+  resolveCheckpoint: vi.fn(),
+}));
+
+import { evaluateBaseFreshness } from '../src/checkpoint-lookup.js';
+import { currentCloudBaseFingerprint } from '@agentbox/sandbox-cloud';
+import { currentCloudBaseFingerprintLive } from '../src/provider/cloud-backend.js';
+
+describe('evaluateBaseFreshness', () => {
+  beforeEach(() => {
+    vi.mocked(currentCloudBaseFingerprint).mockReset();
+    vi.mocked(currentCloudBaseFingerprintLive).mockReset();
+  });
+
+  it("returns 'fresh' for docker without consulting either fingerprint helper", async () => {
+    const r = await evaluateBaseFreshness('docker');
+    expect(r).toEqual({ state: 'fresh' });
+    expect(currentCloudBaseFingerprint).not.toHaveBeenCalled();
+    expect(currentCloudBaseFingerprintLive).not.toHaveBeenCalled();
+  });
+
+  it("returns 'unprepared' when no fingerprint is stored", async () => {
+    vi.mocked(currentCloudBaseFingerprint).mockReturnValue(undefined);
+    const r = await evaluateBaseFreshness('e2b');
+    expect(r).toEqual({ state: 'unprepared' });
+    // Live helper isn't consulted when there's no stored value to compare
+    // against — saves a fingerprint compute on a clean install.
+    expect(currentCloudBaseFingerprintLive).not.toHaveBeenCalled();
+  });
+
+  it("returns 'unknown' when the live fingerprint can't be computed", async () => {
+    vi.mocked(currentCloudBaseFingerprint).mockReturnValue('a'.repeat(64));
+    vi.mocked(currentCloudBaseFingerprintLive).mockResolvedValue(undefined);
+    const r = await evaluateBaseFreshness('e2b');
+    expect(r).toEqual({ state: 'unknown' });
+  });
+
+  it("returns 'unknown' when the live fingerprint helper throws", async () => {
+    vi.mocked(currentCloudBaseFingerprint).mockReturnValue('a'.repeat(64));
+    vi.mocked(currentCloudBaseFingerprintLive).mockRejectedValue(
+      new Error('boom: missing ctl bundle'),
+    );
+    const r = await evaluateBaseFreshness('vercel');
+    expect(r).toEqual({ state: 'unknown' });
+  });
+
+  it("returns 'fresh' when stored and live fingerprints match (checksum-only)", async () => {
+    const sha = 'b'.repeat(64);
+    vi.mocked(currentCloudBaseFingerprint).mockReturnValue(sha);
+    vi.mocked(currentCloudBaseFingerprintLive).mockResolvedValue(sha);
+    const r = await evaluateBaseFreshness('hetzner');
+    expect(r).toEqual({ state: 'fresh' });
+  });
+
+  it("returns 'stale' with a checksum-shaped reason when they differ", async () => {
+    const stored = 'a'.repeat(64);
+    const current = 'c'.repeat(64);
+    vi.mocked(currentCloudBaseFingerprint).mockReturnValue(stored);
+    vi.mocked(currentCloudBaseFingerprintLive).mockResolvedValue(current);
+    const r = await evaluateBaseFreshness('e2b');
+    expect(r.state).toBe('stale');
+    if (r.state !== 'stale') throw new Error('type guard');
+    // The reason quotes the prefixes of both hashes, not any CLI version
+    // strings — staleness is decided purely by content checksum.
+    expect(r.reason).toContain(stored.slice(0, 12));
+    expect(r.reason).toContain(current.slice(0, 12));
+    expect(r.reason).not.toMatch(/cli|version/i);
+  });
+});

--- a/apps/web/content/docs/daytona.mdx
+++ b/apps/web/content/docs/daytona.mdx
@@ -30,6 +30,8 @@ Unlike Docker, Daytona does **not** auto-build the box image on first `create`. 
 agentbox prepare --provider daytona
 ```
 
+When you upgrade AgentBox, `create --provider daytona` notices if the new install would bake a different snapshot (the comparison is checksum-based on the baked files — CLI version strings on their own don't count) and offers to rebake inline; with `-y` or non-TTY it instead warns loudly and boots on the existing snapshot. `agentbox daytona login` also nudges you toward `agentbox prepare --provider daytona` on the first successful login.
+
 See [CLI commands](/docs/cli) for all flags.
 
 <Callout type="warn" title="HEADS UP">

--- a/apps/web/content/docs/e2b.mdx
+++ b/apps/web/content/docs/e2b.mdx
@@ -31,6 +31,8 @@ agentbox prepare --provider e2b
 
 A repeat `prepare` reuses the existing template unless you pass `--force`. The bake takes a couple of minutes the first time; subsequent layer-cached builds are faster. See [CLI commands](/docs/cli) for all flags.
 
+When you upgrade AgentBox, `create --provider e2b` notices if the new install would bake a different runtime (the comparison is checksum-based on the baked files — CLI version strings on their own don't count) and offers to rebuild the template inline; with `-y` or non-TTY it instead prints a loud warning and boots on the existing template. `agentbox e2b login` also nudges you toward `agentbox prepare --provider e2b` on the first successful login, so the login-only path doesn't silently leave you to trip the "no base template" error on `create`.
+
 ## Create a box
 
 Once you're logged in and prepared, the flow is standard. The workspace is seeded from a host git bundle plus your stash and untracked files (see [teleport-a-project](/docs/teleport-a-project)). The box runs as user `vscode`, and `/workspace` is checked out on branch `agentbox/<box-name>`.

--- a/apps/web/content/docs/hetzner.mdx
+++ b/apps/web/content/docs/hetzner.mdx
@@ -40,6 +40,8 @@ agentbox prepare --provider hetzner
 
 The snapshot is a shell mirror of the Docker box image (Node, Python, Docker, the VNC stack, Playwright Chromium, the agents, and the `agentbox-ctl` supervisor). First run takes ~10–15 minutes; after that, every `create --provider hetzner` boots from it in ~15–20s. Re-running is idempotent — pass `--force` to rebake.
 
+When you upgrade AgentBox, `create --provider hetzner` notices if the new install would bake a different snapshot (the comparison is checksum-based on the baked files — CLI version strings on their own don't count) and offers to rebake inline; with `-y` or non-TTY it instead warns loudly and boots on the existing snapshot. `agentbox hetzner login` also nudges you toward `agentbox prepare --provider hetzner` on the first successful login.
+
 <Callout type="warn" title="HEADS UP">
 The bake costs a few minutes and a couple euro-cents, but you only do it once per account.
 </Callout>

--- a/apps/web/content/docs/vercel.mdx
+++ b/apps/web/content/docs/vercel.mdx
@@ -31,6 +31,8 @@ agentbox prepare --provider vercel
 
 A repeat `prepare` reuses the existing snapshot unless you pass `--force`. The bake takes a few minutes; the base snapshot is around 1.3 GB. See [CLI commands](/docs/cli) for all flags.
 
+When you upgrade AgentBox, `create --provider vercel` notices if the new install would bake a different snapshot (the comparison is checksum-based on the baked files — CLI version strings on their own don't count) and offers to rebake inline; with `-y` or non-TTY it instead warns loudly and boots on the existing snapshot. `agentbox vercel login` also nudges you toward `agentbox prepare --provider vercel` on the first successful login.
+
 <Callout title="TIP">
 Run `prepare` with the access-token trio in env — the bake can outlive a 12h OIDC dev token.
 </Callout>

--- a/docs/cloud-create-flow.md
+++ b/docs/cloud-create-flow.md
@@ -205,6 +205,40 @@ If you want to skip even the workspace seed, use
 carries `/workspace`, and step 4 is skipped
 (`cloud-provider.ts:218`).
 
+## Stale base detection at create
+
+`agentbox prepare --provider X` stamps the build-context fingerprint into
+`~/.agentbox/<provider>-prepared.json`'s `base.contextSha256` — a SHA over
+every file that gets baked into the base image / snapshot (the staged
+`agentbox-ctl` bundle, the agent helpers, the dockerfile context, etc.).
+On every `agentbox create` / `agentbox claude`, the CLI recomputes that
+SHA from the same inputs (`evaluateBaseFreshness` in
+`apps/cli/src/checkpoint-lookup.ts`) and compares. A mismatch means the
+local install has drifted from the baked base — typically a CLI upgrade
+that changed one of the baked files.
+
+**Checksum-only.** The CLI version strings stored next to the fingerprint
+are informational; they never influence the decision. A CLI patch that
+doesn't change any baked file produces an identical checksum, so the
+base stays `fresh` and no prompt fires.
+
+What happens when a stale base is detected:
+
+- **TTY** — the wizard merges a confirm into the existing "checkpoint is
+  stale, recreate?" path: *"The &lt;provider&gt; base image is out of date — its
+  baked runtime no longer matches your current install. Recreate the base
+  and run Setup Wizard? (rebuilds the base — ~N min — then starts
+  fresh)"*. **Yes** runs `runPrepare(force: true)` before the create, then
+  proceeds with a fresh base + discarded checkpoint. **No** boots on the
+  existing base (the checkpoint is kept as-is).
+- **`-y` / non-TTY** — logs a loud `▲` warning naming the provider and
+  pointing at `agentbox prepare --provider X --force`, then proceeds on the
+  existing base. Never auto-bakes an expensive snapshot in a scripted run.
+- **`--snapshot <ref>` (interactive)** — no rebuild hijack; the explicit
+  snapshot is a deliberate restore. The non-interactive warn still fires.
+- **Docker** — silent: `ensureImage` already self-heals on a mismatch by
+  rebuilding `agentbox/box:dev` inline before container start.
+
 ## Cloud checkpoints
 
 Cloud checkpoints work in three layers: a Daytona-native snapshot primitive,

--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -66,6 +66,38 @@ resolved at the call site and wins over both the per-provider and
 generic keys. As a one-shot migration, any `prepare` that finds a stale
 non-default `box.image` in project config unsets it and logs a warning.
 
+### 1.2 Create-time base-freshness check
+
+`prepare` stamps a SHA over the baked-runtime files
+(`base.contextSha256` in `~/.agentbox/<provider>-prepared.json`). Every
+`create` / `claude` recomputes that SHA from the current install
+(`evaluateBaseFreshness`) and compares. A mismatch surfaces in the
+existing setup wizard:
+
+- **TTY** → merged confirm offers to rebuild via
+  `runPrepare(force: true)` before the create.
+- **`-y` / non-TTY** → loud warn (`▲`), then proceed on the existing
+  base; the user is told to run
+  `agentbox prepare --provider X --force`. No auto-bake in scripted runs.
+- **Docker** → silent: `ensureImage` self-heals inline on its own
+  mismatch.
+
+Staleness is decided **purely** by content checksum — a CLI patch that
+doesn't change any baked file produces an identical SHA, so the base
+stays `fresh`. See `docs/cloud-create-flow.md` → "Stale base detection
+at create" for the full state machine.
+
+### 1.3 Login → prepare nudge
+
+Each cloud's `agentbox <provider> login` only persists credentials.
+Without a baked base, the next `create` trips the "no base
+template/snapshot" error. To avoid that, each provider's `login` checks
+for a baked base on success and, when none is recorded, prints a
+one-line nudge: *"Base &lt;template|snapshot&gt; not built yet — run
+`agentbox prepare --provider X` (or `agentbox install`) to bake it."*
+The `agentbox install` wizard already calls `runPrepare` directly, so
+users who go through `install` skip both the error and the nudge.
+
 ## 2. The Daytona shape
 
 ### 2.0 Sizing

--- a/docs/e2b_backlog.md
+++ b/docs/e2b_backlog.md
@@ -289,6 +289,22 @@ shipped.
   tripped the wizard's "captured before checkpoint versioning; base
   snapshot unverifiable" branch and stale-prompted forever; now the
   fresh-vs-stale verdict is real for all four clouds.
+- **Login nudge + create-time base-freshness check** (2026-06-03). Two paper-
+  cuts off the e2b first-run path:
+  - `agentbox e2b login` now prints a one-line nudge pointing at
+    `agentbox prepare --provider e2b` when no base template is recorded yet,
+    so the login-only path doesn't silently leave the next `create` to trip
+    the (newly-clean) "no base template found" error.
+  - `agentbox create --provider e2b` / `agentbox claude --provider e2b` now
+    detect a stale base template at create time. Decision is made purely on
+    `contextSha256` — the SHA over the baked runtime files (CLI version
+    strings are informational and never gate freshness, so a CLI patch
+    that touches nothing baked stays `fresh`). TTY → merged "rebuild the
+    base?" confirm; `-y`/non-TTY → loud warn + boot on the existing base
+    (no auto-bake). Verified live: fresh-base TTY skips the prompt; mutating
+    one hex char of `base.contextSha256` fires the prompt; `-y` mode warns
+    and proceeds. Same plumbing covers daytona/hetzner/vercel via the new
+    `Provider.baseFingerprint?()` capability.
 
 ## Coordination notes (orchestrator)
 

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -359,4 +359,22 @@ export interface Provider {
    * omit it and the CLI surfaces a clear "prepare not supported" error.
    */
   prepare?(opts: PrepareOptions): Promise<PrepareResult>;
+  /**
+   * Compute the CURRENT build-context fingerprint for this provider's base
+   * image / snapshot WITHOUT building anything. Side-effect-free: resolves
+   * the same runtime assets `prepare` would bake in, hashes them, and
+   * returns the SHA-256.
+   *
+   * The CLI compares this against the stored fingerprint in
+   * `~/.agentbox/<provider>-prepared.json` (`base.contextSha256`) to decide
+   * whether the user's local install has drifted from the baked base — i.e.
+   * a CLI/runtime upgrade that changed any baked file. Staleness is decided
+   * PURELY by content hash; CLI version strings stored alongside are
+   * informational and MUST NOT influence freshness decisions.
+   *
+   * Returns `undefined` when the assets can't be resolved (e.g. a dev tree
+   * without `pnpm -w build`); callers degrade to "don't nag" rather than
+   * flag a false stale.
+   */
+  baseFingerprint?(): Promise<string | undefined>;
 }

--- a/packages/sandbox-daytona/src/cli.ts
+++ b/packages/sandbox-daytona/src/cli.ts
@@ -13,6 +13,7 @@ import {
   readDaytonaCredStatus,
   secretsPath,
 } from './credentials.js';
+import { readPreparedDaytonaState } from './prepared-state.js';
 
 interface LoginOpts {
   status?: boolean;
@@ -41,6 +42,15 @@ const loginSub = new Command('login')
         return;
       }
       await ensureDaytonaCredentials({ force: true });
+      // Credentials alone don't get a user a working box — they also need a
+      // baked base snapshot. Nudge toward `prepare` so the login → first-create
+      // path doesn't hit the (otherwise-clean) "no Daytona base snapshot"
+      // error. No layering break.
+      if (readPreparedDaytonaState()?.base === undefined) {
+        log.info(
+          'Base snapshot not built yet — run `agentbox prepare --provider daytona` (or `agentbox install`) to bake it.',
+        );
+      }
     } catch (err) {
       reportError(err);
     }

--- a/packages/sandbox-daytona/src/index.ts
+++ b/packages/sandbox-daytona/src/index.ts
@@ -8,6 +8,7 @@ import type { Provider } from '@agentbox/core';
 import { createCloudProvider } from '@agentbox/sandbox-cloud';
 import { daytonaBackend, DEFAULT_BOX_IMAGE_REF } from './backend.js';
 import { prepareDaytona } from './prepare.js';
+import { currentDaytonaBaseFingerprintLive } from './prepared-state.js';
 
 const cloudProvider = createCloudProvider(daytonaBackend, {
   defaultResources: { cpu: 2, memory: 4, disk: 8 },
@@ -16,11 +17,13 @@ const cloudProvider = createCloudProvider(daytonaBackend, {
 export const daytonaProvider: Provider = {
   ...cloudProvider,
   prepare: prepareDaytona,
+  baseFingerprint: () => currentDaytonaBaseFingerprintLive(),
 };
 
 export { daytonaBackend, DEFAULT_BOX_IMAGE_REF };
 export { resolveDockerfileContext, type DockerfileContext } from './dockerfile-context.js';
 export { ensureDaytonaEnvLoaded } from './env-loader.js';
+export { currentDaytonaBaseFingerprintLive } from './prepared-state.js';
 // Called by the CLI provider registry to gate first-run interactive setup.
 // Plain async function — no commander surface — so adding it here doesn't
 // pull commander/clack into consumers' type graphs. The full CLI command

--- a/packages/sandbox-daytona/src/prepared-state.ts
+++ b/packages/sandbox-daytona/src/prepared-state.ts
@@ -77,6 +77,22 @@ export async function computeDaytonaContextFingerprint(): Promise<DaytonaFingerp
   return { contextSha256: await computeContextSha256(files), files };
 }
 
+/**
+ * Compute the CURRENT build-context fingerprint for the daytona base snapshot.
+ * Side-effect-free wrapper around `computeDaytonaContextFingerprint` that
+ * returns just the SHA (or `undefined` when assets can't be resolved). Used
+ * by the CLI's `evaluateBaseFreshness` to compare against the stored
+ * `daytona-prepared.json.base.contextSha256`.
+ */
+export async function currentDaytonaBaseFingerprintLive(): Promise<string | undefined> {
+  try {
+    const fp = await computeDaytonaContextFingerprint();
+    return fp?.contextSha256;
+  } catch {
+    return undefined;
+  }
+}
+
 export function readPreparedDaytonaState(): PreparedDaytonaState | null {
   const raw = readPreparedStateRaw('daytona');
   if (raw === null || typeof raw !== 'object') return null;

--- a/packages/sandbox-e2b/src/cli.ts
+++ b/packages/sandbox-e2b/src/cli.ts
@@ -18,6 +18,7 @@ import {
   readE2bCredStatus,
   secretsPath,
 } from './credentials.js';
+import { readPreparedState } from './prepared-state.js';
 
 interface LoginOpts {
   status?: boolean;
@@ -62,6 +63,17 @@ const loginSub = new Command('login')
         return;
       }
       await ensureE2bCredentials({ force: true });
+      // Credentials alone don't get a user a working box — they also need a
+      // baked base template. Nudge the user toward `prepare` here so the
+      // login → first-create path doesn't hit the (otherwise-clean) "no base
+      // template found" error from `ensureE2bBaseTemplate`. No layering break
+      // (provider package stays free of the `runPrepare` dependency); the
+      // `agentbox install` wizard already calls `runPrepare` directly.
+      if (readPreparedState().base === undefined) {
+        log.info(
+          'Base template not built yet — run `agentbox prepare --provider e2b` (or `agentbox install`) to bake it.',
+        );
+      }
     } catch (err) {
       reportError(err);
     }

--- a/packages/sandbox-e2b/src/index.ts
+++ b/packages/sandbox-e2b/src/index.ts
@@ -30,6 +30,7 @@ import { Sandbox, resolveApiKey } from './sdk.js';
 import { withE2bRetry } from './retry.js';
 import { prepareE2bProvider } from './prepare.js';
 import { buildE2bAttach } from './build-attach.js';
+import { currentE2bBaseFingerprintLive } from './prepared-state.js';
 
 const BACKEND_NAME = 'e2b';
 
@@ -148,6 +149,7 @@ export const e2bProvider: Provider = {
   prepare: prepareE2bProvider,
   buildAttach: buildE2bAttach,
   checkpoint: e2bCheckpoint,
+  baseFingerprint: () => currentE2bBaseFingerprintLive(),
 };
 
 export { e2bBackend, DEFAULT_BOX_IMAGE_REF };
@@ -175,6 +177,7 @@ export {
   type PrepareE2bResult,
 } from './prepare.js';
 export {
+  currentE2bBaseFingerprintLive,
   ensureE2bBaseTemplate,
   preparedStatePath,
   readPreparedState,

--- a/packages/sandbox-e2b/src/prepared-state.ts
+++ b/packages/sandbox-e2b/src/prepared-state.ts
@@ -13,8 +13,9 @@
  * accepted today.
  */
 
-import { readPreparedStateRaw, writePreparedStateRaw, preparedStatePathFor } from '@agentbox/sandbox-core';
+import { computeContextSha256, readPreparedStateRaw, writePreparedStateRaw, preparedStatePathFor } from '@agentbox/sandbox-core';
 import { UserFacingError } from '@agentbox/core';
+import { findStagedCliRuntimeRoot, resolveRuntimeAssets } from './runtime-assets.js';
 
 const SCHEMA = 1 as const;
 
@@ -63,6 +64,29 @@ export function updatePreparedState(mutate: (s: PreparedE2bState) => void): void
   const s = readPreparedState();
   mutate(s);
   writePreparedState(s);
+}
+
+/**
+ * Compute the CURRENT build-context fingerprint for the e2b base template
+ * (the SHA over every file `prepare` would copy into the Template build).
+ * Side-effect-free — never builds. Returns `undefined` when the runtime
+ * assets can't be resolved (dev tree without `pnpm -w build`) so the CLI
+ * can degrade to "can't tell, don't nag" rather than flag a false stale.
+ *
+ * Used by `evaluateBaseFreshness` to compare against the stored value in
+ * `e2b-prepared.json.base.contextSha256`. Must produce a byte-identical
+ * hash to the one `prepare` writes — both go through the same
+ * `resolveRuntimeAssets` + `computeContextSha256` chain.
+ */
+export async function currentE2bBaseFingerprintLive(): Promise<string | undefined> {
+  try {
+    const assets = resolveRuntimeAssets({ cliRuntimeRoot: findStagedCliRuntimeRoot() });
+    return await computeContextSha256(
+      assets.map((a) => ({ rel: a.name, abs: a.localPath })),
+    );
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/packages/sandbox-hetzner/src/cli.ts
+++ b/packages/sandbox-hetzner/src/cli.ts
@@ -29,6 +29,7 @@ import {
 } from './credentials.js';
 import { detectEgressIp } from './egress-ip.js';
 import { normalizeSourceCidr, syncFirewallSource } from './firewall.js';
+import { readPreparedState } from './prepared-state.js';
 
 interface LoginOpts {
   status?: boolean;
@@ -57,6 +58,15 @@ const loginSub = new Command('login')
         return;
       }
       await ensureHetznerCredentials({ force: true });
+      // Credentials alone don't get a user a working box — they also need a
+      // baked base snapshot. Nudge toward `prepare` so the login → first-create
+      // path doesn't hit the (otherwise-clean) "no base snapshot" error from
+      // the snapshot resolver. No layering break.
+      if (readPreparedState().base === undefined) {
+        log.info(
+          'Base snapshot not built yet — run `agentbox prepare --provider hetzner` (or `agentbox install`) to bake it.',
+        );
+      }
     } catch (err) {
       reportError(err);
     }

--- a/packages/sandbox-hetzner/src/index.ts
+++ b/packages/sandbox-hetzner/src/index.ts
@@ -15,6 +15,7 @@ import type { Provider } from '@agentbox/core';
 import { createCloudProvider } from '@agentbox/sandbox-cloud';
 import { hetznerBackend, HETZNER_DEFAULT_BOX_IMAGE_REF } from './backend.js';
 import { prepareHetznerProvider } from './prepare.js';
+import { currentHetznerBaseFingerprintLive } from './prepared-state.js';
 
 const cloudProvider = createCloudProvider(hetznerBackend, {
   defaultResources: { cpu: 2, memory: 4, disk: 40 },
@@ -23,6 +24,7 @@ const cloudProvider = createCloudProvider(hetznerBackend, {
 export const hetznerProvider: Provider = {
   ...cloudProvider,
   prepare: prepareHetznerProvider,
+  baseFingerprint: () => currentHetznerBaseFingerprintLive(),
 };
 
 export { hetznerBackend, HETZNER_DEFAULT_BOX_IMAGE_REF };
@@ -63,6 +65,7 @@ export {
 } from './ssh-cli.js';
 export { pollUntil, type PollOptions } from './poll.js';
 export {
+  currentHetznerBaseFingerprintLive,
   preparedStatePath,
   readPreparedState,
   writePreparedState,

--- a/packages/sandbox-hetzner/src/prepared-state.ts
+++ b/packages/sandbox-hetzner/src/prepared-state.ts
@@ -17,7 +17,8 @@
  * Schema versioned so future shape changes can migrate.
  */
 
-import { preparedStatePathFor, readPreparedStateRaw, writePreparedStateRaw } from '@agentbox/sandbox-core';
+import { computeContextSha256, preparedStatePathFor, readPreparedStateRaw, writePreparedStateRaw } from '@agentbox/sandbox-core';
+import { findStagedCliRuntimeRoot, resolveRuntimeAssets } from './runtime-assets.js';
 
 /**
  * Schema history:
@@ -129,4 +130,27 @@ export function updatePreparedState(mutate: (s: PreparedHetznerState) => void): 
   const s = readPreparedState();
   mutate(s);
   writePreparedState(s);
+}
+
+/**
+ * Compute the CURRENT build-context fingerprint for the hetzner base snapshot
+ * (the SHA over every file `prepare` would scp into the prepare VPS).
+ * Side-effect-free — never builds. Returns `undefined` when the runtime
+ * assets can't be resolved (dev tree without `pnpm -w build`) so the CLI
+ * can degrade to "can't tell, don't nag".
+ *
+ * Used by `evaluateBaseFreshness` to compare against the stored value in
+ * `hetzner-prepared.json.base.contextSha256`. Must produce a byte-identical
+ * hash to the one `prepare` writes — both go through the same
+ * `resolveRuntimeAssets` + `computeContextSha256` chain.
+ */
+export async function currentHetznerBaseFingerprintLive(): Promise<string | undefined> {
+  try {
+    const assets = resolveRuntimeAssets({ cliRuntimeRoot: findStagedCliRuntimeRoot() });
+    return await computeContextSha256(
+      assets.map((a) => ({ rel: a.name, abs: a.localPath })),
+    );
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/sandbox-vercel/src/cli.ts
+++ b/packages/sandbox-vercel/src/cli.ts
@@ -18,6 +18,7 @@ import {
   readVercelCredStatus,
   secretsPath,
 } from './credentials.js';
+import { readPreparedState } from './prepared-state.js';
 import { detectSbx, installSbxHint } from './sbx-cli.js';
 
 interface LoginOpts {
@@ -98,6 +99,15 @@ const loginSub = new Command('login')
         return;
       }
       await ensureVercelCredentials({ force: true });
+      // Credentials alone don't get a user a working box — they also need a
+      // baked base snapshot. Nudge toward `prepare` so the login → first-create
+      // path doesn't hit the (otherwise-clean) "no Vercel base snapshot found"
+      // error from `ensureVercelBaseSnapshot`. No layering break.
+      if (readPreparedState().base === undefined) {
+        log.info(
+          'Base snapshot not built yet — run `agentbox prepare --provider vercel` (or `agentbox install`) to bake it.',
+        );
+      }
     } catch (err) {
       reportError(err);
     }

--- a/packages/sandbox-vercel/src/index.ts
+++ b/packages/sandbox-vercel/src/index.ts
@@ -30,6 +30,7 @@ import {
 import { readCliStamp, recordBox } from '@agentbox/sandbox-core';
 import { prepareVercelProvider } from './prepare.js';
 import { buildVercelAttach } from './build-attach.js';
+import { currentVercelBaseFingerprintLive } from './prepared-state.js';
 
 const BACKEND_NAME = 'vercel';
 
@@ -100,6 +101,7 @@ export const vercelProvider: Provider = {
   prepare: prepareVercelProvider,
   buildAttach: buildVercelAttach,
   checkpoint: vercelCheckpoint,
+  baseFingerprint: () => currentVercelBaseFingerprintLive(),
 };
 
 export { vercelBackend, DEFAULT_BOX_IMAGE_REF };
@@ -119,6 +121,7 @@ export {
   type PrepareVercelResult,
 } from './prepare.js';
 export {
+  currentVercelBaseFingerprintLive,
   ensureVercelBaseSnapshot,
   preparedStatePath,
   readPreparedState,

--- a/packages/sandbox-vercel/src/prepared-state.ts
+++ b/packages/sandbox-vercel/src/prepared-state.ts
@@ -12,8 +12,9 @@
  * accepted today.
  */
 
-import { readPreparedStateRaw, writePreparedStateRaw, preparedStatePathFor } from '@agentbox/sandbox-core';
+import { computeContextSha256, readPreparedStateRaw, writePreparedStateRaw, preparedStatePathFor } from '@agentbox/sandbox-core';
 import { UserFacingError } from '@agentbox/core';
+import { findStagedCliRuntimeRoot, resolveRuntimeAssets } from './runtime-assets.js';
 
 const SCHEMA = 1 as const;
 
@@ -60,6 +61,29 @@ export function updatePreparedState(mutate: (s: PreparedVercelState) => void): v
   const s = readPreparedState();
   mutate(s);
   writePreparedState(s);
+}
+
+/**
+ * Compute the CURRENT build-context fingerprint for the vercel base snapshot
+ * (the SHA over every file `prepare` would `writeFiles` into the builder
+ * sandbox). Side-effect-free — never builds. Returns `undefined` when the
+ * runtime assets can't be resolved (dev tree without `pnpm -w build`) so
+ * the CLI can degrade to "can't tell, don't nag".
+ *
+ * Used by `evaluateBaseFreshness` to compare against the stored value in
+ * `vercel-prepared.json.base.contextSha256`. Must produce a byte-identical
+ * hash to the one `prepare` writes — both go through the same
+ * `resolveRuntimeAssets` + `computeContextSha256` chain.
+ */
+export async function currentVercelBaseFingerprintLive(): Promise<string | undefined> {
+  try {
+    const assets = resolveRuntimeAssets({ cliRuntimeRoot: findStagedCliRuntimeRoot() });
+    return await computeContextSha256(
+      assets.map((a) => ({ rel: a.name, abs: a.localPath })),
+    );
+  } catch {
+    return undefined;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Two paper-cuts off the cloud first-run / upgrade path:

- **Part A — `agentbox <provider> login` nudges users toward `prepare`** when no base template/snapshot has been baked yet. Provider package stays free of the `runPrepare` dependency (no layering break); the `install` wizard's existing prepare-offer still calls `runPrepare` directly. Drops users off the login → first-create → "no base template found" cliff.
- **Part B — `agentbox create` / `agentbox claude` detect a stale cloud base at create time** and merge a rebuild prompt into the existing "checkpoint is stale, recreate?" wizard. Same machinery (`evaluateCheckpoint → wizard → discardCheckpoint`) gets a parallel `evaluateBaseFreshness → wizard → rebuildBase` path; same merged confirm UI; same `discardCheckpoint` semantics. Docker self-heals via `ensureImage`, so its `baseStatus` is always `fresh` — no new prompts there.

**Staleness is checksum-only.** The decision is made purely on `contextSha256` (the SHA over the baked runtime files — `packages/ctl/dist/bin.cjs`, the agent helpers, the dockerfile context, etc.). CLI version strings stored alongside are informational and **never** influence freshness. A CLI patch that doesn't change any baked file produces an identical checksum → base stays `fresh` → no prompt. This is the explicitly-desired behavior: we don't nag people on every minor bump.

**Non-interactive (`-y` / non-TTY) stale base → warn loudly + boot on the existing base.** Never auto-bakes an expensive snapshot in a scripted run; tells the user to run `agentbox prepare --provider X --force`.

**`--snapshot <ref>` is a deliberate restore.** No base-rebuild hijack in TTY; the non-interactive warn still fires.

## What changed

| Area | File |
|---|---|
| New `Provider.baseFingerprint?()` capability | `packages/core/src/provider.ts` |
| Per-cloud `current<P>BaseFingerprintLive()` + provider wiring | `packages/sandbox-{e2b,vercel,hetzner,daytona}/src/{prepared-state,index}.ts` |
| Lazy dispatcher | `apps/cli/src/provider/cloud-backend.ts` (mirrors `cloudBackendForProvider`) |
| `BaseStatus` + `evaluateBaseFreshness` | `apps/cli/src/checkpoint-lookup.ts` |
| Wizard: `baseStatus?` arg + `rebuildBase?` outcome + merged confirm | `apps/cli/src/wizard.ts` |
| Call sites: compute baseStatus, run `runPrepare(force)` on `rebuildBase` | `apps/cli/src/commands/{create,claude}.ts` |
| Login nudges | `packages/sandbox-{e2b,vercel,hetzner,daytona}/src/cli.ts` |
| Unit test for all 5 states | `apps/cli/test/evaluate-base-freshness.test.ts` |
| Public + internal docs | `docs/{cloud-create-flow,cloud-providers,e2b_backlog}.md`, `apps/web/content/docs/{e2b,vercel,hetzner,daytona}.mdx` |

## Live verification (e2b, from a tiny scratch repo)

Ran against a real E2B account from `/tmp/bf-repo`:

1. `agentbox prepare --provider e2b` → wrote `~/.agentbox/e2b-prepared.json` with fresh `base.contextSha256: 244e09b1...`.
2. `agentbox create --provider e2b -y` → went straight to `provisioning e2b sandbox`. No rebuild prompt, no warn.
3. Flipped one hex char (`244e... → 044e...`) of `base.contextSha256`.
4. `agentbox create --provider e2b -y` →
   ```
   ▲  e2b base image is out of date (baked runtime differs (base 044e09b10ec4, current 244e09b10ec4));
      booting on the existing base. Run \`agentbox prepare --provider e2b --force\` to rebuild.
   ◒  provisioning e2b sandbox
   ```
   Loud warn → proceed on existing base. No auto-bake. Matches the plan.
5. TTY (via `pnpm drive`) with the mutated sha →
   ```
   ◆  The e2b base image is out of date — its baked runtime no longer matches your current install.
      Recreate the base and run Setup Wizard? (rebuilds the base — ~2 min — then starts fresh)
   │  ● Yes / ○ No
   ```
   Restored sha → TTY shows the standard "run setup wizard?" prompt (no spurious rebuild prompt).
6. `agentbox create --provider e2b -y --snapshot some-checkpoint` (sha mutated) → warn-only, proceeds.
7. **Docker regression** → `agentbox create -y` went straight to `[image] pulling …` / docker build. No new prompts, no warn lines. `ensureImage` still self-heals on its own mismatch.

Unit tests cover all 5 states (`fresh`, `stale`, `unprepared`, `unknown`, docker shortcut). `pnpm build && pnpm lint && pnpm test` are green (422 tests pass + 1 skipped; 184 ctl tests pass; 145 relay tests pass).

Cleaned up orphan sandboxes after each smoke (e2b `Sandbox.list` shows count: 0).

## Test plan

- [ ] CI green (lint + tests across all packages).
- [ ] Cursor Bugbot clean.
- [ ] `agentbox prepare --provider e2b` writes fresh `contextSha256`.
- [ ] Mutating that sha and running `agentbox create --provider e2b` (TTY) shows the merged rebuild prompt.
- [ ] Same mutation + `-y` shows the loud warn + boots on the existing base, no auto-bake.
- [ ] `--snapshot <ref>` shows warn-only, no rebuild prompt.
- [ ] Docker regression: no new prompts on `agentbox create`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-run and upgrade paths for all cloud providers (wizard prompts, forced prepare, checkpoint discard) but avoids auto-rebake in scripted runs and leaves Docker behavior unchanged.
> 
> **Overview**
> Cloud **create** and **claude** now compare the stored prepared-base **`contextSha256`** to a freshly computed hash (**`evaluateBaseFreshness`**) so an AgentBox upgrade that changes baked runtime files is detected before provisioning. Staleness is **checksum-only** (CLI version metadata does not gate freshness); Docker stays always **fresh** here because **`ensureImage`** self-heals.
> 
> On a TTY, the setup wizard gets a merged **recreate the base?** confirm (with rough per-provider time estimates); accepting runs **`runPrepare --force`** before create and sets **`rebuildBase`**, which also discards a default checkpoint tied to the old base. **`-y` / non-TTY** only **warn** and continue on the existing base—no automatic expensive rebake. Explicit **`--snapshot`** skips the interactive base-rebuild hijack.
> 
> Each cloud provider gains optional **`baseFingerprint()`** and **`current*BaseFingerprintLive()`** helpers (lazy-loaded from **`cloud-backend.ts`**). Successful **`agentbox <provider> login`** nudges **`prepare`** when no base is recorded yet. Docs and a unit test cover the five **`BaseStatus`** outcomes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 977f817e616ccafd0f0d29997b54f7119df42eba. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->