### PR TITLE
fix(schema): document the carry: block in the agentbox.yaml JSON schema

### DIFF
--- a/packages/ctl/schema/agentbox.schema.json
+++ b/packages/ctl/schema/agentbox.schema.json
@@ -31,9 +31,63 @@
       "type": "object",
       "description": "Host-side AgentBox layered-config defaults for this project. Same shape as ~/.agentbox/config.yaml. The supervisor ignores this; @agentbox/config validates it strictly when loaded. See https://agent-box.sh/schema/user-config.schema.json for the full key set.",
       "additionalProperties": true
-    }
+    },
+    "carry": { "$ref": "#/$defs/carry" }
   },
   "$defs": {
+    "carry": {
+      "type": "array",
+      "description": "Host-applied declarative host→box file copy, read by the agentbox CLI at create time (NOT by the supervisor). Bypasses .gitignore. Each entry is a {src,dest,...} mapping or a \"src=dest\" shorthand string. The host prompts once to approve before copying; auto-approve with --carry-yes, skip with --carry skip. When copying a directory, heavy regenerable dirs (.git, node_modules, bin, obj, packages, dist, .next, target) are dropped by default. Use case: develop AgentBox inside an AgentBox by carrying ~/.agentbox/secrets.env + ~/.agentbox/claude-credentials.json.",
+      "items": { "$ref": "#/$defs/carryItem" }
+    },
+    "carryItem": {
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1,
+          "description": "Shorthand: \"src\" (mirror src→src; src must be absolute or ~/) or \"src=dest\"."
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["src"],
+          "properties": {
+            "src": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Host path. Must start with /, ~/, or ./ (~/ = host home; ./ = project root)."
+            },
+            "dest": {
+              "type": "string",
+              "minLength": 1,
+              "description": "In-box destination. Must start with / or ~/ (~/ expands to /home/vscode). Defaults to src when omitted (not allowed when src starts with ./)."
+            },
+            "mode": {
+              "description": "Octal file mode applied in-box, e.g. \"0600\", \"0o600\", or 384.",
+              "oneOf": [
+                { "type": "string", "minLength": 1 },
+                { "type": "integer", "minimum": 0 }
+              ]
+            },
+            "user": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 65535,
+              "description": "Numeric uid that owns the copied file in-box (default 1000 = vscode; 0 keeps it root-owned)."
+            },
+            "exclude": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 },
+              "description": "tar globs (e.g. \"*/cache\") or bare dir names to drop when copying a directory. Additive on top of the default heavy-dir excludes."
+            },
+            "optional": {
+              "type": "boolean",
+              "description": "true skips a missing src silently instead of erroring."
+            }
+          }
+        }
+      ]
+    },
     "command": {
       "description": "Shell string (run via `bash -c`) or argv array. Non-empty.",
       "oneOf": [

--- a/packages/ctl/test/schema-drift.test.ts
+++ b/packages/ctl/test/schema-drift.test.ts
@@ -22,6 +22,11 @@ interface Fixture {
   // accepts them. Those rows are documented here but skipped from the agreement
   // assertion.
   runtimeOnly?: true;
+  // `schemaOnly` is the mirror image: the JSON schema rejects, but the runtime
+  // supervisor accepts. Used for `carry:` — the supervisor only whitelists the
+  // top-level key (the host CLI parses its contents), so it never validates
+  // carry item shape, while the schema does.
+  schemaOnly?: true;
 }
 
 const VALID: Fixture[] = [
@@ -189,6 +194,33 @@ defaults:
 services:
   web:
     command: pnpm dev
+`,
+  },
+  // Top-level `carry:` block — host-applied (read by the agentbox CLI, not the
+  // supervisor). The schema documents/validates the item shape; the supervisor
+  // only whitelists the key (see schemaOnly fixtures below).
+  {
+    name: 'carry shorthand string entry',
+    yaml: `carry:\n  - ~/.agentbox/secrets.env\n`,
+  },
+  {
+    name: 'carry mapping with dest + exclude',
+    yaml: `
+carry:
+  - src: ./legacy
+    dest: ~/legacy
+    exclude: ["*/cache", ".git"]
+    optional: true
+`,
+  },
+  {
+    name: 'carry mapping with mode + user',
+    yaml: `
+carry:
+  - src: ~/.agentbox/secrets.env
+    dest: ~/.agentbox/secrets.env
+    mode: "0600"
+    user: 1000
 `,
   },
 ];
@@ -484,6 +516,28 @@ services:
 `,
     runtimeOnly: true,
   },
+  // carry: the schema validates item shape; the supervisor only whitelists the
+  // top-level key, so it accepts these (schema-only rejections).
+  {
+    name: 'carry item missing src (schema-only)',
+    yaml: `carry:\n  - dest: ~/x\n`,
+    schemaOnly: true,
+  },
+  {
+    name: 'carry item with unknown key (schema-only)',
+    yaml: `carry:\n  - src: ./a\n    dest: ~/a\n    bogus: 1\n`,
+    schemaOnly: true,
+  },
+  {
+    name: 'carry exclude not an array (schema-only)',
+    yaml: `carry:\n  - src: ./a\n    dest: ~/a\n    exclude: "nope"\n`,
+    schemaOnly: true,
+  },
+  {
+    name: 'carry not an array (schema-only)',
+    yaml: `carry: 42\n`,
+    schemaOnly: true,
+  },
 ];
 
 function runtimeAccepts(yaml: string): boolean {
@@ -514,6 +568,15 @@ describe('JSON Schema ↔ runtime validator agreement', () => {
         expect(runtimeAccepts(f.yaml)).toBe(false);
         // Schema accepts — documented gap (cross-field rule).
         expect(schemaAccepts(f.yaml)).toBe(true);
+      });
+      continue;
+    }
+    if (f.schemaOnly) {
+      it(`schema-only reject: ${f.name}`, () => {
+        // Runtime accepts — the supervisor whitelists `carry:` but never
+        // validates its item shape (the host CLI does, separately).
+        expect(runtimeAccepts(f.yaml)).toBe(true);
+        expect(schemaAccepts(f.yaml)).toBe(false);
       });
       continue;
     }


### PR DESCRIPTION
## Problem

An in-box agent fetched the published schema (`agent-box.sh/schema/agentbox.schema.json`) to learn how to bring host files into the box, concluded **"No formal carry key in the schema,"** and fell back to a brittle manual workaround (hand `cp`s + a restore-style task) instead of using `carry:`.

Root cause: the schema is `additionalProperties: false` at the top level with no `carry` property, so it both **hides** `carry` from discovery and would mark any `carry:` block as **invalid** for editors / agents validating against it. The runtime supervisor already whitelists `carry` (`config.ts` `TOP_LEVEL_KEYS`), so this was purely a schema/discoverability gap.

## Changes

- **`packages/ctl/schema/agentbox.schema.json`** — add a rich, strict `carry` definition: an array of `"src=dest"` shorthand strings or `{src,dest,mode,user,exclude,optional}` mappings, with descriptions covering the host-applied semantics, the default heavy-dir excludes, and the new `exclude` key. Mirrors `CarryItem` in `ctl/carry.ts` and the table in `agentbox-yaml.mdx`.
- **`packages/ctl/test/schema-drift.test.ts`** — the supervisor whitelists `carry` but never validates its shape, so the schema is intentionally stricter than the runtime. Added a `schemaOnly` fixture flag (mirror of the existing `runtimeOnly`) plus carry VALID + schemaOnly fixtures, keeping the schema↔runtime agreement test honest.

The web `public/schema/` copy is gitignored and regenerated by `copy-schema.mjs` at web build/deploy, so the live site picks this up on the next deploy.

## Verification

- `pnpm --filter @agentbox/ctl test` — schema-drift green (63 → 67 cases incl. new carry VALID + schemaOnly).
- ajv sanity: a real carry block (shorthand + mapping with `exclude`) validates; a malformed entry (missing `src`) fails.
- `pnpm typecheck` + `pnpm lint` clean; full ctl suite (201 tests) green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema and test-only changes; runtime supervisor behavior is unchanged and carry was already whitelisted.
> 
> **Overview**
> Documents the top-level **`carry:`** block in `agentbox.schema.json` so editors and agents validating against the published schema can discover host→box file copy instead of treating it as an unknown/invalid key.
> 
> The schema adds a strict **`carry`** array definition: shorthand `"src"` / `"src=dest"` strings or objects with **`src`**, **`dest`**, **`mode`**, **`user`**, **`exclude`**, and **`optional`**, plus descriptions for CLI create-time behavior, default heavy-dir excludes, and approval flags. **`schema-drift.test.ts`** gains a **`schemaOnly`** fixture mode (mirror of **`runtimeOnly`**) because the supervisor only whitelists **`carry`** and does not validate item shape—while the schema does—along with valid carry examples and schema-only rejection cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dc2453bb3038608563bb9d68217f5c9d19af06b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->