### PR TITLE
feat(queue): open background -i boxes in a terminal (queue.openIn)

### DIFF
--- a/apps/cli/src/commands/_run-queued-job.ts
+++ b/apps/cli/src/commands/_run-queued-job.ts
@@ -38,6 +38,7 @@ import { buildResyncWarning, prependResyncWarning } from '../lib/resync-warning.
 import { applyClaudeSkipPermissions, applyCodexSkipPermissions } from '../lib/skip-permissions.js';
 import { providerForCreate } from '../provider/registry.js';
 import { cloudAgentStartDetached } from './_cloud-attach.js';
+import { spawnQueuedOpenTerminal } from '../terminal/queue-open.js';
 
 export const runQueuedJobCommand = new Command('_run-queued-job')
   .description('internal: run a queued background agent job (do not invoke directly)')
@@ -131,8 +132,7 @@ async function runDockerJob(
 
   // Auth resolution mirrors the foreground claude path; codex/opencode don't
   // need a host-env probe (they ride the in-box volume that login seeded).
-  const resolved =
-    job.agent === 'claude-code' ? await resolveClaudeAuth(process.env) : null;
+  const resolved = job.agent === 'claude-code' ? await resolveClaudeAuth(process.env) : null;
 
   // browser.default = 'playwright' | 'both' implies installing playwright
   // even if box.withPlaywright wasn't explicitly set.
@@ -147,17 +147,11 @@ async function runDockerJob(
     checkpointRef,
     image: cfg.effective.box.image,
     claudeConfig:
-      job.agent === 'claude-code'
-        ? { isolate: cfg.effective.box.isolateClaudeConfig }
-        : undefined,
+      job.agent === 'claude-code' ? { isolate: cfg.effective.box.isolateClaudeConfig } : undefined,
     codexConfig:
-      job.agent === 'codex'
-        ? { isolate: cfg.effective.box.isolateCodexConfig }
-        : undefined,
+      job.agent === 'codex' ? { isolate: cfg.effective.box.isolateCodexConfig } : undefined,
     opencodeConfig:
-      job.agent === 'opencode'
-        ? { isolate: cfg.effective.box.isolateOpencodeConfig }
-        : undefined,
+      job.agent === 'opencode' ? { isolate: cfg.effective.box.isolateOpencodeConfig } : undefined,
     claudeEnv: resolved?.env,
     withPlaywright,
     withEnv: cfg.effective.box.withEnv,
@@ -230,6 +224,51 @@ async function runDockerJob(
     });
   } else {
     throw new Error(`unknown agent kind: ${String(job.agent satisfies QueueAgentKind)}`);
+  }
+
+  await maybeOpenQueuedTerminal(job, result.record.name, log);
+}
+
+/** The CLI subcommand name for an agent kind (`claude-code` → `claude`). */
+function agentBinaryName(agent: QueueAgentKind): 'claude' | 'codex' | 'opencode' {
+  return agent === 'claude-code' ? 'claude' : agent;
+}
+
+/**
+ * `queue.openIn`: open a fresh host terminal attached to the just-ready box.
+ * Best-effort — a failure here never fails the job (the box is up and the user
+ * can still attach manually). The targeting context was captured on the
+ * submitting host at submit time; we re-invoke the CLI's own `attach` inline in
+ * the new pane.
+ */
+async function maybeOpenQueuedTerminal(
+  job: QueueJob,
+  boxName: string,
+  log: ReturnType<typeof openCommandLog>,
+): Promise<void> {
+  const ctx = job.openTerminal;
+  if (!ctx) return;
+  const cliEntry = process.env['AGENTBOX_CLI_ENTRY'];
+  if (!cliEntry) {
+    log.write('queue.openIn: AGENTBOX_CLI_ENTRY unset; cannot open terminal');
+    return;
+  }
+  const argv = [
+    process.execPath,
+    cliEntry,
+    agentBinaryName(job.agent),
+    'attach',
+    boxName,
+    '--attach-in',
+    'same',
+  ];
+  try {
+    const r = await spawnQueuedOpenTerminal(ctx, argv, boxName);
+    log.write(
+      r.launched ? `queue.openIn: ${r.note}` : `queue.openIn: open failed: ${r.error ?? ''}`,
+    );
+  } catch (err) {
+    log.write(`queue.openIn: open threw: ${err instanceof Error ? err.message : String(err)}`);
   }
 }
 
@@ -319,6 +358,8 @@ async function runCloudJob(
     sessionName,
     extraArgs,
   });
