### PR TITLE
feat(agent): add 'input-needed' wait-for state

### DIFF
--- a/apps/cli/share/host-skills/agentbox-info/SKILL.md
+++ b/apps/cli/share/host-skills/agentbox-info/SKILL.md
@@ -109,20 +109,17 @@ All three feed the same status pipeline; `agent state` / `agent wait-for` work t
 agentbox agent state 1                # → working | idle | waiting | end-plan | question | prompt | compacting | error
 agentbox agent state 1 --json         # full BoxStatusClaude (state, updatedAt, sessionTitle, plan?, question?)
 
-agentbox agent wait-for prompt 1 --timeout 600000      # block until Claude is at the input box, no pending plan/question
-agentbox agent wait-for end-plan 1                     # Claude just called ExitPlanMode; user has to approve
-agentbox agent wait-for question 1                     # AskUserQuestion picker is up
-agentbox agent wait-for idle 1                         # Stop hook fired (turn complete)
-agentbox agent wait-for compacting 1                   # Claude is summarizing context (PreCompact fired)
-agentbox agent wait-for error 1                        # Claude's turn ended with a failure (StopFailure)
-
 agentbox agent get-plan-question 1            # print the plan body OR question + options (human)
 agentbox agent get-plan-question 1 --json     # structured payload
 ```
 
-The `prompt` state is derived: `idle` AND tmux session alive AND no pending plan/question — i.e. "ready for the next user message". Use it as the natural sync point after sending a new prompt.
+**For orchestration, `agent wait-for input-needed` is the tool to reach for.** It is the single sync point that wakes whenever the agent needs *you* — whether the turn **finished and it's ready for the next message**, or it's **blocked** on a question, a plan to approve, a permission prompt, or an error. It matches every state except `working` / `compacting`, and prints the concrete state it matched so you can branch on *why* it woke:
 
-The `end-plan` and `question` matchers tolerate the race where Claude's `Notification:permission_prompt` hook flips the raw state to `waiting` immediately after the matcher hook fires — both states still match while the plan/question payload is pending, and only the matching `PostToolUse` (handled internally with `--clear-pending`) resets them.
+```sh
+agentbox agent wait-for input-needed 1 --timeout 600000   # → prints: prompt | end-plan | question | waiting | error
+```
+
+Prefer it over waiting on one specific transition — a narrow `wait-for end-plan` hangs to its timeout if the agent instead asks a question, hits a permission prompt, finishes, or errors. The granular states are still waitable when you *know* exactly what to expect: `prompt` (ready for next message), `idle` (Stop hook fired), `end-plan`, `question`, `waiting`, `compacting`, `error` — e.g. `agentbox agent wait-for prompt 1`.
 
 ### `agentbox queue wait-for <event>` — queue + box lifecycle
 
@@ -137,42 +134,37 @@ agentbox queue wait-for job-done --job b45f1603841bd2b5  # terminal status (done
 
 All wait-for commands exit 0 on match, exit 1 on timeout, and accept `--json` for parseable output.
 
-### Recipe: queue a plan, then act per turn
+### Recipe: drive a Claude Code from another Claude Code
 
-This is the canonical "drive a Claude Code from another Claude Code" loop. You queue an initial planning prompt, wait for the plan to land, capture it, decide, send the next message, repeat.
+Queue a prompt, then loop on `wait-for input-needed` and act on whatever it reports — that one waiter handles every "the agent needs me" case, so the loop never hangs on an unexpected state.
 
 ```sh
-# 1. Kick off a box with a planning prompt.
+# 1. Kick off a box with a planning prompt, in background.
 agentbox claude -n design -i "Plan how to add an OAuth login flow to apps/web, then enter plan mode. Don't start coding."
 
-# 2. Wait until Claude is at the ExitPlanMode approval prompt.
-agentbox agent wait-for end-plan design --timeout 600000
+# 2. Wait until the agent needs you, and branch on what it reports.
+STATE=$(agentbox agent wait-for input-needed design --timeout 1200000)
+case "$STATE" in
+  end-plan|question) agentbox agent get-plan-question design   # read the plan / question
+                     agentbox drive keypress design "<Enter>" ;;  # approve / answer (option 1 pre-highlighted)
+  waiting)           agentbox drive keypress design "<Enter>" ;;  # approve the tool/permission
+  prompt|idle)       agentbox claude -i "Write the OAuth provider unit tests in apps/web/test/auth/" ;; # turn done — fan out more
+  error)             echo "agent errored — inspect with: agentbox drive snapshot design" ;;
+esac
 
