### PR TITLE
fix(prompts): Ctrl+C at interactive prompts quits instead of accepting "No"

### DIFF
--- a/apps/cli/src/carry-prompt.ts
+++ b/apps/cli/src/carry-prompt.ts
@@ -1,4 +1,4 @@
-import { isCancel, log, select } from '@clack/prompts';
+import { log, select } from './lib/prompt.js';
 import { fmtBytes } from './fmt.js';
 import type { ResolvedCarryEntry } from './lib/carry-resolve.js';
 
@@ -67,7 +67,6 @@ export async function promptForCarry(args: CarryPromptArgs): Promise<CarryDecisi
     initialValue: 'approve',
   });
 
-  if (isCancel(choice)) return 'cancel';
   return choice;
 }
 

--- a/apps/cli/src/commands/checkpoint.ts
+++ b/apps/cli/src/commands/checkpoint.ts
@@ -1,4 +1,4 @@
-import { confirm, isCancel, log } from '@clack/prompts';
+import { confirm, log } from '../lib/prompt.js';
 import { Command } from 'commander';
 import { basename } from 'node:path';
 import {
@@ -380,7 +380,7 @@ const rmSub = new Command('rm')
 
       if (!opts.yes) {
         const ok = await confirm({ message: `Delete checkpoint ${ref}?`, initialValue: false });
-        if (isCancel(ok) || !ok) {
+        if (!ok) {
           log.info('cancelled');
           return;
         }
@@ -484,7 +484,7 @@ async function runCloudCheckpointCreate(box: BoxRecord, opts: CreateOpts): Promi
       message: 'Create checkpoint? The vercel box will stop and reboot.',
       initialValue: false,
     });
-    if (isCancel(ok) || !ok) {
+    if (!ok) {
       log.info('cancelled');
       return;
     }

--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -1,4 +1,4 @@
-import { confirm, intro, isCancel, log, outro, spinner } from '@clack/prompts';
+import { confirm, intro, log, outro, spinner } from '../lib/prompt.js';
 import {
   findProjectRoot,
   loadEffectiveConfig,
@@ -286,7 +286,7 @@ async function maybeRunClaudeLogin(args: {
       ? "You're on a legacy API token (shows as 'Claude API'). Sign in with your Claude subscription instead?"
       : 'Sign in with your Claude subscription? (saved and reused by every box)';
   const answer = await confirm({ message, initialValue: true });
-  if (isCancel(answer) || !answer) {
+  if (!answer) {
     log.info('Skipped sign-in — claude will prompt you to /login inside the box.');
     return;
   }
@@ -339,7 +339,7 @@ async function maybeRunCloudClaudeLogin(args: {
     ? 'Your saved Claude login looks expired. Sign in again? (saved and reused by every box)'
     : 'Sign in with your Claude subscription? (saved and reused by every box)';
   const answer = await confirm({ message, initialValue: true });
-  if (isCancel(answer) || !answer) {
+  if (!answer) {
     log.info('Skipped sign-in — claude will prompt you to /login inside the box.');
     return;
   }

--- a/apps/cli/src/commands/codex.ts
+++ b/apps/cli/src/commands/codex.ts
@@ -1,7 +1,7 @@
 import { access } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { confirm, intro, isCancel, log, outro, spinner } from '@clack/prompts';
+import { confirm, intro, log, outro, spinner } from '../lib/prompt.js';
 import {
   findProjectRoot,
   loadEffectiveConfig,
@@ -233,7 +233,7 @@ async function maybeRunCodexLogin(args: { image: string; yes: boolean }): Promis
     message: 'Sign in to Codex? (saved and reused by every box)',
     initialValue: true,
   });
-  if (isCancel(answer) || !answer) {
+  if (!answer) {
     log.info('Skipped sign-in — codex will prompt you to sign in inside the box.');
     return;
   }
@@ -285,7 +285,7 @@ async function maybeRunCloudCodexLogin(args: { image: string; yes: boolean }): P
     message: 'Sign in to Codex? (saved and reused by every box)',
     initialValue: true,
   });
-  if (isCancel(answer) || !answer) {
+  if (!answer) {
     log.info('Skipped sign-in — codex will prompt you to sign in inside the box.');
     return;
   }

--- a/apps/cli/src/commands/destroy.ts
+++ b/apps/cli/src/commands/destroy.ts
@@ -1,4 +1,4 @@
-import { confirm, isCancel, log } from '@clack/prompts';
+import { confirm, log } from '../lib/prompt.js';
 import { execa } from 'execa';
 import { findProjectRoot } from '@agentbox/config';
 import { readState, resolveBoxRef } from '@agentbox/sandbox-core';
@@ -89,7 +89,7 @@ export const destroyCommand = new Command('destroy')
           message: 'Destroy this box?',
           initialValue: false,
         });
-        if (isCancel(ok) || !ok) {
+        if (!ok) {
           log.info('cancelled');
           return;
         }

--- a/apps/cli/src/commands/download-claude.ts
+++ b/apps/cli/src/commands/download-claude.ts
@@ -1,4 +1,4 @@
-import { confirm, isCancel, log } from '@clack/prompts';
+import { confirm, log } from '../lib/prompt.js';
 import { Command } from 'commander';
 import {
   DEFAULT_BOX_IMAGE,
@@ -70,7 +70,7 @@ export const downloadClaudeCommand = new Command('claude')
           message: `Download ${preview.newItems.length} new Claude extension(s) into ~/.claude? (existing items are never overwritten)`,
           initialValue: false,
         });
-        if (isCancel(ok) || !ok) {
+        if (!ok) {
           log.info('cancelled');
           return;
         }

--- a/apps/cli/src/commands/download-codex.ts
+++ b/apps/cli/src/commands/download-codex.ts
@@ -1,4 +1,4 @@
-import { confirm, isCancel, log } from '@clack/prompts';
+import { confirm, log } from '../lib/prompt.js';
 import { Command } from 'commander';
 import {
   DEFAULT_BOX_IMAGE,
@@ -60,7 +60,7 @@ export const downloadCodexCommand = new Command('codex')
           message: `Download ${preview.newItems.length} Codex item(s) into ~/.codex? (existing items are never overwritten)`,
           initialValue: false,
         });
-        if (isCancel(ok) || !ok) {
+        if (!ok) {
           log.info('cancelled');
           return;
         }

--- a/apps/cli/src/commands/download-config.ts
+++ b/apps/cli/src/commands/download-config.ts
@@ -1,4 +1,4 @@
-import { confirm, isCancel, log } from '@clack/prompts';
+import { confirm, log } from '../lib/prompt.js';
 import { Command } from 'commander';
 import { inspectBox, pullToHost, startBox, unpauseBox } from '@agentbox/sandbox-docker';
 import { resolveBoxOrExit } from '../box-ref.js';
@@ -80,7 +80,7 @@ export const downloadConfigCommand = new Command('config')
           message: `Download ${preview.changes.length} config file(s) into ${box.workspacePath}? (existing files will be overwritten)`,
           initialValue: false,
         });
-        if (isCancel(ok) || !ok) {
+        if (!ok) {
           log.info('cancelled');
           return;
         }

--- a/apps/cli/src/commands/download-env.ts
+++ b/apps/cli/src/commands/download-env.ts
@@ -1,4 +1,4 @@
-import { confirm, isCancel, log } from '@clack/prompts';
+import { confirm, log } from '../lib/prompt.js';
 import { Command } from 'commander';
 import {
   DEFAULT_ENV_PATTERNS,
@@ -94,7 +94,7 @@ export const downloadEnvCommand = new Command('env')
           message: `Download ${preview.changes.length} env/config file(s) into ${box.workspacePath}? (existing files will be overwritten)`,
           initialValue: false,
         });
-        if (isCancel(ok) || !ok) {
+        if (!ok) {
           log.info('cancelled');
           return;
         }

--- a/apps/cli/src/commands/download-opencode.ts
+++ b/apps/cli/src/commands/download-opencode.ts
@@ -1,4 +1,4 @@
-import { confirm, isCancel, log } from '@clack/prompts';
+import { confirm, log } from '../lib/prompt.js';
 import { Command } from 'commander';
 import {
   DEFAULT_BOX_IMAGE,
@@ -60,7 +60,7 @@ export const downloadOpencodeCommand = new Command('opencode')
           message: `Download ${preview.newItems.length} OpenCode item(s) into ~/.config + ~/.local/share opencode? (existing items are never overwritten)`,
           initialValue: false,
         });
-        if (isCancel(ok) || !ok) {
+        if (!ok) {
           log.info('cancelled');
           return;
         }

--- a/apps/cli/src/commands/download.ts
+++ b/apps/cli/src/commands/download.ts
@@ -1,4 +1,4 @@
-import { confirm, isCancel, log } from '@clack/prompts';
+import { confirm, log } from '../lib/prompt.js';
 import { Command } from 'commander';
 import {
   DEFAULT_ENV_PATTERNS,
@@ -82,7 +82,7 @@ export const downloadCommand = new Command('download')
             message: `Overwrite ${box.workspacePath} with the cloud box's /workspace contents?`,
             initialValue: false,
           });
-          if (isCancel(ok) || !ok) {
+          if (!ok) {
             log.info('cancelled');
             return;
           }
@@ -153,7 +153,7 @@ export const downloadCommand = new Command('download')
           message: `Download ${preview.changes.length} changed file(s)${opts.withEnv ? ' (incl. env/config)' : ''} into ${box.workspacePath}?`,
           initialValue: false,
         });
-        if (isCancel(ok) || !ok) {
+        if (!ok) {
           log.info('cancelled');
           return;
         }

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -17,7 +17,7 @@
  * when `~/.agentbox/setup-complete.json` is absent.
  */
 
-import { confirm, intro, isCancel, log, note, outro, select, spinner } from '@clack/prompts';
+import { confirm, intro, log, note, outro, select, spinner } from '../lib/prompt.js';
 import { Command } from 'commander';
 import {
   existsSync,
@@ -376,7 +376,6 @@ async function runProviderLogin(name: ProviderName): Promise<boolean> {
     if (status.configured) {
       log.info('daytona: already configured');
       const rotate = await confirm({ message: 'Re-authenticate Daytona?', initialValue: false });
-      if (isCancel(rotate)) return false;
       if (rotate) await mod.ensureDaytonaCredentials({ force: true });
       return true;
     }
@@ -389,7 +388,6 @@ async function runProviderLogin(name: ProviderName): Promise<boolean> {
     if (status.source !== 'none') {
       log.info('hetzner: already configured');
       const rotate = await confirm({ message: 'Re-authenticate Hetzner?', initialValue: false });
-      if (isCancel(rotate)) return false;
       if (rotate) await mod.ensureHetznerCredentials({ force: true });
       return true;
     }
@@ -402,7 +400,6 @@ async function runProviderLogin(name: ProviderName): Promise<boolean> {
     if (status.auth !== 'none') {
       log.info(`vercel: already configured (${status.auth})`);
       const rotate = await confirm({ message: 'Re-authenticate Vercel?', initialValue: false });
-      if (isCancel(rotate)) return false;
       if (rotate) await mod.ensureVercelCredentials({ force: true });
       return true;
     }
@@ -415,7 +412,6 @@ async function runProviderLogin(name: ProviderName): Promise<boolean> {
   if (status.auth !== 'none') {
     log.info(`e2b: already configured (${status.auth})`);
     const rotate = await confirm({ message: 'Re-authenticate E2B?', initialValue: false });
-    if (isCancel(rotate)) return false;
     if (rotate) await mod.ensureE2bCredentials({ force: true });
     return true;
   }
@@ -465,7 +461,7 @@ export async function runInstallWizard(opts: RunInstallWizardOptions = {}): Prom
     log.error(`system check failed: ${hardFail.label} — ${hardFail.detail}`);
     log.info('run `agentbox doctor` for full detail');
     const cont = await confirm({ message: 'Continue anyway?', initialValue: false });
-    if (isCancel(cont) || !cont) {
+    if (!cont) {
       outro('aborted');
       return false;
     }
@@ -490,10 +486,6 @@ export async function runInstallWizard(opts: RunInstallWizardOptions = {}): Prom
         hint: PROVIDER_HINTS[p],
       })),
     });
-    if (isCancel(picked)) {
-      outro('cancelled');
-      return false;
-    }
     providerName = picked;
   }
 
@@ -512,10 +504,6 @@ export async function runInstallWizard(opts: RunInstallWizardOptions = {}): Prom
       ? 'Build the box image now? (~1GB, a few minutes)'
       : `Bake the ${providerName} base snapshot now? (a few minutes, uses cloud time)`;
   const wantPrepare = opts.yes ? true : await confirm({ message: prepareMsg, initialValue: true });
-  if (isCancel(wantPrepare)) {
-    outro('cancelled');
-    return false;
-  }
   if (wantPrepare) {
     try {
       await runPrepare(providerName, {

--- a/apps/cli/src/commands/opencode.ts
+++ b/apps/cli/src/commands/opencode.ts
@@ -1,7 +1,7 @@
 import { access } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { confirm, intro, isCancel, log, outro, spinner } from '@clack/prompts';
+import { confirm, intro, log, outro, spinner } from '../lib/prompt.js';
 import {
   findProjectRoot,
   loadEffectiveConfig,
@@ -220,7 +220,7 @@ async function maybeRunOpencodeLogin(args: { image: string; yes: boolean }): Pro
     message: 'Sign in to OpenCode? (pick a provider; saved and reused by every box)',
     initialValue: true,
   });
-  if (isCancel(answer) || !answer) {
+  if (!answer) {
     log.info('Skipped sign-in — opencode will prompt you to sign in inside the box.');
     return;
   }
@@ -277,7 +277,7 @@ async function maybeRunCloudOpencodeLogin(args: { image: string; yes: boolean })
     message: 'Sign in to OpenCode? (pick a provider; saved and reused by every box)',
     initialValue: true,
   });
-  if (isCancel(answer) || !answer) {
+  if (!answer) {
     log.info('Skipped sign-in — opencode will prompt you to sign in inside the box.');
     return;
   }

--- a/apps/cli/src/commands/prune.ts
+++ b/apps/cli/src/commands/prune.ts
@@ -1,4 +1,4 @@
-import { confirm, isCancel, log } from '@clack/prompts';
+import { confirm, log } from '../lib/prompt.js';
 import { pruneOrphanProjectConfigs } from '@agentbox/config';
 import type { CloudBackend, CloudSandboxSummary } from '@agentbox/core';
 import { readState } from '@agentbox/sandbox-core';
@@ -113,7 +113,7 @@ export const pruneCommand = new Command('prune')
 
       if (!opts.yes) {
         const ok = await confirm({ message: 'Proceed with prune?', initialValue: true });
-        if (isCancel(ok) || !ok) {
+        if (!ok) {
           log.info('cancelled');
           return;
         }
@@ -189,7 +189,7 @@ async function pruneCloud(provider: CloudPruneProvider, opts: PruneOptions): Pro
       message: `Delete ${String(orphans.length)} orphan sandbox(es)?`,
       initialValue: false,
     });
-    if (isCancel(ok) || !ok) {
+    if (!ok) {
       log.info('cancelled');
       return;
     }

--- a/apps/cli/src/commands/update.ts
+++ b/apps/cli/src/commands/update.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { confirm, intro, isCancel, log, outro, spinner } from '@clack/prompts';
+import { confirm, intro, log, outro, spinner } from '../lib/prompt.js';
 import {
   DEFAULT_BOX_IMAGE,
   ensureRelay,
@@ -88,7 +88,7 @@ export const updateCommand = new Command('self-update')
 
       if (!opts.yes) {
         const ok = await confirm({ message: 'Proceed with update?', initialValue: true });
-        if (isCancel(ok) || !ok) {
+        if (!ok) {
           log.info('cancelled');
           return;
         }

--- a/apps/cli/src/lib/prompt.ts
+++ b/apps/cli/src/lib/prompt.ts
@@ -1,0 +1,77 @@
+// Thin wrapper around @clack/prompts whose interactive input prompts quit the
+// process on Ctrl+C instead of returning the cancel symbol. Without it, the
+// historical `if (isCancel(x) || !x)` pattern at every call site silently
+// mapped Ctrl+C onto a "No" answer and the command kept going.
+//
+// Re-exports the rest of the surface (log, spinner, intro, outro, note, cancel,
+// isCancel, group, tasks, …) unchanged so callers swap a single import line.
+
+import {
+  cancel as clackCancel,
+  confirm as clackConfirm,
+  groupMultiselect as clackGroupMultiselect,
+  isCancel,
+  multiselect as clackMultiselect,
+  password as clackPassword,
+  select as clackSelect,
+  selectKey as clackSelectKey,
+  text as clackText,
+  type ConfirmOptions,
+  type GroupMultiSelectOptions,
+  type MultiSelectOptions,
+  type PasswordOptions,
+  type SelectOptions,
+  type TextOptions,
+} from '@clack/prompts';
+
+export * from '@clack/prompts';
+
+// 128 + SIGINT (the conventional Ctrl+C exit code).
+function onCancel(): never {
+  clackCancel('Cancelled.');
+  process.exit(130);
+}
+
+export async function confirm(opts: ConfirmOptions): Promise<boolean> {
+  const v = await clackConfirm(opts);
+  if (isCancel(v)) onCancel();
+  return v;
+}
+
+export async function select<Value>(opts: SelectOptions<Value>): Promise<Value> {
+  const v = await clackSelect<Value>(opts);
+  if (isCancel(v)) onCancel();
+  return v;
+}
+
+export async function selectKey<Value extends string>(opts: SelectOptions<Value>): Promise<Value> {
+  const v = await clackSelectKey<Value>(opts);
+  if (isCancel(v)) onCancel();
+  return v;
+}
+
+export async function multiselect<Value>(opts: MultiSelectOptions<Value>): Promise<Value[]> {
+  const v = await clackMultiselect<Value>(opts);
+  if (isCancel(v)) onCancel();
+  return v;
+}
+
+export async function groupMultiselect<Value>(
+  opts: GroupMultiSelectOptions<Value>,
+): Promise<Value[]> {
+  const v = await clackGroupMultiselect<Value>(opts);
+  if (isCancel(v)) onCancel();
+  return v;
+}
+
+export async function text(opts: TextOptions): Promise<string> {
+  const v = await clackText(opts);
+  if (isCancel(v)) onCancel();
+  return v;
+}
+
+export async function password(opts: PasswordOptions): Promise<string> {
+  const v = await clackPassword(opts);
+  if (isCancel(v)) onCancel();
+  return v;
+}

--- a/apps/cli/src/portless-prompt.ts
+++ b/apps/cli/src/portless-prompt.ts
@@ -1,4 +1,4 @@
-import { confirm, isCancel, log, spinner } from '@clack/prompts';
+import { confirm, log, spinner } from './lib/prompt.js';
 import { setConfigValue } from '@agentbox/config';
 import {
   detectPortless,
@@ -82,8 +82,6 @@ export async function maybePromptPortless(args: PortlessPromptArgs): Promise<boo
       '(installs the portless CLI and starts a local proxy if needed)',
     initialValue: true,
   });
-  // Cancel (Ctrl-C) leaves the key unset so the prompt reappears next time.
-  if (isCancel(answer)) return false;
 
   try {
     await setConfigValue('global', 'portless.enabled', answer, args.cwd, { raw: false });

--- a/apps/cli/src/wizard.ts
+++ b/apps/cli/src/wizard.ts
@@ -1,4 +1,4 @@
-import { confirm, isCancel, log, multiselect } from '@clack/prompts';
+import { confirm, log, multiselect } from './lib/prompt.js';
 import { findProjectRoot } from '@agentbox/config';
 import type { ProviderName } from '@agentbox/core';
 import { DEFAULT_ENV_PATTERNS, scanHostEnvFiles } from '@agentbox/sandbox-docker';
@@ -222,7 +222,7 @@ export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutco
         `Recreate the base${yamlSuffix}? (rebuilds the base — ~${mins} min — then starts fresh)`,
       initialValue: true,
     });
-    if (isCancel(rebuild) || !rebuild) {
+    if (!rebuild) {
       // Boot on the old base — keep any checkpoint as-is (the user opted in
       // to the existing artifact). Mirrors the "use it anyway" arm below.
       return {
@@ -258,7 +258,7 @@ export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutco
       message: `Snapshot "${args.checkpointRef}" is stale (${status.reason}). Start from base and run Setup Wizard? (No = use it anyway)`,
       initialValue: true,
     });
-    if (isCancel(recreate) || !recreate) {
+    if (!recreate) {
       // Use it anyway — keep the checkpoint, skip setup (create path warns).
       return { action: 'proceed' };
     }
@@ -310,7 +310,7 @@ export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutco
         initialValues: found,
         required: false,
       });
-      if (!isCancel(picked) && Array.isArray(picked) && picked.length > 0) {
+      if (picked.length > 0) {
         envFilesToImport = picked;
       }
     }
@@ -323,7 +323,7 @@ export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutco
       message: 'New project: run setup wizard? Will install dependencies and setup agentbox.yaml',
       initialValue: true,
     });
-    if (isCancel(go) || !go) {
+    if (!go) {
       return {
         action: 'proceed',
         envFilesToImport,

--- a/apps/cli/test/carry-prompt.test.ts
+++ b/apps/cli/test/carry-prompt.test.ts
@@ -3,6 +3,7 @@ import { promptForCarry } from '../src/carry-prompt.js';
 import type { ResolvedCarryEntry } from '../src/lib/carry-resolve.js';
 
 vi.mock('@clack/prompts', () => ({
+  cancel: vi.fn(),
   isCancel: (v: unknown) => v === SYMBOL_CANCEL,
   log: { message: vi.fn() },
   select: vi.fn(),
@@ -77,10 +78,20 @@ describe('promptForCarry', () => {
     ).toBe('cancel');
   });
 
-  it('Ctrl-C (isCancel) maps to cancel', async () => {
+  it('Ctrl-C (isCancel) hard-exits with code 130', async () => {
     select.mockResolvedValueOnce(SYMBOL_CANCEL);
-    expect(
-      await promptForCarry({ resolved: [entry()], isTTY: true }),
-    ).toBe('cancel');
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code?: string | number | null) => {
+        throw new Error(`exit:${String(code)}`);
+      });
+    try {
+      await expect(promptForCarry({ resolved: [entry()], isTTY: true })).rejects.toThrow(
+        'exit:130',
+      );
+      expect(exitSpy).toHaveBeenCalledWith(130);
+    } finally {
+      exitSpy.mockRestore();
+    }
   });
 });

--- a/packages/sandbox-daytona/src/credentials.ts
+++ b/packages/sandbox-daytona/src/credentials.ts
@@ -10,8 +10,29 @@ import {
 } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
-import { confirm, isCancel, intro, log, note, outro, password, spinner, text } from '@clack/prompts';
+import {
+  cancel,
+  confirm,
+  isCancel,
+  intro,
+  log,
+  note,
+  outro,
+  password,
+  spinner,
+  text,
+} from '@clack/prompts';
 import { ensureDaytonaEnvLoaded } from './env-loader.js';
+
+// Ctrl+C at a prompt resolves with the cancel symbol; turn that into a real
+// quit so the command never silently continues as if the user answered "No".
+function exitOnCancel<T>(v: T | symbol): T {
+  if (isCancel(v)) {
+    cancel('Cancelled.');
+    process.exit(130);
+  }
+  return v as T;
+}
 
 const DASHBOARD_KEYS_URL = 'https://app.daytona.io/dashboard/keys';
 
@@ -53,21 +74,18 @@ export async function ensureDaytonaCredentials(
     'API key required',
   );
 
-  const open = await confirm({
-    message: `Open ${DASHBOARD_KEYS_URL} in your browser?`,
-    initialValue: true,
-  });
-  if (isCancel(open)) {
-    log.warn('Daytona setup cancelled — re-run `agentbox daytona login` when ready.');
-    return;
-  }
+  const open = exitOnCancel(
+    await confirm({
+      message: `Open ${DASHBOARD_KEYS_URL} in your browser?`,
+      initialValue: true,
+    }),
+  );
   if (open) openDashboard();
 
   // One retry on auth failure (typos are the common case). Beyond that we bail
   // and surface the validation error; the user can re-run `agentbox daytona login`.
   for (let attempt = 0; attempt < 2; attempt++) {
     const creds = await promptForCredentials();
-    if (creds === null) return;
 
     const result = await validateCredentials(creds);
     if (result.ok) {
@@ -104,35 +122,31 @@ interface Credentials {
   organizationId?: string;
 }
 
-async function promptForCredentials(): Promise<Credentials | null> {
-  const key = await password({
-    message: 'Paste your Daytona API key (or JWT token)',
-    validate(v) {
-      if (!v || v.trim().length === 0) return 'Cannot be empty';
-      return undefined;
-    },
-  });
-  if (isCancel(key)) {
-    log.warn('Daytona setup cancelled.');
-    return null;
-  }
+async function promptForCredentials(): Promise<Credentials> {
+  const key = exitOnCancel(
+    await password({
+      message: 'Paste your Daytona API key (or JWT token)',
+      validate(v) {
+        if (!v || v.trim().length === 0) return 'Cannot be empty';
+        return undefined;
+      },
+    }),
+  );
   const trimmed = key.trim();
 
   // JWTs start with `eyJ` (base64-encoded `{"`). API keys don't, and don't need
   // an org ID — the SDK derives it from the key. Only ask for org ID for JWTs.
   if (trimmed.startsWith('eyJ')) {
-    const org = await text({
-      message: 'Paste your Daytona organization ID',
-      placeholder: 'org_...',
-      validate(v) {
-        if (!v || v.trim().length === 0) return 'Cannot be empty';
-        return undefined;
-      },
-    });
-    if (isCancel(org)) {
-      log.warn('Daytona setup cancelled.');
-      return null;
-    }
+    const org = exitOnCancel(
+      await text({
+        message: 'Paste your Daytona organization ID',
+        placeholder: 'org_...',
+        validate(v) {
+          if (!v || v.trim().length === 0) return 'Cannot be empty';
+          return undefined;
+        },
+      }),
+    );
     return { jwtToken: trimmed, organizationId: org.trim() };
   }
 

--- a/packages/sandbox-e2b/src/credentials.ts
+++ b/packages/sandbox-e2b/src/credentials.ts
@@ -20,6 +20,7 @@ import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { hostOpenCommand } from '@agentbox/sandbox-core';
 import {
+  cancel,
   confirm,
   intro,
   isCancel,
@@ -30,6 +31,16 @@ import {
 } from '@clack/prompts';
 import { ensureE2bEnvLoaded, reloadE2bEnv } from './env-loader.js';
 import { hasUsableCredentials } from './sdk.js';
+
+// Ctrl+C at a prompt resolves with the cancel symbol; turn that into a real
+// quit so the command never silently continues as if the user answered "No".
+function exitOnCancel<T>(v: T | symbol): T {
+  if (isCancel(v)) {
+    cancel('Cancelled.');
+    process.exit(130);
+  }
+  return v as T;
+}
 
 const DASHBOARD_KEYS_URL = 'https://e2b.dev/dashboard?tab=keys';
 
@@ -60,24 +71,20 @@ export async function ensureE2bCredentials(
     'Credentials required',
   );
 
-  const openIt = await confirm({
-    message: `Open ${DASHBOARD_KEYS_URL} to create a key?`,
-    initialValue: true,
-  });
-  if (isCancel(openIt)) {
-    log.warn('E2B setup cancelled.');
-    return;
-  }
+  const openIt = exitOnCancel(
+    await confirm({
+      message: `Open ${DASHBOARD_KEYS_URL} to create a key?`,
+      initialValue: true,
+    }),
+  );
   if (openIt) openDashboard();
 
-  const key = await password({
-    message: 'Paste your E2B API key',
-    validate: (v) => (v && v.trim().length > 0 ? undefined : 'Cannot be empty'),
-  });
-  if (isCancel(key)) {
-    log.warn('E2B setup cancelled.');
-    return;
-  }
+  const key = exitOnCancel(
+    await password({
+      message: 'Paste your E2B API key',
+      validate: (v) => (v && v.trim().length > 0 ? undefined : 'Cannot be empty'),
+    }),
+  );
 
   persistCredentials({ apiKey: key.trim() });
   reloadE2bEnv();

--- a/packages/sandbox-hetzner/src/credentials.ts
+++ b/packages/sandbox-hetzner/src/credentials.ts
@@ -10,9 +10,29 @@ import {
 } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
-import { confirm, isCancel, intro, log, note, outro, password, spinner } from '@clack/prompts';
+import {
+  cancel,
+  confirm,
+  isCancel,
+  intro,
+  log,
+  note,
+  outro,
+  password,
+  spinner,
+} from '@clack/prompts';
 import { makeHetznerClient } from './client.js';
 import { ensureHetznerEnvLoaded } from './env-loader.js';
+
+// Ctrl+C at a prompt resolves with the cancel symbol; turn that into a real
+// quit so the command never silently continues as if the user answered "No".
+function exitOnCancel<T>(v: T | symbol): T {
+  if (isCancel(v)) {
+    cancel('Cancelled.');
+    process.exit(130);
+  }
+  return v as T;
+}
 
 const DASHBOARD_KEYS_URL = 'https://console.hetzner.cloud/projects';
 
@@ -59,20 +79,17 @@ export async function ensureHetznerCredentials(
     'API token required',
   );
 
-  const open = await confirm({
-    message: `Open ${DASHBOARD_KEYS_URL} in your browser?`,
-    initialValue: true,
-  });
-  if (isCancel(open)) {
-    log.warn('Hetzner setup cancelled — re-run `agentbox hetzner login` when ready.');
-    return;
-  }
+  const open = exitOnCancel(
+    await confirm({
+      message: `Open ${DASHBOARD_KEYS_URL} in your browser?`,
+      initialValue: true,
+    }),
+  );
   if (open) openDashboard();
 
   // One retry on auth failure (typos / expired token are the common case).
   for (let attempt = 0; attempt < 2; attempt++) {
     const creds = await promptForCredentials();
-    if (creds === null) return;
 
     const result = await validateCredentials(creds);
     if (result.ok) {
@@ -106,18 +123,16 @@ interface Credentials {
   endpoint?: string;
 }
 
-async function promptForCredentials(): Promise<Credentials | null> {
-  const token = await password({
-    message: 'Paste your Hetzner Cloud API token',
-    validate(v) {
-      if (!v || v.trim().length === 0) return 'Cannot be empty';
-      return undefined;
-    },
-  });
-  if (isCancel(token)) {
-    log.warn('Hetzner setup cancelled.');
-    return null;
-  }
+async function promptForCredentials(): Promise<Credentials> {
+  const token = exitOnCancel(
+    await password({
+      message: 'Paste your Hetzner Cloud API token',
+      validate(v) {
+        if (!v || v.trim().length === 0) return 'Cannot be empty';
+        return undefined;
+      },
+    }),
+  );
   return { token: token.trim() };
 }
 

--- a/packages/sandbox-vercel/src/credentials.ts
+++ b/packages/sandbox-vercel/src/credentials.ts
@@ -10,6 +10,7 @@ import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { hostOpenCommand } from '@agentbox/sandbox-core';
 import {
+  cancel,
   confirm,
   isCancel,
   intro,
@@ -22,6 +23,16 @@ import {
   text,
 } from '@clack/prompts';
 import { ensureVercelEnvLoaded, reloadVercelEnv } from './env-loader.js';
+
+// Ctrl+C at a prompt resolves with the cancel symbol; turn that into a real
+// quit so the command never silently continues as if the user answered "No".
+function exitOnCancel<T>(v: T | symbol): T {
+  if (isCancel(v)) {
+    cancel('Cancelled.');
+    process.exit(130);
+  }
+  return v as T;
+}
 import { hasUsableCredentials } from './sdk.js';
 import { cliStorePaths, isNearExpiry, readCliAuth, readCliCurrentTeam } from './cli-store.js';
 import { detectSbx, installSbx, installSbxHint, loginSbx, resetSbxCache } from './sbx-cli.js';
@@ -76,19 +87,17 @@ export async function ensureVercelCredentials(
     'Credentials required',
   );
 
-  const mode = await select({
-    message: 'How do you want to authenticate?',
-    options: [
-      { value: 'cli', label: 'Sign in with Vercel (browser) — recommended for interactive use' },
-      { value: 'token', label: 'Access token (VERCEL_TOKEN + team + project) — best for CI / headless' },
-      { value: 'oidc', label: 'OIDC token (VERCEL_OIDC_TOKEN in env / secrets.env) — short interactive work' },
-    ],
-    initialValue: 'cli',
-  });
-  if (isCancel(mode)) {
-    log.warn('Vercel setup cancelled — re-run `agentbox vercel login` when ready.');
-    return;
-  }
+  const mode = exitOnCancel(
+    await select({
+      message: 'How do you want to authenticate?',
+      options: [
+        { value: 'cli', label: 'Sign in with Vercel (browser) — recommended for interactive use' },
+        { value: 'token', label: 'Access token (VERCEL_TOKEN + team + project) — best for CI / headless' },
+        { value: 'oidc', label: 'OIDC token (VERCEL_OIDC_TOKEN in env / secrets.env) — short interactive work' },
+      ],
+      initialValue: 'cli',
+    }),
+  );
 
   if (mode === 'cli') {
     await runCliLogin();
@@ -116,7 +125,6 @@ export async function ensureVercelCredentials(
   }
 
   const creds = await promptForTokenTrio();
-  if (creds === null) return;
   persistCredentials(creds);
   log.success(`Vercel credentials saved to ${secretsPath()}`);
   await ensureSbxInstalled();
@@ -129,40 +137,35 @@ interface TokenTrio {
   projectId: string;
 }
 
-async function promptForTokenTrio(): Promise<TokenTrio | null> {
-  const openIt = await confirm({
-    message: `Open ${DASHBOARD_TOKENS_URL} to create a token?`,
-    initialValue: true,
-  });
-  if (isCancel(openIt)) return null;
+async function promptForTokenTrio(): Promise<TokenTrio> {
+  const openIt = exitOnCancel(
+    await confirm({
+      message: `Open ${DASHBOARD_TOKENS_URL} to create a token?`,
+      initialValue: true,
+    }),
+  );
   if (openIt) openDashboard();
 
-  const token = await password({
-    message: 'Paste your Vercel access token',
-    validate: (v) => (v && v.trim().length > 0 ? undefined : 'Cannot be empty'),
-  });
-  if (isCancel(token)) {
-    log.warn('Vercel setup cancelled.');
-    return null;
-  }
-  const teamId = await text({
-    message: 'Team ID (team settings → General)',
-    placeholder: 'team_...',
-    validate: (v) => (v && v.trim().length > 0 ? undefined : 'Cannot be empty'),
-  });
-  if (isCancel(teamId)) {
-    log.warn('Vercel setup cancelled.');
-    return null;
-  }
-  const projectId = await text({
-    message: 'Project ID (project settings → General)',
-    placeholder: 'prj_...',
-    validate: (v) => (v && v.trim().length > 0 ? undefined : 'Cannot be empty'),
-  });
-  if (isCancel(projectId)) {
-    log.warn('Vercel setup cancelled.');
-    return null;
-  }
+  const token = exitOnCancel(
+    await password({
+      message: 'Paste your Vercel access token',
+      validate: (v) => (v && v.trim().length > 0 ? undefined : 'Cannot be empty'),
+    }),
+  );
+  const teamId = exitOnCancel(
+    await text({
+      message: 'Team ID (team settings → General)',
+      placeholder: 'team_...',
+      validate: (v) => (v && v.trim().length > 0 ? undefined : 'Cannot be empty'),
+    }),
+  );
+  const projectId = exitOnCancel(
+    await text({
+      message: 'Project ID (project settings → General)',
+      placeholder: 'prj_...',
+      validate: (v) => (v && v.trim().length > 0 ? undefined : 'Cannot be empty'),
+    }),
+  );
   return { token: token.trim(), teamId: teamId.trim(), projectId: projectId.trim() };
 }
 
@@ -258,7 +261,7 @@ async function ensureSbxInstalled(): Promise<{ bin: string } | null> {
       message: `The Vercel sandbox CLI (needed for interactive attach) isn't installed. Install it now? (${installSbxHint()})`,
       initialValue: true,
     });
-    if (isCancel(doInstall) || !doInstall) {
+    if (!doInstall) {
       log.warn(
         `Install it with \`${installSbxHint()}\` to use \`agentbox shell|claude|codex|opencode\` on Vercel boxes.`,
       );
@@ -358,25 +361,27 @@ async function resolveProjectId(token: string, teamId: string): Promise<string |
   const preferred =
     projects.find((p) => p.name === 'agentbox') ??
     projects.find((p) => p.name === 'vercel-sandbox-default-project');
-  const choice = await select({
-    message: 'Which Vercel project should sandboxes run under?',
-    options: [
-      ...projects.map((p) => ({ value: p.id, label: p.name })),
-      { value: CREATE, label: 'Create a new project…' },
-    ],
-    initialValue: preferred ? preferred.id : CREATE,
-  });
-  if (isCancel(choice)) return null;
+  const choice = exitOnCancel(
+    await select({
+      message: 'Which Vercel project should sandboxes run under?',
+      options: [
+        ...projects.map((p) => ({ value: p.id, label: p.name })),
+        { value: CREATE, label: 'Create a new project…' },
+      ],
+      initialValue: preferred ? preferred.id : CREATE,
+    }),
+  );
 
   if (choice !== CREATE) return choice;
 
-  const name = await text({
-    message: 'New project name',
-    placeholder: 'agentbox',
-    defaultValue: 'agentbox',
-    validate: (v) => (v && v.trim().length > 0 ? undefined : 'Cannot be empty'),
-  });
-  if (isCancel(name)) return null;
+  const name = exitOnCancel(
+    await text({
+      message: 'New project name',
+      placeholder: 'agentbox',
+      defaultValue: 'agentbox',
+      validate: (v) => (v && v.trim().length > 0 ? undefined : 'Cannot be empty'),
+    }),
+  );
   try {
     const created = await createProject(token, teamId, name.trim() || 'agentbox');
     return created.id;

--- a/packages/sandbox-vercel/src/credentials.ts
+++ b/packages/sandbox-vercel/src/credentials.ts
@@ -257,10 +257,12 @@ function writeManaged(record: Record<string, string>): void {
 async function ensureSbxInstalled(): Promise<{ bin: string } | null> {
   let det = await detectSbx();
   if (!det.installed) {
-    const doInstall = await confirm({
-      message: `The Vercel sandbox CLI (needed for interactive attach) isn't installed. Install it now? (${installSbxHint()})`,
-      initialValue: true,
-    });
+    const doInstall = exitOnCancel(
+      await confirm({
+        message: `The Vercel sandbox CLI (needed for interactive attach) isn't installed. Install it now? (${installSbxHint()})`,
+        initialValue: true,
+      }),
+    );
     if (!doInstall) {
       log.warn(
         `Install it with \`${installSbxHint()}\` to use \`agentbox shell|claude|codex|opencode\` on Vercel boxes.`,


### PR DESCRIPTION
## Summary

Pressing **Ctrl+C** at an interactive prompt in commands like `agentbox claude`, `agentbox create`, `agentbox codex`, etc. silently accepted the "No" answer and the command kept going. This fixes that: Ctrl+C now quits the whole command with exit code 130 (the SIGINT convention).

### Root cause

`@clack/prompts` resolves a prompt promise with a *cancel symbol* on Ctrl+C — it doesn't kill the process. Throughout the CLI we then lumped that symbol together with a negative answer:

\`\`\`ts
const answer = await confirm({ message, initialValue: true });
if (isCancel(answer) || !answer) {
  // Ctrl+C and an explicit "No" both land here → command continues as "No"
  return { action: 'proceed' };
}
\`\`\`

So e.g. \`apps/cli/src/commands/claude.ts:288\` ("Sign in with your Claude subscription?") — Ctrl+C silently proceeded to create the box unauthenticated.

### Fix

- New \`apps/cli/src/lib/prompt.ts\` wraps \`@clack/prompts\` so the five interactive input prompts (\`confirm\`, \`select\`, \`multiselect\`, \`text\`, \`password\`, plus \`selectKey\`/\`groupMultiselect\`) exit(130) on the cancel symbol. Everything else (\`log\`, \`spinner\`, \`intro\`, \`outro\`, \`note\`, \`isCancel\`, …) re-exports unchanged.
- 17 files in \`apps/cli/src\` swap to the wrapper. \`if (isCancel(x) || !x)\` collapses to \`if (!x)\`; standalone \`isCancel\` guards are deleted as unreachable.
- The four cloud provider \`credentials.ts\` files (daytona, hetzner, vercel, e2b) get a local \`exitOnCancel<T>()\` helper with the same semantics — avoids pushing a UI dep down into the shared packages.

\`apps/cli/src/index.ts\`'s top-level \`parseAsync(...).catch\` is untouched — \`onCancel()\` calls \`process.exit\` directly, never throws.

### Behavior change (intended)

Sites that previously *silently continued* on Ctrl+C now *quit*. Most notable:
- The Portless first-run \`confirm\` (used to silently say "no" and skip the proxy setup; now quits).
- The setup-wizard "run setup wizard?" confirm (used to proceed with the bare box; now quits).
- The \`Sign in with your Claude subscription?\` confirm (used to skip the sign-in; now quits).

The explicit "No" answer continues to behave exactly as before — only the cancel-symbol path changed.

## Test plan
- [x] \`pnpm -C apps/cli test\` — 497/497 passing; new \`Ctrl-C maps to exit(130)\` assertion in carry-prompt.test.ts.
- [x] \`pnpm -C apps/cli typecheck\` + 4 provider typechecks clean.
- [x] \`pnpm lint\` (13 packages) clean.
- [x] Real-PTY end-to-end (pexpect): \`Cancelled.\` printed, exit 130.
- [x] Real-PTY end-to-end of \`agentbox create\` in a no-yaml project: Ctrl+C at the Portless \`confirm\` prompt quits cleanly; \`agentbox list\` confirms no box was created.
- [x] Regression: \`n<Enter>\` still returns false and exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad CLI UX change affecting every interactive confirm/select path; low technical risk but users who relied on Ctrl+C as "skip" will see commands abort instead.
> 
> **Overview**
> **Ctrl+C at interactive prompts now ends the command with exit code 130** instead of being treated like a "No" and continuing.
> 
> Adds `apps/cli/src/lib/prompt.js`, a thin wrapper around `@clack/prompts` that calls `cancel()` and `process.exit(130)` when the user cancels `confirm`, `select`, `multiselect`, `text`, `password`, and related helpers. CLI commands that used `if (isCancel(x) || !x)` are switched to import from this module and only check `!x` for explicit declines.
> 
> The same **exit-on-cancel** behavior is applied locally in Daytona, Hetzner, Vercel, and E2B `credentials.ts` via `exitOnCancel()` so cloud login wizards quit on Ctrl+C without pulling the CLI wrapper into those packages.
> 
> **Intended UX change:** flows that previously kept going after Ctrl+C (e.g. skipping sign-in, Portless opt-in, setup wizard, carry `select` "cancel") now abort the whole command; choosing "No" at a confirm is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c2a9cf5f1afc43dcf86cb5001a9f6c7e6b7ac64. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->