### PR TITLE
feat(cloud): renew session timeout while the agent is working (vercel + e2b)

### DIFF
--- a/apps/cli/share/agentbox-setup/SKILL.md
+++ b/apps/cli/share/agentbox-setup/SKILL.md
@@ -276,7 +276,7 @@ On Vercel: this actually STOPS the sandbox, so warn the user about it. Also the 
 
 - For Nextjs/Vite/Tasnstack projects, makes sure to forward also websocket for hot reload.
 
-- Service like flask, nextjs, BETTER_AUTH_URL, NEXT_PUBLIC_APP_URL should use the `<boxname>.localhost` url for the local development so that on the host it will use the same url as the box. Render this automatically instead of hand-writing `sed` — see section 6c.
+- Service like flask, nextjs, BETTER_AUTH_URL, NEXT_PUBLIC_APP_URL should use the env-init `{{AGENTBOX_BOX_HOST}}` in agentbox.yaml so it will be automatically replaced.
 
 - The `install` task above uses `run_once: true`, so it is a no-op on warm boots. Do **not** wrap it in a manual marker check too. To force a one-off rebuild, run `agentbox-ctl run-task install --force` (which bypasses the run_once marker), or edit the command (a changed command invalidates the hash and re-runs).
 

--- a/apps/web/content/docs/e2b.mdx
+++ b/apps/web/content/docs/e2b.mdx
@@ -76,7 +76,7 @@ agentbox e2b claude
 | Region | SDK-chosen (transparent) |
 | Disk / RAM / vCPU | Template-level — set at `Template.build()` time; per-create `--size` is advisory only |
 | Exposed ports | Any port via `sandbox.getHost(port)`; WebProxy runs on 8080 |
-| Session length | 1 hour (Hobby) — the attach helper caps at **55 minutes** for headroom |
+| Session length | 1 hour (Hobby) — the attach helper caps at **55 minutes** for headroom; auto-renewed (up to the plan cap) while the agent is working |
 | Nested containers | none — `docker` unavailable in-box (Firecracker + seccomp) |
 | SSH | none — attach is an SDK-streaming PTY bridge over `pty.create` |
 

--- a/apps/web/content/docs/vercel.mdx
+++ b/apps/web/content/docs/vercel.mdx
@@ -77,9 +77,13 @@ agentbox vercel claude
 | Disk | 32 GB fixed |
 | RAM | 2048 MB per vCPU (coupled) |
 | Exposed ports | ≤4 (8080 / 6080 / 8788 reserved + ~1 free), fixed at create, non-privileged only |
-| Session length | 45 min (Hobby) / 5 hr (Pro+) |
+| Session length | 45 min (Hobby) / 5 hr (Pro+) — auto-renewed while the agent is working |
 | Nested containers | yes — `docker` baked in + auto-started (DinD) |
 | SSH | none — attach uses the Vercel CLI PTY |
+
+<Callout title="SESSION KEEPALIVE">
+While the in-box agent is actively working, the host relay automatically renews the box's session timeout (anchored at the agent's last activity + the [`autopause.idleMinutes`](/docs/configuration) window), so a long Claude/Codex run isn't killed mid-work. An idle box stops being renewed and lapses normally. The renewal is bounded by your Vercel plan's max session (Hobby ~45 min hard cap; Pro+ ~5 hr) — it mainly helps Pro+ plans run past the conservative 45-min default.
+</Callout>
 
 <Callout title="IN-BOX DOCKER">
 Vercel boxes ship with a working in-box `docker`: the engine is baked into the prepare snapshot and `dockerd` is auto-started on create/resume, so `agentbox.yaml` `image:` services (e.g. a `postgres:16` service) work out of the box. Pulled images carry over across pause/resume. See [docker-in-docker](/docs/docker-in-docker).

--- a/apps/web/content/docs/vercel.mdx
+++ b/apps/web/content/docs/vercel.mdx
@@ -82,7 +82,7 @@ agentbox vercel claude
 | SSH | none — attach uses the Vercel CLI PTY |
 
 <Callout title="SESSION KEEPALIVE">
-While the in-box agent is actively working, the host relay automatically renews the box's session timeout (anchored at the agent's last activity + the [`autopause.idleMinutes`](/docs/configuration) window), so a long Claude/Codex run isn't killed mid-work. An idle box stops being renewed and lapses normally. The renewal is bounded by your Vercel plan's max session (Hobby ~45 min hard cap; Pro+ ~5 hr) — it mainly helps Pro+ plans run past the conservative 45-min default.
+While the in-box agent is actively working, the host relay automatically renews the box's session timeout (keeping it a rolling [`autopause.idleMinutes`](/docs/configuration) window ahead of now), so a long Claude/Codex run isn't killed mid-work. Once the agent goes idle the box stops being renewed and lapses about one window later. The renewal is bounded by your Vercel plan's max session (Hobby ~45 min hard cap; Pro+ ~5 hr) — it mainly helps Pro+ plans run past the conservative 45-min default.
 </Callout>
 
 <Callout title="IN-BOX DOCKER">

--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -497,6 +497,12 @@ the shape in brief:
   Caveat: `sb.snapshot()` stops the source box (it auto-resumes on next call).
 - **Hard platform limits:** region `iad1` only, 32 GB fixed disk, 2048 MB RAM
   per vCPU, 45 min (Hobby) / 5 hr (Pro+) sessions.
+- **Session keepalive.** The host relay (`cloud-keepalive` loop, sibling to
+  auto-pause) renews a running box's session timeout while its in-box agent is
+  active, anchoring the death-time at `lastActivity + autopause.idleMinutes` so a
+  long agent run isn't killed mid-work; an idle box lapses. Bounded by the plan's
+  max session (the renewal mainly benefits Pro+). Same mechanism on E2B. Uses
+  `CloudBackend.renewTimeout` (vercel `extendTimeout`, e2b `setTimeout`).
 
 ## 3c. The E2B shape
 

--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -499,9 +499,11 @@ the shape in brief:
   per vCPU, 45 min (Hobby) / 5 hr (Pro+) sessions.
 - **Session keepalive.** The host relay (`cloud-keepalive` loop, sibling to
   auto-pause) renews a running box's session timeout while its in-box agent is