-# 3. Read the plan back as text (or JSON) and decide.
-PLAN=$(agentbox agent get-plan-question design)
-echo "$PLAN"
-
-# 4. Approve via tmux — option 1 ("Yes, and use auto mode") is already highlighted.
-agentbox drive keypress design "<Enter>"
-
-# 5. Wait for the turn to finish.
-agentbox agent wait-for prompt design --timeout 1200000
-
-# 6. Fan out follow-up work to a fresh box, in background, while reviewing this one.
-agentbox claude -i "Write the OAuth provider unit tests in apps/web/test/auth/"
-
-# 7. Block until everything settles before reporting back.
+# 3. Block until the whole batch settles before reporting back.
 agentbox queue wait-for empty-queue --timeout 3600000
 ```
 
-The same shape covers `agent wait-for question` + `agent get-plan-question` (read the choices, send the answer index via `drive keypress 1 "<Down><Enter>"`, then `wait-for prompt`).
+Wrap step 2 in a loop to babysit a box across many turns. Use the narrow `wait-for <state>` forms only when a step must gate on one specific transition.
 
 ### Quick mental model
 
-- `drive` = "send keystrokes / read screen" — provider-uniform tmux capture-pane / send-keys.
-- `agent` = "what is the Claude TUI currently doing" — hook-driven, race-free, machine-readable.
-- `queue wait-for` = "block on queue or box lifecycle transitions" — poll-based, no new endpoint.
-- All three commands are **stateless** — safe to invoke from any script, any agent, in parallel.
+- `agent wait-for input-needed` = the orchestration sync point — "wake me when the agent needs me" (done OR blocked). Reach for this first.
+- `agent` (`state` / `get-plan-question` / narrow `wait-for`) = "what is the agent currently doing" — hook-driven, race-free, machine-readable.
+- `drive` = "send keystrokes / read screen" — provider-uniform tmux capture-pane / send-keys; how you act once `wait-for` returns.
+- `queue wait-for` = "block on queue or box lifecycle transitions" (`empty-queue`, `box-running`, `job-done`, …) — settle a whole batch.
+- All commands are **stateless** — safe to invoke from any script, any agent, in parallel.
 - `--json` everywhere. Default human text is for the operator; an agent should pass `--json`.
 
 ## Git through the host relay

--- a/apps/cli/src/lib/wait/agent-state.ts
+++ b/apps/cli/src/lib/wait/agent-state.ts
@@ -45,6 +45,10 @@ export function isPromptReady(claude: BoxStatusClaude): boolean {
  * of chaining `wait-for end-plan` / `wait-for question` / `wait-for prompt`.
  */
 export function isInputNeeded(claude: BoxStatusClaude): boolean {
+  // While the agent is busy it never "needs input" — even if a stale plan /
+  // question payload is still attached (the payload guards below would
+  // otherwise match through a `working` / `compacting` state).
+  if (claude.state === 'working' || claude.state === 'compacting') return false;
   return (
     claude.state === 'waiting' ||
     claude.state === 'end-plan' ||

--- a/apps/cli/src/lib/wait/agent-state.ts
+++ b/apps/cli/src/lib/wait/agent-state.ts
@@ -12,6 +12,7 @@ export const AGENT_WAIT_STATES = [
   'prompt',
   'compacting',
   'error',
+  'input-needed',
 ] as const;
 export type AgentWaitState = (typeof AGENT_WAIT_STATES)[number];
 
@@ -34,7 +35,29 @@ export function isPromptReady(claude: BoxStatusClaude): boolean {
   );
 }
 
+/**
+ * `input-needed` means "the orchestrator needs to take action": the agent has
+ * stopped making autonomous progress and wants a human — whether because the
+ * task finished and the prompt is ready for the next message, or because the
+ * subagent is blocked (permission prompt, plan to approve, question to answer,
+ * or an error). The only states that do NOT match are `working` / `compacting`,
+ * where the agent is still busy. It's the robust single waiter to race instead
+ * of chaining `wait-for end-plan` / `wait-for question` / `wait-for prompt`.
+ */
+export function isInputNeeded(claude: BoxStatusClaude): boolean {
+  return (
+    claude.state === 'waiting' ||
+    claude.state === 'end-plan' ||
+    claude.state === 'question' ||
+    claude.state === 'error' ||
+    claude.plan !== undefined ||
+    claude.question !== undefined ||
+    isPromptReady(claude)
+  );
+}
+
 export function matchesAgentWaitState(claude: BoxStatusClaude, target: AgentWaitState): boolean {
+  if (target === 'input-needed') return isInputNeeded(claude);
   if (target === 'prompt') return isPromptReady(claude);
   if (target === 'end-plan') {
     // ExitPlanMode triggers Notification:permission_prompt → state=waiting

--- a/apps/cli/test/agent-state.test.ts
+++ b/apps/cli/test/agent-state.test.ts
@@ -129,6 +129,12 @@ describe('isInputNeeded / wait-for input-needed', () => {
     expect(isInputNeeded(claude({ state: 'compacting' }))).toBe(false);
   });
 
+  it('does NOT match a busy state even when a stale plan/question payload lingers', () => {
+    expect(isInputNeeded(claude({ state: 'working', plan: PLAN }))).toBe(false);
+    expect(isInputNeeded(claude({ state: 'working', question: QUESTION }))).toBe(false);
+    expect(isInputNeeded(claude({ state: 'compacting', plan: PLAN }))).toBe(false);
+  });
+
   it('does NOT match idle when the session is down (nothing to give input to)', () => {
     expect(isInputNeeded(claude({ state: 'idle', sessionRunning: false }))).toBe(false);
   });

--- a/apps/cli/test/agent-state.test.ts
+++ b/apps/cli/test/agent-state.test.ts
@@ -4,6 +4,7 @@ import {
   AGENT_WAIT_STATES,
   derivedAgentState,
   isAgentWaitState,
+  isInputNeeded,
   isPromptReady,
   matchesAgentWaitState,
 } from '../src/lib/wait/agent-state.js';
@@ -101,6 +102,40 @@ describe('derivedAgentState', () => {
   it('renders the raw state otherwise', () => {
     expect(derivedAgentState(claude({ state: 'working' }))).toBe('working');
     expect(derivedAgentState(claude({ state: 'waiting' }))).toBe('waiting');
+  });
+});
+
+describe('isInputNeeded / wait-for input-needed', () => {
+  it("includes 'input-needed' in the waitable union", () => {
+    expect(isAgentWaitState('input-needed')).toBe(true);
+  });
+
+  it('matches every state where the agent wants a human', () => {
+    // Blocked mid-turn.
+    expect(isInputNeeded(claude({ state: 'waiting' }))).toBe(true);
+    expect(isInputNeeded(claude({ state: 'end-plan', plan: PLAN }))).toBe(true);
+    expect(isInputNeeded(claude({ state: 'question', question: QUESTION }))).toBe(true);
+    // Sticky-payload race: plan/question survive a 'waiting' flicker.
+    expect(isInputNeeded(claude({ state: 'waiting', plan: PLAN }))).toBe(true);
+    expect(isInputNeeded(claude({ state: 'waiting', question: QUESTION }))).toBe(true);
+    // Turn finished — prompt ready for the next message.
+    expect(isInputNeeded(claude())).toBe(true);
+    // Errored.
+    expect(isInputNeeded(claude({ state: 'error' }))).toBe(true);
+  });
+
+  it('does NOT match while the agent is still busy', () => {
+    expect(isInputNeeded(claude({ state: 'working' }))).toBe(false);
+    expect(isInputNeeded(claude({ state: 'compacting' }))).toBe(false);
+  });
+
+  it('does NOT match idle when the session is down (nothing to give input to)', () => {
+    expect(isInputNeeded(claude({ state: 'idle', sessionRunning: false }))).toBe(false);
+  });
+
+  it('is reachable through matchesAgentWaitState', () => {
+    expect(matchesAgentWaitState(claude({ state: 'question', question: QUESTION }), 'input-needed')).toBe(true);
+    expect(matchesAgentWaitState(claude({ state: 'working' }), 'input-needed')).toBe(false);
   });
 });
 

--- a/apps/web/content/docs/background-and-parallel.mdx
+++ b/apps/web/content/docs/background-and-parallel.mdx
@@ -96,22 +96,7 @@ b7c8d9e0f1a2b3c4d5  queued   claude  nightly-deps  docker    5    30s   Upgrade 
 queue.maxConcurrent = 5 (queue.enabled=true)
 ```
 
