### PR TITLE
fix(e2b): detached attach pre-start no longer hangs the CLI

### DIFF
--- a/docs/e2b_backlog.md
+++ b/docs/e2b_backlog.md
@@ -435,6 +435,29 @@ mode … Yes, I accept" gate.
   agentbox-in-agentbox, the in-box `git` shim rejects the create's
   `git clone --no-checkout` seed step — put the real `/usr/bin/git` ahead of
   `/usr/local/bin/git` on PATH for the host-side create.)
+- 2026-06-23: Fix `agentbox e2b claude` hanging on a blank screen at attach
+  (then `agentbox attach` works). Root cause: the create→attach path runs
+  `cloudAgentAttach` with `extraArgs` (always `--dangerously-skip-permissions`)
+  and a new-terminal `openIn` (iTerm2 split / tmux / cmux), which triggers
+  `startDetachedSession` to pre-create the agent's tmux session **before**
+  spawning the new pane (so the re-invoked attach, which carries no extraArgs,
+  finds the session via `tmux has-session`). `startDetachedSession` →
+  `runDetached` spawns the provider's `detached` attach argv and **awaits its
+  exit**. On SSH/Vercel the detached argv runs the inner command (`tmux
+  new-session -d …; <config>`) as the remote process and exits — but the E2B
+  attach-helper always opens a **persistent interactive in-box PTY shell** and
+  blocks on `handle.wait()`; with no trailing `exec tmux attach` to replace the
+  shell, it idles at a prompt forever, so `await startDetachedSession` never
+  returns and the CLI hangs right after `box ready` (no pane ever opens). The
+  `tmux new-session` had already run, so the session + agent existed — which is
+  why Ctrl+C then `agentbox attach` rendered fine. Fix: `buildE2bAttach` now
+  appends `--detached` to the helper argv when `opts.detached` is set, and the
+  helper, in that mode, runs the inner command once via the non-interactive
+  `sb.commands.run` and exits with its code instead of opening a PTY. Verified
+  live: the detached helper now exits in ~1s (was: hung >30s) after creating the
+  session + launching claude, and `agentbox claude start <e2b-box> --
+  --dangerously-skip-permissions` completes (`Attached in new iTerm2 split.`) in
+  ~1s instead of hanging. Regression tests in `test/build-attach.test.ts`.
 - 2026-06-17: Fix `ERR_REQUIRE_ESM` crash on Node < 20.19 (e.g. 20.18, which
   our `engines.node >=20.10` permits). The `e2b` SDK ships **no `exports` map**
   (only `main`→CJS / `module`→ESM), so an ESM `import 'e2b'` falls back to the

--- a/packages/sandbox-e2b/src/attach-helper.ts
+++ b/packages/sandbox-e2b/src/attach-helper.ts
@@ -13,7 +13,7 @@
  *                                    │                            │
  *   stdout (host PTY) ◄── onData ────┴──────────────────  ◄────────┘
  *
- * Argv: `node attach-helper.cjs --sandbox-id <id> [--user <name>]`.
+ * Argv: `node attach-helper.cjs --sandbox-id <id> [--user <name>] [--detached]`.
  * Env:
  *   E2B_API_KEY                E2B credentials (resolved via the credentials
  *                              loader; the spawning CLI threads it in).
@@ -26,6 +26,16 @@
  * Exit code mirrors the inner command (the tmux session). Detach
  * (`Ctrl+a d`) collapses tmux → the PTY exits 0; an SDK transport error
  * exits 1 so the CLI's reconnect loop fires.
