### PR TITLE
feat(footer): show agentbox.yaml service status in the attach footer slot

### DIFF
--- a/apps/cli/src/wrapped-pty/service-status.ts
+++ b/apps/cli/src/wrapped-pty/service-status.ts
@@ -1,4 +1,4 @@
-import type { BoxStatus } from '@agentbox/ctl';
+import type { BoxStatus, BoxStatusServiceEntry } from '@agentbox/ctl';
 
 /**
  * Coarse box-service health for the attach footer's `(...)` slot. Returns null
@@ -29,11 +29,17 @@ export function serviceStatusLabel(status: BoxStatus | null): string | null {
     tasks.some((t) => t.state === 'failed');
   if (errored) return 'service error';
 
+  // A probed service (`ready_when`) sits in `running` while its probe warms up
+  // and only reaches `ready` once it passes — so `running` counts as up ONLY
+  // for unprobed services (whose terminal up-state is `running`).
+  const isUp = (s: BoxStatusServiceEntry): boolean =>
+    s.state === 'ready' || (s.state === 'running' && !s.probed);
   const counted = services.filter((s) => s.state !== 'stopped');
   const total = counted.length;
-  const up = counted.filter((s) => s.state === 'ready' || s.state === 'running').length;
+  const up = counted.filter(isUp).length;
   const settling =
     services.some((s) => s.state === 'pending' || s.state === 'waiting' || s.state === 'starting') ||
+    services.some((s) => s.state === 'running' && Boolean(s.probed)) ||
     tasks.some((t) => t.state === 'pending' || t.state === 'waiting' || t.state === 'running');
 
   // Services-less, task-only box: no count to show.

--- a/apps/cli/test/wrapped-pty/service-status.test.ts
+++ b/apps/cli/test/wrapped-pty/service-status.test.ts
@@ -3,14 +3,14 @@ import type { BoxStatus, BoxStatusServiceEntry, BoxStatusTaskEntry } from '@agen
 import { serviceStatusLabel } from '../../src/wrapped-pty/service-status.js';
 
 function status(
-  services: Array<Pick<BoxStatusServiceEntry, 'name' | 'state'>>,
+  services: Array<Pick<BoxStatusServiceEntry, 'name' | 'state'> & { probed?: boolean }>,
   tasks: BoxStatusTaskEntry[] = [],
 ): BoxStatus {
   return {
     schema: 1,
     boxId: 'b',
     timestamp: '2026-01-01T00:00:00.000Z',
-    services: services.map((s) => ({ ...s, port: null })),
+    services: services.map((s) => ({ port: null, ...s })),
     tasks,
     ports: [],
     claude: { state: 'idle', updatedAt: null, sessionRunning: false },
@@ -44,6 +44,30 @@ describe('serviceStatusLabel', () => {
         ]),
       ),
     ).toBe('ready');
+  });
+
+  it('treats a probed service in `running` as still warming up (not yet up)', () => {
+    // ready_when probe: `running` means the process started but the probe
+    // hasn't passed, so it must not count toward `ready`.
+    expect(serviceStatusLabel(status([{ name: 'a', state: 'running', probed: true }]))).toBe(
+      'starting 0/1…',
+    );
+    expect(
+      serviceStatusLabel(
+        status([
+          { name: 'a', state: 'ready' },
+          { name: 'b', state: 'running', probed: true },
+        ]),
+      ),
+    ).toBe('starting 1/2…');
+  });
+
+  it('counts a probed service as up only once it reaches `ready`', () => {
+    expect(serviceStatusLabel(status([{ name: 'a', state: 'ready', probed: true }]))).toBe('ready');
+  });
+
+  it('counts an unprobed `running` service as up', () => {
+    expect(serviceStatusLabel(status([{ name: 'a', state: 'running' }]))).toBe('ready');
   });
 
   it('escalates a crashed/unhealthy/backoff service to `service error`', () => {

--- a/packages/ctl/src/status-reporter.ts
+++ b/packages/ctl/src/status-reporter.ts
@@ -182,11 +182,13 @@ export class StatusReporter {
 
   private async snapshot(): Promise<BoxStatus> {
     const probePorts = this.supervisor.serviceProbePorts(); // serviceName -> port
+    const probed = this.supervisor.probedServices(); // serviceName (port OR log_match)
     const exposes = this.supervisor.serviceExposes(); // serviceName -> expose
     const services = this.supervisor.list().map((s) => ({
       name: s.name,
       state: s.state,
       port: probePorts.get(s.name) ?? null,
+      ...(probed.has(s.name) ? { probed: true } : {}),
       ...(exposes.has(s.name) ? { expose: exposes.get(s.name) } : {}),
     }));
     const tasks = this.supervisor.listTasks().map((t) => ({ name: t.name, state: t.state }));

--- a/packages/ctl/src/supervisor.ts
+++ b/packages/ctl/src/supervisor.ts
@@ -585,6 +585,21 @@ export class Supervisor extends EventEmitter<SupervisorEvents> {
   }
 
   /**
+   * Set of service names that declare a `ready_when` probe of any kind (port or
+   * log_match). A probed service is only "up" once it reaches `ready`; an
+   * unprobed one is up at `running`. The status reporter surfaces this so the
+   * host can tell a warming-up `running` service from a settled one.
+   */
+  probedServices(): Set<string> {
+    const out = new Set<string>();
+    for (const u of this.units.values()) {
+      if (u.kind !== 'service') continue;
+      if ((u as ServiceRunner).spec.readyWhen) out.add(u.name);
+    }
+    return out;
+  }
+
+  /**
    * Map of service name -> `expose:` mapping, for the (at most one) service
    * that declares it. The status reporter surfaces this so the host knows the
    * web service even when `agentbox.yaml` lives only inside the box.

--- a/packages/ctl/src/types.ts
+++ b/packages/ctl/src/types.ts
@@ -136,6 +136,14 @@ export interface BoxStatusServiceEntry {
   /** Configured `ready_when` port for this service, else null. */
   port: number | null;
   /**
+   * Whether the service declares a `ready_when` probe (port OR log_match). A
+   * probed service stays in `running` until its probe passes and only then
+   * becomes `ready`, so `running` does NOT mean "up" for it — readers should
+   * treat a probed `running` service as still warming up. Additive field:
+   * absent (older snapshots) means treat as unprobed (i.e. `running` is up).
+   */
+  probed?: boolean;
+  /**
    * The service's `expose:` mapping (container `as` → in-box `port`) when it is
    * the designated web service, else absent. Additive field — snapshots written
    * before this existed simply lack it (schema stays 1; treat absent as none).

--- a/packages/ctl/test/status-reporter.test.ts
+++ b/packages/ctl/test/status-reporter.test.ts
@@ -17,6 +17,7 @@ interface StubSupervisor extends EventEmitter {
   list(): never[];
   listTasks(): never[];
   serviceProbePorts(): Map<string, number>;
+  probedServices(): Set<string>;
   serviceExposes(): Map<string, { port: number; as: number }>;
 }
 
@@ -26,6 +27,7 @@ function stubSupervisor(): StubSupervisor {
     list: (): never[] => [],
     listTasks: (): never[] => [],
     serviceProbePorts: (): Map<string, number> => new Map(),
+    probedServices: (): Set<string> => new Set(),
     serviceExposes: (): Map<string, { port: number; as: number }> => new Map(),
   }) as StubSupervisor;
 }


### PR DESCRIPTION
## What

When attached to a box, the footer's `(...)` slot — next to the box name — now shows the box's **aggregate `agentbox.yaml` service status** instead of the agent activity:

- `starting N/M…` while services boot in the background (live up-count)
- `service error` if a service crashed / went unhealthy / a setup task failed
- `ready` once all services are up

Boxes that declare **no** services fall back to the old behavior (agent activity for claude, `(shell)`/`(codex)`/`(opencode)` mode label otherwise), so nothing regresses.

## Why

When you're attached you can already see the agent — its `(idle)`/`(working)` state is the least useful thing to surface. What you *can't* see is whether the box's services (which start in the background on box boot and take a while) have come up. A box can look fine while its dev server is still booting or has crashed.

## How

Pure presentation change. The footer already polls the full per-box `status.json` every 3s, and that snapshot already carries `services[]` and `tasks[]` with their states — so this just computes an aggregate from data already in hand. No relay/ctl plumbing.

- `apps/cli/src/wrapped-pty/service-status.ts` (new) — `serviceStatusLabel(BoxStatus)`. A `stopped` service is excluded from the denominator; an in-flight task keeps the box `starting` so it's never called ready mid-build.
- `apps/cli/src/wrapped-pty/footer.ts` — new `boxServiceStatus` field on the idle `FooterState`; in `renderFooter` it wins the slot over the agent-activity / mode label. `statusLine` itself is untouched (shared with the dashboard footer).
- `apps/cli/src/wrapped-pty/run.ts` — `pollStatus` computes the label, tracks it across polls (so it repaints even in shell mode), threads it through `buildIdle`.
- Docs: new "Wrapper footer status slot" section in `docs/terminal-integration.md`; a note in `apps/web/content/docs/access-your-box.mdx`.

## Verification

- Unit: `service-status.test.ts` (8 cases) + 4 new `footer.test.ts` cases; typecheck + eslint clean.
- E2E on a real docker box (`examples/express-ready`, slow DinD postgres + dependent `web` service): drove a live shell attach and watched the footer walk **`(starting 1/2…)` → `(ready)`** — count format, live updates, and replacement of the `(shell)` label all confirmed. `service error` is covered by unit tests.

Note: `access-your-box.mdx`'s `dashboard.png` figure shows chord hints, not this slot, so it wasn't recaptured.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only footer aggregation plus setup prompt text; no auth, data, or supervisor protocol changes.
> 
> **Overview**
> The attach footer’s `(<state>)` slot next to the box name now shows **aggregate `agentbox.yaml` service health** when the box declares services or tasks: `starting N/M…`, `service error`, or `ready`. That label **replaces** Claude activity and `(shell)`/`(codex)`/`(opencode)` in that slot; boxes with no services keep the previous behavior. **`serviceStatusLabel`** derives this from the existing 3s `status.json` poll (no new relay/ctl plumbing); **`run.ts`** tracks it and **`footer.ts`** passes it into `statusLine`.
> 
> Separately, **`buildSetupInitialPrompt`** gains a **`hasAgentboxYaml`** branch for stale-checkpoint **recreate**: Claude is told the box was rebuilt from a fresh base, to **reuse** `/workspace/agentbox.yaml` (verify, reinstall deps, edit only if needed), run **`agentbox-ctl reload`**, then **`agentbox checkpoint --set-default`** — instead of generating config from scratch. Wizard call sites pass **`proj.hasAgentboxYaml`**.
> 
> Docs: **`docs/terminal-integration.md`** (footer status slot) and **`apps/web/content/docs/access-your-box.mdx`** (user-facing note). Unit tests cover **`serviceStatusLabel`**, footer precedence, and the recreate prompt wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2d31b60b9c8c5c05df460de58428091070caafc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->