-`queue wait-for <event>` is the building block for "submit a batch, then wait until they all finish" — it blocks until a queue or box lifecycle event fires, exits `0` on match and `1` on timeout, and takes `--timeout <ms>` (default 600000) plus `--json`. The events are:
-
-| Event | Fires when | Needs |
-| --- | --- | --- |
-| `empty-queue` | no queued or running jobs remain | — |
-| `new-box` | any new box gets registered | — |
-| `box-running` | the box enters `running` | `--box <ref>` |
-| `box-paused` | the box enters `paused` | `--box <ref>` |
-| `box-stopped` | the box stops or goes missing | `--box <ref>` |
-| `job-done` | the job reaches a terminal status (done/failed/cancelled) | `--job <id>` |
-
-```bash
-agentbox claude -i "task one"
-agentbox claude -i "task two"
-agentbox queue wait-for empty-queue --timeout 1800000
-```
+`queue wait-for <event>` blocks on queue and box *lifecycle* transitions (`empty-queue`, `box-running`/`box-paused`/`box-stopped`, `job-done`, …) — useful to settle a whole batch. See [CLI commands](/docs/cli) for the full event list and flags. For driving a single agent's turn, reach for `agent wait-for` below — that's the primary orchestration gate.
 
 <Callout type="warn" title="CANCEL VS DESTROY">
 `queue cancel` only stops jobs still in `queued`. A **running** job keeps going — stop it by destroying its box with `agentbox destroy <box>` (the error message tells you the box name).
