### PR TITLE
fix(resync): content-aware conflict detection for the host→box untracked-file overlay

### DIFF
--- a/apps/cli/src/lib/resync-warning.ts
+++ b/apps/cli/src/lib/resync-warning.ts
@@ -24,7 +24,8 @@ export function buildResyncWarning(r: ResyncResult): string | null {
     "[agentbox] I synced this box with the host's latest workspace (new commits + the " +
     "host's uncommitted/untracked changes). These files had conflicting host changes that " +
     "I SKIPPED to keep your box's version — review them if the host edits matter:\n" +
-    unique.map((f) => `  - ${f}`).join('\n')
+    unique.map((f) => `  - ${f}`).join('\n') +
+    '\nAgentbox.yaml services DID NOT RUN. Start them manually with `agentbox-ctl reload` once the conflicts are resolved.'
   );
 }
 

--- a/packages/sandbox-docker/src/in-box-git.ts
+++ b/packages/sandbox-docker/src/in-box-git.ts
@@ -1,3 +1,6 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { execa } from 'execa';
 import type { GitWorktreeRecord } from '@agentbox/core';
 import { execInBox, type DockerExecResult } from './docker.js';
@@ -635,6 +638,29 @@ function splitNul(s: string): string[] {
   return s.split('\0').filter((p) => p.length > 0);
 }
 
+/**
+ * Sentinel token emitted by the box-side probe for a path that exists but is
+ * NOT a plain file (dir/symlink) — always a conflict so we never clobber it.
+ */
+const NON_REGULAR_TOKEN = '-';
+
+/**
+ * Classify a host untracked file against what the box already has at that path.
+ * `boxToken` is the box-side probe result: undefined when the path is absent in
+ * the box (safe to copy), {@link NON_REGULAR_TOKEN} when it exists but isn't a
+ * plain file, otherwise the sha256 of the box file's contents. `hostHash` is the
+ * sha256 of the host file. A byte-identical file is a no-op (neither copied nor
+ * reported); anything else that already exists is a conflict the box keeps.
+ */
+export function classifyUntrackedOverlay(
+  boxToken: string | undefined,
+  hostHash: string,
+): 'copy' | 'identical' | 'conflict' {
+  if (boxToken === undefined) return 'copy';
+  if (boxToken === NON_REGULAR_TOKEN) return 'conflict';
+  return boxToken === hostHash ? 'identical' : 'conflict';
+}
+
 /** Conflicted (unmerged) paths in the box worktree, if any. */
 async function unmergedPaths(container: string, ct: string): Promise<string[]> {
   const r = await gitIn(container, ct, ['diff', '--name-only', '--diff-filter=U', '-z']);
@@ -769,12 +795,19 @@ export async function resyncWorkspaceFromHost(
       }
     }
 
