### PR TITLE
fix: CLI load crash on Node <20.19 + vercel CLI-login team resolution

### DIFF
--- a/docs/e2b_backlog.md
+++ b/docs/e2b_backlog.md
@@ -354,6 +354,23 @@ mode … Yes, I accept" gate.
   relay and can launch boxes on other providers, so they can fully smoke-test.
 
 ## Changelog
+- 2026-06-17: Fix `ERR_REQUIRE_ESM` crash on Node < 20.19 (e.g. 20.18, which
+  our `engines.node >=20.10` permits). The `e2b` SDK ships **no `exports` map**
+  (only `main`→CJS / `module`→ESM), so an ESM `import 'e2b'` falls back to the
+  CJS `dist/index.js`, which `require("chalk")`. Its declared `chalk@^5.3.0`
+  resolves to the ESM-only chalk@5, and on Node < 20.19 (before `require(esm)`
+  was unflagged) that `require` throws `ERR_REQUIRE_ESM` — crashing the whole
+  CLI at command registration (`cli.ts` → `credentials.ts` → `sdk.ts` →
+  `import 'e2b'`), so **every** `agentbox` command died, not just e2b ones.
+  Fix: a scoped pnpm override `e2b>chalk: ^4.1.2` in the root `package.json`
+  pins **e2b's** chalk to the CJS chalk@4 (same `red`/`hex`/`gray`/`dim` API
+  e2b uses), so `require("chalk")` works on every supported Node. chalk is the
+  only pure-ESM (no `require` condition) package e2b's CJS build requires — its
+  other ESM deps (`@bufbuild/protobuf`, `@connectrpc/*`, `openapi-fetch`) are
+  dual-package. The rest of the monorepo keeps chalk@5. Verified live on Node
+  v20.18.0: `import 'e2b'`, `agentbox daytona login`, `agentbox e2b login
+  --status`, and `agentbox --help` all load cleanly. Do not remove the override
+  on a dep cleanup — newer e2b (2.30.1) still has the broken packaging.
 - 2026-06-03: Cold-attach "blank pane looks hung" fix (shared cloud path).
   Symptom: `agentbox e2b claude` reached `box ready`, showed the recap panel,
   then the attach sat on a featureless blank screen long enough that the user

--- a/docs/vercel-backlog.md
+++ b/docs/vercel-backlog.md
@@ -66,6 +66,15 @@ implementation (per the project convention), not as end-of-PR cleanup.
     login we list the team's projects (`vercel-rest.ts`) and the user picks one
     (clack select, pre-selecting `agentbox`/`vercel-sandbox-default-project`, with
     a create-new option) — cached as `VERCEL_PROJECT_ID`.
+  - **Team resolution (fixed 2026-06-16).** The current `sbx`/`sandbox` CLI no
+    longer writes `currentTeam` to its `config.json`, so the post-login harvest
+    used to dead-end with "no credentials were found in the Vercel CLI store"
+    even on a successful sign-in. `runCliLogin` now resolves the team in
+    precedence order `VERCEL_TEAM_ID` → CLI `currentTeam` → the account's
+    `defaultTeamId` (from `GET /v2/user`, which `getUser` now surfaces) — the
+    same team `sbx login` scopes its default sandbox project to. Verified live
+    against the real CLI store + API (`currentTeam` null, `defaultTeamId` carried
+    the team through).
   - Store path resolver is platform-aware (macOS `~/Library/Application Support`,
     Linux `$XDG_DATA_HOME`/`~/.local/share`, Windows `%APPDATA%`) with an
     `AGENTBOX_VERCEL_CLI_DIR` override for tests.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
     "pnpm": ">=9"
   },
   "packageManager": "pnpm@9.15.0",
+  "pnpm": {
+    "overrides": {
+      "e2b>chalk": "^4.1.2"
+    }
+  },
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",

--- a/packages/sandbox-vercel/src/credentials.ts
+++ b/packages/sandbox-vercel/src/credentials.ts
@@ -298,15 +298,19 @@ async function runCliLogin(): Promise<void> {
     return;
   }
 