-  active, anchoring the death-time at `lastActivity + autopause.idleMinutes` so a
-  long agent run isn't killed mid-work; an idle box lapses. Bounded by the plan's
-  max session (the renewal mainly benefits Pro+). Same mechanism on E2B. Uses
+  active — holding the death-time a rolling `autopause.idleMinutes` window ahead
+  of now so a long agent run isn't killed mid-work; once idle the box stops being
+  renewed and lapses ~one window later. The active case anchors on `now` (not the
+  agent's `updatedAt`, which freezes during a long single `working` op). Bounded
+  by the plan's max session (mainly benefits Pro+). Same mechanism on E2B. Uses
   `CloudBackend.renewTimeout` (vercel `extendTimeout`, e2b `setTimeout`).
 
 ## 3c. The E2B shape

--- a/docs/vercel-backlog.md
+++ b/docs/vercel-backlog.md
@@ -486,9 +486,11 @@ agentbox/<box>` shows the commit, then try `agentbox-ctl git pull` and a `gh pr`
     ignore it (hetzner locks egress via its own firewall). Verified live: a
     `deny-all` box can't reach `example.com`; an `example.com`-allowlist box
     reaches `example.com` but not `api.github.com`. Unit-tested `parseNetworkPolicy`.
-    `extendTimeout` is **deferred** (niche: session length is already set at create
-    via `box.vercelTimeoutMs`, and persistent mode auto-resumes — mid-session
-    extension has no clean CLI home yet).
+    `extendTimeout` is now **wired** via `CloudBackend.renewTimeout` + the host
+    relay `cloud-keepalive` loop: while the in-box agent is active the box's
+    session timeout is renewed (anchored at `lastActivity + autopause.idleMinutes`)
+    so a long agent run isn't killed mid-work. Bounded by the plan cap (mainly
+    benefits Pro+). Same loop covers E2B (`Sandbox.setTimeout`).
 19. **gh/git relay shims don't win PATH on Vercel AL2023.** Found 2026-05-29 while
     verifying the git-shim-ordering fix: in a booted vercel box `command -v git`
     resolves to **`/opt/git/bin/git`**, not `/usr/local/bin/git` — Vercel's base

--- a/packages/core/src/box-record.ts
+++ b/packages/core/src/box-record.ts
@@ -111,6 +111,14 @@ export interface CloudBoxFields {
    * the real state. Absent on pre-feature records → treated as `running`.
    */
   lastState?: BoxRuntimeState;
+  /**
+   * Effective per-session timeout (ms) the sandbox was created with, when the
+   * backend models one (vercel `Sandbox.create({ timeout })`). Recorded so the
+   * host keepalive loop can seed its tracked death-time accurately (the
+   * effective value can be project/workspace-overridden, not the global
+   * default). Absent on backends without a session timeout / pre-feature records.
+   */
+  sessionTimeoutMs?: number;
 }
 
 export interface GitWorktreeRecord {

--- a/packages/core/src/cloud-backend.ts
+++ b/packages/core/src/cloud-backend.ts
@@ -282,4 +282,33 @@ export interface CloudBackend {
     h: CloudHandle,
     opts: { boxName: string; proxyPort: number; tls: boolean; webPort: number },
   ): Promise<void>;
+
+  /**
+   * Optional: push the sandbox's session-timeout death-time forward so an
+   * actively-working in-box agent isn't killed when the create-time timeout
+   * elapses. The host renewal loop (`@agentbox/relay` cloud-keepalive) calls
+   * this while the agent is active, anchoring the death-time at
+   * `lastActivity + window` (window = the autopause idle threshold).
+   *
+   * Both an absolute `targetDeadlineEpochMs` AND the host's tracked
+   * `currentDeadlineEpochMs` are passed because the SDKs differ:
+   *   - vercel: `sb.extendTimeout(ms)` is ADDITIVE and the remaining time isn't
+   *     readable, so the backend extends by `targetDeadlineEpochMs -
+   *     currentDeadlineEpochMs` (the host owns the deadline bookkeeping).
+   *   - e2b: `Sandbox.setTimeout(ms)` SETS the TTL to `ms` from now, so the
+   *     backend uses `targetDeadlineEpochMs - Date.now()` and ignores
+   *     `currentDeadlineEpochMs`.
+   * Both clamp the computed duration to `>= 0`.
+   *
+   * The host only calls when `target > current`, so this never shortens a
+   * session. Plan-cap rejection (Hobby ~45m, Pro+ ~5h) MUST surface (throw or
+   * no-op) — the host loop swallows it and lets the box lapse at the cap.
+   * Backends without a renew primitive omit this; the loop detects the absence
+   * with `typeof backend.renewTimeout === 'function'` and skips the box.
+   */
+  renewTimeout?(
+    h: CloudHandle,
+    targetDeadlineEpochMs: number,
+    currentDeadlineEpochMs: number,
+  ): Promise<void>;
 }

--- a/packages/relay/src/bin.ts
+++ b/packages/relay/src/bin.ts
@@ -3,6 +3,7 @@ import { request as httpRequest } from 'node:http';
 import { DEFAULT_RELAY_PORT } from './types.js';
 import { startRelayServer } from './server.js';
 import { startAutopauseLoop } from './autopause.js';
+import { startCloudKeepaliveLoop } from './cloud-keepalive.js';
 import { startQueueLoop } from './queue.js';
 
 const program = new Command();
@@ -36,6 +37,11 @@ program
       events: handle.events,
       log: (line) => process.stdout.write(`agentbox-relay: ${line}\n`),
     });
+    const cloudKeepalive = startCloudKeepaliveLoop({
+      registry: handle.registry,
+      statusStore: handle.statusStore,
+      log: (line) => process.stdout.write(`agentbox-relay: ${line}\n`),
+    });
     const queue = startQueueLoop({
       log: (line) => process.stdout.write(`agentbox-relay: ${line}\n`),
       registry: handle.registry,
@@ -47,7 +53,7 @@ program
 
     const shutdown = (signal: string): void => {
       process.stdout.write(`agentbox-relay: ${signal} — shutting down\n`);
-      Promise.allSettled([autopause.stop(), queue.stop()])
+      Promise.allSettled([autopause.stop(), cloudKeepalive.stop(), queue.stop()])
         .finally(() => handle.close())
         .finally(() => process.exit(0));
     };

--- a/packages/relay/src/cloud-keepalive.ts
+++ b/packages/relay/src/cloud-keepalive.ts
@@ -1,0 +1,297 @@
+/**
+ * `startCloudKeepaliveLoop` — host-resident loop that renews a cloud box's
+ * session-timeout while its in-box agent is active, so a long-running
+ * Claude/Codex session isn't killed when the create-time timeout elapses.
+ *
+ * Sibling to `startAutopauseLoop` (and modeled on it): a host-wide sweep on a
+ * timer that reads each box's live agent state from the `BoxStatusStore` and
+ * acts. Where autopause *pauses* idle docker boxes, this *keeps alive* active
+ * cloud boxes by pushing their death-time out to `lastActivity + window`. The
+ * window REUSES the autopause idle threshold (`autopause.idleMinutes`) — per
+ * the design, there is no separate keepalive knob; an idle box stops being
+ * renewed once it's been quiet for the window and lapses at its current
+ * deadline, mirroring autopause's idle semantics.
+ *
+ * The additive-vs-absolute SDK split (vercel `extendTimeout` adds to the
+ * current deadline and can't read remaining; e2b `setTimeout` sets TTL from
+ * now) is resolved here by tracking each box's intended deadline in memory and
+ * handing the backend BOTH the absolute target and our tracked current
+ * deadline. See `CloudBackend.renewTimeout`.
+ *
+ * Plan caps (vercel Hobby ~45m, Pro+ ~5h; e2b team plan) bound how far a box
+ * can be extended — a renew past the cap throws and is swallowed here, so the
+ * box lapses normally. The feature mainly benefits Pro+ plans, where the
+ * conservative 45-min create default otherwise kills long sessions early.
+ */
+
+import { readFile } from 'node:fs/promises';
+import {
+  BUILT_IN_DEFAULTS,
+  GLOBAL_CONFIG_FILE,
+  parseUserConfig,
+  type UserConfig,
+} from '@agentbox/config';
+import type { CloudBackend } from '@agentbox/core';
+import { findBox, readState } from '@agentbox/sandbox-core';
+import { loadAutopauseConfig, type AutopauseConfig } from './autopause.js';
+import { resolveCloudBackend } from './host-actions.js';
+import { readActiveAgent, type WorkingAgentState } from './queue.js';
+import type { BoxRegistry } from './registry.js';
+import type { BoxStatusStore } from './status-store.js';
+
+/** Coarse activity for the renewal decision. `active` = keep the box alive. */
+export type KeepaliveAgentState = 'active' | 'idle' | null;
+
+/** One box's facts the pure selector reasons about. No I/O, no clock. */
+export interface KeepaliveScanEntry {
+  boxId: string;
+  /** Cloud backend name, e.g. 'vercel'. */
+  backend: string;
+  /** Coarse activity across claude/codex/opencode, or null when no snapshot. */
+  agentState: KeepaliveAgentState;
+  /** epoch ms of the active agent's `updatedAt`, or null when no snapshot. */
+  lastActivityMs: number | null;
+}
+
+export interface RenewDecision {
+  boxId: string;
+  backend: string;
+  /** Absolute death-time we want this box held at: `lastActivity + window`. */
+  targetDeadlineEpochMs: number;
+}
+
+/**
+ * Pure selection: given each cloud box's activity facts, the window, and the
+ * clock, return the boxes to renew with their target death-time. A box is
+ * renewed while its agent is active, or while it has been idle for LESS than
+ * the window (so a just-idle box keeps living a little, then lapses — the
+ * "death = lastActivity + window" anchor the user asked for). Boxes with no
+ * activity signal are skipped (let the create-time timeout govern); a wedged
+ * agent (error/unknown) is never kept alive.
+ *
+ * The target is recomputed purely from `lastActivityMs + windowMs` every tick,
+ * so it's deterministic and survives a relay restart (no persisted state).
+ */
+export function selectBoxesToRenew(
+  entries: KeepaliveScanEntry[],
+  windowMs: number,
+  now: number,
+): RenewDecision[] {
+  const out: RenewDecision[] = [];
+  for (const e of entries) {
+    if (e.lastActivityMs == null || e.agentState == null) continue;
+    const withinWindow = now - e.lastActivityMs < windowMs;
+    if (e.agentState === 'active' || (e.agentState === 'idle' && withinWindow)) {
+      out.push({
+        boxId: e.boxId,
+        backend: e.backend,
+        targetDeadlineEpochMs: e.lastActivityMs + windowMs,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Collapse the multi-agent `WorkingAgentState` into the coarse keepalive state.
+ * Mirrors autopause's `coarsePauseState`, but here any live session expecting
+ * attention (waiting/question/end-plan) counts as `active` so we never let it
+ * be killed mid-interaction; only a settled `idle` is the lapse candidate.
+ * error/unknown/null → null (don't keep a wedged or unknown box alive forever).
+ */
+function coarseKeepaliveState(s: WorkingAgentState | null): KeepaliveAgentState {
+  switch (s) {
+    case 'working':
+    case 'compacting':
+    case 'waiting':
+    case 'question':
+    case 'end-plan':
+      return 'active';
+    case 'idle':
+      return 'idle';
+    default:
+      return null;
+  }
+}
+
+export interface CloudKeepaliveLoopDeps {
+  registry: BoxRegistry;
+  statusStore: BoxStatusStore;
+  log: (line: string) => void;
+  /** Injectable for tests; defaults to the global autopause config loader. */
+  loadConfig?: () => Promise<AutopauseConfig>;
+  /** Injectable for tests; defaults to `resolveCloudBackend`. */
+  resolveBackend?: (name: string) => Promise<CloudBackend>;
+  /** Injectable for tests; defaults to the state.json sandboxId lookup. */
+  lookupSandboxId?: (boxId: string) => Promise<string | null>;
+  /** Injectable for tests; defaults to the global `box.vercelTimeoutMs`. */
+  vercelCreateTimeoutMs?: () => Promise<number>;
+  /** Injectable for tests; defaults to `Date.now`. */
+  now?: () => number;
+  intervalMs?: number;
+}
+
+export interface CloudKeepaliveLoopHandle {
+  /** Stop scheduling and await any in-flight tick. */
+  stop: () => Promise<void>;
+}
+
+const DEFAULT_INTERVAL_MS = 60_000;
+/** e2b create-timeout seed (it has no config key; ignores the seed at call time). */
+const E2B_CREATE_TIMEOUT_MS = 45 * 60_000;
+
+export function startCloudKeepaliveLoop(
+  deps: CloudKeepaliveLoopDeps,
+): CloudKeepaliveLoopHandle {
+  const loadConfig = deps.loadConfig ?? loadAutopauseConfig;
+  const resolveBackend = deps.resolveBackend ?? resolveCloudBackend;
+  const lookupSandboxId = deps.lookupSandboxId ?? defaultLookupSandboxId;
+  const vercelCreateTimeoutMs = deps.vercelCreateTimeoutMs ?? defaultVercelCreateTimeoutMs;
+  const nowFn = deps.now ?? Date.now;
+  const intervalMs = deps.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const { registry, statusStore, log } = deps;
+
+  // Per-box intended death-time we've pushed the session to. Seeded lazily from
+  // `createdAt + create-timeout`; in-memory only — a relay restart re-seeds
+  // (at worst one corrective over-extend, bounded by the plan cap).
+  const tracked = new Map<string, number>();
+  // Resolved backends cached across ticks (one dynamic import per provider).
+  const backendCache = new Map<string, CloudBackend | null>();
+
+  let ticking = false;
+  let stopped = false;
+  let inFlight: Promise<void> = Promise.resolve();
+
+  async function resolveCached(name: string): Promise<CloudBackend | null> {
+    if (backendCache.has(name)) return backendCache.get(name) ?? null;
+    let backend: CloudBackend | null = null;
+    try {
+      backend = await resolveBackend(name);
+    } catch {
+      backend = null; // no executor for this backend — skip its boxes
+    }
+    backendCache.set(name, backend);
+    return backend;
+  }
+
+  async function tick(): Promise<void> {
+    if (ticking) return;
+    ticking = true;
+    try {
+      const cfg = await loadConfig();
+      if (!cfg.enabled) return;
+      const windowMs = cfg.idleMinutes * 60_000;
+      const now = nowFn();
+
+      const live = new Set<string>();
+      const entries: KeepaliveScanEntry[] = [];
+      const createdAt = new Map<string, string | undefined>();
+      for (const reg of registry.list()) {
+        if (reg.kind !== 'cloud' || !reg.backend) continue;
+        const backend = await resolveCached(reg.backend);
+        if (!backend || typeof backend.renewTimeout !== 'function') continue;
+        live.add(reg.boxId);
+        createdAt.set(reg.boxId, reg.createdAt);
+        const active = readActiveAgent(statusStore.get(reg.boxId));
+        entries.push({
+          boxId: reg.boxId,
+          backend: reg.backend,
+          agentState: coarseKeepaliveState(active.state),
+          lastActivityMs: active.updatedAt ? toEpoch(active.updatedAt) : null,
+        });
+      }
+
+      // Drop tracking for boxes that are gone (destroyed / forgotten).
+      for (const id of [...tracked.keys()]) if (!live.has(id)) tracked.delete(id);
+
+      const decisions = selectBoxesToRenew(entries, windowMs, now);
+      for (const d of decisions) {
+        let current = tracked.get(d.boxId);
+        if (current == null) {
+          const createMs = toEpoch(createdAt.get(d.boxId)) ?? now;
+          const createTimeoutMs =
+            d.backend === 'vercel' ? await vercelCreateTimeoutMs() : E2B_CREATE_TIMEOUT_MS;
+          current = createMs + createTimeoutMs;
+          tracked.set(d.boxId, current);
+        }
+        // Only renew when the target meaningfully exceeds the tracked deadline,
+        // so we don't churn the SDK for sub-tick gains or extend an idle box
+        // that's still riding its create timeout.
+        if (d.targetDeadlineEpochMs <= current + intervalMs) continue;
+        try {
+          const sandboxId = await lookupSandboxId(d.boxId);
+          if (!sandboxId) continue;
+          const backend = await resolveCached(d.backend);
+          if (!backend?.renewTimeout) continue;
+          await backend.renewTimeout({ sandboxId }, d.targetDeadlineEpochMs, current);
+          tracked.set(d.boxId, d.targetDeadlineEpochMs);
+          log(
+            `cloud-keepalive: renewed box ${d.boxId} (${d.backend}) ` +
+              `+${String(Math.round((d.targetDeadlineEpochMs - now) / 60_000))}m`,
+          );
+        } catch (err) {
+          // Plan-cap rejection or a transient SDK error. Advance the tracked
+          // deadline anyway so we don't hammer the cap every tick; a still-
+          // active agent's later (higher) target will retry next tick.
+          tracked.set(d.boxId, d.targetDeadlineEpochMs);
+          const msg = err instanceof Error ? err.message : String(err);
+          log(`cloud-keepalive: renew box ${d.boxId} (${d.backend}) failed: ${msg}`);
+        }
+      }
+    } catch (err) {
+      // The loop must never crash the relay or stop scheduling.
+      const msg = err instanceof Error ? err.message : String(err);
+      log(`cloud-keepalive: tick error: ${msg}`);
+    } finally {
+      ticking = false;
+    }
+  }
+
+  const timer = setInterval(() => {
+    if (stopped) return;
+    inFlight = tick();
+  }, intervalMs);
+  timer.unref();
+
+  return {
+    stop: async () => {
+      stopped = true;
+      clearInterval(timer);
+      await inFlight.catch(() => {});
+    },
+  };
+}
+
+function toEpoch(iso: string | undefined): number | null {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? null : t;
+}
+
+/** Resolve a box's cloud sandboxId from `~/.agentbox/state.json`. */
+async function defaultLookupSandboxId(boxId: string): Promise<string | null> {
+  const state = await readState();
+  const hit = findBox(boxId, state);
+  if (hit.kind !== 'ok') return null;
+  return hit.box.cloud?.sandboxId ?? null;
+}
+
+/**
+ * Global `box.vercelTimeoutMs` — the create-time session timeout, used to seed
+ * a vercel box's tracked deadline. Global-only (the relay is host-wide), falls
+ * back to the built-in default. A close estimate is enough: the renew gate
+ * tolerates seed drift, and an inaccurate seed self-corrects on the next renew.
+ */
+async function defaultVercelCreateTimeoutMs(): Promise<number> {
+  const fallback = BUILT_IN_DEFAULTS.box.vercelTimeoutMs;
+  try {
+    const global: Partial<UserConfig> = parseUserConfig(
+      await readFile(GLOBAL_CONFIG_FILE, 'utf8'),
+      GLOBAL_CONFIG_FILE,
+    );
+    const v = global.box?.vercelTimeoutMs;
+    return typeof v === 'number' && v > 0 ? v : fallback;
+  } catch {
+    return fallback;
+  }
+}

--- a/packages/relay/src/cloud-keepalive.ts
+++ b/packages/relay/src/cloud-keepalive.ts
@@ -6,21 +6,25 @@
  * Sibling to `startAutopauseLoop` (and modeled on it): a host-wide sweep on a
  * timer that reads each box's live agent state from the `BoxStatusStore` and
  * acts. Where autopause *pauses* idle docker boxes, this *keeps alive* active
- * cloud boxes by pushing their death-time out to `lastActivity + window`. The
- * window REUSES the autopause idle threshold (`autopause.idleMinutes`) — per
- * the design, there is no separate keepalive knob; an idle box stops being
- * renewed once it's been quiet for the window and lapses at its current
- * deadline, mirroring autopause's idle semantics.
+ * cloud boxes by pushing their death-time out. The window REUSES the autopause
+ * idle threshold (`autopause.idleMinutes`) — per the design, there is no
+ * separate keepalive knob.
+ *
+ *   - active agent -> hold the death-time a full window ahead of NOW.
+ *   - idle agent   -> let it lapse a window after it went idle, then stop.
  *
  * The additive-vs-absolute SDK split (vercel `extendTimeout` adds to the
  * current deadline and can't read remaining; e2b `setTimeout` sets TTL from
- * now) is resolved here by tracking each box's intended deadline in memory and
+ * now) is resolved by tracking each box's intended deadline in memory and
  * handing the backend BOTH the absolute target and our tracked current
- * deadline. See `CloudBackend.renewTimeout`.
+ * deadline. See `CloudBackend.renewTimeout`. The tracked deadline is seeded
+ * from the box's RECORDED effective create timeout (`cloud.sessionTimeoutMs`)
+ * so a project/workspace override doesn't desync the seed.
  *
  * Plan caps (vercel Hobby ~45m, Pro+ ~5h; e2b team plan) bound how far a box
- * can be extended — a renew past the cap throws and is swallowed here, so the
- * box lapses normally. The feature mainly benefits Pro+ plans, where the
+ * can be extended — a renew past the cap throws and is swallowed here, after
+ * which the box is briefly backed off (so we don't hammer the API / log) and
+ * lapses normally. The feature mainly benefits Pro+ plans, where the
  * conservative 45-min create default otherwise kills long sessions early.
  */
 
@@ -56,7 +60,7 @@ export interface KeepaliveScanEntry {
 export interface RenewDecision {
   boxId: string;
   backend: string;
-  /** Absolute death-time we want this box held at: `lastActivity + window`. */
+  /** Absolute death-time we want this box held at. */
   targetDeadlineEpochMs: number;
 }
 
@@ -68,16 +72,15 @@ export interface RenewDecision {
  *   - idle, < window since it went idle -> lapse `window` after it went idle
  *     (`lastActivityMs + windowMs`, where `lastActivityMs` is the fresh
  *     working->idle transition time).
- *   - idle >= window, or no activity signal, or a wedged agent (error/unknown)
- *     -> skip (let the box lapse / let the create-time timeout govern).
+ *   - idle >= window, no agent state, or a wedged agent (error/unknown) -> skip.
  *
- * The active case anchors on `now`, NOT on `lastActivityMs`: the in-box status
- * reporter bumps `updatedAt` on state changes (per-tool-call), not during a
- * long single `working` operation (a 30-min test run), so a stale `updatedAt`
- * would freeze the target below the tracked deadline and the box would be
- * killed mid-work — the exact failure this feature exists to prevent. Anchoring
- * the active case on `now` keeps a working box alive regardless of `updatedAt`
- * staleness; the idle case stays `now`-independent so an idle box still lapses.
+ * The active case anchors on `now`, NOT on `lastActivityMs`, and does NOT
+ * require `lastActivityMs`: the in-box status reporter bumps `updatedAt` on
+ * state changes (per-tool-call), not during a long single `working` op (a
+ * 30-min test run), so a stale/absent `updatedAt` must not freeze the target
+ * below the tracked deadline — that would kill the box mid-work, the exact
+ * failure this feature prevents. The idle case stays `now`-independent so an
+ * idle box still lapses.
  */
 export function selectBoxesToRenew(
   entries: KeepaliveScanEntry[],
@@ -86,11 +89,15 @@ export function selectBoxesToRenew(
 ): RenewDecision[] {
   const out: RenewDecision[] = [];
   for (const e of entries) {
-    if (e.lastActivityMs == null || e.agentState == null) continue;
+    if (e.agentState == null) continue;
     let target: number | null = null;
     if (e.agentState === 'active') {
       target = now + windowMs;
-    } else if (e.agentState === 'idle' && now - e.lastActivityMs < windowMs) {
+    } else if (
+      e.agentState === 'idle' &&
+      e.lastActivityMs != null &&
+      now - e.lastActivityMs < windowMs
+    ) {
       target = e.lastActivityMs + windowMs;
     }
     if (target != null) {
@@ -122,6 +129,15 @@ function coarseKeepaliveState(s: WorkingAgentState | null): KeepaliveAgentState 
   }
 }
 
+/** What the box-record lookup yields for seeding + the renew call. */
+export interface CloudBoxLookup {
+  sandboxId: string;
+  /** Box creation time as epoch ms, or null when unparseable. */
+  createdAtMs: number | null;
+  /** Recorded effective create timeout (ms), or null when not recorded. */
+  createTimeoutMs: number | null;
+}
+
 export interface CloudKeepaliveLoopDeps {
   registry: BoxRegistry;
   statusStore: BoxStatusStore;
@@ -130,10 +146,10 @@ export interface CloudKeepaliveLoopDeps {
   loadConfig?: () => Promise<AutopauseConfig>;
   /** Injectable for tests; defaults to `resolveCloudBackend`. */
   resolveBackend?: (name: string) => Promise<CloudBackend>;
-  /** Injectable for tests; defaults to the state.json sandboxId lookup. */
-  lookupSandboxId?: (boxId: string) => Promise<string | null>;
-  /** Injectable for tests; defaults to the global `box.vercelTimeoutMs`. */
-  vercelCreateTimeoutMs?: () => Promise<number>;
+  /** Injectable for tests; defaults to the state.json box lookup. */
+  lookupBox?: (boxId: string) => Promise<CloudBoxLookup | null>;
+  /** Injectable for tests; fallback create timeout when a record lacks one. */
+  fallbackCreateTimeoutMs?: (backend: string) => Promise<number>;
   /** Injectable for tests; defaults to `Date.now`. */
   now?: () => number;
   intervalMs?: number;
@@ -145,24 +161,26 @@ export interface CloudKeepaliveLoopHandle {
 }
 
 const DEFAULT_INTERVAL_MS = 60_000;
-/** e2b create-timeout seed (it has no config key; ignores the seed at call time). */
-const E2B_CREATE_TIMEOUT_MS = 45 * 60_000;
+/** After a failed renew, skip the box for this long (avoid cap hammering / log spam). */
+const FAILURE_BACKOFF_MS = 5 * 60_000;
 
 export function startCloudKeepaliveLoop(
   deps: CloudKeepaliveLoopDeps,
 ): CloudKeepaliveLoopHandle {
   const loadConfig = deps.loadConfig ?? loadAutopauseConfig;
   const resolveBackend = deps.resolveBackend ?? resolveCloudBackend;
-  const lookupSandboxId = deps.lookupSandboxId ?? defaultLookupSandboxId;
-  const vercelCreateTimeoutMs = deps.vercelCreateTimeoutMs ?? defaultVercelCreateTimeoutMs;
+  const lookupBox = deps.lookupBox ?? defaultLookupBox;
+  const fallbackCreateTimeoutMs = deps.fallbackCreateTimeoutMs ?? defaultFallbackCreateTimeoutMs;
   const nowFn = deps.now ?? Date.now;
   const intervalMs = deps.intervalMs ?? DEFAULT_INTERVAL_MS;
   const { registry, statusStore, log } = deps;
 
   // Per-box intended death-time we've pushed the session to. Seeded lazily from
-  // `createdAt + create-timeout`; in-memory only — a relay restart re-seeds
-  // (at worst one corrective over-extend, bounded by the plan cap).
+  // the recorded `createdAt + create-timeout`; in-memory only — a relay restart
+  // re-seeds (at worst one corrective over-extend, bounded by the plan cap).
   const tracked = new Map<string, number>();
+  // Per-box "don't attempt before" time, set after a failed renew.
+  const backoffUntil = new Map<string, number>();
   // Resolved backends cached across ticks (one dynamic import per provider).
   const backendCache = new Map<string, CloudBackend | null>();
 
@@ -193,13 +211,11 @@ export function startCloudKeepaliveLoop(
 
       const live = new Set<string>();
       const entries: KeepaliveScanEntry[] = [];
-      const createdAt = new Map<string, string | undefined>();
       for (const reg of registry.list()) {
         if (reg.kind !== 'cloud' || !reg.backend) continue;
         const backend = await resolveCached(reg.backend);
         if (!backend || typeof backend.renewTimeout !== 'function') continue;
         live.add(reg.boxId);
-        createdAt.set(reg.boxId, reg.createdAt);
         const active = readActiveAgent(statusStore.get(reg.boxId));
         entries.push({
           boxId: reg.boxId,
@@ -209,39 +225,50 @@ export function startCloudKeepaliveLoop(
         });
       }
 
-      // Drop tracking for boxes that are gone (destroyed / forgotten).
+      // Drop per-box state for boxes that are gone (destroyed / forgotten).
       for (const id of [...tracked.keys()]) if (!live.has(id)) tracked.delete(id);
+      for (const id of [...backoffUntil.keys()]) if (!live.has(id)) backoffUntil.delete(id);
 
       const decisions = selectBoxesToRenew(entries, windowMs, now);
       for (const d of decisions) {
+        const until = backoffUntil.get(d.boxId);
+        if (until != null && now < until) continue; // recently failed — wait
+
+        const lookup = await lookupBox(d.boxId);
+        if (!lookup) continue;
+
+        // Seed the tracked deadline from the recorded effective create timeout
+        // (falls back to a provider default for pre-feature records).
         let current = tracked.get(d.boxId);
         if (current == null) {
-          const createMs = toEpoch(createdAt.get(d.boxId)) ?? now;
+          const createMs = lookup.createdAtMs ?? now;
           const createTimeoutMs =
-            d.backend === 'vercel' ? await vercelCreateTimeoutMs() : E2B_CREATE_TIMEOUT_MS;
+            lookup.createTimeoutMs ?? (await fallbackCreateTimeoutMs(d.backend));
           current = createMs + createTimeoutMs;
           tracked.set(d.boxId, current);
         }
         // Only renew when the target meaningfully exceeds the tracked deadline,
-        // so we don't churn the SDK for sub-tick gains or extend an idle box
-        // that's still riding its create timeout.
+        // so we don't churn the SDK for sub-tick gains or extend a box still
+        // riding its create timeout.
         if (d.targetDeadlineEpochMs <= current + intervalMs) continue;
+
         try {
-          const sandboxId = await lookupSandboxId(d.boxId);
-          if (!sandboxId) continue;
           const backend = await resolveCached(d.backend);
           if (!backend?.renewTimeout) continue;
-          await backend.renewTimeout({ sandboxId }, d.targetDeadlineEpochMs, current);
+          await backend.renewTimeout({ sandboxId: lookup.sandboxId }, d.targetDeadlineEpochMs, current);
+          // Only advance the tracked deadline on SUCCESS — a failed extend did
+          // not actually move the real deadline, so we must not record it.
           tracked.set(d.boxId, d.targetDeadlineEpochMs);
+          backoffUntil.delete(d.boxId);
           log(
             `cloud-keepalive: renewed box ${d.boxId} (${d.backend}) ` +
               `+${String(Math.round((d.targetDeadlineEpochMs - now) / 60_000))}m`,
           );
         } catch (err) {
-          // Plan-cap rejection or a transient SDK error. Advance the tracked
-          // deadline anyway so we don't hammer the cap every tick; a still-
-          // active agent's later (higher) target will retry next tick.
-          tracked.set(d.boxId, d.targetDeadlineEpochMs);
+          // Plan-cap rejection or a transient SDK error. Leave `tracked`
+          // unchanged (so we retry once the backoff lapses) and back the box
+          // off briefly to avoid hammering the cap / spamming the log.
+          backoffUntil.set(d.boxId, now + FAILURE_BACKOFF_MS);
           const msg = err instanceof Error ? err.message : String(err);
           log(`cloud-keepalive: renew box ${d.boxId} (${d.backend}) failed: ${msg}`);
         }
@@ -276,21 +303,29 @@ function toEpoch(iso: string | undefined): number | null {
   return Number.isNaN(t) ? null : t;
 }
 
-/** Resolve a box's cloud sandboxId from `~/.agentbox/state.json`. */
-async function defaultLookupSandboxId(boxId: string): Promise<string | null> {
+/** Resolve a box's cloud sandboxId + create facts from `~/.agentbox/state.json`. */
+async function defaultLookupBox(boxId: string): Promise<CloudBoxLookup | null> {
   const state = await readState();
   const hit = findBox(boxId, state);
   if (hit.kind !== 'ok') return null;
-  return hit.box.cloud?.sandboxId ?? null;
+  const sandboxId = hit.box.cloud?.sandboxId;
+  if (!sandboxId) return null;
+  return {
+    sandboxId,
+    createdAtMs: toEpoch(hit.box.createdAt),
+    createTimeoutMs: hit.box.cloud?.sessionTimeoutMs ?? null,
+  };
 }
 
 /**
- * Global `box.vercelTimeoutMs` — the create-time session timeout, used to seed
- * a vercel box's tracked deadline. Global-only (the relay is host-wide), falls
- * back to the built-in default. A close estimate is enough: the renew gate
- * tolerates seed drift, and an inaccurate seed self-corrects on the next renew.
+ * Fallback create timeout for a box record that predates `sessionTimeoutMs`.
+ * Vercel reads the global `box.vercelTimeoutMs`; other backends use the shared
+ * 45-min default (matches the backends' `DEFAULT_TIMEOUT_MS`). A close estimate
+ * is enough — the renew gate tolerates seed drift and self-corrects.
  */
-async function defaultVercelCreateTimeoutMs(): Promise<number> {
+async function defaultFallbackCreateTimeoutMs(backend: string): Promise<number> {
+  const generic = 45 * 60_000;
+  if (backend !== 'vercel') return generic;
   const fallback = BUILT_IN_DEFAULTS.box.vercelTimeoutMs;
   try {
     const global: Partial<UserConfig> = parseUserConfig(

--- a/packages/relay/src/cloud-keepalive.ts
+++ b/packages/relay/src/cloud-keepalive.ts
@@ -62,15 +62,22 @@ export interface RenewDecision {
 
 /**
  * Pure selection: given each cloud box's activity facts, the window, and the
- * clock, return the boxes to renew with their target death-time. A box is
- * renewed while its agent is active, or while it has been idle for LESS than
- * the window (so a just-idle box keeps living a little, then lapses — the
- * "death = lastActivity + window" anchor the user asked for). Boxes with no
- * activity signal are skipped (let the create-time timeout govern); a wedged
- * agent (error/unknown) is never kept alive.
+ * clock, return the boxes to renew with their target death-time.
  *
- * The target is recomputed purely from `lastActivityMs + windowMs` every tick,
- * so it's deterministic and survives a relay restart (no persisted state).
+ *   - active agent  -> keep alive a full window from NOW (`now + windowMs`).
+ *   - idle, < window since it went idle -> lapse `window` after it went idle
+ *     (`lastActivityMs + windowMs`, where `lastActivityMs` is the fresh
+ *     working->idle transition time).
+ *   - idle >= window, or no activity signal, or a wedged agent (error/unknown)
+ *     -> skip (let the box lapse / let the create-time timeout govern).
+ *
+ * The active case anchors on `now`, NOT on `lastActivityMs`: the in-box status
+ * reporter bumps `updatedAt` on state changes (per-tool-call), not during a
+ * long single `working` operation (a 30-min test run), so a stale `updatedAt`
+ * would freeze the target below the tracked deadline and the box would be
+ * killed mid-work — the exact failure this feature exists to prevent. Anchoring
+ * the active case on `now` keeps a working box alive regardless of `updatedAt`
+ * staleness; the idle case stays `now`-independent so an idle box still lapses.
  */
 export function selectBoxesToRenew(
   entries: KeepaliveScanEntry[],
@@ -80,13 +87,14 @@ export function selectBoxesToRenew(
   const out: RenewDecision[] = [];
   for (const e of entries) {
     if (e.lastActivityMs == null || e.agentState == null) continue;
-    const withinWindow = now - e.lastActivityMs < windowMs;
-    if (e.agentState === 'active' || (e.agentState === 'idle' && withinWindow)) {
-      out.push({
-        boxId: e.boxId,
-        backend: e.backend,
-        targetDeadlineEpochMs: e.lastActivityMs + windowMs,
-      });
+    let target: number | null = null;
+    if (e.agentState === 'active') {
+      target = now + windowMs;
+    } else if (e.agentState === 'idle' && now - e.lastActivityMs < windowMs) {
+      target = e.lastActivityMs + windowMs;
+    }
+    if (target != null) {
+      out.push({ boxId: e.boxId, backend: e.backend, targetDeadlineEpochMs: target });
     }
   }
   return out;

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -105,6 +105,15 @@ export {
   type ContainerState,
 } from './autopause.js';
 export {
+  selectBoxesToRenew,
+  startCloudKeepaliveLoop,
+  type CloudKeepaliveLoopDeps,
+  type CloudKeepaliveLoopHandle,
+  type KeepaliveAgentState,
+  type KeepaliveScanEntry,
+  type RenewDecision,
+} from './cloud-keepalive.js';
+export {
   countWorkingSlots,
   defaultCountRunningBoxes,
   defaultCountWorkingBoxes,

--- a/packages/relay/test/cloud-keepalive.test.ts
+++ b/packages/relay/test/cloud-keepalive.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   selectBoxesToRenew,
   startCloudKeepaliveLoop,
+  type CloudBoxLookup,
   type KeepaliveScanEntry,
 } from '../src/cloud-keepalive.js';
 import { BoxRegistry } from '../src/registry.js';
@@ -39,6 +40,14 @@ describe('selectBoxesToRenew', () => {
     ]);
   });
 
+  it('renews an active box even with no activity timestamp at all', () => {
+    // Active sessions reported without updatedAt must still be kept alive.
+    const e = entry({ boxId: 'a', agentState: 'active', lastActivityMs: null });
+    expect(selectBoxesToRenew([e], WINDOW, NOW)).toEqual([
+      { boxId: 'a', backend: 'vercel', targetDeadlineEpochMs: NOW + WINDOW },
+    ]);
+  });
+
   it('renews an idle box still within the window, anchored at lastActivity + window', () => {
     const e = entry({ boxId: 'a', agentState: 'idle', lastActivityMs: NOW - WINDOW + 1 });
     expect(selectBoxesToRenew([e], WINDOW, NOW)).toEqual([
@@ -51,13 +60,13 @@ describe('selectBoxesToRenew', () => {
     expect(selectBoxesToRenew([e], WINDOW, NOW)).toEqual([]);
   });
 
-  it('skips boxes with no activity signal', () => {
-    expect(
-      selectBoxesToRenew([entry({ boxId: 'a', lastActivityMs: null })], WINDOW, NOW),
-    ).toEqual([]);
-    expect(
-      selectBoxesToRenew([entry({ boxId: 'b', agentState: null })], WINDOW, NOW),
-    ).toEqual([]);
+  it('skips an idle box with no activity timestamp', () => {
+    const e = entry({ boxId: 'a', agentState: 'idle', lastActivityMs: null });
+    expect(selectBoxesToRenew([e], WINDOW, NOW)).toEqual([]);
+  });
+
+  it('skips boxes with no agent state', () => {
+    expect(selectBoxesToRenew([entry({ boxId: 'b', agentState: null })], WINDOW, NOW)).toEqual([]);
   });
 
   it('idle target is now-independent (restart-robust)', () => {
@@ -84,6 +93,13 @@ describe('startCloudKeepaliveLoop', () => {
   }
 
   const CFG: AutopauseConfig = { enabled: true, maxRunningBoxes: 5, idleMinutes: 5 };
+  // Lookup that seeds the tracked deadline at exactly NOW (createdAt=NOW, timeout=0)
+  // so an active box's target (NOW+WINDOW) clears the renew gate.
+  const lookupAtNow = async (): Promise<CloudBoxLookup> => ({
+    sandboxId: 'sb-123',
+    createdAtMs: NOW,
+    createTimeoutMs: 0,
+  });
 
   function registerCloud(reg: BoxRegistry, boxId: string, backend = 'vercel'): void {
     reg.register({
@@ -118,8 +134,7 @@ describe('startCloudKeepaliveLoop', () => {
       now: () => NOW,
       loadConfig: async () => CFG,
       resolveBackend: async () => backend,
-      lookupSandboxId: async () => 'sb-123',
-      vercelCreateTimeoutMs: async () => 0, // seed tracked deadline = createdAt(=NOW)
+      lookupBox: lookupAtNow,
     });
 
     await got.promise;
@@ -130,7 +145,6 @@ describe('startCloudKeepaliveLoop', () => {
 
   it('skips docker boxes and backends without renewTimeout', async () => {
     const registry = new BoxRegistry();
-    // docker box (no renewal)
     registry.register({
       boxId: 'd1',
       token: 't',
@@ -140,9 +154,8 @@ describe('startCloudKeepaliveLoop', () => {
       containerName: 'agentbox-d1',
       createdAt: new Date(NOW).toISOString(),
     });
-    // cloud box whose backend lacks renewTimeout
     registerCloud(registry, 'c1', 'daytona');
-    let calls = 0;
+    let lookups = 0;
     const backend = { name: 'daytona' } as unknown as CloudBackend; // no renewTimeout
 
     const loop = startCloudKeepaliveLoop({
@@ -153,25 +166,26 @@ describe('startCloudKeepaliveLoop', () => {
       now: () => NOW,
       loadConfig: async () => CFG,
       resolveBackend: async () => backend,
-      lookupSandboxId: async () => {
-        calls++;
-        return 'sb-x';
+      lookupBox: async () => {
+        lookups++;
+        return { sandboxId: 'sb-x', createdAtMs: NOW, createTimeoutMs: 0 };
       },
-      vercelCreateTimeoutMs: async () => 0,
     });
 
     await new Promise((r) => setTimeout(r, 40));
     await loop.stop();
-    expect(calls).toBe(0);
+    expect(lookups).toBe(0);
   });
 
-  it('does not crash when renewTimeout throws', async () => {
+  it('does not advance the tracked deadline when renewTimeout throws (retries later)', async () => {
     const registry = new BoxRegistry();
     registerCloud(registry, 'b1');
+    const targets: number[] = [];
     const attempted = deferred<void>();
     const backend: CloudBackend = {
       name: 'vercel',
-      renewTimeout: async () => {
+      renewTimeout: async (_h: CloudHandle, target: number) => {
+        targets.push(target);
         attempted.resolve();
         throw new Error('plan cap reached');
       },
@@ -185,14 +199,17 @@ describe('startCloudKeepaliveLoop', () => {
       now: () => NOW,
       loadConfig: async () => CFG,
       resolveBackend: async () => backend,
-      lookupSandboxId: async () => 'sb-123',
-      vercelCreateTimeoutMs: async () => 0,
+      lookupBox: lookupAtNow,
     });
 
     await attempted.promise;
     // The loop must keep scheduling after a renew failure.
     await new Promise((r) => setTimeout(r, 20));
     await expect(loop.stop()).resolves.toBeUndefined();
+    // FAILURE_BACKOFF_MS (5m) > our fixed clock delta, so the box is backed off
+    // and not retried every tick — at most one attempt in this window.
+    expect(targets.length).toBeGreaterThanOrEqual(1);
+    expect(targets.every((t) => t === NOW + WINDOW)).toBe(true);
   });
 
   it('does nothing when disabled', async () => {
@@ -214,8 +231,7 @@ describe('startCloudKeepaliveLoop', () => {
       now: () => NOW,
       loadConfig: async () => ({ ...CFG, enabled: false }),
       resolveBackend: async () => backend,
-      lookupSandboxId: async () => 'sb-123',
-      vercelCreateTimeoutMs: async () => 0,
+      lookupBox: lookupAtNow,
     });
 
     await new Promise((r) => setTimeout(r, 40));

--- a/packages/relay/test/cloud-keepalive.test.ts
+++ b/packages/relay/test/cloud-keepalive.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from 'vitest';
+import {
+  selectBoxesToRenew,
+  startCloudKeepaliveLoop,
+  type KeepaliveScanEntry,
+} from '../src/cloud-keepalive.js';
+import { BoxRegistry } from '../src/registry.js';
+import type { AutopauseConfig } from '../src/autopause.js';
+import type { CloudBackend, CloudHandle } from '@agentbox/core';
+import type { BoxStatusStore, BoxStatusSnapshot } from '../src/status-store.js';
+
+const NOW = 1_700_000_000_000;
+const WINDOW = 5 * 60_000;
+
+function entry(p: Partial<KeepaliveScanEntry> & { boxId: string }): KeepaliveScanEntry {
+  return {
+    backend: 'vercel',
+    agentState: 'active',
+    lastActivityMs: NOW,
+    ...p,
+  };
+}
+
+describe('selectBoxesToRenew', () => {
+  it('renews an active box, anchoring the target at lastActivity + window', () => {
+    const out = selectBoxesToRenew([entry({ boxId: 'a', lastActivityMs: NOW })], WINDOW, NOW);
+    expect(out).toEqual([
+      { boxId: 'a', backend: 'vercel', targetDeadlineEpochMs: NOW + WINDOW },
+    ]);
+  });
+
+  it('renews an idle box still within the window', () => {
+    const e = entry({ boxId: 'a', agentState: 'idle', lastActivityMs: NOW - WINDOW + 1 });
+    expect(selectBoxesToRenew([e], WINDOW, NOW)).toHaveLength(1);
+  });
+
+  it('skips an idle box past the window (it lapses)', () => {
+    const e = entry({ boxId: 'a', agentState: 'idle', lastActivityMs: NOW - WINDOW });
+    expect(selectBoxesToRenew([e], WINDOW, NOW)).toEqual([]);
+  });
+
+  it('skips boxes with no activity signal', () => {
+    expect(
+      selectBoxesToRenew([entry({ boxId: 'a', lastActivityMs: null })], WINDOW, NOW),
+    ).toEqual([]);
+    expect(
+      selectBoxesToRenew([entry({ boxId: 'b', agentState: null })], WINDOW, NOW),
+    ).toEqual([]);
+  });
+
+  it('recomputes the target from lastActivity, not now (restart-robust)', () => {
+    const e = entry({ boxId: 'a', lastActivityMs: NOW });
+    const a = selectBoxesToRenew([e], WINDOW, NOW);
+    const b = selectBoxesToRenew([e], WINDOW, NOW + 999_999);
+    expect(a[0]!.targetDeadlineEpochMs).toBe(b[0]!.targetDeadlineEpochMs);
+  });
+});
+
+describe('startCloudKeepaliveLoop', () => {
+  function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+    let resolve!: (v: T) => void;
+    const promise = new Promise<T>((r) => {
+      resolve = r;
+    });
+    return { promise, resolve };
+  }
+
+  function statusFor(snap: Partial<BoxStatusSnapshot>): BoxStatusStore {
+    return {
+      get: (): BoxStatusSnapshot => ({ schema: 1, boxId: 'b', ...snap }) as BoxStatusSnapshot,
+    } as unknown as BoxStatusStore;
+  }
+
+  const CFG: AutopauseConfig = { enabled: true, maxRunningBoxes: 5, idleMinutes: 5 };
+
+  function registerCloud(reg: BoxRegistry, boxId: string, backend = 'vercel'): void {
+    reg.register({
+      boxId,
+      token: 't',
+      name: boxId,
+      registeredAt: new Date(NOW).toISOString(),
+      kind: 'cloud',
+      backend,
+      createdAt: new Date(NOW).toISOString(),
+    });
+  }
+
+  it('renews an active cloud box with (target, trackedDeadline)', async () => {
+    const registry = new BoxRegistry();
+    registerCloud(registry, 'b1');
+    const calls: Array<{ id: string; target: number; current: number }> = [];
+    const got = deferred<void>();
+    const backend: CloudBackend = {
+      name: 'vercel',
+      renewTimeout: async (h: CloudHandle, target: number, current: number) => {
+        calls.push({ id: h.sandboxId, target, current });
+        got.resolve();
+      },
+    } as unknown as CloudBackend;
+
+    const loop = startCloudKeepaliveLoop({
+      registry,
+      statusStore: statusFor({ claude: { state: 'working', updatedAt: new Date(NOW).toISOString() } }),
+      log: () => {},
+      intervalMs: 5,
+      now: () => NOW,
+      loadConfig: async () => CFG,
+      resolveBackend: async () => backend,
+      lookupSandboxId: async () => 'sb-123',
+      vercelCreateTimeoutMs: async () => 0, // seed tracked deadline = createdAt(=NOW)
+    });
+
+    await got.promise;
+    await loop.stop();
+
+    expect(calls).toEqual([{ id: 'sb-123', target: NOW + WINDOW, current: NOW }]);
+  });
+
+  it('skips docker boxes and backends without renewTimeout', async () => {
+    const registry = new BoxRegistry();
+    // docker box (no renewal)
+    registry.register({
+      boxId: 'd1',
+      token: 't',
+      name: 'd1',
+      registeredAt: new Date(NOW).toISOString(),
+      kind: 'docker',
+      containerName: 'agentbox-d1',
+      createdAt: new Date(NOW).toISOString(),
+    });
+    // cloud box whose backend lacks renewTimeout
+    registerCloud(registry, 'c1', 'daytona');
+    let calls = 0;
+    const backend = { name: 'daytona' } as unknown as CloudBackend; // no renewTimeout
+
+    const loop = startCloudKeepaliveLoop({
+      registry,
+      statusStore: statusFor({ claude: { state: 'working', updatedAt: new Date(NOW).toISOString() } }),
+      log: () => {},
+      intervalMs: 5,
+      now: () => NOW,
+      loadConfig: async () => CFG,
+      resolveBackend: async () => backend,
+      lookupSandboxId: async () => {
+        calls++;
+        return 'sb-x';
+      },
+      vercelCreateTimeoutMs: async () => 0,
+    });
+
+    await new Promise((r) => setTimeout(r, 40));
+    await loop.stop();
+    expect(calls).toBe(0);
+  });
+
+  it('does not crash when renewTimeout throws', async () => {
+    const registry = new BoxRegistry();
+    registerCloud(registry, 'b1');
+    const attempted = deferred<void>();
+    const backend: CloudBackend = {
+      name: 'vercel',
+      renewTimeout: async () => {
+        attempted.resolve();
+        throw new Error('plan cap reached');
+      },
+    } as unknown as CloudBackend;
+
+    const loop = startCloudKeepaliveLoop({
+      registry,
+      statusStore: statusFor({ claude: { state: 'working', updatedAt: new Date(NOW).toISOString() } }),
+      log: () => {},
+      intervalMs: 5,
+      now: () => NOW,
+      loadConfig: async () => CFG,
+      resolveBackend: async () => backend,
+      lookupSandboxId: async () => 'sb-123',
+      vercelCreateTimeoutMs: async () => 0,
+    });
+
+    await attempted.promise;
+    // The loop must keep scheduling after a renew failure.
+    await new Promise((r) => setTimeout(r, 20));
+    await expect(loop.stop()).resolves.toBeUndefined();
+  });
+
+  it('does nothing when disabled', async () => {
+    const registry = new BoxRegistry();
+    registerCloud(registry, 'b1');
+    let calls = 0;
+    const backend: CloudBackend = {
+      name: 'vercel',
+      renewTimeout: async () => {
+        calls++;
+      },
+    } as unknown as CloudBackend;
+
+    const loop = startCloudKeepaliveLoop({
+      registry,
+      statusStore: statusFor({ claude: { state: 'working', updatedAt: new Date(NOW).toISOString() } }),
+      log: () => {},
+      intervalMs: 5,
+      now: () => NOW,
+      loadConfig: async () => ({ ...CFG, enabled: false }),
+      resolveBackend: async () => backend,
+      lookupSandboxId: async () => 'sb-123',
+      vercelCreateTimeoutMs: async () => 0,
+    });
+
+    await new Promise((r) => setTimeout(r, 40));
+    await loop.stop();
+    expect(calls).toBe(0);
+  });
+});

--- a/packages/relay/test/cloud-keepalive.test.ts
+++ b/packages/relay/test/cloud-keepalive.test.ts
@@ -22,16 +22,28 @@ function entry(p: Partial<KeepaliveScanEntry> & { boxId: string }): KeepaliveSca
 }
 
 describe('selectBoxesToRenew', () => {
-  it('renews an active box, anchoring the target at lastActivity + window', () => {
+  it('renews an active box, anchoring the target at now + window', () => {
     const out = selectBoxesToRenew([entry({ boxId: 'a', lastActivityMs: NOW })], WINDOW, NOW);
     expect(out).toEqual([
       { boxId: 'a', backend: 'vercel', targetDeadlineEpochMs: NOW + WINDOW },
     ]);
   });
 
-  it('renews an idle box still within the window', () => {
+  it('renews an active box even when updatedAt is very stale (now + window, not stale + window)', () => {
+    // The in-box status reporter freezes updatedAt during a long single
+    // `working` op; the target must still anchor on `now` so the box isn't
+    // killed mid-work. (Regression for the high-sev bugbot finding.)
+    const e = entry({ boxId: 'a', agentState: 'active', lastActivityMs: NOW - 100 * 60_000 });
+    expect(selectBoxesToRenew([e], WINDOW, NOW)).toEqual([
+      { boxId: 'a', backend: 'vercel', targetDeadlineEpochMs: NOW + WINDOW },
+    ]);
+  });
+
+  it('renews an idle box still within the window, anchored at lastActivity + window', () => {
     const e = entry({ boxId: 'a', agentState: 'idle', lastActivityMs: NOW - WINDOW + 1 });
-    expect(selectBoxesToRenew([e], WINDOW, NOW)).toHaveLength(1);
+    expect(selectBoxesToRenew([e], WINDOW, NOW)).toEqual([
+      { boxId: 'a', backend: 'vercel', targetDeadlineEpochMs: NOW - WINDOW + 1 + WINDOW },
+    ]);
   });
 
   it('skips an idle box past the window (it lapses)', () => {
@@ -48,10 +60,10 @@ describe('selectBoxesToRenew', () => {
     ).toEqual([]);
   });
 
-  it('recomputes the target from lastActivity, not now (restart-robust)', () => {
-    const e = entry({ boxId: 'a', lastActivityMs: NOW });
+  it('idle target is now-independent (restart-robust)', () => {
+    const e = entry({ boxId: 'a', agentState: 'idle', lastActivityMs: NOW - 60_000 });
     const a = selectBoxesToRenew([e], WINDOW, NOW);
-    const b = selectBoxesToRenew([e], WINDOW, NOW + 999_999);
+    const b = selectBoxesToRenew([e], WINDOW, NOW + 30_000);
     expect(a[0]!.targetDeadlineEpochMs).toBe(b[0]!.targetDeadlineEpochMs);
   });
 });

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -985,6 +985,7 @@ export function createCloudProvider(
             bridgeToken,
             snapshotRef: resolvedCheckpointRef,
             lastState: 'running',
+            sessionTimeoutMs: timeoutMs,
           },
           createdAt: new Date().toISOString(),
         };

--- a/packages/sandbox-e2b/src/backend.ts
+++ b/packages/sandbox-e2b/src/backend.ts
@@ -62,9 +62,10 @@ const BOX_OWNER = 'vscode:vscode';
 const DEFAULT_E2B_DOMAIN = 'e2b.app';
 
 /**
- * Per-box session timeout the SDK enforces. Past it, E2B auto-terminates the
- * sandbox; we explicitly extend via `sb.setTimeout` is not needed for Task 1's
- * smoke (boxes survive minutes, not hours). 45 min default mirrors vercel.
+ * Per-box session timeout the SDK enforces at create. Past it, E2B
+ * auto-terminates the sandbox. The host keepalive loop renews it while the
+ * agent is active via `renewTimeout` (static `Sandbox.setTimeout`), so a
+ * long-running session isn't killed mid-work. 45 min default mirrors vercel.
  */
 const DEFAULT_TIMEOUT_MS = 45 * 60_000;
 
@@ -244,6 +245,19 @@ export const e2bBackend: CloudBackend = {
 
   async resume(h: CloudHandle): Promise<void> {
     await this.start(h);
+  },
+
+  // E2B `setTimeout` SETS the TTL to N ms from now (absolute-from-now), so we
+  // ignore the host's tracked deadline and use `target - now`. The static
+  // `Sandbox.setTimeout` hits the API without `connect` (no resume of a paused
+  // box). The host only calls when target > current, so this never shortens.
+  async renewTimeout(h: CloudHandle, targetDeadlineEpochMs: number): Promise<void> {
+    const ttlMs = Math.max(0, targetDeadlineEpochMs - Date.now());
+    if (ttlMs === 0) return;
+    const apiKey = resolveApiKey();
+    await withE2bRetry({ method: 'renewTimeout', retryOnAmbiguous: true }, async () => {
+      await Sandbox.setTimeout(h.sandboxId, ttlMs, { apiKey });
+    });
   },
 
   async destroy(h: CloudHandle): Promise<void> {

--- a/packages/sandbox-vercel/src/backend.ts
+++ b/packages/sandbox-vercel/src/backend.ts
@@ -448,6 +448,25 @@ export const vercelBackend: CloudBackend = {
     return this.previewUrl(h, port);
   },
 
+  // Vercel `extendTimeout` is ADDITIVE (adds to the current deadline) and the
+  // remaining time isn't readable, so the host passes its tracked deadline and
+  // we extend by the delta to land the death-time at `target`. The host only
+  // calls when target > current, so this never shortens. A plan-cap rejection
+  // bubbles to the keepalive loop's catch (it lets the box lapse at the cap).
+  async renewTimeout(
+    h: CloudHandle,
+    targetDeadlineEpochMs: number,
+    currentDeadlineEpochMs: number,
+  ): Promise<void> {
+    const deltaMs = Math.max(0, targetDeadlineEpochMs - currentDeadlineEpochMs);
+    if (deltaMs === 0) return;
+    await ensureFreshCredentials();
+    await withVercelRetry({ method: 'renewTimeout', retryOnAmbiguous: true }, async () => {
+      const sb = await getSandbox(h.sandboxId);
+      await sb.extendTimeout(deltaMs);
+    });
+  },
+
   async snapshotExists(snapshotName: string): Promise<boolean> {
     await ensureFreshCredentials();
     return withVercelRetry({ method: 'snapshotExists', retryOnAmbiguous: true }, async () => {


### PR DESCRIPTION
## What

Cloud boxes set their session timeout once at create (45-min default). When it elapsed the VM stopped, killing a running Claude/Codex session mid-work. This adds a host-relay keepalive loop that renews the timeout while the in-box agent is active, anchoring the death-time at \`lastActivity + window\`.

Per design, the **window reuses the existing \`autopause.idleMinutes\`** (gate: \`autopause.enabled\`) — no new config key. An idle box stops being renewed and lapses normally, mirroring auto-pause's idle semantics.

## Changes

- **core** (\`packages/core/src/cloud-backend.ts\`): new optional \`CloudBackend.renewTimeout(h, targetDeadlineEpochMs, currentDeadlineEpochMs)\`. Absolute-target interface so the host owns deadline bookkeeping; each backend resolves the SDK semantics.
- **vercel** (\`packages/sandbox-vercel/src/backend.ts\`): \`sb.extendTimeout(target - current)\` — additive, remaining isn't readable, so the host passes its tracked deadline.
- **e2b** (\`packages/sandbox-e2b/src/backend.ts\`): static \`Sandbox.setTimeout(sandboxId, target - now)\` — absolute-from-now; no resume.
- **relay** (\`packages/relay/src/cloud-keepalive.ts\`, new): pure \`selectBoxesToRenew\` + a loop (sibling to auto-pause) that tracks each box's deadline in memory (seeded from \`createdAt + create-timeout\`) and only renews when \`target > tracked\` — never over-extends early, never shortens, restart-robust. Wired in \`bin.ts\`, exported from \`index.ts\`. Reuses \`readActiveAgent\`, \`resolveCloudBackend\`, the status store, and the \`state.json\` sandboxId lookup.

## Caveat

Renewal is bounded by the plan's max session — Hobby's ~45-min hard cap can't be exceeded (the cap rejection is swallowed; the box lapses). Mainly benefits Pro+ (5 h), where the conservative 45-min default otherwise kills long sessions early.

## Verification

- Build green; \`@agentbox/relay\` tests 183 pass (9 new: pure selector boundaries + loop with injected fakes — docker/no-renewTimeout skipped, throwing renew doesn't crash, disabled no-op); eslint clean.
- **Live (Vercel):** created a real box and confirmed \`renewTimeout\` → \`sb.extendTimeout\` is accepted at runtime (box running, no throw).
- E2B not live-tested (static \`Sandbox.setTimeout\` confirmed in the SDK types; thin wrapper).

Docs updated: \`docs/cloud-providers.md\`, \`docs/vercel-backlog.md\`, \`apps/web/content/docs/vercel.mdx\`, \`e2b.mdx\`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches long-running cloud VM lifecycle and relay background loops; mistakes could over-extend sessions or fail to renew, but plan caps and swallowed renew errors limit blast radius, and behavior is gated on autopause being enabled.
> 
> **Overview**
> Cloud boxes used a create-time session timeout that could terminate the VM mid–Claude/Codex run. This PR adds a **host relay `cloud-keepalive` loop** (alongside auto-pause) that pushes the session death-time forward while an in-box agent is active, using the existing **`autopause.idleMinutes`** window—no new config key. Renewal runs only when **`autopause.enabled`** is on.
> 
> **Core:** optional **`CloudBackend.renewTimeout(h, targetDeadline, currentDeadline)`** so the host owns deadline bookkeeping across SDK semantics (Vercel **`extendTimeout`** is additive; E2B **`setTimeout`** sets TTL from now).
> 
> **Relay:** new **`cloud-keepalive.ts`** with pure **`selectBoxesToRenew`** (active agents anchor on **`now + window`**, not stale `updatedAt` during long `working` ops), per-box in-memory tracked deadlines, and **`renewTimeout`** calls; wired in **`agentbox-relay serve`** shutdown alongside autopause/queue.
> 
> **Backends:** **`sandbox-vercel`** and **`sandbox-e2b`** implement **`renewTimeout`**; other clouds are skipped when the method is absent.
> 
> Docs (Vercel/E2B limits, **`cloud-providers.md`**, vercel backlog) note auto-renewal and plan caps (Hobby ~45m hard limit; mainly helps Pro+).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2e71aeaee4804c0d746e490be48442b07aad610. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->