-    // --- overlay host untracked files, skipping any the box already has ---
+    // --- overlay host untracked files; box wins only when it actually differs ---
     if (hostUntracked.length > 0) {
-      // Filter to paths that don't already exist in the box worktree (box wins).
-      // `ct` is passed as $1 (never interpolated) so a worktree path with spaces
-      // is safe; `bash` for `read -d ''` (NUL), which dash lacks.
-      const filter = await execa(
+      // Probe the box for each host path. A path absent in the box is copied; a
+      // path present and byte-identical is a no-op (NOT a conflict — this is the
+      // common case right after create-time seeding copied these same untracked
+      // files in); a path present but differing (or a non-regular file we won't
+      // clobber) is the box's version we keep and report.
+      //
+      // For each existing path we emit `<token>\0<path>\0`: the file's sha256
+      // (fed on stdin so filenames with spaces/newlines are safe), or `-` for a
+      // non-regular file. `ct` is passed as $1 (never interpolated) so a worktree
+      // path with spaces is safe; `bash` for `read -d ''` (NUL), which dash lacks.
+      const probe = await execa(
         'docker',
         [
           'exec',
@@ -784,15 +817,47 @@ export async function resyncWorkspaceFromHost(
           opts.container,
           'bash',
           '-c',
-          'cd "$1" && while IFS= read -r -d "" f; do [ -e "$f" ] && printf "%s\\0" "$f"; done',
+          'cd "$1" && while IFS= read -r -d "" f; do ' +
+            'if [ -f "$f" ] && [ ! -L "$f" ]; then ' +
+            'printf "%s\\0%s\\0" "$(sha256sum < "$f" | cut -d" " -f1)" "$f"; ' +
+            'elif [ -e "$f" ]; then printf "%s\\0%s\\0" "-" "$f"; fi; done',
           'bash',
           ct,
         ],
         { input: hostUntracked.join('\0'), reject: false },
       );
-      const existing = new Set(filter.exitCode === 0 ? splitNul(filter.stdout) : []);
-      const toCopy = hostUntracked.filter((p) => !existing.has(p));
-      for (const p of hostUntracked) if (existing.has(p)) res.overlaySkipped.push(p);
+      const boxTokens = new Map<string, string>();
+      if (probe.exitCode === 0) {
+        const flat = splitNul(probe.stdout);
+        for (let i = 0; i + 1 < flat.length; i += 2) {
+          const token = flat[i];
+          const path = flat[i + 1];
+          if (token !== undefined && path !== undefined) boxTokens.set(path, token);
+        }
+      }
+      const toCopy: string[] = [];
+      let identical = 0;
+      for (const p of hostUntracked) {
+        const boxToken = boxTokens.get(p);
+        let hostHash = '';
+        if (boxToken !== undefined && boxToken !== NON_REGULAR_TOKEN) {
+          try {
+            hostHash = createHash('sha256').update(await readFile(join(hostMain, p))).digest('hex');
+          } catch {
+            // Host file vanished/unreadable since `ls-files` — can't copy it and
+            // the box already has its own version; keep the box's, don't report.
+            identical++;
+            continue;
+          }
+        }
+        const verdict = classifyUntrackedOverlay(boxToken, hostHash);
+        if (verdict === 'copy') toCopy.push(p);
+        else if (verdict === 'conflict') res.overlaySkipped.push(p);
+        else identical++;
+      }
+      if (identical > 0) {
+        log(`resync: ${ct}: ${String(identical)} untracked host file(s) already identical in box (no-op)`);
+      }
       if (toCopy.length > 0) {
         const tarOut = await execa('tar', ['-C', hostMain, '--null', '-T', '-', '-cf', '-'], {
           input: toCopy.join('\0'),

--- a/packages/sandbox-docker/test/classify-untracked-overlay.test.ts
+++ b/packages/sandbox-docker/test/classify-untracked-overlay.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { classifyUntrackedOverlay } from '../src/in-box-git.js';
+
+describe('classifyUntrackedOverlay', () => {
+  it('copies when the box has no file at the path', () => {
+    expect(classifyUntrackedOverlay(undefined, 'abc123')).toBe('copy');
+  });
+
+  it('is a no-op when the box file is byte-identical to the host file', () => {
+    // The bug we fixed: identical files (e.g. seeded at create then re-probed on
+    // the immediate resync) must NOT count as conflicts.
+    expect(classifyUntrackedOverlay('deadbeef', 'deadbeef')).toBe('identical');
+  });
+
+  it('conflicts when the box file differs from the host file', () => {
+    expect(classifyUntrackedOverlay('deadbeef', 'cafe00')).toBe('conflict');
+  });
+
+  it('conflicts when the box path is a non-regular file (dir/symlink sentinel)', () => {
+    // Never clobber a box dir/symlink, regardless of the host hash.
+    expect(classifyUntrackedOverlay('-', 'anything')).toBe('conflict');
+  });
+});


### PR DESCRIPTION
## Why

On resync (agent session start, and create-from-checkpoint) AgentBox overlays the host's untracked files onto the box worktree, keeping the box's version on conflict. A conflict sets `hadConflicts`, which **skips running `agentbox.yaml` services** and injects a warning into the agent's prompt.

The untracked overlay classified a file as a conflict **purely on existence** (`[ -e "$f" ]`) — so a box file that is **byte-for-byte identical** to the host's (the common case right after create-time seeding copied those same untracked files in) was counted as a false conflict, needlessly skipping services and warning the agent.

## What

Make the untracked overlay **content-aware** in `resyncWorkspaceFromHost` (`packages/sandbox-docker/src/in-box-git.ts`):

- One box-side `docker exec` probe emits, for each existing path, `<sha256>\0<path>\0` (hash fed on stdin so spaces/newlines in names are safe), or a `-` sentinel for a non-regular file (dir/symlink) we must not clobber.
- Host side computes each file's sha256 and compares:
  - **identical** → no-op (not copied, not reported) ← the fix
  - **differs**, or **non-regular** box path → conflict (box version kept, reported)
  - **absent** in box → copied (unchanged)

The stash overlay and branch merge already use git's content-aware 3-way merge — unchanged. **Docker-only:** cloud providers seed untracked files via a one-shot tar onto a freshly wiped tree (`workspace-seed.ts`), with no overlay/conflict detection, so nothing to change there.

Adds a pure `classifyUntrackedOverlay(boxToken, hostHash)` helper + unit test.

This pairs with the prompt-notice ("Agentbox.yaml services DID NOT RUN…") added in `resync-warning.ts`, which now only fires on genuine conflicts.

## Verification

- `pnpm build` + `pnpm lint` clean; 281 package tests pass incl. the new 4.
- Ran the box-side probe snippet end-to-end in a real container: an identical untracked file emits a hash **matching the host's** (→ `identical`, no conflict); a directory and a symlink emit the `-` sentinel (→ `conflict`, never clobbered); an absent path emits nothing (→ `copy`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted resync/overlay logic with a pure helper and unit tests; reduces false positives that skipped services rather than widening conflict handling.
> 
> **Overview**
> Fixes **false resync conflicts** when overlaying host untracked files onto the box: paths that already exist in the box are no longer treated as conflicts just because they exist—only when content differs or the box path is a non-regular file (dir/symlink).
> 
> `resyncWorkspaceFromHost` now probes the box with **SHA-256** per path (via `classifyUntrackedOverlay`), compares to the host file hash, and treats byte-identical files as a **no-op** (not copied, not in `overlaySkipped`). That stops `hadConflicts` from firing right after create-time seeding copied the same untracked files, so **`agentbox.yaml` services can run** and the agent prompt warning stays for real conflicts only.
> 
> The resync warning text also tells users that services did not run and to use **`agentbox-ctl reload`** after resolving conflicts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4874743b3595ae3a7a41c1c69573747dfa76df16. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->