### PR TITLE
fix(claude): detect a dead in-box login from the shared volume before launch (docker)

### DIFF
--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -20,6 +20,7 @@ import {
   formatDetachNotice,
   hostBackupHasCredentials,
   hostClaudeBackupExpired,
+  imageExists,
   inspectBox,
   rebuildPluginNativeDeps,
   runInteractiveClaudeLogin,
@@ -29,6 +30,7 @@ import {
   startClaudeSession,
   syncClaudeCredentials,
   unpauseBox,
+  volumeClaudeCredentials,
   warmUpClaudeCredentials,
   type BoxRecord,
 } from '@agentbox/sandbox-docker';
@@ -268,17 +270,34 @@ async function maybeRunClaudeLogin(args: {
    *  the volume's `_claude.json` before the login container runs. */
   hostWorkspace: string;
 }): Promise<void> {
-  // Skip when: non-interactive / --yes; the user explicitly provided auth via
-  // host env (respect an intentional ANTHROPIC_API_KEY); or the host backup
-  // already holds real credentials (every box gets seeded from it). A legacy
-  // auth.json setup-token (`auth-file`) still gets the offer — that is the
-  // "Claude API" -> subscription upgrade.
+  // Skip when: non-interactive / --yes; or the user explicitly provided auth
+  // via host env (respect an intentional ANTHROPIC_API_KEY).
   if (!process.stdin.isTTY || args.yes) return;
   if (args.authSource === 'host-env') return;
-  if (await hostBackupHasCredentials()) return;
 
-  const message =
-    args.authSource === 'auth-file'
+  // Docker boots every box from the shared claude-config volume's live
+  // `.credentials.json`; the host backup is only a mirror that diverges when an
+  // in-box refresh fails (claude blanks the volume's refreshToken, and the
+  // create-time extract then skips it, so the backup keeps a stale token). So
+  // decide off the *volume*, not the backup:
+  //  - usable refresh token present -> trust the in-box refresh, no prompt
+  //    (a merely-expired access token renews itself; don't nag);
+  //  - file present but refresh token blanked -> the login is dead (the seed
+  //    only restores the same stale backup), so offer a fresh sign-in;
+  //  - no file yet -> the box seeds from the host backup, so only offer
+  //    sign-in when there is nothing to seed from either.
+  // The probe needs the image locally; skip it (fall back to the backup check)
+  // when it isn't, so a first-ever run doesn't trigger an implicit pull here.
+  const vol = (await imageExists(args.image))
+    ? await volumeClaudeCredentials(SHARED_CLAUDE_VOLUME, args.image)
+    : { present: false, hasRefreshToken: false };
+  if (vol.hasRefreshToken) return;
+  const blanked = vol.present && !vol.hasRefreshToken;
+  if (!vol.present && (await hostBackupHasCredentials())) return;
+
+  const message = blanked
+    ? 'Your saved Claude login looks expired. Sign in again? (saved and reused by every box)'
+    : args.authSource === 'auth-file'
       ? "You're on a legacy API token (shows as 'Claude API'). Sign in with your Claude subscription instead?"
       : 'Sign in with your Claude subscription? (saved and reused by every box)';
   const answer = await confirm({ message, initialValue: true });

--- a/apps/web/content/docs/run-an-agent.mdx
+++ b/apps/web/content/docs/run-an-agent.mdx
@@ -73,7 +73,7 @@ Auto-approve is safe to default on because the box can't touch your machine — 
 
 ## First-run auth
 
-Credentials are handled on the host and seeded into every box (macOS Keychain doesn't transfer into containers). On the first `agentbox claude` with no credentials, AgentBox offers an interactive sign-in that's saved and reused by every future box. Skip it with `-y` (or in CI) and claude will prompt you to `/login` inside the box.
+Credentials are handled on the host and seeded into every box (macOS Keychain doesn't transfer into containers). On the first `agentbox claude` with no credentials — or when a saved login has gone dead and can no longer refresh — AgentBox offers an interactive sign-in that's saved and reused by every future box. Skip it with `-y` (or in CI) and claude will prompt you to `/login` inside the box.
 
 ```bash
 agentbox claude login                 # sign in once, reused by every box

--- a/packages/sandbox-docker/src/claude-credentials.ts
+++ b/packages/sandbox-docker/src/claude-credentials.ts
@@ -180,6 +180,74 @@ export async function hostBackupHasCredentials(
   }
 }
 
+export interface VolumeClaudeCredentials {
+  /** A `.credentials.json` exists in the shared claude-config volume. */
+  present: boolean;
+  /** That file carries a usable (non-empty) `claudeAiOauth.refreshToken`. */
+  hasRefreshToken: boolean;
+}
+
+/**
+ * Parse the `PRESENT=<yes|no> REFRESH=<yes|no>` line the probe container prints.
+ * Pure — unit-tested independently of docker.
+ */
+export function parseVolumeClaudeCredentials(stdout: string): VolumeClaudeCredentials {
+  return {
+    present: /\bPRESENT=yes\b/.test(stdout),
+    hasRefreshToken: /\bREFRESH=yes\b/.test(stdout),
+  };
+}
+
+// Probe the live `.credentials.json` the box actually boots from. `jq` ships in
+// the box image; the "usable" test matches SYNC_SCRIPT — a non-empty
+// `claudeAiOauth.refreshToken`. A file present with a blanked refreshToken is
+// the dead state claude leaves behind after a rejected refresh.
+const VOLUME_CRED_PROBE_SCRIPT = `
+PRESENT=no
+REFRESH=no
+VOL=/dst/.credentials.json
+if [ -f "$VOL" ]; then
+  PRESENT=yes
+  if jq -e '(.claudeAiOauth.refreshToken // "") | length > 0' "$VOL" >/dev/null 2>&1; then REFRESH=yes; fi
+fi
+echo "PRESENT=$PRESENT REFRESH=$REFRESH"
+`;
+
+/**
+ * Inspect the shared claude-config VOLUME's live `.credentials.json` — the
+ * authoritative store the in-box claude reads and refreshes. Unlike the host
+ * backup (a mirror that lags and diverges when a refresh fails), this reports
+ * what the next box will actually boot with: whether a credentials file exists
+ * and whether it still holds a usable refresh token. Used to offer a re-login
+ * only when the volume's login is dead (file present, refresh token blanked),
+ * not on a merely-stale access token the in-box refresh can renew on its own.
+ *
+ * Best-effort: an unreadable volume / missing image resolves to
+ * `{ present: false, hasRefreshToken: false }` and never throws into a flow.
+ */
+export async function volumeClaudeCredentials(
+  volume: string,
+  image: string,
+): Promise<VolumeClaudeCredentials> {
+  try {
+    const { stdout } = await execa('docker', [
+      'run',
+      '--rm',
+      '--user',
+      '0',
+      '-v',
+      `${volume}:/dst`,
+      image,
+      'sh',
+      '-c',
+      VOLUME_CRED_PROBE_SCRIPT,
+    ]);
+    return parseVolumeClaudeCredentials(stdout);
+  } catch {
+    return { present: false, hasRefreshToken: false };
+  }
+}
+
 /**
  * Parse the `EXTRACTED=<yes|no> SEEDED=<yes|no> VOLREAL=<yes|no>` line the
  * helper container prints. Pure — unit-tested independently of docker.

--- a/packages/sandbox-docker/src/index.ts
+++ b/packages/sandbox-docker/src/index.ts
@@ -47,6 +47,8 @@ export {
   isRealAgentCredential,
   parseSyncResult,
   parseExtractResult,
+  parseVolumeClaudeCredentials,
+  volumeClaudeCredentials,
   syncClaudeCredentials,
   extractVolumeAuthToBackup,
   extractCodexCredentials,
@@ -54,6 +56,7 @@ export {
   type CredentialAgentKind,
   type CredentialSyncDirection,
   type SyncClaudeCredentialsResult,
+  type VolumeClaudeCredentials,
 } from './claude-credentials.js';
 export {
   buildCodexAttachArgv,

--- a/packages/sandbox-docker/test/claude-credentials.test.ts
+++ b/packages/sandbox-docker/test/claude-credentials.test.ts
@@ -8,6 +8,7 @@ import {
   isRealAgentCredential,
   parseExtractResult,
   parseSyncResult,
+  parseVolumeClaudeCredentials,
 } from '../src/claude-credentials.js';
 
 describe('parseExtractResult', () => {
@@ -15,6 +16,40 @@ describe('parseExtractResult', () => {
     expect(parseExtractResult('COPIED=yes')).toEqual({ copied: true });
     expect(parseExtractResult('COPIED=no')).toEqual({ copied: false });
     expect(parseExtractResult('garbage')).toEqual({ copied: false });
+  });
+});
+
+describe('parseVolumeClaudeCredentials', () => {
+  it('reads a present file with a usable refresh token', () => {
+    expect(parseVolumeClaudeCredentials('PRESENT=yes REFRESH=yes')).toEqual({
+      present: true,
+      hasRefreshToken: true,
+    });
+  });
+
+  it('reports a present-but-blanked file (the dead state) as no refresh token', () => {
+    expect(parseVolumeClaudeCredentials('PRESENT=yes REFRESH=no')).toEqual({
+      present: true,
+      hasRefreshToken: false,
+    });
+  });
+
+  it('reports an absent file', () => {
+    expect(parseVolumeClaudeCredentials('PRESENT=no REFRESH=no')).toEqual({
+      present: false,
+      hasRefreshToken: false,
+    });
+  });
+
+  it('is tolerant of empty / garbage output', () => {
+    expect(parseVolumeClaudeCredentials('')).toEqual({
+      present: false,
+      hasRefreshToken: false,
+    });
+    expect(parseVolumeClaudeCredentials('docker: command not found')).toEqual({
+      present: false,
+      hasRefreshToken: false,
+    });
   });
 });
 


### PR DESCRIPTION
## Problem

Running `agentbox claude` on **docker** dropped the user straight into a login error inside Claude, with no re-login offered beforehand — even though the cloud path already detects expired logins.

Docker boots every box from the **shared `agentbox-claude-config` volume**'s live `.credentials.json`. The host backup (`~/.agentbox/claude-credentials.json`) is only a mirror, re-extracted at create time **and only when the volume still has a usable refresh token**. When an in-box refresh fails, Claude blanks the volume's `refreshToken` (`""`); the extract then skips it, so the backup keeps a stale-but-present token. The two **diverge**, and the pre-launch sign-in offer gated solely on the backup having *any* refresh token:

```ts
if (await hostBackupHasCredentials()) return;  // backup looks fine -> skip, box boots dead
```

Confirmed live: volume `refreshToken: ""` while the host backup still held one → no re-login offered → login error.

## Fix

Decide off the **volume** (the authoritative store the box boots from), not the backup:

- usable refresh token present → **no prompt** (a merely-stale *access* token renews itself in-box; checking `expiresAt` here would over-prompt every idle morning)
- file present but refresh token **blanked** → the login is dead → **offer a fresh sign-in**
- no file yet → box seeds from the host backup as before

New best-effort helper `volumeClaudeCredentials(volume, image)` (pure parser `parseVolumeClaudeCredentials`, unit-tested), gated behind `imageExists` so a first-ever run doesn't trigger an implicit pull.

**Known limitation (accepted):** a *present-but-dead* refresh token (token there, server rejects it) still isn't caught — only a live validation would, which was deliberately set aside to avoid a container round-trip on every launch. The blanked-token signal covers the observed failure.

## Verification

- Live: after a subsequent run re-seeded and the refresh **succeeded** (access token renewed, not expired), the volume reports `hasRefreshToken: true` → the gate correctly does **not** prompt, while the host backup is still 17h "expired" (proving the volume-based check avoids the over-prompt a backup-expiry check would cause).
- `parseVolumeClaudeCredentials` unit tests added (4 cases); full `@agentbox/sandbox-docker` suite (291) and CLI `assert-creds` (16) green; lint clean; both packages build.
- Docs: `apps/web/content/docs/run-an-agent.mdx` notes the offer also appears "when a saved login has gone dead and can no longer refresh."

https://claude.ai/code/session_01PTY4KwAeZdAVvgSWxjpYfs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to interactive pre-launch auth prompts and a best-effort Docker probe; no changes to credential sync, box create, or cloud auth flows.
> 
> **Overview**
> Fixes **Docker** pre-launch sign-in gating so it no longer trusts only `~/.agentbox/claude-credentials.json` when the shared **`agentbox-claude-config`** volume’s live `.credentials.json` is already dead.
> 
> Adds **`volumeClaudeCredentials`** in `@agentbox/sandbox-docker`: a short-lived container reads the volume and reports whether credentials exist and whether **`claudeAiOauth.refreshToken`** is non-empty (matching existing sync logic). **`maybeRunClaudeLogin`** uses that when the box image is already local (`imageExists`); otherwise it falls back to the prior host-backup check so first run doesn’t pull an image just to probe.
> 
> **Behavior:** usable refresh token on the volume → no prompt (stale access tokens can refresh in-box); file present with blanked refresh token → **“Your saved Claude login looks expired…”** and offer sign-in; no volume file yet → still skip the prompt if the host backup can seed. Cloud path is unchanged (still host backup + expiry).
> 
> Docs in **`run-an-agent.mdx`** note the sign-in offer also appears when a saved login can no longer refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c93cd047131d0ea6463a121fe50eef68c552f8e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->