-  const harvested = harvestCliCredentials();
-  if (!harvested) {
-    log.warn('Sign-in finished but no credentials were found in the Vercel CLI store. Try again.');
+  const auth = readCliAuth();
+  if (!auth) {
+    log.warn('Sign-in finished but no access token was found in the Vercel CLI store. Try again.');
     return;
   }
 
   // Validate the token early so a bad/expired session fails here, not mid-op.
+  // The same call yields the account's default team, which scopes sandboxes when
+  // the CLI store records no selected team (the current `sbx` CLI no longer
+  // writes `currentTeam` to its config.json).
+  let user: { id: string; username?: string; defaultTeamId?: string };
   try {
-    await getUser(harvested.token);
+    user = await getUser(auth.token);
   } catch (err) {
     log.warn(
       `The Vercel session looks invalid (${err instanceof Error ? err.message : String(err)}). ` +
@@ -315,29 +319,38 @@ async function runCliLogin(): Promise<void> {
     return;
   }
 
-  const projectId = await resolveProjectId(harvested.token, harvested.teamId);
+  const teamId = resolveCliTeamId(user.defaultTeamId);
+  if (!teamId) {
+    log.warn(
+      'Signed in, but could not determine a Vercel team to scope sandboxes to. ' +
+        'Set VERCEL_TEAM_ID in `~/.agentbox/secrets.env` and re-run `agentbox vercel login`.',
+    );
+    return;
+  }
+
+  const projectId = await resolveProjectId(auth.token, teamId);
   if (projectId === null) {
     log.warn('No project selected — re-run `agentbox vercel login` to finish setup.');
     return;
   }
 
-  persistCliCredentials({ teamId: harvested.teamId, projectId });
+  persistCliCredentials({ teamId, projectId });
   reloadVercelEnv();
   log.success(`Signed in with Vercel — credentials managed by the sandbox CLI (saved scope to ${secretsPath()}).`);
   outro('Setup complete.');
 }
 
 /**
- * Read the live token + team id from the Vercel CLI store. teamId prefers an
- * already-cached `VERCEL_TEAM_ID` (e.g. from a prior login) and falls back to
- * the CLI's `currentTeam`. Null when the CLI isn't logged in.
+ * Resolve the team id sandboxes run under, in precedence order:
+ *   1. `VERCEL_TEAM_ID` — a prior login's cache or a user override.
+ *   2. the CLI store's `currentTeam` — older `vercel`/`sandbox` CLIs wrote it.
+ *   3. the account's default team — the current `sbx` CLI records no selected
+ *      team, so we fall back to the team its OAuth token defaults to (the same
+ *      team `sbx login` scopes its default sandbox project to).
+ * Null when none is available.
  */
-function harvestCliCredentials(): { token: string; teamId: string } | null {
-  const auth = readCliAuth();
-  if (!auth) return null;
-  const teamId = process.env.VERCEL_TEAM_ID ?? readCliCurrentTeam();
-  if (!teamId) return null;
-  return { token: auth.token, teamId };
+function resolveCliTeamId(defaultTeamId?: string): string | null {
+  return process.env.VERCEL_TEAM_ID ?? readCliCurrentTeam() ?? defaultTeamId ?? null;
 }
 
 /**

--- a/packages/sandbox-vercel/src/vercel-rest.ts
+++ b/packages/sandbox-vercel/src/vercel-rest.ts
@@ -53,10 +53,17 @@ async function api(
   return json;
 }
 
-/** Validate the token and return the authenticated user (probe / status). */
-export async function getUser(token: string): Promise<{ id: string; username?: string }> {
+/**
+ * Validate the token and return the authenticated user (probe / status).
+ * `defaultTeamId` is the team the account (and the `sbx` CLI's default sandbox
+ * project) is scoped to — the CLI-login flow falls back to it when the CLI store
+ * records no selected team.
+ */
+export async function getUser(
+  token: string,
+): Promise<{ id: string; username?: string; defaultTeamId?: string }> {
   const json = (await api(token, '/v2/user')) as {
-    user?: { id: string; username?: string };
+    user?: { id: string; username?: string; defaultTeamId?: string };
   };
   const user = json.user;
   if (!user?.id) throw new Error('Vercel /v2/user returned no user');

--- a/packages/sandbox-vercel/test/vercel-rest.test.ts
+++ b/packages/sandbox-vercel/test/vercel-rest.test.ts
@@ -27,6 +27,13 @@ describe('getUser', () => {
     expect((init as RequestInit).headers).toMatchObject({ Authorization: 'Bearer vca_x' });
   });
 
+  it('surfaces defaultTeamId — the CLI-login team fallback when the store has no currentTeam', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(200, { user: { id: 'u1', username: 'me', defaultTeamId: 'team_abc' } }),
+    );
+    await expect(getUser('vca_x')).resolves.toMatchObject({ defaultTeamId: 'team_abc' });
+  });
+
   it('throws with the API message on failure', async () => {
     fetchMock.mockResolvedValue(jsonResponse(403, { error: { message: 'Not authorized' } }));
     await expect(getUser('vca_x')).rejects.toThrow(/403.*Not authorized/);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  e2b>chalk: ^4.1.2
+
 importers:
 
   .:
@@ -2668,10 +2671,6 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
-
-  chalk@5.6.2:
-    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -6761,8 +6760,6 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  chalk@5.6.2: {}
-
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -6888,7 +6885,7 @@ snapshots:
       '@bufbuild/protobuf': 2.12.0
       '@connectrpc/connect': 2.0.0-rc.3(@bufbuild/protobuf@2.12.0)
       '@connectrpc/connect-web': 2.0.0-rc.3(@bufbuild/protobuf@2.12.0)(@connectrpc/connect@2.0.0-rc.3(@bufbuild/protobuf@2.12.0))
-      chalk: 5.6.2
+      chalk: 4.1.2
       compare-versions: 6.1.1
       dockerfile-ast: 0.7.1
       glob: 11.1.0


### PR DESCRIPTION
Two isolated, user-facing fixes targeted for a **v0.17.1 patch release** (no control-plane logic).

## 1. `fix(e2b)` — CLI crashed with `ERR_REQUIRE_ESM` on Node < 20.19

Every `agentbox` command (not just e2b ones) died at startup on Node 20.10–20.18 — which `engines.node >=20.10` permits, e.g. a user on **20.18.0**:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module .../chalk@5.6.2/.../index.js
from .../e2b@2.27.1/dist/index.js not supported.
```

Root cause chain:
- Command registration pulls in the e2b command tree → `cli.ts` → `credentials.ts` → `sdk.ts` → top-level `import 'e2b'`.
- `e2b` ships **no `exports` map** (only `main`→CJS / `module`→ESM), so an ESM `import 'e2b'` loads the **CJS** `dist/index.js`, which `require("chalk")`.
- e2b declares `chalk@^5`, which resolves to the **ESM-only** chalk@5.
- `require(esm)` only became legal in **Node 20.19.0**; before that it throws `ERR_REQUIRE_ESM`.

**Fix:** a scoped pnpm override `e2b>chalk: ^4.1.2` pins **e2b's** chalk to the CJS chalk@4 (same `red`/`hex`/`gray`/`dim` API e2b uses). chalk is the only pure-ESM (no `require` condition) package e2b's CJS build requires — its other ESM deps are dual-package. The rest of the monorepo keeps chalk@5. (Upstream workaround — even the latest e2b@2.30.1 still has the broken packaging.)

## 2. `fix(vercel)` — CLI-login harvest dead-ended after a successful sign-in

The current Vercel sandbox CLI no longer writes `currentTeam` to its config, so the harvest failed with "no credentials were found in the Vercel CLI store" even after a valid sign-in. `runCliLogin` now harvests the token alone and resolves the team via `VERCEL_TEAM_ID` → CLI `currentTeam` → account `defaultTeamId` (from `GET /v2/user`).

## Verification

- `pnpm install --frozen-lockfile` clean (lockfile regenerated against main's dep graph).
- Build green; sandbox-vercel (82) + sandbox-e2b (14) unit tests pass; typecheck clean.
- **Live on Node v20.18.0:** `import 'e2b'`, `agentbox daytona login`, `agentbox e2b login --status`, `agentbox vercel login --status`, and `agentbox --help` all load with no `ERR_REQUIRE_ESM`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped dependency override and Vercel login credential harvesting only; no changes to sandbox control-plane or auth token storage semantics beyond fixing team resolution after CLI sign-in.
> 
> **Overview**
> Patches two user-facing startup/login failures aimed at a **v0.17.1**-style release.
> 
> **Node &lt; 20.19 — whole CLI crashed at import.** Registering the e2b command tree pulled in the CJS `e2b` build, which `require()`s chalk@5 (ESM-only); on Node 20.10–20.18 that throws `ERR_REQUIRE_ESM`, so **every** `agentbox` command failed—not only e2b. The fix adds a scoped pnpm override `e2b>chalk: ^4.1.2` in the root `package.json` and lockfile so e2b’s dependency resolves to CJS chalk@4; the rest of the monorepo can still use chalk@5. Docs in `docs/e2b_backlog.md` record the rationale and warn not to drop the override on casual dep cleanup.
> 
> **Vercel browser login — harvest failed after a good sign-in.** Current `sbx` no longer writes `currentTeam` to the CLI store, so the old “token + team from store” step returned no credentials. `runCliLogin` now reads the token alone, validates via `getUser`, and resolves team with **`VERCEL_TEAM_ID` → CLI `currentTeam` → `defaultTeamId` from `/v2/user`** (`resolveCliTeamId` in `credentials.ts`; `getUser` and tests updated). `docs/vercel-backlog.md` documents the team-resolution fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d77496ef24bc37f69e737801c71ed933b4aea662. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->