### PR TITLE
feat(queue): warn on queue.openIn set; document cmux socket-control caveat

### DIFF
--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -201,11 +201,28 @@ const setCommand = new Command('set')
         );
       } else {
         process.stdout.write(`${key} = ${fmtValue(r.coerced)}   (wrote ${r.path})\n`);
+        warnOnSet(key, r.coerced);
       }
     } catch (err) {
       handleError(err);
     }
   });
+
+/**
+ * Print key-specific caveats after a successful `config set`. Kept here (not in
+ * the config package) because it's about CLI/runtime behavior, not the value's
+ * validity.
+ */
+function warnOnSet(key: string, value: unknown): void {
+  if (key === 'queue.openIn' && value !== 'none') {
+    process.stderr.write(
+      'note: queue.openIn only opens a terminal when you submit the `-i` job from inside tmux, cmux, or iTerm2.\n' +
+        "      cmux: the box is opened by the relay's queue worker, a cmux-external process, so cmux's default\n" +
+        '      `socketControlMode: cmuxOnly` blocks it. Set `socketControlMode` to `automation` (or `password`)\n' +
+        '      in ~/.config/cmux/cmux.json and run `cmux reload-config` for cmux opens to work.\n',
+    );
+  }
+}
 
 const unsetCommand = new Command('unset')
   .description('Remove a config key from the global or per-project file (default: --project)')

--- a/apps/web/content/docs/configuration.mdx
+++ b/apps/web/content/docs/configuration.mdx
@@ -253,6 +253,10 @@ agentbox config set queue.openIn split --global
 
 By default a background `-i` run just queues and prints its job line. Set `queue.openIn` to `split`, `window`, or `tab` and the host relay opens an attached terminal onto the box the moment its worker finishes creating it — no need to find the box and `attach` by hand. It only fires when the submitting shell is inside tmux, cmux, or iTerm2; cmux opens a new workspace for every mode, and iTerm2 opens relative to the frontmost window. Unlike `attach.openIn` there is no `same` mode (the box is created asynchronously, so it is always a fresh terminal).
 
+<Callout type="warn" title="cmux: allow socket control">
+The box is opened by the relay's queue **worker**, a detached host process — not a cmux-initiated one. cmux's default `socketControlMode: cmuxOnly` only trusts processes cmux itself started, so it blocks the worker and nothing opens. To use `queue.openIn` under cmux, set `socketControlMode` to `automation` (or `password`) in `~/.config/cmux/cmux.json` and run `cmux reload-config`. tmux and iTerm2 need no such change.
+</Callout>
+
 Auto-pause only ever targets a box whose live agent has settled to **idle** for `idleMinutes`. A box where **any** agent (Claude, Codex, or OpenCode) is working, compacting, or waiting on you is never auto-paused. If a box does get paused while you still need it, `agentbox drive …`, `agentbox shell`, and `agentbox unpause` all resume it on demand (drive auto-unpauses before it reaches the session).
 
 See [background and parallel](/docs/background-and-parallel) and [checkpoints and pausing](/docs/checkpoints-and-pausing).

--- a/docs/terminal-integration.md
+++ b/docs/terminal-integration.md
@@ -80,7 +80,12 @@ detached (no "current" pane):
 - tmux targets the captured `$TMUX_PANE` so the split/window lands in the
   submitting pane's session and shows up live in the attached client.
 - cmux always opens a **new workspace** (every mode) — a detached worker has no
-  reliable focused surface to split/tab into.
+  reliable focused surface to split/tab into. **Caveat:** cmux's default
+  `socketControlMode: cmuxOnly` only trusts cmux-initiated processes, so it
+  rejects the worker's socket connection (the failure surfaces as a broken-pipe
+  in the queue log). cmux opens require `socketControlMode: automation` (or
+  `password`) in `~/.config/cmux/cmux.json` + `cmux reload-config`. `config set
+  queue.openIn` prints this caveat. tmux/iTerm2 are unaffected.
 - iTerm2 opens relative to the **frontmost** window (no stable submit-time handle
   is captured in v1).
 - Unknown host terminal at submit → nothing is captured and nothing opens.


### PR DESCRIPTION
## Context

Follow-up to #61. While testing `queue.openIn` under **cmux**, the box never opened. Root cause: cmux's default `socketControlMode: cmuxOnly` only trusts **cmux-initiated** processes, and the relay's queue **worker** is a detached host process — so cmux rejects its socket connection (`Failed to write to socket (Broken pipe)`) and nothing opens. tmux and iTerm2 are unaffected (tmux drives its socket freely; iTerm2 uses Apple events).

The capture + worker-spawn logic itself works correctly — the job manifests recorded the right `openTerminal` targeting and the worker attempted the open. It's purely cmux's socket security.

## Change

- **`agentbox config set queue.openIn <split|window|tab>`** now prints a note: the feature only fires when you submit `-i` from inside tmux/cmux/iTerm2, and **cmux** specifically needs `socketControlMode` set to `automation` (or `password`) in `~/.config/cmux/cmux.json` + `cmux reload-config`, because the relay worker is cmux-external.
- Documents the same caveat in `configuration.mdx` (a warning callout) and `docs/terminal-integration.md`.

No behavior change to the open path itself — this is the discoverability fix for the cmux limitation (kept cmux's secure default intact rather than forcing it down).

## Verification

```
$ agentbox config set queue.openIn split --project
queue.openIn = split   (wrote …/config.yaml)
note: queue.openIn only opens a terminal when you submit the `-i` job from inside tmux, cmux, or iTerm2.
      cmux: the box is opened by the relay's queue worker, a cmux-external process, so cmux's default
      `socketControlMode: cmuxOnly` blocks it. Set `socketControlMode` to `automation` (or `password`)
      in ~/.config/cmux/cmux.json and run `cmux reload-config` for cmux opens to work.
```

`pnpm build`, `typecheck`, `lint`, `test` all green. Diff is 3 files; the added `warnOnSet` helper is prettier-clean (pre-existing prettier drift in the rest of config.ts left untouched).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and post-set stderr messaging only; no changes to queue open or config validation logic.
> 
> **Overview**
> Adds **discoverability** for why `queue.openIn` can fail under **cmux** without changing the open path.
> 
> After a successful non-JSON `agentbox config set queue.openIn` (when the value is not `none`), the CLI prints a **stderr note**: the feature only runs when `-i` is submitted from tmux, cmux, or iTerm2, and cmux must allow **non-cmux-initiated** socket clients because the relay queue worker is external (`socketControlMode: automation` or `password` in `~/.config/cmux/cmux.json` + `cmux reload-config`).
> 
> The same cmux **`socketControlMode: cmuxOnly`** limitation is documented in **`configuration.mdx`** (warning callout under queue & autopause) and **`docs/terminal-integration.md`** (queue.openIn section).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3011c6c25710e5a8b50907c995053092d9e9891c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->