### PR TITLE
fix(wizard): prompt on a stale default checkpoint even for configured projects

### DIFF
--- a/apps/cli/src/commands/create.ts
+++ b/apps/cli/src/commands/create.ts
@@ -32,6 +32,7 @@ import {
   serializeEnvFilesForEnv,
   WIZARD_AUTOLAUNCH_ENV,
   WIZARD_ENV_FILES_ENV,
+  WIZARD_RECREATE_ENV,
 } from '../wizard.js';
 import { evaluateBaseFreshness } from '../checkpoint-lookup.js';
 import { runPrepare } from './prepare.js';
@@ -336,8 +337,11 @@ export const createCommand = new Command('create')
     }
     // Drop a stale/dead default checkpoint so the box provisions from the
     // current base. On the docker switch-to-claude re-dispatch below the
-    // default isn't forwarded as `--snapshot`, so the inner `agentbox claude`
-    // re-evaluates and discards it too — no extra signal needed.
+    // default isn't forwarded as `--snapshot`; the inner `agentbox claude`
+    // re-evaluates a *missing/dead* default and discards it too. A *stale*
+    // default that the user chose to RECREATE is forwarded explicitly via
+    // WIZARD_RECREATE_ENV, because the inner non-interactive pass would
+    // otherwise keep a stale checkpoint for a configured project.
     const effectiveCheckpointRef = wiz.discardCheckpoint ? undefined : checkpointRef;
     if (wiz.action === 'switch-to-claude' && isDocker) {
       // Docker: hand off to `agentbox claude` whose default action creates +
@@ -345,12 +349,14 @@ export const createCommand = new Command('create')
       // normal create flow below and attach claude post-create, because
       // `agentbox claude`'s default action ignores --provider.
       process.env[WIZARD_AUTOLAUNCH_ENV] = '1';
+      if (wiz.recreate) process.env[WIZARD_RECREATE_ENV] = '1';
       const serialized = serializeEnvFilesForEnv(wiz.envFilesToImport);
       if (serialized !== undefined) process.env[WIZARD_ENV_FILES_ENV] = serialized;
       try {
         await claudeCommand.parseAsync(passthroughFlags(opts), { from: 'user' });
       } finally {
         delete process.env[WIZARD_AUTOLAUNCH_ENV];
+        delete process.env[WIZARD_RECREATE_ENV];
         delete process.env[WIZARD_ENV_FILES_ENV];
       }
       return;

--- a/apps/cli/src/wizard.ts
+++ b/apps/cli/src/wizard.ts
@@ -59,6 +59,15 @@ export interface WizardOutcome {
    * invalidates any artifact captured against it.
    */
   rebuildBase?: boolean;
+  /**
+   * Set when the user explicitly chose to recreate a stale *default* checkpoint
+   * (vs merely dropping a dead/missing one). On the docker `switch-to-claude`
+   * handoff the caller forwards this via {@link WIZARD_RECREATE_ENV} so the
+   * inner autolaunch pass runs setup + recaptures the snapshot, instead of
+   * `nonInteractiveOutcome` silently keeping the stale checkpoint for a
+   * configured project.
+   */
+  recreate?: boolean;
 }
 
 interface WizardArgs {
@@ -123,6 +132,16 @@ export const WIZARD_AUTOLAUNCH_ENV = 'AGENTBOX_WIZARD_AUTOLAUNCH';
 export const WIZARD_ENV_FILES_ENV = 'AGENTBOX_WIZARD_ENV_FILES';
 
 /**
+ * Sentinel set by `agentbox create` on the docker `switch-to-claude` handoff
+ * when the user chose to recreate a stale default checkpoint. Without it the
+ * re-dispatched `agentbox claude` re-enters non-interactively via
+ * `nonInteractiveOutcome`, which keeps a stale default checkpoint for a
+ * configured project — silently discarding the recreate the user just
+ * confirmed. The inner pass reads this and runs setup (which re-snapshots).
+ */
+export const WIZARD_RECREATE_ENV = 'AGENTBOX_WIZARD_RECREATE';
+
+/**
  * Patterns scanned for the wizard's env-file multiselect. Same set as
  * `--with-env` minus `agentbox.yaml`: the wizard fires precisely *because*
  * there's no agentbox.yaml on the host, so it can never be a match.
@@ -138,6 +157,18 @@ export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutco
     if (args.command !== 'claude') return { action: 'proceed' };
     const envFiles = parseEnvFilesFromEnv(process.env[WIZARD_ENV_FILES_ENV]);
     const proj = await findProjectRoot(args.workspace);
+    // The outer `agentbox create` pass already prompted and the user chose to
+    // recreate a stale default checkpoint. Honor it here — discard the stale
+    // snapshot and run setup (which recaptures it) — instead of letting
+    // `nonInteractiveOutcome` keep it for a configured project.
+    if (process.env[WIZARD_RECREATE_ENV] === '1') {
+      return {
+        action: 'launch-with-prompt',
+        initialPrompt: buildSetupInitialPrompt(proj.root),
+        envFilesToImport: envFiles,
+        discardCheckpoint: true,
+      };
+    }
     return nonInteractiveOutcome(args, proj, await checkpointStatus(args, proj.root), envFiles);
   }
 
@@ -296,6 +327,7 @@ export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutco
       envFilesToImport,
       discardCheckpoint: discardCheckpoint || undefined,
       rebuildBase: rebuildBase || undefined,
+      recreate: recreateChosen || undefined,
     };
   }
 
@@ -305,6 +337,7 @@ export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutco
     envFilesToImport,
     discardCheckpoint: discardCheckpoint || undefined,
     rebuildBase: rebuildBase || undefined,
+    recreate: recreateChosen || undefined,
   };
 }
 

--- a/apps/cli/src/wizard.ts
+++ b/apps/cli/src/wizard.ts
@@ -192,29 +192,15 @@ export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutco
     }
   }
 
-  // An existing agentbox.yaml means the project is already configured; don't
-  // nag. Still drop a dead *default* checkpoint so create doesn't try to boot
-  // a pruned image/snapshot (a stale-but-bootable one is kept — the create
-  // path warns about it). A stale base was handled above (early-returned).
-  if (proj.hasAgentboxYaml) {
-    return { action: 'proceed', discardCheckpoint: discardOnMissing(status, fromDefault) };
-  }
-
-  // A usable checkpoint carries node_modules/env *and* the agentbox.yaml from
-  // when it was captured — skip the "generate one?" prompt entirely. "Usable"
-  // = fresh, or a stale snapshot the user pinned explicitly via `--snapshot`
-  // (kept as-is; the create path warns). A stale *default* is re-prompted
-  // below; a missing one falls through to normal setup. Skipped when the user
-  // already opted in to rebuilding the base — the old checkpoint's gone with it.
-  if (!rebuildBase && (status.state === 'fresh' || (status.state === 'stale' && !fromDefault))) {
-    log.info(`starting from checkpoint "${args.checkpointRef}"; skipping agentbox.yaml setup`);
-    return { action: 'proceed' };
-  }
-
-  // Stale default checkpoint: don't silently boot the old base layers. Offer
-  // to recreate (re-run setup on the current base) or use it anyway. Skipped
-  // when `rebuildBase` is already true — the base rebuild implies a discard,
-  // and recreateChosen below short-circuits the second "set up?" confirm.
+  // Stale DEFAULT checkpoint: the box would boot the old base layers and miss
+  // any base-image update (a CLI upgrade, an edited managed prompt, ...).
+  // Prompt BEFORE the agentbox.yaml early-return — this is about base
+  // freshness, NOT whether the project is configured (mirrors the stale-cloud-
+  // base prompt above). On "recreate" we discard the stale checkpoint and fall
+  // through to the setup flow, which recaptures a fresh `--set-default`
+  // snapshot on the current base (fast when an agentbox.yaml already exists);
+  // on "use it anyway" we keep it as a warm start. Skipped when a base rebuild
+  // was already chosen (it implies a discard).
   let discardCheckpoint = rebuildBase;
   let recreateChosen = rebuildBase;
   if (!rebuildBase && status.state === 'stale' && fromDefault) {
@@ -228,9 +214,35 @@ export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutco
     }
     discardCheckpoint = true;
     recreateChosen = true;
-  } else if (!rebuildBase && status.state === 'missing') {
-    // No bootable artifact for this provider — drop a dead default ref so
-    // create provisions fresh, then fall through to normal setup.
+  }
+
+  // An existing agentbox.yaml means the project is already configured; don't
+  // nag with the setup wizard — UNLESS we're recreating a stale checkpoint,
+  // which must run setup so it captures a fresh snapshot on the current base.
+  // Still drop a dead *default* checkpoint so create doesn't try to boot a
+  // pruned image/snapshot. A stale base was handled above (early-returned).
+  if (proj.hasAgentboxYaml && !recreateChosen) {
+    return { action: 'proceed', discardCheckpoint: discardOnMissing(status, fromDefault) };
+  }
+
+  // A usable checkpoint carries node_modules/env *and* the agentbox.yaml from
+  // when it was captured — skip the "generate one?" prompt entirely. "Usable"
+  // = fresh, or a stale snapshot the user pinned explicitly via `--snapshot`
+  // (kept as-is; the create path warns). A stale *default* was handled above;
+  // a missing one falls through to normal setup. Skipped when rebuilding the
+  // base or recreating (the old checkpoint's gone with it).
+  if (
+    !rebuildBase &&
+    !recreateChosen &&
+    (status.state === 'fresh' || (status.state === 'stale' && !fromDefault))
+  ) {
+    log.info(`starting from checkpoint "${args.checkpointRef}"; skipping agentbox.yaml setup`);
+    return { action: 'proceed' };
+  }
+
+  // Missing default checkpoint: drop the dead ref so create provisions fresh,
+  // then fall through to normal setup.
+  if (!rebuildBase && !recreateChosen && status.state === 'missing') {
     discardCheckpoint = discardOnMissing(status, fromDefault) ?? false;
   }
 

--- a/apps/cli/test/wizard.test.ts
+++ b/apps/cli/test/wizard.test.ts
@@ -1,13 +1,52 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
   buildSetupInitialPrompt,
   IN_BOX_SETUP_GUIDE_PATH,
+  maybeRunSetupWizard,
   parseEnvFilesFromEnv,
   passthroughFlags,
   serializeEnvFilesForEnv,
+  WIZARD_AUTOLAUNCH_ENV,
+  WIZARD_ENV_FILES_ENV,
+  WIZARD_RECREATE_ENV,
 } from '../src/wizard.js';
 
 const NUL = String.fromCharCode(0);
+
+describe('maybeRunSetupWizard — create→claude autolaunch handoff', () => {
+  afterEach(() => {
+    delete process.env[WIZARD_AUTOLAUNCH_ENV];
+    delete process.env[WIZARD_RECREATE_ENV];
+    delete process.env[WIZARD_ENV_FILES_ENV];
+  });
+
+  it('carries the stale-checkpoint recreate across the handoff (discard + run setup)', async () => {
+    // The outer `agentbox create` pass set these before re-dispatching to
+    // `agentbox claude`. The inner pass must honor the recreate the user
+    // already confirmed — not silently keep the stale checkpoint.
+    process.env[WIZARD_AUTOLAUNCH_ENV] = '1';
+    process.env[WIZARD_RECREATE_ENV] = '1';
+    const outcome = await maybeRunSetupWizard({
+      workspace: process.cwd(),
+      yes: false,
+      command: 'claude',
+    });
+    expect(outcome.action).toBe('launch-with-prompt');
+    expect(outcome.discardCheckpoint).toBe(true);
+    expect(outcome.initialPrompt).toBeTruthy();
+  });
+
+  it('non-claude command in autolaunch is a no-op proceed', async () => {
+    process.env[WIZARD_AUTOLAUNCH_ENV] = '1';
+    process.env[WIZARD_RECREATE_ENV] = '1';
+    const outcome = await maybeRunSetupWizard({
+      workspace: process.cwd(),
+      yes: false,
+      command: 'create',
+    });
+    expect(outcome.action).toBe('proceed');
+  });
+});
 
 describe('passthroughFlags', () => {
   it('returns empty for an empty options object', () => {


### PR DESCRIPTION
## Problem
The interactive stale-snapshot prompt — *"Snapshot X is stale … Recreate it from the current base? (No = use it anyway)"* (`wizard.ts`) — sat **after** the `hasAgentboxYaml` early-return. So any project with an `agentbox.yaml` (i.e. every configured project) skipped the prompt entirely and silently booted the old base layers, missing base-image updates (e.g. a CLI upgrade / new in-box behavior).

The only remaining signal was the `createBox` log warning, but the CLI pipes that channel into the clack **spinner** (`s.message`), so the multi-line WARNING is immediately overwritten and scrolls by unseen. Net: a configured project got **neither** a visible prompt nor a visible warning when restoring a stale default checkpoint.

This was found via a real case: an `optima` box kept booting from a checkpoint frozen with the old `agentbox-ctl` (no new scraper), with no visible warning.

## Fix
Hoist the stale-default-checkpoint prompt **above** the configured-project early-return — mirroring the stale-**cloud-base** prompt, which already deliberately runs there (its comment: *"re-prompt BEFORE the agentbox.yaml early-return"*). Checkpoint staleness is about base freshness, not whether the project is set up.

- On **recreate**: discard the stale checkpoint and fall through to the setup flow, which recaptures a fresh `--set-default` snapshot on the current base. Fast when an `agentbox.yaml` already exists (the `/agentbox-setup` skill ends with `agentbox checkpoint --set-default`). The `hasAgentboxYaml` early-return now fires only when **not** recreating.
- On **use it anyway**: keep the warm checkpoint, exactly as before.
- Non-interactive (`-y`/`-i`) behavior is unchanged.

## Verification
- `pnpm build` / typecheck / lint clean; wizard + commands unit tests pass (32).
- **PTY harness against the real `optima` project** (has `agentbox.yaml` + a stale default checkpoint): `agentbox claude` now shows the recreate prompt —
  > Snapshot "optima-bbce43c9a-1" is stale (base image updated since capture (captured e601c80c5cfa, current f995e4c91767)). Recreate it from the current base? (No = use it anyway)

  — which it did **not** show before this change. Aborted at the prompt so no box was provisioned.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI wizard and env-sentinel changes around checkpoint staleness; behavior is covered by new unit tests with no auth or data-path impact.
> 
> **Overview**
> **Moves the stale default-checkpoint prompt ahead of the configured-project (`agentbox.yaml`) short-circuit**, so projects that already have config still see *"Snapshot … is stale … Start from base and run Setup Wizard?"* instead of silently booting old base layers. Choosing **recreate** discards the stale snapshot and continues into setup (which recaptures a fresh default on the current base); **use it anyway** is unchanged.
> 
> **Fixes the Docker `agentbox create` → `agentbox claude` handoff** when the user chose recreate: the inner autolaunch pass no longer uses `nonInteractiveOutcome`, which kept a stale default checkpoint for configured projects. A new `WIZARD_RECREATE_ENV` sentinel (and `recreate` on `WizardOutcome`) forces `launch-with-prompt` with `discardCheckpoint: true` on the inner pass.
> 
> Unit tests cover the autolaunch recreate path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd2b2596af06ba56e253bdf2fe7fec8ed62583b7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->