### PR TITLE
docs(providers): usage-first cloud provider pages (install-led setup)

### DIFF
--- a/apps/web/content/docs/daytona.mdx
+++ b/apps/web/content/docs/daytona.mdx
@@ -1,25 +1,36 @@
 ---
 title: Daytona
-description: Managed cloud sandboxes seeded from a git bundle, with shared credential volumes
+description: Run your agents in a managed Daytona cloud sandbox seeded from your host repo
 ---
 
-Use Daytona when the work outgrows your laptop, a teammate needs to attach, or you want a snapshot-ready remote environment. A Daytona box is a managed cloud sandbox (default **2 vCPU / 4 GB RAM / 8 GB disk**) seeded from your host repo, with agent static config baked into a published snapshot and renewable tokens on a shared per-org volume.
+Run your agents in a managed Daytona cloud sandbox (default **2 vCPU / 4 GB RAM / 8 GB disk**) when the work outgrows your laptop or a teammate needs to attach — no local Docker needed. Each box is a remote Daytona sandbox you drive with the same `agentbox` commands as a local box, seeded from your host repo with renewable agent tokens on a shared per-org volume.
 
-Daytona is one of AgentBox's four backends — see [the provider model](/docs/core-concepts) and its siblings [local Docker](/docs/local-docker), [Hetzner](/docs/hetzner), and [Vercel](/docs/vercel).
-
-<Callout title="TIP">
-Switch one box with `--provider daytona`, or pin a project with `box.provider: daytona` in [`agentbox.yaml`](/docs/agentbox-yaml). The rest of the CLI (`shell`, `claude`, `url`, `cp`, `checkpoint`, …) routes on `box.provider` automatically. See [configuration](/docs/configuration).
-</Callout>
+Switch per box with `--provider daytona`, or pin it project-wide with `box.provider: daytona` in [`agentbox.yaml`](/docs/agentbox-yaml). Comparing options? See [local-docker](/docs/local-docker), [hetzner](/docs/hetzner), [vercel](/docs/vercel), and [e2b](/docs/e2b).
 
 ## Set up
 
-`agentbox daytona login` prompts for your `DAYTONA_API_KEY` (required) and `DAYTONA_ORGANIZATION_ID` (optional), and persists them to `~/.agentbox/secrets.env`. Your project `.env` is never harvested.
+The easiest path is the interactive wizard — it signs you in and bakes the base snapshot in one flow:
 
 ```bash
-agentbox daytona login
+agentbox install        # then select daytona
 ```
 
-`agentbox daytona create|claude|codex|opencode` is sugar for the same command with `--provider daytona`. The first time you use `--provider daytona`, the login prompt fires automatically.
+Approve the browser sign-in when prompted (or paste a `DAYTONA_API_KEY`; an optional `DAYTONA_ORGANIZATION_ID` can also be entered). Credentials persist to `~/.agentbox/secrets.env`; project `.env` files are never harvested. `install` also bakes the base snapshot (a one-time `agentbox prepare --provider daytona` under the hood) with the AgentBox runtime — `agentbox-ctl`, the agents, tmux — so every new box boots in seconds instead of eating a ~7-minute cold Dockerfile build.
+
+For CI or scripted setup, run the explicit equivalents:
+
+```bash
+agentbox daytona login                 # credentials only
+agentbox prepare --provider daytona    # bake the base snapshot
+```
+
+## Use it
+
+```bash
+agentbox daytona claude
+```
+
+`agentbox daytona create|claude|codex|opencode` is sugar for the same command with `--provider daytona`.
 
 ## Prepare image
 

--- a/apps/web/content/docs/e2b.mdx
+++ b/apps/web/content/docs/e2b.mdx
@@ -1,21 +1,42 @@
 ---
 title: E2B
-description: A Firecracker microVM per box with a Dockerfile-baked base template, public preview URLs, and free pause/resume
+description: Run your agents in a fast E2B cloud sandbox with public preview URLs and free pause/resume
 ---
 
-Use E2B when you want a fast snapshot-based remote env with public HTTPS preview URLs **and you want to bake the base image straight from a Dockerfile** — uniquely among AgentBox's cloud providers, E2B's `prepare` drives the SDK's `Template.build()` from a Dockerfile rather than booting+snapshotting a vanilla base. Each box is one E2B Sandbox — a Firecracker microVM on Debian 12 — with first-class pause/resume, id-addressed `Sandbox.createSnapshot` checkpoints, and a public `*.e2b.app` URL reachable from your browser and from inside the [box](/docs/core-concepts).
+Run your agents in a fast E2B cloud sandbox with a public HTTPS preview URL and free pause/resume — no local Docker needed. Each box is a remote E2B sandbox you drive with the same `agentbox` commands as a local box.
 
