### PR TITLE
fix(status): list tasks/services/ports in --inspect and cloud status

### DIFF
--- a/apps/cli/src/commands/_status-render.ts
+++ b/apps/cli/src/commands/_status-render.ts
@@ -1,0 +1,72 @@
+import {
+  renderPortsTable,
+  renderStatusTable,
+  renderTaskTable,
+  type BoxStatus,
+  type StatusReply,
+} from '@agentbox/ctl';
+import { execInBox } from '@agentbox/sandbox-docker';
+
+export async function fetchLive(state: string, container: string): Promise<StatusReply | null> {
+  // Only a running container is reachable via `docker exec` (macOS can see the
+  // socket file but can't connect to it). Paused/stopped — or a failed exec —
+  // falls back to the snapshot the relay persisted to disk.
+  if (state !== 'running') return null;
+  const proc = await execInBox(container, ['agentbox-ctl', 'status', '--json'], {
+    user: 'vscode',
+  });
+  if (proc.exitCode !== 0) return null;
+  try {
+    return JSON.parse(proc.stdout) as StatusReply;
+  } catch {
+    return null;
+  }
+}
+
+/** TASKS / SERVICES / PORTS blocks from a live `agentbox-ctl status` pull. */
+export function renderLiveSections(live: StatusReply): string[] {
+  const out: string[] = [];
+  if (live.tasks.length > 0) {
+    out.push('TASKS', renderTaskTable(live.tasks), '');
+  }
+  out.push('SERVICES', renderStatusTable(live.services), '');
+  out.push('PORTS', renderPortsTable(live.ports));
+  return out;
+}
+
+/** TASKS / SERVICES / PORTS blocks from a persisted box-status snapshot. */
+export function renderPersistedSections(s: BoxStatus): string[] {
+  const out: string[] = [];
+  if (s.tasks.length > 0) {
+    out.push('TASKS');
+    out.push(...s.tasks.map((t) => `  ${t.name}  ${t.state}`));
+    out.push('');
+  }
+  out.push('SERVICES');
+  if (s.services.length === 0) {
+    out.push('  (none)');
+  } else {
+    out.push(
+      ...s.services.map(
+        (svc) => `  ${svc.name}  ${svc.state}${svc.port !== null ? `  :${String(svc.port)}` : ''}`,
+      ),
+    );
+  }
+  out.push('');
+  out.push('PORTS');
+  if (s.ports.length === 0) {
+    out.push('  (none listening)');
+  } else {
+    const other = s.ports
+      .filter((p) => !p.service)
+      .map((p) => p.port)
+      .sort((a, b) => a - b);
+    out.push(
+      ...s.ports
+        .filter((p) => p.service)
+        .map((p) => `  :${String(p.port)}  (${p.service})`),
+    );
+    if (other.length > 0) out.push(`  other (${other.length}): ${other.join(', ')}`);
+  }
+  return out;
+}