@@ -143,10 +128,11 @@ agentbox drive resize 1 200 60
 
 ### `agentbox agent` — monitor the agent's live state
 
-Where `drive` reads raw pixels, `agentbox agent` reports *what the agent is doing*, hook-driven and race-free. The state is one of `working | idle | waiting | end-plan | question | prompt | compacting | error` — so you can watch a box flip from **working** to **idle**, or block until it's **waiting** for input.
+Where `drive` reads raw pixels, `agentbox agent` reports *what the agent is doing*, hook-driven and race-free. The state is one of `working | idle | waiting | end-plan | question | prompt | compacting | error | input-needed` — so you can watch a box flip from **working** to **idle**, or block until it needs you.
 
 ```bash
 agentbox agent state 1                              # → working | idle | waiting | end-plan | ...
+agentbox agent wait-for input-needed 1              # wake whenever the agent needs you: question, plan, permission, done, or error
 agentbox agent wait-for idle 1 --timeout 1200000    # block until the turn completes (Stop hook)
 agentbox agent wait-for prompt 1                    # block until it's ready for the next message
 agentbox agent wait-for end-plan 1                  # Claude just called ExitPlanMode; awaits approval
@@ -154,9 +140,23 @@ agentbox agent wait-for question 1                  # an AskUserQuestion picker 
 agentbox agent get-plan-question 1                  # read the pending plan body or question + options
 ```
 
+**`input-needed` is the most important orchestration event** — the single signal that *you* (or the orchestrating agent) need to take action. It fires whenever the agent stops working and wants a human, whether because the **task finished and the prompt is ready** for the next message, or because the **subagent is blocked** on a question, a plan to approve, a permission prompt, or an error. It's the robust replacement for chaining separate `wait-for end-plan` / `wait-for question` / `wait-for prompt` calls — each of those hangs until *its* timeout if the agent happens to reach a *different* state. `wait-for input-needed` also prints the concrete state it matched (`prompt` / `end-plan` / `question` / `waiting` / `error`), so a script can branch on *why* it woke.
+
+| State | `agent wait-for` matches when |
+| --- | --- |
+| **`input-needed`** | **the agent needs you for anything — a question, plan approval, permission prompt, finished turn (prompt ready), or an error (i.e. any state except `working` / `compacting`)** |
+| `prompt` | idle, session up, no pending plan/question — ready for the next message |
+| `idle` | the turn finished (Stop hook fired) |
+| `end-plan` | ExitPlanMode fired — a plan awaits approval |
+| `question` | an AskUserQuestion picker is up |
+| `waiting` | a tool/permission prompt is pending |
+| `working` | the agent is actively working |
+| `compacting` | the context is being compacted |
+| `error` | the turn ended in an error |
+
 ### Putting it together
 