+
+  await maybeOpenQueuedTerminal(job, result.record.name, log);
 }
 
 function buildOverridesFromJob(job: QueueJob): Partial<UserConfig> {

--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -42,6 +42,7 @@ import { buildResyncWarning } from '../lib/resync-warning.js';
 import { applyClaudeSkipPermissions } from '../lib/skip-permissions.js';
 import { parseMaxOption } from '../lib/queue/parse-max-option.js';
 import { submitQueueJob } from '../lib/queue/submit.js';
+import { captureOpenTerminalContext } from '../terminal/queue-open.js';
 import {
   ATTACH_IN_HELP,
   INLINE_HELP,
@@ -587,6 +588,7 @@ export const claudeCommand = new Command('claude')
         createOpts: { ...pickCreateOpts(opts), carry: carryForQueue },
         maxRunningOverride,
         maxWorkingOverride,
+        openTerminal: captureOpenTerminalContext(cfg.effective.queue.openIn),
       });
       outro(
         `job ${result.job.id} queued (${String(result.runningCount)}/${String(result.maxConcurrent)} running); log: ${result.job.logPath}`,

--- a/apps/cli/src/commands/codex.ts
+++ b/apps/cli/src/commands/codex.ts
@@ -42,6 +42,7 @@ import {
 } from '../lib/queue/assert-creds.js';
 import { parseMaxOption } from '../lib/queue/parse-max-option.js';
 import { submitQueueJob } from '../lib/queue/submit.js';
+import { captureOpenTerminalContext } from '../terminal/queue-open.js';
 import { buildPromptArgs } from '../lib/queue/build-prompt-args.js';
 import { maybeResyncWorkspace } from '../lib/resync-start.js';
 import { buildResyncWarning } from '../lib/resync-warning.js';
@@ -494,6 +495,7 @@ export const codexCommand = new Command('codex')
         createOpts: { ...pickCodexCreateOpts(opts), carry: carryForQueue },
         maxRunningOverride,
         maxWorkingOverride,
+        openTerminal: captureOpenTerminalContext(cfg.effective.queue.openIn),
       });
       outro(
         `job ${result.job.id} queued (${String(result.runningCount)}/${String(result.maxConcurrent)} running); log: ${result.job.logPath}`,

--- a/apps/cli/src/commands/opencode.ts
+++ b/apps/cli/src/commands/opencode.ts
@@ -42,6 +42,7 @@ import {
 } from '../lib/queue/assert-creds.js';
 import { parseMaxOption } from '../lib/queue/parse-max-option.js';
 import { submitQueueJob } from '../lib/queue/submit.js';
+import { captureOpenTerminalContext } from '../terminal/queue-open.js';
 import { maybeResyncWorkspace } from '../lib/resync-start.js';
 import { buildResyncWarning } from '../lib/resync-warning.js';
 import {
@@ -469,6 +470,7 @@ export const opencodeCommand = new Command('opencode')
         createOpts: { ...pickOpencodeCreateOpts(opts), carry: carryForQueue },
         maxRunningOverride,
         maxWorkingOverride,
+        openTerminal: captureOpenTerminalContext(cfg.effective.queue.openIn),
       });
       outro(
         `job ${result.job.id} queued (${String(result.runningCount)}/${String(result.maxConcurrent)} running); log: ${result.job.logPath}`,

--- a/apps/cli/src/lib/queue/submit.ts
+++ b/apps/cli/src/lib/queue/submit.ts
@@ -8,6 +8,7 @@ import {
   type QueueAgentKind,
   type QueueJob,
   type QueueJobCreateOpts,
+  type QueueJobOpenTerminal,
 } from '@agentbox/relay';
 import { DEFAULT_RELAY_PORT, ensureRelay } from '@agentbox/sandbox-docker';
 
@@ -22,6 +23,12 @@ export interface SubmitQueueJobInput {
   maxRunningOverride?: number;
   /** Per-invocation override of queue.maxWorking. */
   maxWorkingOverride?: number;
+  /**
+   * Host-terminal targeting captured at submit time (when `queue.openIn` is not
+   * `none`). Carried on the job so the worker opens a fresh terminal onto the
+   * box once it is ready. Absent → open nothing.
+   */
+  openTerminal?: QueueJobOpenTerminal;
 }
 
 export interface SubmitQueueJobResult {
@@ -67,6 +74,7 @@ export async function submitQueueJob(
     createOpts: input.createOpts,
     maxConcurrent: ceiling,
     ...(maxWorking !== undefined ? { maxWorking } : {}),
+    ...(input.openTerminal !== undefined ? { openTerminal: input.openTerminal } : {}),
     createdAt: new Date().toISOString(),
     logPath: queueLogPath(id),
   };

--- a/apps/cli/src/terminal/host.ts
+++ b/apps/cli/src/terminal/host.ts
@@ -67,6 +67,24 @@ export interface SpawnInNewTerminalArgs {
   cwd: string;
   /** Short title for the new tmux window / iTerm2 tab when applicable. */
   title: string;
+  /**
+   * Env for the spawned tmux/cmux helper. Defaults to the current process env.
+   * The queue worker passes a captured env (the submitting shell's `TMUX` /
+   * `CMUX_SOCKET_PATH`) because its own env points at whatever terminal first
+   * started the long-lived relay, not this job's terminal.
+   */
+  env?: NodeJS.ProcessEnv;
+  /**
+   * tmux target pane (`$TMUX_PANE`). When set, tmux verbs get `-t <pane>` so a
+   * detached spawner (the queue worker, which has no "current" pane) splits /
+   * opens from the submitting pane's session.
+   */
+  tmuxTarget?: string;
+  /**
+   * Force cmux to open a new top-level workspace for every mode. Set by the
+   * queue worker, which has no reliable focused surface to split/tab into.
+   */
+  cmuxWorkspaceOnly?: boolean;
 }
 
 export interface SpawnInNewTerminalResult {
@@ -103,17 +121,20 @@ async function spawnInTmux(args: SpawnInNewTerminalArgs): Promise<SpawnInNewTerm
   // tmux hands it to /bin/sh -c, which is why each argv element needs
   // single-quoting.
   const cmdStr = shellJoin(args.argv);
+  // `-t <pane>` is only added when the caller passes an explicit target (the
+  // queue worker); the foreground path omits it and tmux uses the current pane.
+  const target = args.tmuxTarget ? ['-t', args.tmuxTarget] : [];
   let tmuxArgv: string[];
   let noteKind: string;
   if (args.mode === 'split') {
-    tmuxArgv = ['split-window', '-h', '-c', args.cwd, '--', cmdStr];
+    tmuxArgv = ['split-window', '-h', ...target, '-c', args.cwd, '--', cmdStr];
     noteKind = 'tmux split';
   } else {
     // `window` and `tab` both map to tmux's only "another full screen" primitive.
-    tmuxArgv = ['new-window', '-n', args.title, '-c', args.cwd, '--', cmdStr];
+    tmuxArgv = ['new-window', ...target, '-n', args.title, '-c', args.cwd, '--', cmdStr];
     noteKind = 'tmux window';
   }
-  const r = await runQuiet('tmux', tmuxArgv);
+  const r = await runQuiet('tmux', tmuxArgv, args.env);
   if (r.code !== 0) {
     return {
       launched: false,
@@ -138,23 +159,30 @@ async function spawnInTmux(args: SpawnInNewTerminalArgs): Promise<SpawnInNewTerm
  * what you usually want; `window` is the explicit "somewhere separate" choice.
  */
 async function spawnInCmux(args: SpawnInNewTerminalArgs): Promise<SpawnInNewTerminalResult> {
-  const bin = cmuxBinary();
+  const bin = cmuxBinary(args.env);
 
-  if (args.mode === 'window') {
+  // `window` always means a separate workspace; the queue worker forces every
+  // mode here (`cmuxWorkspaceOnly`) because a detached spawner has no focused
+  // surface to split/tab into.
+  if (args.mode === 'window' || args.cmuxWorkspaceOnly) {
     // A separate top-level cmux workspace. `new-workspace` carries cwd + command
     // atomically (it types `--command` + Enter into the new workspace's shell,
     // which parses the shell-quoting we applied in `cmdStr`).
-    const r = await runQuiet(bin, [
-      'new-workspace',
-      '--name',
-      args.title,
-      '--cwd',
-      args.cwd,
-      '--command',
-      shellJoin(args.argv),
-      '--focus',
-      'true',
-    ]);
+    const r = await runQuiet(
+      bin,
+      [
+        'new-workspace',
+        '--name',
+        args.title,
+        '--cwd',
+        args.cwd,
+        '--command',
+        shellJoin(args.argv),
+        '--focus',
+        'true',
+      ],
+      args.env,
+    );
     if (r.code !== 0) {
       return {
         launched: false,
@@ -176,7 +204,7 @@ async function spawnInCmux(args: SpawnInNewTerminalArgs): Promise<SpawnInNewTerm
       : ['new-surface', '--focus', 'true'];
   const noteKind = args.mode === 'split' ? 'cmux split' : 'cmux tab';
 
-  const created = await runQuiet(bin, createArgv);
+  const created = await runQuiet(bin, createArgv, args.env);
   if (created.code !== 0) {
     return {
       launched: false,
@@ -196,7 +224,7 @@ async function spawnInCmux(args: SpawnInNewTerminalArgs): Promise<SpawnInNewTerm
   }
   const cmdLine = `cd ${shellQuote(args.cwd)} && exec ${shellJoin(args.argv)}`;
   // `\n` is interpreted by `cmux send` as Enter, which runs the typed command.
-  const sent = await runQuiet(bin, ['send', '--surface', surfaceRef, `${cmdLine}\n`]);
+  const sent = await runQuiet(bin, ['send', '--surface', surfaceRef, `${cmdLine}\n`], args.env);
   if (sent.code !== 0) {
     return {
       launched: false,
@@ -281,10 +309,12 @@ interface QuietResult {
 }
 
 /** Spawn `cmd argv...`, capture stdout + stderr. Resolves on exit. The tmux /
- *  iTerm2 callers ignore stdout; the cmux caller parses it for the surface ref. */
-function runQuiet(cmd: string, argv: string[]): Promise<QuietResult> {
+ *  iTerm2 callers ignore stdout; the cmux caller parses it for the surface ref.
+ *  `env` defaults to the current process env; the queue worker passes a captured
+ *  env so tmux/cmux talk to the submitting shell's server, not the relay's. */
+function runQuiet(cmd: string, argv: string[], env?: NodeJS.ProcessEnv): Promise<QuietResult> {
   return new Promise((resolve) => {
-    const child = spawn(cmd, argv, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const child = spawn(cmd, argv, { stdio: ['ignore', 'pipe', 'pipe'], env });
     let stdout = '';
     let stderr = '';
     child.stdout?.on('data', (chunk: Buffer) => {

--- a/apps/cli/src/terminal/queue-open.ts
+++ b/apps/cli/src/terminal/queue-open.ts
@@ -1,0 +1,84 @@
+import type { QueueJobOpenTerminal } from '@agentbox/relay';
+import type { QueueOpenIn } from '@agentbox/config';
+import {
+  cmuxBinary,
+  detectHostTerminal,
+  spawnInNewTerminal,
+  type SpawnInNewTerminalResult,
+} from './host.js';
+
+/**
+ * Capture the submitting shell's host-terminal targeting so a queued (`-i`)
+ * job's worker can open a fresh terminal onto the box the moment it is ready.
+ *
+ * Must run on the submitting host with the live interactive env — the relay
+ * daemon (which spawns the worker) is long-lived, so its own env can't be
+ * trusted to point at this submit's terminal.
+ *
+ * Returns `undefined` when `mode` is `none` or the host terminal is not one we
+ * can drive (tmux / cmux / iTerm2) — in both cases nothing is opened.
+ */
+export function captureOpenTerminalContext(
+  mode: QueueOpenIn,
+  env: NodeJS.ProcessEnv = process.env,
+  cwd: string = process.cwd(),
+): QueueJobOpenTerminal | undefined {
+  if (mode === 'none') return undefined;
+  const host = detectHostTerminal(env);
+  if (host === 'unknown') return undefined;
+
+  const base = { host, mode, cwd } as const;
+  if (host === 'tmux') {
+    return { ...base, host, tmuxSocket: env['TMUX'], tmuxPane: env['TMUX_PANE'] };
+  }
+  if (host === 'cmux') {
+    return {
+      ...base,
+      host,
+      cmuxSocket: env['CMUX_SOCKET_PATH'],
+      cmuxBundledCli: cmuxBinary(env),
+    };
+  }
+  // iTerm2: osascript drives the app via Apple events, no captured handle.
+  return { ...base, host };
+}
+
+/**
+ * Open the terminal described by a captured context, running `argv` in it. Runs
+ * on the host from the queue worker once the box is ready. Rebuilds the env from
+ * the captured socket(s) since the worker's own env points at the relay's
+ * originating terminal, not this job's. cmux always opens a new workspace (the
+ * worker has no focused surface to split/tab into).
+ */
+export function spawnQueuedOpenTerminal(
+  ctx: QueueJobOpenTerminal,
+  argv: string[],
+  title: string,
+): Promise<SpawnInNewTerminalResult> {
+  if (ctx.host === 'tmux') {
+    return spawnInNewTerminal({
+      host: 'tmux',
+      mode: ctx.mode,
+      argv,
+      cwd: ctx.cwd,
+      title,
+      env: ctx.tmuxSocket ? { ...process.env, TMUX: ctx.tmuxSocket } : process.env,
+      tmuxTarget: ctx.tmuxPane,
+    });
+  }
+  if (ctx.host === 'cmux') {
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    if (ctx.cmuxSocket) env['CMUX_SOCKET_PATH'] = ctx.cmuxSocket;
+    if (ctx.cmuxBundledCli) env['CMUX_BUNDLED_CLI_PATH'] = ctx.cmuxBundledCli;
+    return spawnInNewTerminal({
+      host: 'cmux',
+      mode: ctx.mode,
+      argv,
+      cwd: ctx.cwd,
+      title,
+      env,
+      cmuxWorkspaceOnly: true,
+    });
+  }
+  return spawnInNewTerminal({ host: 'iterm2', mode: ctx.mode, argv, cwd: ctx.cwd, title });
+}

--- a/apps/cli/test/queue-open.test.ts
+++ b/apps/cli/test/queue-open.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { captureOpenTerminalContext } from '../src/terminal/queue-open.js';
+
+const CWD = '/Users/x/proj';
+
+describe('captureOpenTerminalContext', () => {
+  it('returns undefined when the mode is "none" (default — open nothing)', () => {
+    expect(
+      captureOpenTerminalContext('none', { TMUX: '/tmp/tmux-501/default,1,0' }, CWD),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when the host terminal is unknown', () => {
+    expect(
+      captureOpenTerminalContext('split', { TERM_PROGRAM: 'Apple_Terminal' }, CWD),
+    ).toBeUndefined();
+  });
+
+  it('captures the tmux socket + pane for a tmux host', () => {
+    expect(
+      captureOpenTerminalContext(
+        'split',
+        { TMUX: '/private/tmp/tmux-501/default,12345,0', TMUX_PANE: '%5' },
+        CWD,
+      ),
+    ).toEqual({
+      host: 'tmux',
+      mode: 'split',
+      cwd: CWD,
+      tmuxSocket: '/private/tmp/tmux-501/default,12345,0',
+      tmuxPane: '%5',
+    });
+  });
+
+  it('captures the cmux socket + bundled CLI for a cmux host', () => {
+    expect(
+      captureOpenTerminalContext(
+        'window',
+        {
+          CMUX_SOCKET_PATH: '/Users/x/Library/Application Support/cmux/cmux.sock',
+          CMUX_BUNDLED_CLI_PATH: '/Applications/cmux.app/Contents/Resources/cmux',
+          TERM_PROGRAM: 'ghostty',
+        },
+        CWD,
+      ),
+    ).toEqual({
+      host: 'cmux',
+      mode: 'window',
+      cwd: CWD,
+      cmuxSocket: '/Users/x/Library/Application Support/cmux/cmux.sock',
+      cmuxBundledCli: '/Applications/cmux.app/Contents/Resources/cmux',
+    });
+  });
+
+  it('captures an iTerm2 host with no extra handle (osascript drives it)', () => {
+    expect(captureOpenTerminalContext('tab', { TERM_PROGRAM: 'iTerm.app' }, CWD)).toEqual({
+      host: 'iterm2',
+      mode: 'tab',
+      cwd: CWD,
+    });
+  });
+});

--- a/apps/web/content/docs/background-and-parallel.mdx
+++ b/apps/web/content/docs/background-and-parallel.mdx
@@ -44,6 +44,8 @@ job a1b2c3d4e5f6a1b2c3 queued (2/5 running); log: ~/.agentbox/queue/a1b2c3d4e5f6
 
 Credentials for the chosen agent must already be on the host — the background worker can't do an interactive login. If they're missing, submission fails loud. Authenticate first (see [run an agent](/docs/run-an-agent)).
 
+By default a queued run opens nothing — attach later with `agentbox claude attach <box>`. To have the box pop open automatically the moment its worker finishes creating it, set [`queue.openIn`](/docs/configuration#queue--autopause) to `split`, `window`, or `tab` (when you submit from inside tmux, cmux, or iTerm2). The relay opens an attached terminal onto the box for you — no need to watch for it to come up.
+
 <Callout type="warn" title="NOT PRINT MODE">
 `-i` is `--initial-prompt` (the background queue), **not** Claude's own `-p` headless print mode. The difference: `-i` seeds a real, **interactive** agent session you can attach to, drive, and resume — it just starts detached. `-p` is the non-interactive print mode that runs once and exits. To use print mode, pass it through after `--`:
 
@@ -64,6 +66,7 @@ The queue is configured with **global** config keys (the relay is host-wide, so 
 | `queue.maxConcurrent` | `5` | Max simultaneously **running boxes** (all providers) before `-i` jobs queue. |
 | `queue.maxWorking` | `0` (off) | Max agents actively **working** (quota-consuming) at once; `0` falls back to the running-box gate. |
 | `queue.idleGraceSeconds` | `15` | Seconds an agent must stay non-working before it frees its working slot. |
+| `queue.openIn` | `none` | When a queued box becomes ready, open an attached terminal onto it: `split`, `window`, or `tab` (tmux/cmux/iTerm2). `none` opens nothing. |
 
 The default caps **running boxes**. Turn on `queue.maxWorking` for a smarter **working-agent** cap — paused or idle boxes don't count, so you can keep more boxes alive cheaply (see [checkpoints and pausing](/docs/checkpoints-and-pausing)) while still bounding active quota burn. Because `maxConcurrent` counts boxes across all providers, cloud `-i` jobs on [Daytona](/docs/daytona), [Hetzner](/docs/hetzner), or [Vercel](/docs/vercel) share the same gate.
 

--- a/apps/web/content/docs/configuration.mdx
+++ b/apps/web/content/docs/configuration.mdx
@@ -240,6 +240,7 @@ See [browser and screen](/docs/browser-and-screen).
 | `queue.maxConcurrent` | int | `5` | max simultaneously-running boxes before `-i` jobs queue; override with `--max-running <n>` |
 | `queue.maxWorking` | int | `0` (off) | max agents actively working at once before `-i` jobs queue; override with `--max-working <n>` |
 | `queue.idleGraceSeconds` | int | `15` | debounce before an agent frees its working slot; only used when `maxWorking > 0` |
+| `queue.openIn` | enum `none`/`split`/`window`/`tab` | `none` | when a background `-i` job's box becomes ready, open an attached terminal onto it (a tmux/cmux split, window, or tab); `none` opens nothing |
 | `autopause.enabled` | bool | `true` | let the relay periodically pause idle boxes when more than `maxRunningBoxes` run |
 | `autopause.maxRunningBoxes` | int | `5` | target ceiling of running boxes before idle ones get paused |
 | `autopause.idleMinutes` | int | `5` | minutes a box must be continuously idle before it's eligible for auto-pause |
@@ -247,7 +248,10 @@ See [browser and screen](/docs/browser-and-screen).
 ```bash
 agentbox config set queue.maxConcurrent 3 --global
 agentbox config set autopause.idleMinutes 10 --global
+agentbox config set queue.openIn split --global
 ```
+
+By default a background `-i` run just queues and prints its job line. Set `queue.openIn` to `split`, `window`, or `tab` and the host relay opens an attached terminal onto the box the moment its worker finishes creating it — no need to find the box and `attach` by hand. It only fires when the submitting shell is inside tmux, cmux, or iTerm2; cmux opens a new workspace for every mode, and iTerm2 opens relative to the frontmost window. Unlike `attach.openIn` there is no `same` mode (the box is created asynchronously, so it is always a fresh terminal).
 
 Auto-pause only ever targets a box whose live agent has settled to **idle** for `idleMinutes`. A box where **any** agent (Claude, Codex, or OpenCode) is working, compacting, or waiting on you is never auto-paused. If a box does get paused while you still need it, `agentbox drive …`, `agentbox shell`, and `agentbox unpause` all resume it on demand (drive auto-unpauses before it reaches the session).
 

--- a/docs/terminal-integration.md
+++ b/docs/terminal-integration.md
@@ -45,6 +45,46 @@ Mechanics:
 - Anything that fails (unknown host, shell mode, spawn non-zero) falls through to
   inline attach.
 
+## `queue.openIn` — open a background `-i` box when it is ready
+
+`QueueOpenIn = 'none' | 'split' | 'window' | 'tab'` (config key `queue.openIn`,
+default `none`; config-only — no CLI flag). The foreground `attach.openIn` above
+runs in the submitting process; the background `-i` path can't, because the box
+doesn't exist yet (it's created later by the relay's queue worker, and its name
+isn't even known until then). So the open happens **from the worker, on the
+host, the moment the box is ready** — not from a waiting pane at submit time.
+
+Flow:
+- At submit (`captureOpenTerminalContext`, `terminal/queue-open.ts`): if
+  `queue.openIn !== 'none'` and the submitting shell is a known host terminal,
+  capture the targeting (`host`, `mode`, `cwd`, tmux `$TMUX`/`$TMUX_PANE`, cmux
+  `$CMUX_SOCKET_PATH`/CLI) onto the queue job (`QueueJob.openTerminal`). The live
+  submit env is the source of truth — the long-lived relay/worker inherit a
+  **stale** terminal env from whenever the relay first started.
+- When the box is ready (`_run-queued-job.ts` → `maybeOpenQueuedTerminal`): the
+  worker calls `spawnQueuedOpenTerminal`, which re-invokes
+  `agentbox <agent> attach <box> --attach-in same` in a fresh terminal via
+  `spawnInNewTerminal`, passing the captured env so tmux/cmux talk to the
+  submitting shell's server. Best-effort: any failure is logged, never fails the
+  job.
+
+Per-host targeting differs from the foreground path because the worker is
+detached (no "current" pane):
+
+| mode     | tmux                          | cmux            | iTerm2            |
+| -------- | ----------------------------- | --------------- | ----------------- |
+| `split`  | `split-window -h -t <pane>`   | `new-workspace` | `split vertically` |
+| `tab`    | `new-window -t <pane>`        | `new-workspace` | `create tab`       |
+| `window` | `new-window -t <pane>`        | `new-workspace` | `create window`    |
+
+- tmux targets the captured `$TMUX_PANE` so the split/window lands in the
+  submitting pane's session and shows up live in the attached client.
+- cmux always opens a **new workspace** (every mode) — a detached worker has no
+  reliable focused surface to split/tab into.
+- iTerm2 opens relative to the **frontmost** window (no stable submit-time handle
+  is captured in v1).
+- Unknown host terminal at submit → nothing is captured and nothing opens.
+
 ## Terminal title
 
 `apps/cli/src/terminal/title.ts`: `setTerminalTitle` emits OSC 0

--- a/packages/config/schema/user-config.schema.json
+++ b/packages/config/schema/user-config.schema.json
@@ -155,7 +155,8 @@
         "enabled": { "type": "boolean" },
         "maxConcurrent": { "type": "integer" },
         "maxWorking": { "type": "integer" },
-        "idleGraceSeconds": { "type": "integer" }
+        "idleGraceSeconds": { "type": "integer" },
+        "openIn": { "enum": ["none", "split", "window", "tab"] }
       }
     },
     "maintenance": {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -15,6 +15,7 @@ export {
   type KeyType,
   type LoadedConfig,
   type ProviderKind,
+  type QueueOpenIn,
   type UserConfig,
 } from './types.js';
 

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -16,6 +16,11 @@ export type ProviderKind = 'docker' | 'daytona' | 'hetzner' | 'vercel' | 'e2b';
 /** Where `agentbox claude|codex|opencode` opens the attached session when the host
  *  shell is running inside tmux, cmux, or iTerm2. `same` keeps today's inline behavior. */
 export type AttachOpenIn = 'split' | 'window' | 'tab' | 'same';
+/** Where a background `-i` (queued) run opens the box once the worker has created
+ *  it. `none` (default) opens nothing — the historical behavior. The open is
+ *  driven by the host relay's queue worker when the box becomes ready, not at
+ *  submit time, so there is no `same` (inline) mode here. */
+export type QueueOpenIn = 'none' | 'split' | 'window' | 'tab';
 
 export interface UserConfig {
   /**
@@ -134,6 +139,7 @@ export interface UserConfig {
     maxConcurrent?: number;
     maxWorking?: number;
     idleGraceSeconds?: number;
+    openIn?: QueueOpenIn;
   };
   cloud?: {
     useCurrentBranch?: boolean;
@@ -248,6 +254,7 @@ export interface EffectiveConfig {
     maxConcurrent: number;
     maxWorking: number;
     idleGraceSeconds: number;
+    openIn: QueueOpenIn;
   };
   cloud: {
     useCurrentBranch: boolean;
@@ -383,6 +390,7 @@ export const BUILT_IN_DEFAULTS: EffectiveConfig = {
     maxConcurrent: 5,
     maxWorking: 0,
     idleGraceSeconds: 15,
+    openIn: 'none',
   },
   cloud: {
     useCurrentBranch: false,
@@ -808,6 +816,13 @@ export const KEY_REGISTRY: readonly KeyDescriptor[] = [
     type: 'int',
     description:
       'Seconds an agent must stay non-working before it frees its working slot (debounce against brief idle flaps between turns). Only used when queue.maxWorking > 0.',
+  },
+  {
+    key: 'queue.openIn',
+    type: 'enum',
+    enumValues: ['none', 'split', 'window', 'tab'] as const,
+    description:
+      'When a background `-i` job finishes creating its box, where the host relay opens an attached terminal onto it: `none` (default — open nothing, just queue), `split`, `window`, or `tab`. Honored only when the submitting shell runs inside tmux, cmux, or iTerm2 (the targeting is captured at submit time). cmux opens a new workspace for every mode; iTerm2 opens relative to the frontmost window. Unlike `attach.openIn` there is no `same` mode — the box is created asynchronously, so it is always a fresh terminal.',
   },
   {
     key: 'cloud.useCurrentBranch',

--- a/packages/config/test/schema-drift.test.ts
+++ b/packages/config/test/schema-drift.test.ts
@@ -81,6 +81,7 @@ maintenance:
     name: 'queue full',
     yaml: 'queue:\n  enabled: true\n  maxConcurrent: 5\n  maxWorking: 3\n  idleGraceSeconds: 20\n',
   },
+  { name: 'queue openIn', yaml: 'queue:\n  openIn: split\n' },
   { name: 'maintenance only', yaml: 'maintenance:\n  pruneProjectConfigs: true\n' },
   { name: 'portless only', yaml: 'portless:\n  enabled: true\n' },
   { name: 'portless stateDir', yaml: 'portless:\n  enabled: false\n  stateDir: /tmp/portless\n' },
@@ -142,6 +143,10 @@ const INVALID: Fixture[] = [
   {
     name: 'queue unknown leaf',
     yaml: 'queue:\n  maxWorkers: 3\n',
+  },
+  {
+    name: 'queue openIn unknown enum value',
+    yaml: 'queue:\n  openIn: same\n',
   },
   {
     name: 'maintenance wrong type for int',

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -117,6 +117,7 @@ export {
   type QueueConfig,
   type QueueJob,
   type QueueJobCreateOpts,
+  type QueueJobOpenTerminal,
   type QueueJobStatus,
   type QueueLoopDeps,
   type QueueLoopHandle,

--- a/packages/relay/src/queue.ts
+++ b/packages/relay/src/queue.ts
@@ -26,6 +26,29 @@ export const QUEUE_DIR = join(STATE_DIR, 'queue');
 export type QueueJobStatus = 'queued' | 'running' | 'done' | 'failed' | 'cancelled';
 export type QueueAgentKind = 'claude-code' | 'codex' | 'opencode';
 
+/**
+ * Host-terminal targeting captured on the submitting host when `queue.openIn`
+ * is not `none`, carried on the job so the worker can open a fresh terminal
+ * onto the box the moment it is ready. The relay treats this as opaque
+ * pass-through; the CLI worker (`_run-queued-job`) is what reads and acts on it.
+ *
+ * The targeting is captured at submit time because the relay daemon is
+ * long-lived and idempotent — its own env reflects whatever terminal first
+ * started it, not this submit's terminal.
+ */
+export interface QueueJobOpenTerminal {
+  host: 'tmux' | 'cmux' | 'iterm2';
+  mode: 'split' | 'window' | 'tab';
+  /** Submitting shell's cwd, so the new pane resolves project-scoped refs. */
+  cwd: string;
+  /** tmux server socket (`$TMUX`) + the pane to split (`$TMUX_PANE`). */
+  tmuxSocket?: string;
+  tmuxPane?: string;
+  /** cmux control socket (`$CMUX_SOCKET_PATH`) + bundled CLI path. */
+  cmuxSocket?: string;
+  cmuxBundledCli?: string;
+}
+
 /** On-disk job manifest. Read/written under `~/.agentbox/queue/<id>.json`. */
 export interface QueueJob {
   id: string;
@@ -55,6 +78,11 @@ export interface QueueJob {
    * avoid double-counting the in-flight startup slot once the box registers.
    */
   boxId?: string;
+  /**
+   * Host-terminal targeting for `queue.openIn`. Set at submit time when the
+   * submitting shell ran inside a supported terminal; absent → open nothing.
+   */
+  openTerminal?: QueueJobOpenTerminal;
   createdAt: string;
   startedAt?: string;
   finishedAt?: string;


### PR DESCRIPTION
## What

Adds the ability for a background `-i` (queued) agent run to **open the box in a terminal** once it's ready — a tmux/cmux/iTerm2 split, window, or tab. Controlled by a new config key **`queue.openIn`** (`none` | `split` | `window` | `tab`), **default `none`** so current behavior (queue and open nothing) is unchanged. Config-only, no CLI flag.

```bash
agentbox config set queue.openIn split --global
agentbox claude -i "fix the failing test"   # box pops open in a split when ready
```

## Why this shape

`-i` submits a queue job and returns immediately — the box doesn't exist yet (the relay's queue **worker** creates it later) and its name isn't known until then. The long-lived relay/worker also inherit a **stale** terminal env (whatever terminal first started the relay). So:

1. **At submit** (`captureOpenTerminalContext`, `terminal/queue-open.ts`): if `queue.openIn !== none` and the submitting shell is a known host terminal, capture the targeting (host, mode, cwd, tmux `$TMUX`/`$TMUX_PANE`, cmux socket/CLI) onto the queue job (`QueueJob.openTerminal`).
2. **When the box is ready** (`_run-queued-job.ts` → `maybeOpenQueuedTerminal` → `spawnQueuedOpenTerminal`): the worker opens a fresh terminal **from the host** and re-invokes `agentbox <agent> attach <box> --attach-in same` in it. Best-effort — a failure is logged and never fails the job.

This avoids an empty "waiting" pane at submit time and works for both named and auto-named boxes, across docker and the cloud providers.

### Per-host targeting (worker is detached, no "current" pane)

| mode | tmux | cmux | iTerm2 |
| --- | --- | --- | --- |
| `split` | `split-window -h -t <pane>` | new workspace | split vertically |
| `tab` | `new-window -t <pane>` | new workspace | new tab |
| `window` | `new-window -t <pane>` | new workspace | new window |

- tmux targets the captured pane so it lands in the submitting session, live in the attached client.
- cmux always opens a **new workspace** (a detached worker has no reliable focused surface to split/tab into).
- iTerm2 opens relative to the **frontmost** window (no stable submit-time handle captured in v1).
- Unknown host terminal at submit → nothing captured, nothing opens.

## Changes

- Config: `queue.openIn` typed key + default `none` + `KEY_REGISTRY` entry + JSON schema (`packages/config`).
- Capture + spawn helpers (`apps/cli/src/terminal/queue-open.ts`); `spawnInNewTerminal` extended with explicit env + tmux target + cmux-workspace-only (`host.ts`), defaults preserve the foreground path.
- `QueueJob.openTerminal` carried through `submitQueueJob`; wired into the `-i` branch of claude/codex/opencode.
- Worker opens the terminal after the seeded session starts (docker + cloud paths).
- Docs: `docs/terminal-integration.md`, web `configuration.mdx` + `background-and-parallel.mdx`.

## Tests

- New unit tests for `captureOpenTerminalContext` (none/unknown/tmux/cmux/iTerm2).
- Config schema-drift fixtures for `queue.openIn` (valid `split`; rejects `same`, which is valid only for `attach.openIn`).
- `pnpm build`, `typecheck`, `lint`, `test` all green.

## Manual verification (follow-up)

Live end-to-end (needs a real box create from inside a multiplexer) is not part of this PR's automated checks: `agentbox config set queue.openIn split`, then `agentbox claude -i "say hi"` from inside tmux/cmux/iTerm2 and confirm the box opens attached when the worker finishes; confirm `none` still opens nothing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default `none` preserves prior behavior; terminal open is best-effort and does not affect job success or box lifecycle.
> 
> **Overview**
> Adds **`queue.openIn`** (`none` | `split` | `window` | `tab`, default **`none`**) so background `-i` jobs can auto-open an attached terminal when the box is ready, instead of only printing the job line.
> 
> On submit, **`captureOpenTerminalContext`** records the submitting shell’s tmux/cmux/iTerm2 targeting (socket, pane, cwd) onto the queue job. After the worker finishes creating the box and starting the agent session (docker and cloud), **`maybeOpenQueuedTerminal`** best-effort spawns a new pane and runs `agentbox <agent> attach <box> --attach-in same`. Failures are logged only; the job still succeeds.
> 
> **`spawnInNewTerminal`** now accepts optional env, tmux `-t` pane target, and cmux workspace-only mode so the detached relay worker can target the user’s terminal, not the relay’s stale env. Claude, codex, and opencode `-i` paths pass the captured context through **`submitQueueJob`**; relay carries opaque **`QueueJob.openTerminal`** on the manifest. Docs and schema drift tests updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fd355639d0f7212f18f065d22349106d69648c5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->