--- a/apps/cli/src/commands/inspect.ts
+++ b/apps/cli/src/commands/inspect.ts
@@ -69,7 +69,9 @@ async function renderText(i: InspectedBox): Promise<string> {
   // in-box daemon when running, else the persisted snapshot.
   const live = await fetchLive(i.state, i.record.container);
   if (live) {
-    lines.push('', ...renderLiveSections(live));
+    // Label the source: the `persisted` row above shows snapshot counts, so
+    // flag these sections as live to explain any disagreement with it.
+    lines.push('', '(live from agentbox-ctl)', '', ...renderLiveSections(live));
   } else if (i.persistedStatus) {
     lines.push('', `(persisted snapshot from ${i.persistedStatus.timestamp})`, '');
     lines.push(...renderPersistedSections(i.persistedStatus));

--- a/apps/cli/src/commands/inspect.ts
+++ b/apps/cli/src/commands/inspect.ts
@@ -10,6 +10,7 @@ import { renderEndpointLines } from '../endpoints-render.js';
 import { fmtBytes } from '../fmt.js';
 import { providerForBox } from '../provider/registry.js';
 import { watchRender } from '../watch.js';
+import { fetchLive, renderLiveSections, renderPersistedSections } from './_status-render.js';
 import { handleLifecycleError } from './_errors.js';
 
 export interface InspectRunOptions {
@@ -63,6 +64,16 @@ async function renderText(i: InspectedBox): Promise<string> {
     `host export   ${i.hostPaths.mergedExport}  (run \`agentbox open\` to refresh)`,
     `created       ${i.record.createdAt}`,
   ];
+
+  // Append the same service/task/port detail plain `status` shows: live from the
+  // in-box daemon when running, else the persisted snapshot.
+  const live = await fetchLive(i.state, i.record.container);
+  if (live) {
+    lines.push('', ...renderLiveSections(live));
+  } else if (i.persistedStatus) {
+    lines.push('', `(persisted snapshot from ${i.persistedStatus.timestamp})`, '');
+    lines.push(...renderPersistedSections(i.persistedStatus));
+  }
   return lines.join('\n');
 }
 
@@ -165,6 +176,13 @@ async function renderCloudText(box: BoxRecord): Promise<string> {
     `persisted     ${persisted ? `${persisted.timestamp} (${String(persisted.services.length)} svc, ${String(persisted.tasks.length)} tasks, ${String(persisted.ports.length)} ports)` : '(none)'}`,
     `created       ${box.createdAt}`,
   ];
+
+  // Cloud boxes have no host container to `docker exec` into, so the persisted
+  // snapshot (mirrored by the host poller) is the only source for task/service
+  // detail. Surface it instead of just the count line above.
+  if (persisted) {
+    lines.push('', ...renderPersistedSections(persisted));
+  }
   return lines.join('\n');
 }
 

--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -24,7 +24,7 @@ export const statusCommand = withWatchOptions(
       'box ref: project index, id, id prefix, name, or container (default: the only box in this project)',
     )
     .option('-j, --json', 'machine-readable JSON output')
-    .option('--inspect', 'add detailed box info (volumes, limits, paths) to the service/task status'),
+    .option('--inspect', 'show detailed box info (volumes, limits, paths) plus service/task status'),
 ).action(async (idOrName: string | undefined, opts: StatusOptions) => {
   try {
     if (opts.json && opts.watch) {

--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -1,23 +1,13 @@
 import { log } from '@clack/prompts';
 import { Command } from 'commander';
-import {
-  renderPortsTable,
-  renderStatusTable,
-  renderTaskTable,
-  type BoxStatus,
-  type StatusReply,
-} from '@agentbox/ctl';
-import {
-  boxResourceStats,
-  execInBox,
-  inspectBox,
-  type InspectedBox,
-} from '@agentbox/sandbox-docker';
+import type { BoxStatus } from '@agentbox/ctl';
+import { boxResourceStats, inspectBox, type InspectedBox } from '@agentbox/sandbox-docker';
 import type { BoxResourceStats } from '@agentbox/core';
 import { resolveBoxOrExit } from '../box-ref.js';
 import { renderEndpointLines } from '../endpoints-render.js';
 import { fmtAgo, fmtBytes, fmtPercent } from '../fmt.js';
 import { withWatchOptions, watchRender, type WatchableOptions } from '../watch.js';
+import { fetchLive, renderLiveSections, renderPersistedSections } from './_status-render.js';
 import { runInspect } from './inspect.js';
 import { handleLifecycleError } from './_errors.js';
 
@@ -34,7 +24,7 @@ export const statusCommand = withWatchOptions(
       'box ref: project index, id, id prefix, name, or container (default: the only box in this project)',
     )
     .option('-j, --json', 'machine-readable JSON output')
-    .option('--inspect', 'show detailed box info (volumes, limits, paths) instead of service/task status'),
+    .option('--inspect', 'add detailed box info (volumes, limits, paths) to the service/task status'),
 ).action(async (idOrName: string | undefined, opts: StatusOptions) => {
   try {
     if (opts.json && opts.watch) {
@@ -91,22 +81,6 @@ export const statusCommand = withWatchOptions(
   }
 });
 
-async function fetchLive(state: string, container: string): Promise<StatusReply | null> {
-  // Only a running container is reachable via `docker exec` (macOS can see the
-  // socket file but can't connect to it). Paused/stopped — or a failed exec —
-  // falls back to the snapshot the relay persisted to disk.
-  if (state !== 'running') return null;
-  const proc = await execInBox(container, ['agentbox-ctl', 'status', '--json'], {
-    user: 'vscode',
-  });
-  if (proc.exitCode !== 0) return null;
-  try {
-    return JSON.parse(proc.stdout) as StatusReply;
-  } catch {
-    return null;
-  }
-}
-
 async function buildStatusText(id: string, container: string): Promise<string> {
   const inspected = await inspectBox(id);
   const { state, endpoints, persistedStatus } = inspected;
@@ -122,11 +96,7 @@ async function buildStatusText(id: string, container: string): Promise<string> {
   out.push('', 'SHELLS', renderShells(inspected));
 
   if (live) {
-    if (live.tasks.length > 0) {
-      out.push('', 'TASKS', renderTaskTable(live.tasks));
-    }
-    out.push('', 'SERVICES', renderStatusTable(live.services));
-    out.push('', 'PORTS', renderPortsTable(live.ports));
+    out.push('', ...renderLiveSections(live));
     return out.join('\n');
   }
 
@@ -200,37 +170,9 @@ function renderShells(i: InspectedBox): string {
 }
 
 function renderPersisted(s: BoxStatus, state: string): string {
-  const out: string[] = [`(persisted snapshot from ${s.timestamp}; box is ${state})`, ''];
-  if (s.tasks.length > 0) {
-    out.push('TASKS');
-    out.push(...s.tasks.map((t) => `  ${t.name}  ${t.state}`));
-    out.push('');
-  }
-  out.push('SERVICES');
-  if (s.services.length === 0) {
-    out.push('  (none)');
-  } else {
-    out.push(
-      ...s.services.map(
-        (svc) => `  ${svc.name}  ${svc.state}${svc.port !== null ? `  :${String(svc.port)}` : ''}`,
-      ),
-    );
-  }
-  out.push('');
-  out.push('PORTS');
-  if (s.ports.length === 0) {
-    out.push('  (none listening)');
-  } else {
-    const other = s.ports
-      .filter((p) => !p.service)
-      .map((p) => p.port)
-      .sort((a, b) => a - b);
-    out.push(
-      ...s.ports
-        .filter((p) => p.service)
-        .map((p) => `  :${String(p.port)}  (${p.service})`),
-    );
-    if (other.length > 0) out.push(`  other (${other.length}): ${other.join(', ')}`);
-  }
-  return out.join('\n');
+  return [
+    `(persisted snapshot from ${s.timestamp}; box is ${state})`,
+    '',
+    ...renderPersistedSections(s),
+  ].join('\n');
 }

--- a/apps/cli/test/status-render.test.ts
+++ b/apps/cli/test/status-render.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import type { BoxStatus, StatusReply } from '@agentbox/ctl';
+import { renderLiveSections, renderPersistedSections } from '../src/commands/_status-render.js';
+
+const persisted: BoxStatus = {
+  schema: 1,
+  boxId: 'b9615a54d',
+  timestamp: '2026-06-22T13:36:34.446Z',
+  services: [],
+  tasks: [
+    { name: 'install', state: 'done' },
+    { name: 'build', state: 'running' },
+  ],
+  ports: [
+    { port: 80, service: 'web' },
+    { port: 5173, service: null },
+  ],
+  claude: { state: 'working', updatedAt: null },
+} as unknown as BoxStatus;
+
+describe('renderPersistedSections', () => {
+  it('lists each task by name and state (not just a count)', () => {
+    const text = renderPersistedSections(persisted).join('\n');
+    expect(text).toContain('TASKS');
+    expect(text).toContain('install  done');
+    expect(text).toContain('build  running');
+  });
+
+  it('renders named ports and rolls anonymous ports into an "other" line', () => {
+    const text = renderPersistedSections(persisted).join('\n');
+    expect(text).toContain(':80  (web)');
+    expect(text).toContain('other (1): 5173');
+  });
+
+  it('omits the TASKS heading when there are no tasks', () => {
+    const noTasks = { ...persisted, tasks: [] } as unknown as BoxStatus;
+    expect(renderPersistedSections(noTasks).join('\n')).not.toContain('TASKS');
+  });
+});
+
+describe('renderLiveSections', () => {
+  it('renders a TASKS table when tasks are present', () => {
+    const live: StatusReply = {
+      services: [],
+      tasks: [
+        {
+          name: 'build',
+          state: 'running',
+          pid: 12,
+          lastExitCode: null,
+          startedAt: '2026-06-22T13:30:00Z',
+          finishedAt: null,
+          command: 'pnpm build',
+        },
+      ],
+      ports: [{ port: 80, service: 'web' }],
+    };
+    const text = renderLiveSections(live).join('\n');
+    expect(text).toContain('TASKS');
+    expect(text).toContain('build');
+    expect(text).toContain('SERVICES');
+    expect(text).toContain('PORTS');
+  });
+
+  it('omits TASKS when no tasks are configured', () => {
+    const live: StatusReply = { services: [], tasks: [], ports: [] };
+    expect(renderLiveSections(live).join('\n')).not.toContain('TASKS');
+  });
+});


### PR DESCRIPTION
## Problem

`agentbox status --inspect` (and plain `agentbox status` for **cloud boxes**, which always routes through the cloud inspect renderer since there's no host container to `docker exec` into) only printed a count line — e.g. `(0 svc, 4 tasks, 9 ports)` — and never listed the individual tasks. The per-task entries were already present in the persisted box-status snapshot; they just weren't rendered.

This regressed when the standalone `agentbox inspect` command was folded into `status --inspect` (commit `07f33f8`): only the one-line count survived, not the TASKS/SERVICES/PORTS sections that plain docker `status` still shows.

## Fix

- New `apps/cli/src/commands/_status-render.ts` with shared helpers: `fetchLive`, `renderLiveSections`, `renderPersistedSections` (extracted from `status.ts`; separate module avoids an import cycle with `inspect.ts`).
- `inspect.ts`: `renderText` (docker) and `renderCloudText` now append TASKS/SERVICES/PORTS — live from the in-box daemon when a docker box is running, else the persisted snapshot. Cloud renders the persisted snapshot.
- `status.ts`: reuses the shared helpers (behavior unchanged); `--inspect` help text fixed from "instead of service/task status" to "add ... to the service/task status".

## Test

- New `test/status-render.test.ts` (5 tests) asserting tasks are listed by name+state, ports roll up correctly, and the TASKS heading is omitted when there are none.
- Full apps/cli suite green (558 pass); `pnpm lint` + build clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display and refactor only; no auth, data, or runtime behavior changes beyond richer terminal output.
> 
> **Overview**
> Restores **TASKS / SERVICES / PORTS** detail in `agentbox status --inspect` and cloud status output, which had regressed to only a one-line persisted count after inspect was folded into status.
> 
> Shared logic moves to `_status-render.ts` (`fetchLive`, `renderLiveSections`, `renderPersistedSections`) so `status.ts` and `inspect.ts` stay in sync without an import cycle. **Docker inspect** appends live `agentbox-ctl` sections when the box is running (labeled as live), otherwise the persisted snapshot; **cloud inspect** always prints the persisted snapshot sections. Plain `status` behavior is unchanged aside from delegating rendering to the helpers; `--inspect` help now says it **adds** service/task status rather than replacing it.
> 
> Adds `status-render.test.ts` covering task names/states, port rollup, and omitting empty TASKS headings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c784bb70052bec1f9bf2d71efaa6298486857cb6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->