### PR TITLE
fix(cloud): resolve workspace path to absolute in create (relative -w broke git seed)

### DIFF
--- a/docs/e2b_backlog.md
+++ b/docs/e2b_backlog.md
@@ -312,6 +312,28 @@ mode … Yes, I accept" gate.
 
 #### Deferred follow-ups (intentional, not blocking)
 
+- **E2B checkpoints are full-state (disk + RAM), not disk-only — disk-only is
+  future work.** `checkpoint create` uses `Sandbox.createSnapshot`, which
+  `pause`s the box and persists the **entire VM state (memory + filesystem)**;
+  booting a box from the checkpoint (`Sandbox.create({ template: snapshotId })`)
+  **resumes** that paused state rather than booting fresh. Verified live
+  (2026-06-23): a box created from a checkpoint kept the source box's running
+  process (same PID), tmpfs/`/dev/shm` contents, frozen `boot_id`, and
+  continuing uptime. The E2B SDK (2.27.1 and 2.30.5) exposes **no disk-only
+  snapshot option** — the snapshot API takes only `{ name }`, and the model is
+  inherently pause-based. This is mostly a cleanliness/fragility concern (a
+  fresh box resumes the source's stale ctl/dockerd/agent processes), NOT a
+  correctness blocker: the create-from-checkpoint flow re-seeds `/workspace`
+  from the host git bundle (overlay delta), so **the per-box branch still
+  updates to the host's current tip** — verified: a box from a checkpoint picked
+  up an unpushed host-`main` commit made *after* the checkpoint, via
+  `checkpoint restore: /workspace: delta bundle (<oldTip>..<newTip>)`. A true
+  disk-only checkpoint would need `Template.build().fromTemplate(base).copy(<box
+  state>)` (boots fresh, like the base snapshot) — feasible (the SDK has
+  `fromTemplate` + `copy`) but the open question is *what FS state to capture*
+  (E2B has no `docker commit`-style rootfs diff), and it is slower to create
+  than the seconds-fast memory snapshot. Tracked as future work; ships as
+  full-state.
 - **No `Template.list()` in the SDK.** `prune --provider e2b` enumerates
   sandboxes only; built templates have to be removed from the E2B
   dashboard. Document this in the provider page; ship as-is.
@@ -396,6 +418,18 @@ mode … Yes, I accept" gate.
   relay and can launch boxes on other providers, so they can fully smoke-test.
 
 ## Changelog
+- 2026-06-23: **Fix: cloud create with a relative `-w` path failed the git-clone
+  workspace seed (all cloud providers).** `agentbox create --provider e2b -w
+  ../repo` died with `git clone … 'file://../repo' … fatal: '/repo' does not
+  appear to be a git repository` — `file://` URLs require an absolute path, so
+  the relative one resolved to host `/repo`. The docker provider already does
+  `resolve(opts.workspacePath)`; the cloud `Provider.create` did not. Fixed by
+  resolving `req.workspacePath` to absolute at the top of `createCloudProvider`'s
+  `create` (in `packages/sandbox-cloud/src/cloud-provider.ts`), mirroring docker
+  — which also keeps the box record's `workspacePath` cwd-independent. Found
+  while testing e2b checkpoints; the fix is cloud-wide (daytona/hetzner/vercel/
+  e2b). Verified live: `-w ../agentbox-test-repo-gh` now clones + completes, and
+  the box record stores the resolved absolute path.
 - 2026-06-23: **DinD shipped — docker baked into the base, auto-launched on
   create/resume (mirrors vercel).** Following the empirical verification below,
   enabled in-box docker by: (1) adding a "docker engine (in-box DinD)" step to

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -11,7 +11,7 @@
  * "no relay configured" error.
  */
 
-import { basename } from 'node:path';
+import { basename, resolve } from 'node:path';
 import { generateBoxId } from '@agentbox/core';
 import type {
   AttachKind,
@@ -494,7 +494,17 @@ export function createCloudProvider(
   return {
     name: providerName,
 
-    async create(req: CreateBoxRequest): Promise<CreatedBox> {
+    async create(reqRaw: CreateBoxRequest): Promise<CreatedBox> {
+      // Resolve the host workspace path to absolute up front, mirroring the
+      // docker provider (`resolve(opts.workspacePath)` in sandbox-docker's
+      // create). A relative `-w ../repo` would otherwise flow into the
+      // git-clone seed as `git clone file://../repo` — `file://` needs an
+      // absolute path, so git reads it as host `/repo` and fails with "does
+      // not appear to be a git repository". Resolving here also keeps the
+      // box record's workspacePath stable regardless of the caller's cwd.
+      const req: CreateBoxRequest = reqRaw.workspacePath
+        ? { ...reqRaw, workspacePath: resolve(reqRaw.workspacePath) }
+        : reqRaw;
       const log = req.onLog ?? (() => {});
       const { id, name, branch } = mintBox(req);
       const image = opts.provisionImage


### PR DESCRIPTION
## Problem

`agentbox create --provider <cloud> -w ../repo` (relative `-w`) failed the git-clone workspace seed on every cloud backend:

```
git clone --no-checkout 'file://../repo' ...
fatal: '/repo' does not appear to be a git repository
```

`file://` URLs require an **absolute** path, so a relative `-w` collapsed to host `/repo`. The docker provider already resolves the path (`resolve(opts.workspacePath)` in sandbox-docker's `create`); the cloud `Provider.create` passed `req.workspacePath` through verbatim — so daytona / hetzner / vercel / e2b all tripped on a relative `-w`.

## Fix

Resolve `req.workspacePath` to absolute at the top of `createCloudProvider`'s `create` (`packages/sandbox-cloud/src/cloud-provider.ts`), mirroring docker. Also keeps the box record's `workspacePath` cwd-independent.

## Also (docs)

Documents in `docs/e2b_backlog.md` that **E2B checkpoints are full-state (disk + RAM)**: `createSnapshot` pauses and persists the whole VM, and creating a box from the checkpoint *resumes* it (verified: same PID, tmpfs, frozen boot_id, continuing uptime). The SDK has no disk-only snapshot option. This is a cleanliness concern, not a correctness blocker — **branch-update-from-checkpoint still works** because the create flow re-seeds `/workspace` from the host (verified: a box from a checkpoint picked up an unpushed `main` commit made *after* the checkpoint via `checkpoint restore: /workspace: delta bundle (oldTip..newTip)`). A true disk-only checkpoint (`Template.build().fromTemplate(base).copy(...)`) is noted as future work.

## Verification

- Live: `agentbox create --provider e2b -w ../agentbox-test-repo-gh` now clones + completes; box record stores the resolved absolute path.
- `sandbox-cloud` build / typecheck / lint / tests (76) all green.

Found while testing E2B checkpoints.

https://claude.ai/code/session_01PTY4KwAeZdAVvgSWxjpYfs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized path normalization at create entry; behavior aligns with docker and only affects workspace seeding and persisted paths.
> 
> **Overview**
> **Cloud create** now resolves `-w` / `workspacePath` with `path.resolve()` at the start of `createCloudProvider`'s `create`, matching the docker provider. Relative paths like `-w ../repo` no longer break the git-clone workspace seed (`file://` URLs must be absolute; otherwise git treated them as `/repo`). Stored box records also get a cwd-stable absolute `workspacePath`. Applies to all cloud backends (daytona, hetzner, vercel, e2b).
> 
> **Docs:** `docs/e2b_backlog.md` records that E2B checkpoints are **full VM state (disk + RAM)** via `Sandbox.createSnapshot` (no disk-only SDK option), with live verification notes and that create-from-checkpoint still re-seeds `/workspace` from the host so branch tips can advance. Disk-only checkpoints are noted as future work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 725e0d15e1e5ed03d45a27be11b80f1c087abb40. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->