### PR TITLE
fix(cloud): clean up create/attach output + cold-start banner + docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,9 @@
 ## Testing / verifying
 
 `create`, `claude`, `codex`, and `opencode` tee their progress to a file at
-`~/.agentbox/logs/<command>.log`. The command prints `log: <path>` to stderr at
-startup, and `~/.agentbox/logs/latest.log` always points at the most recent run.
-The log is rotated 1-deep — the previous run is at `<command>.log.prev`.
+`~/.agentbox/logs/<command>.log`, and `~/.agentbox/logs/latest.log` always points
+at the most recent run. The log is rotated 1-deep — the previous run is at
+`<command>.log.prev`.
 
 When verifying a change:
 

--- a/apps/cli/src/commands/_cloud-attach.ts
+++ b/apps/cli/src/commands/_cloud-attach.ts
@@ -78,16 +78,39 @@ export interface CloudAgentAttachArgs {
 }
 
 /**
+ * Printed in the agent's tmux pane the instant the session's command starts,
+ * BEFORE the agent binary paints its first frame. On a cold cloud sandbox the
+ * agent CLI (node cold-start + a large seed prompt + TUI init) can take several
+ * seconds to draw — and a tmux client that attaches during that window sees a
+ * featureless blank pane (verified: tmux pushes the frame correctly once the
+ * program draws, so the gap is pure program-startup latency, not a redraw bug).
+ * Without this line the run looks hung and users Ctrl+C then re-attach. The
+ * agent clears the screen on startup, so the line vanishes the moment real
+ * output arrives. Shared by every cloud provider; e2b/vercel microVMs are the
+ * slowest cold-starters so they benefit most.
+ *
+ * No escape sequences (plain text) on purpose: this string threads through
+ * several shell-quoting layers (single-quoted `bash -lc` body, the outer
+ * `shellSingle` wrap in `renderInnerCommand`, then the provider transport), and
+ * plain ASCII is the one thing guaranteed to survive all of them intact.
+ */
+function agentStartBanner(binary: string): string {
+  return `printf "  agentbox: starting ${binary} (first paint may take a few seconds)...\\r\\n"; `;
+}
+
+/**
  * Render the inner shell command tmux runs inside the cloud sandbox. Exported
  * so unit tests can exercise the base64 round-trip without spinning up SSH.
  *
- * Empty `extraArgs` keeps the no-args path identical to the pre-args
- * behaviour — `bash -lc 'exec <binary>'` with a backslash-space so the outer
- * shell-quoting layers don't split `exec` from the binary name.
+ * Both paths run `agentStartBanner` first so the freshly-attached pane is never
+ * blank during the agent's cold-start. The body is single-quoted (`bash -lc
+ * '…'`) in both branches so the outer `shellSingle` wrap composes the same way;
+ * `exec <binary>` still replaces the shell so the agent keeps PID 2 (Ctrl-c in
+ * the agent tears the session down cleanly).
  */
 export function buildCloudAttachInnerCommand(binary: string, extraArgs?: string[]): string {
   if (!extraArgs || extraArgs.length === 0) {
-    return `bash -lc exec\\ ${binary}`;
+    return `bash -lc '${agentStartBanner(binary)}exec ${binary}'`;
   }
   // One arg per line, base64-encoded. The launcher runs `mapfile -t A` against
   // the decoded stream, then `exec <binary> "${A[@]}"` so each arg lands as
@@ -114,7 +137,7 @@ export function buildCloudAttachInnerCommand(binary: string, extraArgs?: string[
   // in renderInnerCommand re-escapes any internal `'` as `'\''`; this body has
   // no single quotes (it uses double quotes around the here-string), so it
   // composes fine.
-  return `bash -lc 'mapfile -t A <<< "$(echo ${blob} | base64 -d)"; exec ${binary} "\${A[@]}"'`;
+  return `bash -lc '${agentStartBanner(binary)}mapfile -t A <<< "$(echo ${blob} | base64 -d)"; exec ${binary} "\${A[@]}"'`;
 }
 
 export async function cloudAgentAttach(args: CloudAgentAttachArgs): Promise<void> {

--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -468,7 +468,6 @@ export const claudeCommand = new Command('claude')
   )
   .action(async (claudeArgs: string[], opts: ClaudeCreateOptions) => {
     const cmdLog = openCommandLog('claude');
-    process.stderr.write(`log: ${cmdLog.path}\n`);
     intro('Starting Claude in a box...');
 
     // -c / --continue / --resume <id>: handled by agentbox (the teleport runs

--- a/apps/cli/src/commands/codex.ts
+++ b/apps/cli/src/commands/codex.ts
@@ -411,7 +411,6 @@ export const codexCommand = new Command('codex')
   )
   .action(async (codexArgs: string[], opts: CodexCreateOptions) => {
     const cmdLog = openCommandLog('codex');
-    process.stderr.write(`log: ${cmdLog.path}\n`);
     intro('Starting Codex in a box...');
 
     let resumeMode: ResumeMode | null = null;

--- a/apps/cli/src/commands/create.ts
+++ b/apps/cli/src/commands/create.ts
@@ -221,7 +221,6 @@ export const createCommand = new Command('create')
   )
   .action(async (opts: CreateOptions) => {
     const cmdLog = openCommandLog('create');
-    process.stderr.write(`log: ${cmdLog.path}\n`);
     intro('Setting up a new box...');
 
     const cfg = await loadEffectiveConfig(opts.workspace, {

--- a/apps/cli/src/commands/opencode.ts
+++ b/apps/cli/src/commands/opencode.ts
@@ -396,7 +396,6 @@ export const opencodeCommand = new Command('opencode')
   )
   .action(async (opencodeArgs: string[], opts: OpencodeCreateOptions) => {
     const cmdLog = openCommandLog('opencode');
-    process.stderr.write(`log: ${cmdLog.path}\n`);
     intro('Starting OpenCode in a box...');
 
     // OpenCode session teleport is not yet supported (v1 stub). Detect resume

--- a/apps/cli/src/wizard.ts
+++ b/apps/cli/src/wizard.ts
@@ -168,7 +168,7 @@ export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutco
     const yamlSuffix = proj.hasAgentboxYaml ? '' : ' and run Setup Wizard';
     const rebuild = await confirm({
       message:
-        `The ${provider} base image is out of date — its baked runtime no longer matches your current install. ` +
+        `The ${provider} base image is out of date. ` +
         `Recreate the base${yamlSuffix}? (rebuilds the base — ~${mins} min — then starts fresh)`,
       initialValue: true,
     });

--- a/apps/cli/test/cloud-attach.test.ts
+++ b/apps/cli/test/cloud-attach.test.ts
@@ -18,11 +18,21 @@ function decodeArgs(cmd: string): string[] {
 }
 
 describe('buildCloudAttachInnerCommand', () => {
-  it('preserves the no-args fast path', () => {
-    // Identical to the pre-args behaviour so an unchanged contract stays
-    // wire-compatible with any caller that relied on the literal shape.
-    expect(buildCloudAttachInnerCommand('claude')).toBe('bash -lc exec\\ claude');
-    expect(buildCloudAttachInnerCommand('codex', [])).toBe('bash -lc exec\\ codex');
+  it('runs the start banner then execs the agent on the no-args path', () => {
+    // The pane prints a "starting" line before the agent paints (so a cold
+    // cloud attach is never blank), then `exec`s the binary so it keeps PID 2.
+    const cmd = buildCloudAttachInnerCommand('claude');
+    expect(cmd).toBe(
+      `bash -lc 'printf "  agentbox: starting claude (first paint may take a few seconds)...\\r\\n"; exec claude'`,
+    );
+    expect(buildCloudAttachInnerCommand('codex', [])).toContain('exec codex');
+  });
+
+  it('prints the start banner before the agent on the args path too', () => {
+    const cmd = buildCloudAttachInnerCommand('claude', ['--model', 'sonnet']);
+    expect(cmd).toContain('agentbox: starting claude');
+    // banner must precede the mapfile launcher so it paints during cold-start.
+    expect(cmd.indexOf('agentbox: starting')).toBeLessThan(cmd.indexOf('mapfile -t A'));
   });
 
   it('encodes a single simple arg', () => {

--- a/apps/web/app/global.css
+++ b/apps/web/app/global.css
@@ -470,3 +470,12 @@ figure.shiki[data-terminal]::before {
 figure.shiki[data-terminal] > div:first-child {
   top: 6px;
 }
+
+/* Box-drawing / block-art blocks (the Claude Code welcome panel): IBM Plex
+ * Mono has no glyphs for ─ │ █ ▐ … so the browser falls back per-glyph to a
+ * font with a different advance width, shredding the alignment. A system mono
+ * stack renders every glyph at one cell width, so the art lines up. */
+figure.shiki[data-monoart] code,
+figure.shiki[data-monoart] code span {
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace !important;
+}

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -57,7 +57,7 @@ Agent-specific: `--attach-in <split|window|tab|same>`, `-d, --no-attach`, `-i, -
 
 <Figure src="/screenshots/claude-tui.png" caption="agentbox claude creates the box and drops you into a detachable Claude Code session." />
 
-These commands tee progress to `~/.agentbox/logs/<command>.log` and print `log: <path>` at startup; `~/.agentbox/logs/latest.log` always points at the most recent run.
+These commands tee progress to `~/.agentbox/logs/<command>.log`; `~/.agentbox/logs/latest.log` always points at the most recent run.
 
 See [Run an agent](/docs/run-an-agent), [Teleport a project](/docs/teleport-a-project), [Background & parallel](/docs/background-and-parallel), and [Sync & git](/docs/sync-and-git).
 

--- a/apps/web/content/docs/daytona.mdx
+++ b/apps/web/content/docs/daytona.mdx
@@ -3,7 +3,7 @@ title: Daytona
 description: Run your agents in a managed Daytona cloud sandbox seeded from your host repo
 ---
 
-Run your agents in a managed Daytona cloud sandbox (default **2 vCPU / 4 GB RAM / 8 GB disk**) when the work outgrows your laptop or a teammate needs to attach — no local Docker needed. Each box is a remote Daytona sandbox you drive with the same `agentbox` commands as a local box, seeded from your host repo with renewable agent tokens on a shared per-org volume.
+Run your agents in a managed Daytona cloud sandbox (default **2 vCPU / 4 GB RAM / 8 GB disk**) when the work outgrows your laptop or a teammate needs to attach — no local Docker needed. Each box is a remote Daytona sandbox you drive with the same `agentbox` commands as a local box, seeded from your host repo with renewable agent tokens on a shared per-org volume. Heads up: Daytona's snapshot/checkpoint path is still slow and experimental, and a running box bills per-second (no free pause).
 
 Switch per box with `--provider daytona`, or pin it project-wide with `box.provider: daytona` in [`agentbox.yaml`](/docs/agentbox-yaml). Comparing options? See [local-docker](/docs/local-docker), [hetzner](/docs/hetzner), [vercel](/docs/vercel), and [e2b](/docs/e2b).
 
@@ -111,6 +111,18 @@ agentbox create --provider daytona --checkpoint setup
 ```
 
 Two differences from Docker: there is no `--merged` (Daytona snapshots are flattened by construction) and no `--replace` (deletes are async — `checkpoint rm` then recreate). Full mechanics live in [checkpoints & pausing](/docs/checkpoints-and-pausing).
+
+## Specs
+
+| Spec | |
+| --- | --- |
+| Base image | Daytona snapshot baked from `Dockerfile.box` |
+| Build method | Server-side snapshot via `agentbox prepare --provider daytona` (~7 min); no first-create auto-build |
+| Docker-in-Docker | Yes (CAP_SYS_ADMIN; dockerd at create + start) |
+| SSH | None — in-box bridge relay long-polled by the host (SSH-token attach for interactive sessions) |
+| Arch | x86_64 (amd64) |
+| Live snapshots | Slow/experimental snapshots (`_experimental_createSnapshot`); no native pause — a running box bills per-second |
+| Preview URL | Signed CloudFront `https://{port}-{token}.proxy.daytona.work` (1h TTL, up to 24h via `--ttl`) |
 
 ## Caveats
 

--- a/apps/web/content/docs/e2b.mdx
+++ b/apps/web/content/docs/e2b.mdx
@@ -3,7 +3,7 @@ title: E2B
 description: Run your agents in a fast E2B cloud sandbox with public preview URLs and free pause/resume
 ---
 
-Run your agents in a fast E2B cloud sandbox with a public HTTPS preview URL and free pause/resume — no local Docker needed. Each box is a remote E2B sandbox you drive with the same `agentbox` commands as a local box.
+Run your agents in a fast E2B cloud sandbox with a public HTTPS preview URL and free pause/resume — no local Docker needed. Each box is a remote E2B sandbox you drive with the same `agentbox` commands as a local box. It runs on Firecracker, so there's no [Docker-in-Docker](/docs/docker-in-docker) and the Hobby tier caps sessions at one hour — but it's the only provider that builds its base straight from a Dockerfile.
 
 Switch per box with `--provider e2b`, or pin it project-wide with `box.provider: e2b` in [`agentbox.yaml`](/docs/agentbox-yaml). Comparing options? See [local-docker](/docs/local-docker), [hetzner](/docs/hetzner), [daytona](/docs/daytona), and [vercel](/docs/vercel).
 
@@ -118,6 +118,18 @@ agentbox prune --provider e2b -y
 ```
 
 `agentbox doctor --provider e2b` checks the credential file + the prepared base template.
+
+## Specs
+
+| Spec | |
+| --- | --- |
+| Base image | Debian 12 |
+| Build method | Dockerfile via the SDK's `Template.build()` (`agentbox prepare --provider e2b`) — the only AgentBox cloud built from a Dockerfile |
+| Docker-in-Docker | None (Firecracker + seccomp) |
+| SSH | None — SDK-streaming PTY bridge over `pty.create` |
+| Arch | x86_64 (amd64) |
+| Live snapshots | Free pause/resume (`Sandbox.pause`/`connect`) + id-addressed snapshots (`Sandbox.createSnapshot`) |
+| Preview URL | Public HTTPS `https://{port}-{sandboxId}.e2b.app` (no token) |
 
 ## Caveats
 

--- a/apps/web/content/docs/hetzner.mdx
+++ b/apps/web/content/docs/hetzner.mdx
@@ -3,7 +3,7 @@ title: Hetzner
 description: Run your agents on a real, inexpensive Hetzner VPS with full root and Docker-in-Docker
 ---
 
-Run your agents on a real, inexpensive cloud VM you fully control — no local Docker needed. Each box is its own Hetzner Cloud VPS (1:1) you drive with the same `agentbox` commands as a local box, reached over pure OpenSSH (no third-party agent in the box — you own root).
+Run your agents on a real, inexpensive cloud VM you fully control — no local Docker needed. Each box is its own Hetzner Cloud VPS (1:1) you drive with the same `agentbox` commands as a local box, reached over pure OpenSSH (no third-party agent in the box — you own root). Heads up: a Hetzner box is a real VPS that bills ~€4/mo even when stopped — pause is poweroff/poweron, not free — and its firewall locks to your current egress IP.
 
 Switch per box with `--provider hetzner`, or pin it project-wide with `box.provider: hetzner` in [`agentbox.yaml`](/docs/agentbox-yaml). Pick Hetzner for bare-VPS control (full kernel, your own region), a Cloud Firewall locked to your egress IP, and full [Docker-in-Docker](/docs/docker-in-docker). Cost is roughly €4/mo per *running* box. Comparing options? See [local-docker](/docs/local-docker), [daytona](/docs/daytona), [vercel](/docs/vercel), and [e2b](/docs/e2b).
 
@@ -113,6 +113,18 @@ agentbox checkpoint create smoke setup
 <Callout title="TIP">
 Because Hetzner checkpoints are full-disk snapshots, capturing one after your project's setup lets later boxes boot ready-to-go and skip workspace seeding.
 </Callout>
+
+## Specs
+
+| Spec | |
+| --- | --- |
+| Base image | Ubuntu 24.04 snapshot |
+| Build method | Baked snapshot — install script on a throwaway VPS then `create_image` (`agentbox prepare --provider hetzner`); no Dockerfile |
+| Docker-in-Docker | Yes (full root, unmodified) |
+| SSH | Yes — one persistent OpenSSH ControlMaster per box |
+| Arch | x86_64 (amd64) |
+| Live snapshots | `create_image` snapshots (no-pause default); pause = poweroff/poweron and a stopped VPS still bills ~€4/mo |
+| Preview URL | SSH local port forward via `ssh -O forward`, mirrored to `https://<box-name>.localhost` (Portless) |
 
 ## Caveats
 

--- a/apps/web/content/docs/index.mdx
+++ b/apps/web/content/docs/index.mdx
@@ -38,6 +38,17 @@ Install AgentBox globally and run the one-time setup. The setup step wires up
 npm -g i @madarco/agentbox && agentbox install
 ```
 
+During `agentbox install` you'll be prompted to log in to any cloud providers you
+want to use (Vercel, Hetzner, Daytona, E2B) — this is **not** needed for the
+default local Docker provider. You'll then be asked to build the base image for
+each selected provider (e.g. the local Ubuntu Docker image, the Vercel base
+sandbox, the E2B template, etc.) so the first box starts fast.
+
+<Callout title="NOTE">
+  You can run `agentbox install` again at any time to add more providers — each
+  run only logs in and builds the base image for the providers you pick.
+</Callout>
+
 ## Launch your first box
 
 One command teleports your current project into a fresh box and attaches an agent
@@ -49,17 +60,41 @@ $ agentbox claude
 ↳ teleporting ./my-app → /workspace
 ↳ injecting ~/.claude credentials & sessions
 ✓ box 1 ready in 0.8s · claude code attached
-claude@box-1:~/workspace$
+
+╭─ Claude Code v2.1.161 ───────────────────────────────────╮
+│                                                          │
+│                   Welcome back, User!                    │
+│                                                          │
+│                        ▐▛███▜▌                           │
+│                       ▝▜█████▛▘                          │
+│                         ▘▘ ▝▝                            │
+│                                                          │
+│        Opus 4.8 (1M context) · Claude Max ·              │
+│        user@example.com's Organization                   │
+│        ~/workspace                                       │
+│                                                          │
+╰──────────────────────────────────────────────────────────╯
 ```
+
+The first time you launch a box in a project, you'll be asked to complete the
+setup wizard. It creates an `agentbox.yaml` file describing how to install and run
+your project, and captures a snapshot of the box with all your project's
+dependencies already installed — so the next box boots fast. You can optionally
+commit `agentbox.yaml` to your repo to share it with your team, or simply ask the
+agent to download it into your local machine.
 
 That's it — you're now inside an isolated box with your files mounted two-way at
 `/workspace` and Claude Code running in a detachable tmux session. Detach any time
-with `Ctrl-b d`; the agent keeps working.
+with `Ctrl+b d`; the agent keeps working.
 
 On Cloud boxes, the workspace is synced with the box but the git credentials are kept
 on your computer, and each write operation needs to be authorized from the footer.
 
 ### Watch it work
+
+Detach with `Ctrl+b` followed by `d` in rapid succession. Then you can reattach
+with `agentbox claude attach 1`, where `1` is the number assigned in sequence to
+every box in the same project.
 
 You can attach to any running Claude / Codex / OpenCode session, and also open the box's live screen to follow the agent's browser and IDE in real time.
 

--- a/apps/web/content/docs/local-docker.mdx
+++ b/apps/web/content/docs/local-docker.mdx
@@ -3,7 +3,7 @@ title: Local Docker
 description: The default provider — one local container per box, isolated by a per-box git branch
 ---
 
-Local Docker is the default — no `--provider` flag needed. `agentbox claude` and `agentbox create` use it out of the box.
+Local Docker is the default — no `--provider` flag needed. `agentbox claude` and `agentbox create` use it out of the box. Everything runs on your own machine, so a box is free and instant but only lives while your laptop is on and shares its CPU/RAM.
 
 Each box is one local container. `/workspace` is an in-container git worktree on branch `agentbox/<box-name>`, and the host's `.git/` is bind-mounted so commits land on the host immediately. It's fast, free, and fully local. It's the docker row of the provider matrix — see [core-concepts](/docs/core-concepts) for the box model, or reach for a cloud alternative with [hetzner](/docs/hetzner), [daytona](/docs/daytona), or [vercel](/docs/vercel).
 
@@ -92,3 +92,15 @@ agentbox url 1
 Capture warm state to start future boxes fast with `agentbox checkpoint create <box> --set-default`. Checkpoint after your setup wizard runs to carry build caches into every new box. See [checkpoints-and-pausing](/docs/checkpoints-and-pausing).
 
 The bind-mounted host `.git/` means commits land on the host immediately; pushes go through the host relay, so no credentials live in the box (see [sync-and-git](/docs/sync-and-git)). Inspect a box's files on the host with `agentbox open` or `agentbox download`.
+
+## Specs
+
+| Spec | |
+| --- | --- |
+| Base image | `agentbox/box:dev` (Debian-based) |
+| Build method | Pulled from GHCR by build-context fingerprint; built locally on a pull miss (`--build` forces) |
+| Docker-in-Docker | Yes (always-on in-box `dockerd`) |
+| SSH | None — local Docker exec + TTY bridge |
+| Arch | Host-native (arm64 on Apple Silicon, amd64 on Intel/Linux) |
+| Live snapshots | Instant `docker pause`/`unpause` (cgroup freezer); checkpoints are layered `docker commit` |
+| Preview URL | `https://<box-name>.localhost` (Portless) + mapped loopback ports |

--- a/apps/web/content/docs/vercel.mdx
+++ b/apps/web/content/docs/vercel.mdx
@@ -3,7 +3,7 @@ title: Vercel
 description: Run your agents in a fast Vercel cloud sandbox with public preview URLs and persistent pause/resume
 ---
 
-Run your agents in a fast Vercel cloud sandbox with a public HTTPS preview URL and persistent pause/resume — no local Docker needed. Each box is a remote Vercel sandbox you drive with the same `agentbox` commands as a local box.
+Run your agents in a fast Vercel cloud sandbox with a public HTTPS preview URL and persistent pause/resume — no local Docker needed. Each box is a remote Vercel sandbox you drive with the same `agentbox` commands as a local box. It runs on Firecracker, so there's no [Docker-in-Docker](/docs/docker-in-docker), and capturing a checkpoint stops the VM first (pause auto-snapshots on stop).
 
 Switch per box with `--provider vercel`, or pin it project-wide with `box.provider: vercel` in [`agentbox.yaml`](/docs/agentbox-yaml). Comparing options? See [local-docker](/docs/local-docker), [hetzner](/docs/hetzner), [daytona](/docs/daytona), and [e2b](/docs/e2b).
 
@@ -125,6 +125,18 @@ agentbox create --provider vercel --checkpoint setup
 <Callout type="warn" title="HEADS UP">
 `checkpoint create` stops the source box to capture the snapshot (it auto-resumes on the next call), so expect a brief pause on a running box. AgentBox self-heals a stale checkpoint: `create` probes liveness, prunes the dangling manifest, and falls back to the base snapshot.
 </Callout>
+
+## Specs
+
+| Spec | |
+| --- | --- |
+| Base image | Amazon Linux 2023 |
+| Build method | Baked snapshot — `provision.sh` then `sandbox.snapshot()` (`agentbox prepare --provider vercel`); no Dockerfile |
+| Docker-in-Docker | None (Firecracker + seccomp) |
+| SSH | None — attach uses the Vercel CLI PTY |
+| Arch | x86_64 (amd64) |
+| Live snapshots | Yes, but capturing one stops the VM first (persistent boxes auto-snapshot on stop, auto-resume on start) |
+| Preview URL | Public HTTPS `sandbox.domain(port)` → `https://<box>.vercel.run` (no token); ≤4 ports |
 
 ## Caveats
 

--- a/apps/web/source.config.ts
+++ b/apps/web/source.config.ts
@@ -28,6 +28,13 @@ export default defineConfig({
             if (terminalLangs.has(this.options.lang)) {
               node.properties['data-terminal'] = '';
             }
+            // Box-drawing / block-element art (the Claude Code welcome panel)
+            // needs a font that renders those glyphs at a single cell width —
+            // IBM Plex Mono lacks them and falls back per-glyph, breaking
+            // alignment. Flag such blocks so the CSS swaps in a system mono.
+            if (/[─-▟]/.test(this.source)) {
+              node.properties['data-monoart'] = '';
+            }
           },
         },
       ],

--- a/docs/e2b_backlog.md
+++ b/docs/e2b_backlog.md
@@ -354,6 +354,32 @@ mode … Yes, I accept" gate.
   relay and can launch boxes on other providers, so they can fully smoke-test.
 
 ## Changelog
+- 2026-06-03: Cold-attach "blank pane looks hung" fix (shared cloud path).
+  Symptom: `agentbox e2b claude` reached `box ready`, showed the recap panel,
+  then the attach sat on a featureless blank screen long enough that the user
+  Ctrl+C'd; a later `agentbox claude attach <n>` rendered fine. Investigated
+  live against a running box and ruled out the usual suspects:
+  - The PTY bridge is fine — attaching to an existing session paints the first
+    byte in ~275ms and the full frame within seconds.
+  - tmux is fine — a session whose program delays its first draw correctly
+    receives the frame the instant the program paints (no redraw bug).
+  - The dashboard probe is fine — `tmux list-sessions -F '#{session_name}'`
+    runs as `vscode` and returns `claude`; `agentbox list` shows
+    `claude:working`. The earlier "dashboard shows no agent session" was the
+    same transient cold-start window (session not yet created / not yet drawn).
+  - claude itself is fast on e2b — native-installer binary, `--version` 99ms,
+    warm interactive first-paint ~750ms; box has free RAM, no swap.
+  Root cause: the freshly-attached tmux client shows a blank pane during the
+  agent's **cold first-run** (238MB binary fault-in + first-time
+  config/plugin/skill/MCP init), which on the 2-vCPU microVM is several
+  seconds with **zero feedback**. Fix: `buildCloudAttachInnerCommand`
+  (`apps/cli/src/commands/_cloud-attach.ts`) now prints
+  `agentbox: starting <agent> (first paint may take a few seconds)...` into the
+  pane before `exec`-ing the agent, so the attach is never blank. Plain ASCII
+  (no escape codes) so it survives every shell-quoting layer; the agent clears
+  it on first draw. Applies to every cloud provider (e2b/vercel are the slowest
+  cold-starters so they benefit most). Verified live: banner paints at ~380ms
+  against a 6s slow-start stand-in. Tests in `test/cloud-attach.test.ts`.
 - 2026-06-03: E2B usability pass — onboarding seed + shell exec + VNC + tag.
   Live-verified end-to-end against `agentbox-base:latest`.
   - **Onboarding (the blocker)**: cloud creates were dropping into Claude's

--- a/packages/sandbox-cloud/src/agent-credentials.ts
+++ b/packages/sandbox-cloud/src/agent-credentials.ts
@@ -347,7 +347,6 @@ async function seedCredentialsOne(
     }
     const sizeKB = (tarSize / 1024).toFixed(1);
     log(`${spec.kind}: uploading ${sizeKB} KB credentials tarball`);
-    process.stderr.write(`[agent-creds] ${spec.kind}: uploading ${sizeKB} KB...\n`);
     const t0 = Date.now();
     const remoteTar = `/tmp/agentbox-${spec.kind}-creds.tar.gz`;
     try {
@@ -361,11 +360,10 @@ async function seedCredentialsOne(
         `${spec.kind}: credentials upload failed (${err instanceof Error ? err.message : String(err)}); ` +
         `agent falls back to interactive login`;
       log(msg);
-      process.stderr.write(`[agent-creds] ${msg}\n`);
       return;
     }
     const upDt = ((Date.now() - t0) / 1000).toFixed(1);
-    process.stderr.write(`[agent-creds] ${spec.kind}: upload done in ${upDt}s\n`);
+    log(`${spec.kind}: upload done in ${upDt}s`);
 
     const extractCmd = hasVolume
       ? // Daytona volumes are S3-backed FUSE and reject chmod/utime. The
@@ -404,11 +402,9 @@ async function seedCredentialsOne(
         `agent falls back to interactive login. ` +
         `stdout: ${extract.stdout.slice(-200)} stderr: ${extract.stderr.slice(-200)}`;
       log(msg);
-      process.stderr.write(`[agent-creds] ${msg}\n`);
       return;
     }
     log(`${spec.kind}: credentials seeded`);
-    process.stderr.write(`[agent-creds] ${spec.kind}: credentials seeded\n`);
   } finally {
     await staged.cleanup();
   }


### PR DESCRIPTION
## Summary

Cloud create/attach UX polish plus the docs that describe it.

- **Spinner no longer corrupted during credential seeding.** `seedCredentialsOne` wrote to the terminal through two channels at once — the clack spinner (`onLog` → `s.message`, in-place) and five raw `process.stderr.write('[agent-creds] ...\n')` calls added in #54. Since the three agents (claude/codex/opencode) seed concurrently, those raw newline writes interleaved with and shredded the in-place spinner. Removed all five; the one unique message ("upload done in Xs") now goes through `log()` so it still shows in the spinner and the command log. Provider-agnostic — fixes e2b, vercel, hetzner, daytona.
- **Removed the `log: <path>` startup line** printed to stderr by `create` / `claude` / `codex` / `opencode`. The log file is still written and rotated, and `~/.agentbox/logs/latest.log` still tracks the latest run.
- **Cold-start attach banner.** Cloud attach now prints `agentbox: starting <agent> (first paint may take a few seconds)...` in the tmux pane before the agent draws, so a freshly attached cold cloud box (e2b/vercel microVMs are slowest) is never a blank pane. The agent clears the screen on startup, so the line vanishes once real output arrives.
- **Docs.** `install` flow + first-box walkthrough updates (`index.mdx`, provider pages, `e2b_backlog.md`), and a mono-art CSS + rehype path (`global.css`, `source.config.ts`) so the Claude Code welcome panel's box-drawing glyphs render at a single cell width instead of falling back per-glyph.

## Test plan

- `vitest run test/cloud-attach.test.ts` — 9 passing (banner precedes the launcher on both the no-args and args paths).
- `pnpm lint` — clean.
- `pnpm build` — green; verified `agent-creds` and the `log:` print are gone from the rebuilt CLI bundle.
- Manual: `agentbox e2b claude` — seed lines update in place on one spinner row, no `[agent-creds]` bleed, no `log:` line; attach shows the starting banner during cold-start.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX and documentation changes plus a small, tested shell command tweak for cloud attach; no auth, billing, or data-model changes.
> 
> **Overview**
> Polishes **cloud create/attach UX** and **docs** without changing core lifecycle semantics.
> 
> **Attach:** Shared `buildCloudAttachInnerCommand` now prints a plain-text **`agentbox: starting <agent>…`** line in the tmux pane before `exec`, so cold cloud attaches (especially e2b/Vercel) are not a blank screen during agent startup. No-args and base64-arg paths both use single-quoted `bash -lc` bodies; unit tests in `cloud-attach.test.ts` updated.
> 
> **Terminal output:** Drops the startup **`log: <path>`** line from `create`, `claude`, `codex`, and `opencode` (files still tee to `~/.agentbox/logs/`). **`seedCredentialsOne`** stops writing raw **`[agent-creds]`** lines to stderr so concurrent agent seeding no longer corrupts the clack spinner; upload timing goes through `log()` instead.
> 
> **Docs/site:** Provider pages gain **Specs** tables and sharper intros; `index.mdx` expands install/first-box guidance; CLI docs drop the `log:` mention. Docs site adds **`data-monoart`** styling so box-drawing welcome art renders with a system mono stack. Wizard stale-base copy is slightly shorter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7544a49b9ad6361a278e3d8fe44f07c4ebc0575e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->