-`-i` to launch, `agent wait-for` to sync on a turn, `drive` to act, and `queue wait-for` to settle the batch compose into a "drive one agent from another" loop:
+`-i` to launch, `agent wait-for` to sync on the agent's turn (the primary gate — `input-needed` to wake on anything, or a specific state when you know what to expect), `drive` to act, and `queue wait-for` to settle the batch compose into a "drive one agent from another" loop:
 
 ```bash
 # 1. Kick off a box with a planning prompt, in the background.
@@ -175,7 +175,7 @@ agentbox claude -i "Write the OAuth provider unit tests in apps/web/test/auth/"
 agentbox queue wait-for empty-queue --timeout 3600000
 ```
 
-The mental model: **`drive`** sends keystrokes and reads the screen, **`agent`** tells you what the agent's TUI is doing, and **`queue wait-for`** blocks on queue and box lifecycle transitions. For the full flag tables, see [CLI commands](/docs/cli).
+The mental model: **`agent wait-for`** is the primary gate — it blocks until the agent's turn reaches a state you care about (`input-needed` wakes on any), **`drive`** sends keystrokes and reads the screen, **`agent state`** tells you what the agent's TUI is doing, and **`queue wait-for`** settles the whole batch on queue and box lifecycle transitions. For the full flag tables, see [CLI commands](/docs/cli).
 
 ## Monitor everything at once
 


### PR DESCRIPTION
## What

Adds a single synthetic state to `agentbox agent wait-for`: **`input-needed`**.

It fires whenever the orchestrator needs to take action — either the agent **finished its turn and the prompt is ready** for the next message, or the **subagent is blocked** on a question, a plan to approve, a permission prompt, or an error. Concretely, it matches every claude state **except** `working` / `compacting`.

## Why

The common orchestration pattern `agent wait-for end-plan <box>` only matches the `end-plan` condition. If the agent instead asks an `AskUserQuestion`, hits a permission prompt, finishes its turn, or errors, the waiter never matches and **hangs until its timeout**. Every "agent now needs me" branch needed its own `wait-for`, and they can't be raced in one call.

`wait-for input-needed` is the robust single waiter. It also prints the **concrete matched state** (`prompt` / `end-plan` / `question` / `waiting` / `error`) so a script can branch on *why* it woke.

## Changes

- **`apps/cli/src/lib/wait/agent-state.ts`** — add `input-needed` to `AGENT_WAIT_STATES` (flows into validation + `--help`), new `isInputNeeded()` helper (reuses `isPromptReady`), one branch in `matchesAgentWaitState`. No change needed in `agent.ts` — it reuses the matcher in both the fast-path and event-loop and already emits the derived concrete state.
- **`apps/cli/test/agent-state.test.ts`** — unit coverage for every branch.
- **`apps/web/content/docs/background-and-parallel.mdx`** — restructured the Orchestration page: removed the `queue wait-for` "building block" framing + events table, promoted `agent wait-for` as the primary gate with `input-needed` headlined and a full state table.

## Verification

- Unit: 434-test CLI suite green (22 in `agent-state`).
- Build + lint clean; `agent wait-for --help` lists `input-needed`.
- Live e2e against a real docker box through the real `agentbox-ctl` -> relay -> `status.json` -> `wait-for` pipeline:
  - `working` -> times out (no match)
  - `question` / `waiting` / `error` / `end-plan` -> matches, prints the concrete state
  - `idle` without a session -> no match (correct gating — nothing to hand input to)
  - `idle` + live session (task done) -> matches, prints `prompt`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI wait-state matching and docs only; no auth, persistence, or relay protocol changes beyond a new derived predicate.
> 
> **Overview**
> Adds **`input-needed`** to `agent wait-for` — a single waiter that matches whenever the subagent is not actively busy (`working` / `compacting`), covering finished turns (**prompt** ready), **questions**, **plan approval**, permission **waiting**, and **errors**, including sticky plan/question payloads during state flickers. Orchestrators can replace fragile chains of `wait-for end-plan` / `question` / `prompt` with one call; the CLI still reports the concrete matched state for branching.
> 
> Implementation is in `agent-state.ts` (`isInputNeeded`, union + matcher) with unit tests. Docs on orchestration & parallel runs now treat **`agent wait-for`** as the primary gate and headline **`input-needed`**, with a full state table; **`queue wait-for`** is scoped to batch lifecycle only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07055082efd7d68d1e35fea21dce2795bf875603. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->