-Switch per box with `--provider e2b`, or pin it project-wide with `box.provider: e2b` in [`agentbox.yaml`](/docs/agentbox-yaml). The rest of the CLI (`shell`, `claude`, `url`, `cp`, `checkpoint`, …) routes on `box.provider` automatically. Comparing options? See [local-docker](/docs/local-docker), [hetzner](/docs/hetzner), [daytona](/docs/daytona), and [vercel](/docs/vercel).
+Switch per box with `--provider e2b`, or pin it project-wide with `box.provider: e2b` in [`agentbox.yaml`](/docs/agentbox-yaml). Comparing options? See [local-docker](/docs/local-docker), [hetzner](/docs/hetzner), [daytona](/docs/daytona), and [vercel](/docs/vercel).
+
+<Callout title="Nightly">
+E2B support is available in the **nightly** build of AgentBox.
+</Callout>
 
 ## Set up
 
-The first time you use `--provider e2b` AgentBox prompts you to log in; you can also run it explicitly. Sign in with `agentbox e2b login` — it prompts for `E2B_API_KEY` (mint at [e2b.dev/dashboard](https://e2b.dev/dashboard?tab=keys)) and persists it to `~/.agentbox/secrets.env`. Credentials are read only from your shell env or `~/.agentbox/secrets.env` — project-local `.env` files are never harvested.
+The easiest path is the interactive wizard — it signs you in and bakes the base image in one flow:
 
 ```bash
-agentbox e2b login
+agentbox install        # then select e2b
+```
+
+Paste an `E2B_API_KEY` (mint at [e2b.dev/dashboard](https://e2b.dev/dashboard?tab=keys)) when prompted. Credentials persist to `~/.agentbox/secrets.env`; project `.env` files are never harvested. `install` also bakes the base template (a one-time `agentbox prepare --provider e2b` under the hood) with the AgentBox runtime — `agentbox-ctl`, the agents, tmux — so every new box boots ready in seconds.
+
+For CI or scripted setup, run the explicit equivalents:
+
+```bash
+agentbox e2b login                 # credentials only
+agentbox prepare --provider e2b    # bake the base template
 ```
 
 See [environment](/docs/environment) for where the `E2B_API_KEY` and `~/.agentbox/secrets.env` live.
+
+## Use it
+
+```bash
+agentbox e2b claude
+```
+
+`agentbox e2b create|claude|codex|opencode` is sugar for the same command with `--provider e2b`.
 
 ## Prepare the base template (Dockerfile → `Template.build()`)
 

--- a/apps/web/content/docs/hetzner.mdx
+++ b/apps/web/content/docs/hetzner.mdx
@@ -1,27 +1,28 @@
 ---
 title: Hetzner
-description: A bare VPS per box with an auto-locked firewall, over pure OpenSSH
+description: Run your agents on a real, inexpensive Hetzner VPS with full root and Docker-in-Docker
 ---
 
-Use Hetzner when you want a real, inexpensive cloud VM you fully control. With `--provider hetzner`, each box is its own Hetzner Cloud VPS (1:1), reached over pure OpenSSH. No third-party agent runs inside the box — you own root.
+Run your agents on a real, inexpensive cloud VM you fully control — no local Docker needed. Each box is its own Hetzner Cloud VPS (1:1) you drive with the same `agentbox` commands as a local box, reached over pure OpenSSH (no third-party agent in the box — you own root).
 
-Pick Hetzner for bare-VPS control (full kernel, your own region), a Cloud Firewall locked to your egress IP, and full [Docker-in-Docker](/docs/docker-in-docker). Cost is roughly €4/mo per *running* box. The siblings: a managed-SDK sandbox is [Daytona](/docs/daytona); a Firecracker microVM with public HTTPS URLs but no in-box Docker is [Vercel](/docs/vercel); free and local is [local Docker](/docs/local-docker).
-
-The whole CLI surface (`shell`, `claude`, `url`, `cp`, `checkpoint`, …) routes on `box.provider` and works identically across backends — see [core concepts](/docs/core-concepts) and the [CLI reference](/docs/cli).
-
-<Callout title="TIP">
-Pin Hetzner project-wide with `box.provider: hetzner` in [`agentbox.yaml`](/docs/agentbox-yaml), or pass `--provider hetzner` per box. See [configuration](/docs/configuration).
-</Callout>
+Switch per box with `--provider hetzner`, or pin it project-wide with `box.provider: hetzner` in [`agentbox.yaml`](/docs/agentbox-yaml). Pick Hetzner for bare-VPS control (full kernel, your own region), a Cloud Firewall locked to your egress IP, and full [Docker-in-Docker](/docs/docker-in-docker). Cost is roughly €4/mo per *running* box. Comparing options? See [local-docker](/docs/local-docker), [daytona](/docs/daytona), [vercel](/docs/vercel), and [e2b](/docs/e2b).
 
 ## Set up
 
-`agentbox hetzner login` stores your `HCLOUD_TOKEN` — a **Read & Write** API token from a Hetzner project's **Security → API Tokens** page — to `~/.agentbox/secrets.env`. The token is project-scoped, so boxes are created in whichever Hetzner project minted it.
+The easiest path is the interactive wizard — it signs you in and bakes the base snapshot in one flow:
 
 ```bash
-agentbox hetzner login
+agentbox install        # then select hetzner
 ```
 
-First use of `--provider hetzner` triggers this login automatically, so the explicit step is optional. See [CLI commands](/docs/cli) for all flags.
+Paste a Hetzner Cloud API token when prompted — a **Read & Write** token from the target project's *Security → API Tokens* page (boxes will be created in whichever project minted it). Credentials persist to `~/.agentbox/secrets.env`; project `.env` files are never harvested. `install` also bakes the base snapshot (a one-time `agentbox prepare --provider hetzner` under the hood) with the AgentBox runtime — `agentbox-ctl`, the agents, tmux — so every new box boots ready in ~15-20s.
+
+For CI or scripted setup, run the explicit equivalents:
+
+```bash
+agentbox hetzner login                 # credentials only
+agentbox prepare --provider hetzner    # bake the base snapshot
+```
 
 <Callout title="NOTE">
 Mint the token under the specific Hetzner *project* you want boxes to live in, and make it **Read & Write**. Read-only tokens can't create servers.
@@ -29,6 +30,14 @@ Mint the token under the specific Hetzner *project* you want boxes to live in, a
 
 {/* SCREENSHOT /screenshots/hetzner_api.jpg — Hetzner Cloud console → Security → API tokens, the Read & Write token + Generate button (token value masked). Captured manually from the console. */}
 <Figure src="/screenshots/hetzner_api.jpg" caption="Mint a Read & Write API token under Security → API Tokens in the Hetzner console." />
+
+## Use it
+
+```bash
+agentbox hetzner claude
+```
+
+`agentbox hetzner create|claude|codex|opencode` is sugar for the same command with `--provider hetzner`.
 
 ## Prepare snapshot
 

--- a/apps/web/content/docs/vercel.mdx
+++ b/apps/web/content/docs/vercel.mdx
@@ -1,18 +1,27 @@
 ---
 title: Vercel
-description: A Firecracker microVM per box with persistent snapshots and public preview URLs
+description: Run your agents in a fast Vercel cloud sandbox with public preview URLs and persistent pause/resume
 ---
 
-Use Vercel when you want a fast snapshot-based remote env with public HTTPS preview URLs and persistent pause/resume. Each box is one Vercel Sandbox — a Firecracker microVM on Amazon Linux 2023 — with first-class snapshots and a public `*.vercel.run` URL reachable from your browser and from inside the [box](/docs/core-concepts).
+Run your agents in a fast Vercel cloud sandbox with a public HTTPS preview URL and persistent pause/resume — no local Docker needed. Each box is a remote Vercel sandbox you drive with the same `agentbox` commands as a local box.
 
-Switch per box with `--provider vercel`, or pin it project-wide with `box.provider: vercel` in [`agentbox.yaml`](/docs/agentbox-yaml). The rest of the CLI (`shell`, `claude`, `url`, `cp`, `checkpoint`, …) routes on `box.provider` automatically. Comparing options? See [local-docker](/docs/local-docker), [hetzner](/docs/hetzner), and [daytona](/docs/daytona).
+Switch per box with `--provider vercel`, or pin it project-wide with `box.provider: vercel` in [`agentbox.yaml`](/docs/agentbox-yaml). Comparing options? See [local-docker](/docs/local-docker), [hetzner](/docs/hetzner), [daytona](/docs/daytona), and [e2b](/docs/e2b).
 
 ## Set up
 
-The first time you use `--provider vercel` AgentBox prompts you to log in; you can also run it explicitly. Sign in with `agentbox vercel login` (CLI login is easiest; an access-token trio or OIDC also work for CI). Credentials are read only from your shell env or `~/.agentbox/secrets.env` — project-local `.env` files are never harvested.
+The easiest path is the interactive wizard — it signs you in and bakes the base snapshot in one flow:
 
 ```bash
-agentbox vercel login
+agentbox install        # then select vercel
+```
+
+Approve the browser CLI login when prompted (or paste an access-token trio / OIDC for CI — the access-token trio is best for long bakes since OIDC dev tokens expire on a ~12h cycle). Credentials persist to `~/.agentbox/secrets.env`; project `.env` files are never harvested. `install` also bakes the base snapshot (a one-time `agentbox prepare --provider vercel` under the hood) with the AgentBox runtime — `agentbox-ctl`, the agents, tmux — so every new box boots ready in seconds.
+
+For CI or scripted setup, run the explicit equivalents:
+
+```bash
+agentbox vercel login                 # credentials only
+agentbox prepare --provider vercel    # bake the base snapshot
 ```
 
 <Callout title="WHICH AUTH">
@@ -20,6 +29,14 @@ OIDC dev tokens expire on a ~12h cycle with no headless refresh. For long-runnin
 </Callout>
 
 See [environment](/docs/environment) for where the `VERCEL_*` vars and `~/.agentbox/secrets.env` live.
+
+## Use it
+
+```bash
+agentbox vercel claude
+```
+
+`agentbox vercel create|claude|codex|opencode` is sugar for the same command with `--provider vercel`.
 
 ## Prepare the base snapshot
 


### PR DESCRIPTION
## Summary

Rewrites the **top** of the four cloud provider doc pages (`e2b.mdx`, `vercel.mdx`, `hetzner.mdx`, `daytona.mdx`) to be **usage-first** rather than opening with provider-internals (Firecracker microVM, Dockerfile bake mechanics, SDK details).

The Set up section now leads with `agentbox install` — the one-flow wizard that already does login + base bake in a single invocation (`apps/cli/src/commands/install.ts`'s `runInstallWizard()` calls `runProviderLogin()` then `runPrepare()` for all four cloud providers). The explicit `agentbox <p> login` + `agentbox prepare --provider <p>` pair is now framed as the scriptable/CI equivalent.

E2B also gets a `<Callout title="Nightly">` near the top noting it ships in the nightly build.

All existing deeper sections (Prepare details, Create, Limits, Sizing, Pause/resume, Checkpoints, Caveats, Related) are unchanged.

`local-docker.mdx` is intentionally not touched.

## Before / after (e2b.mdx top — representative)

**Before**

```
Use E2B when you want a fast snapshot-based remote env with public HTTPS preview URLs
**and you want to bake the base image straight from a Dockerfile** — uniquely among
AgentBox's cloud providers, E2B's `prepare` drives the SDK's `Template.build()` …

## Set up
…sign in with `agentbox e2b login` — it prompts for `E2B_API_KEY`…
```

**After**

```
Run your agents in a fast E2B cloud sandbox with a public HTTPS preview URL and free
pause/resume — no local Docker needed. Each box is a remote E2B sandbox you drive with
the same `agentbox` commands as a local box.

<Callout title="Nightly">
E2B support is available in the **nightly** build of AgentBox.
</Callout>

## Set up
The easiest path is the interactive wizard — it signs you in and bakes the base image
in one flow:

    agentbox install        # then select e2b

Paste an `E2B_API_KEY` (mint at e2b.dev/dashboard) when prompted. …

For CI or scripted setup, run the explicit equivalents:

    agentbox e2b login                 # credentials only
    agentbox prepare --provider e2b    # bake the base template

## Use it
    agentbox e2b claude
```

## Test plan

- [x] `pnpm --filter @agentbox/web build` — Fumadocs MDX compiles clean (29 static pages)
- [x] `pnpm lint` — repo-wide clean
- [ ] Eyeball one rendered page locally before merge (`pnpm --filter @agentbox/web dev`)
- [ ] CI green
- [ ] Cursor Bugbot clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to MDX provider pages; no runtime, auth, or application code changes.
> 
> **Overview**
> Rewrites the **intro and setup** of the Daytona, E2B, Hetzner, and Vercel doc pages so readers see **how to run agents in the cloud** first, not provider internals (microVMs, Dockerfile bake mechanics, long CLI routing blurbs).
> 
> **Set up** now recommends **`agentbox install`** as the primary path (login + base bake in one wizard), with **`agentbox <provider> login`** plus **`agentbox prepare --provider <provider>`** documented as the CI/scripted alternative. Each page adds a short **Use it** section with **`agentbox <provider> claude`** and provider sugar commands. Frontmatter descriptions and opening copy are tightened; cross-links include **e2b** where missing. **E2B** gets a **Nightly** callout. Some tip/callout blocks and redundant “first use auto-login” wording are removed or folded into the new flow. Deeper sections below setup are unchanged; **local-docker** is not touched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f1e70962c6905802499443f3015fe41404a5d5d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->