+ *
+ * `--detached`: pre-start mode. The inner command only creates + configures the
+ * tmux session (renderInnerCommand with `detached:true`, i.e. NO trailing
+ * `exec tmux attach`). Unlike the SSH/Vercel transports — where the detached
+ * argv runs the inner command as the remote process and EXITS — this helper's
+ * interactive path opens a persistent in-box PTY shell that, with nothing to
+ * `exec` into, idles at a prompt forever (the PTY never exits, so the host
+ * `runDetached` await never resolves and `agentbox <agent>` hangs after "box
+ * ready"). So in detached mode we skip the PTY entirely: run the inner command
+ * once via the non-interactive `commands.run` and exit with its code.
  */
 
 import { Sandbox } from 'e2b';
@@ -34,11 +44,13 @@ import { ensureE2bEnvLoaded } from './env-loader.js';
 interface ParsedArgs {
   sandboxId: string;
   user: string;
+  detached: boolean;
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
   let sandboxId: string | undefined;
   let user = 'vscode';
+  let detached = false;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--sandbox-id') {
@@ -47,17 +59,19 @@ function parseArgs(argv: string[]): ParsedArgs {
     } else if (a === '--user') {
       user = argv[i + 1] ?? user;
       i++;
+    } else if (a === '--detached') {
+      detached = true;
     }
   }
   if (!sandboxId) {
     process.stderr.write('attach-helper: --sandbox-id is required\n');
     process.exit(2);
   }
-  return { sandboxId, user };
+  return { sandboxId, user, detached };
 }
 
 async function main(): Promise<void> {
-  const { sandboxId, user } = parseArgs(process.argv.slice(2));
+  const { sandboxId, user, detached } = parseArgs(process.argv.slice(2));
   ensureE2bEnvLoaded();
 
   const inner = process.env.AGENTBOX_E2B_INNER_CMD;
@@ -82,6 +96,30 @@ async function main(): Promise<void> {
       `attach-helper: could not connect to sandbox ${sandboxId}: ${err instanceof Error ? err.message : String(err)}\n`,
     );
     process.exit(1);
+  }
+
+  // Detached pre-start: just run the session-create command once and exit (no
+  // PTY, no stdin wiring). Opening the interactive PTY here would idle forever
+  // because the detached inner has no `exec tmux attach` to take over the
+  // shell — see the file header. `commands.run` mirrors the backend's exec.
+  if (detached) {
+    try {
+      const r = await sb.commands.run(inner, {
+        user: user as 'root' | 'user',
+        cwd: '/workspace',
+        timeoutMs: 5 * 60_000,
+      });
+      process.exit(r.exitCode ?? 0);
+    } catch (err) {
+      // commands.run throws on non-zero exit; surface the code so a real
+      // session-create failure isn't masked, but never hang.
+      const code = (err as { exitCode?: number }).exitCode;
+      if (typeof code === 'number') process.exit(code);
+      process.stderr.write(
+        `attach-helper: detached pre-start failed: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      process.exit(1);
+    }
   }
 
   // Default to 80x24 if stdout isn't a TTY (e.g. piped). The PTY API requires

--- a/packages/sandbox-e2b/src/build-attach.ts
+++ b/packages/sandbox-e2b/src/build-attach.ts
@@ -81,6 +81,12 @@ export async function buildE2bAttach(
     '--user',
     'vscode',
   ];
+  // Detached pre-start (new-tab attach / `-i` queue worker): the inner command
+  // only creates the tmux session (no `exec tmux attach`). The helper must run
+  // it once and EXIT rather than open a persistent interactive PTY that idles
+  // forever — otherwise the host's `runDetached` await never resolves and
+  // `agentbox <agent>` hangs after "box ready". See attach-helper.ts header.
+  if (opts?.detached) argv.push('--detached');
 
   return {
     argv,

--- a/packages/sandbox-e2b/test/build-attach.test.ts
+++ b/packages/sandbox-e2b/test/build-attach.test.ts
@@ -60,6 +60,19 @@ describe('buildE2bAttach', () => {
     });
   });
 
+  it('omits --detached for a normal (interactive) attach', async () => {
+    const spec = await buildE2bAttach(boxWith('sbx_1'), 'agent', { command: 'exec claude' });
+    expect(spec.argv).not.toContain('--detached');
+  });
+
+  it('appends --detached for a detached pre-start so the helper runs once and exits', async () => {
+    const spec = await buildE2bAttach(boxWith('sbx_1'), 'agent', {
+      command: 'exec claude',
+      detached: true,
+    });
+    expect(spec.argv).toContain('--detached');
+  });
+
   it('passes the kind through to renderInnerCommand', async () => {
     const spec = await buildE2bAttach(boxWith('sbx_1'), 'logs', { service: 'web' });
     expect(spec.env?.AGENTBOX_E2B_INNER_CMD).toBe('INNER(logs)');


### PR DESCRIPTION
## Problem

`agentbox e2b claude` could hang on a **blank screen** right after `box ready`. Ctrl+C then `agentbox attach` rendered fine — which was the key clue.

## Root cause

The create→attach path runs `cloudAgentAttach` with `extraArgs` (always includes `--dangerously-skip-permissions`) and a new-terminal `openIn` (iTerm2 split / tmux / cmux). That triggers `startDetachedSession` to **pre-create** the agent's tmux session *before* spawning the new pane, so the re-invoked attach (which carries no args) finds it via `tmux has-session`.

`startDetachedSession` → `runDetached` spawns the provider's **`detached`** attach argv and **awaits its exit**:
- SSH providers / Vercel: `ssh <inner>` runs the detached command (`tmux new-session -d …`) as the remote process and **exits** → await resolves.
- **E2B**: the attach-helper always opens a *persistent interactive in-box PTY shell* and blocks on `handle.wait()`. The detached inner has no trailing `exec tmux attach` to replace that shell, so it idles at a prompt **forever** → `await startDetachedSession` never returns → the CLI hangs after `box ready`, before any pane opens.

The `tmux new-session` had already run, so the session + agent existed — which is exactly why Ctrl+C (kills the hung CLI) then `agentbox attach` (finds the live, now-painted session) worked.

Confirmed empirically: the detached helper hung >30s; the regular interactive helper rendered claude's UI fine. The PTY bridge was never the problem.

## Fix

- `buildE2bAttach` appends `--detached` to the helper argv when `opts.detached` is set.
- The helper, in `--detached` mode, runs the inner command **once** via the non-interactive `sb.commands.run` and exits with its code, instead of opening a PTY that never closes.

## Verification (live, real E2B sandbox)

- Detached helper now **exits in ~1s** (was: hung >30s), after correctly creating the tmux session + launching claude.
- `agentbox claude start <e2b-box> -- --dangerously-skip-permissions` completes (`Attached in new iTerm2 split.`) in ~1s instead of hanging.
- Typecheck + lint clean; 16/16 package tests pass (2 new regression tests for the `--detached` flag).

https://claude.ai/code/session_01PTY4KwAeZdAVvgSWxjpYfs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to E2B attach-helper detached pre-start; interactive PTY path unchanged and covered by new unit tests.
> 
> **Overview**
> Fixes **`agentbox e2b claude`** (and similar new-tab attach flows) hanging on a blank screen after **box ready** while **`agentbox attach`** still worked.
> 
> **Root cause:** `startDetachedSession` awaits the provider’s detached attach process. SSH/Vercel run the tmux session-create inner command and exit; the E2B **attach-helper** always opened an interactive in-box PTY. With a detached inner command (no `exec tmux attach`), that PTY never finished, so the host never continued to open the new pane.
> 
> **Change:** When `buildE2bAttach` is called with `opts.detached`, the helper argv includes **`--detached`**. The helper then runs `AGENTBOX_E2B_INNER_CMD` once via **`sb.commands.run`** and exits with its code instead of wiring a PTY. Interactive attach behavior is unchanged.
> 
> Regression coverage in **`test/build-attach.test.ts`**; backlog changelog documents the incident and verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c371cb6c36ca374edf64ad557c170b7b640c56d7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->