### PR TITLE
feat(e2b): configurable session timeout so the keepalive holds boxes open while working

### DIFF
--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -37,6 +37,7 @@ import {
 import { Command } from 'commander';
 import { resolveClaudeAuth, type ResolvedClaudeAuth } from '../auth.js';
 import { reattachRef, resolveBoxOrExit, resolveBoxOrShift } from '../box-ref.js';
+import { cloudSizingProviderOptions } from '../lib/cloud-sizing.js';
 import { assertAgentCredsAvailable, MissingAgentCredsError } from '../lib/queue/assert-creds.js';
 import { buildPromptArgs } from '../lib/queue/build-prompt-args.js';
 import { maybeResyncWorkspace } from '../lib/resync-start.js';
@@ -782,6 +783,9 @@ export const claudeCommand = new Command('claude')
           useBranch,
           resyncOnStart: opts.resync,
           projectRoot,
+          // Per-provider session-lifetime (e2b/vercel timeout) so the keepalive
+          // seeds correctly; mirrors `agentbox create`.
+          providerOptions: cloudSizingProviderOptions(provider.name, cfg.effective),
         },
         binary: 'claude',
         hasSeedPrompt:

--- a/apps/cli/src/commands/codex.ts
+++ b/apps/cli/src/commands/codex.ts
@@ -48,6 +48,7 @@ import { buildPromptArgs } from '../lib/queue/build-prompt-args.js';
 import { maybeResyncWorkspace } from '../lib/resync-start.js';
 import { buildResyncWarning } from '../lib/resync-warning.js';
 import { agentResumeArgs } from '../agent-sessions.js';
+import { cloudSizingProviderOptions } from '../lib/cloud-sizing.js';
 import { applyCodexSkipPermissions } from '../lib/skip-permissions.js';
 import {
   ATTACH_IN_HELP,
@@ -580,6 +581,8 @@ export const codexCommand = new Command('codex')
           useBranch,
           resyncOnStart: opts.resync,
           projectRoot,
+          // Per-provider session-lifetime (e2b/vercel timeout); mirrors create.
+          providerOptions: cloudSizingProviderOptions(provider.name, cfg.effective),
         },
         binary: 'codex',
         sessionName: cfg.effective.codex.sessionName,

--- a/apps/cli/src/commands/create.ts
+++ b/apps/cli/src/commands/create.ts
@@ -18,6 +18,7 @@ import {
 import { Command } from 'commander';
 import { execSync, spawnSync } from 'node:child_process';
 import { runCarryGate } from '../lib/carry-gate.js';
+import { cloudSizingProviderOptions } from '../lib/cloud-sizing.js';
 import { FromBranchError, UseBranchError, resolveBranchSelection } from '../lib/from-branch.js';
 import { openCommandLog } from '../lib/log-file.js';
 import { makeProgressReporter } from '../lib/progress.js';
@@ -433,15 +434,10 @@ export const createCommand = new Command('create')
           portless: portlessEnabled,
           portlessStateDir: cfg.effective.portless.stateDir || undefined,
           ...(effectiveSize ? { size: effectiveSize } : {}),
-          // Vercel-only sizing (box.vercelVcpus / vercelTimeoutMs). The cloud
-          // scaffold reads these as overrides; other providers ignore them.
-          ...(provider.name === 'vercel'
-            ? {
-                vcpus: cfg.effective.box.vercelVcpus,
-                timeoutMs: cfg.effective.box.vercelTimeoutMs,
-                networkPolicy: cfg.effective.box.vercelNetworkPolicy,
-              }
-            : {}),
+          // Per-provider sizing / session-lifetime overrides (vercel vcpus /
+          // timeout / network policy, e2b timeout). The cloud scaffold reads
+          // them; other providers ignore them.
+          ...cloudSizingProviderOptions(provider.name, cfg.effective),
         },
       });
       s.stop(`box ${result.record.container} ready`);

--- a/apps/cli/src/commands/opencode.ts
+++ b/apps/cli/src/commands/opencode.ts
@@ -40,6 +40,7 @@ import {
   MissingAgentCredsError,
   opencodeAuthAvailable,
 } from '../lib/queue/assert-creds.js';
+import { cloudSizingProviderOptions } from '../lib/cloud-sizing.js';
 import { parseMaxOption } from '../lib/queue/parse-max-option.js';
 import { submitQueueJob } from '../lib/queue/submit.js';
 import { captureOpenTerminalContext } from '../terminal/queue-open.js';
@@ -543,6 +544,8 @@ export const opencodeCommand = new Command('opencode')
           useBranch,
           resyncOnStart: opts.resync,
           projectRoot,
+          // Per-provider session-lifetime (e2b/vercel timeout); mirrors create.
+          providerOptions: cloudSizingProviderOptions(provider.name, cfg.effective),
         },
         binary: 'opencode',
         sessionName: cfg.effective.opencode.sessionName,

--- a/apps/cli/src/lib/cloud-sizing.ts
+++ b/apps/cli/src/lib/cloud-sizing.ts
@@ -1,0 +1,33 @@
+import type { EffectiveConfig } from '@agentbox/config';
+
+/**
+ * Per-provider sizing / session-lifetime overrides threaded through
+ * `CreateBoxRequest.providerOptions`. The cloud scaffold
+ * (`packages/sandbox-cloud/src/cloud-provider.ts`) reads these; providers that
+ * don't recognise a key ignore it.
+ *
+ * - **vercel**: `vcpus` (RAM is coupled at 2 GB/vCPU), `timeoutMs` (session
+ *   length before auto-snapshot), `networkPolicy`.
+ * - **e2b**: `timeoutMs` — the session timeout the box is created with (and
+ *   records as `cloud.sessionTimeoutMs`, which seeds the host keepalive loop so
+ *   it can push the deadline forward while the agent is working).
+ *
+ * Shared by `agentbox create` and the agent-create commands (`claude` / `codex`
+ * / `opencode`) so a box gets the same lifetime regardless of how it was made.
+ */
+export function cloudSizingProviderOptions(
+  providerName: string,
+  cfg: EffectiveConfig,
+): Record<string, unknown> {
+  if (providerName === 'vercel') {
+    return {
+      vcpus: cfg.box.vercelVcpus,
+      timeoutMs: cfg.box.vercelTimeoutMs,
+      networkPolicy: cfg.box.vercelNetworkPolicy,
+    };
+  }
+  if (providerName === 'e2b') {
+    return { timeoutMs: cfg.box.e2bTimeoutMs };
+  }
+  return {};
+}

--- a/apps/cli/test/cloud-sizing.test.ts
+++ b/apps/cli/test/cloud-sizing.test.ts
@@ -1,0 +1,33 @@
+import type { EffectiveConfig } from '@agentbox/config';
+import { describe, expect, it } from 'vitest';
+import { cloudSizingProviderOptions } from '../src/lib/cloud-sizing.js';
+
+// Only the `box` slice is read; cast a minimal shape through unknown.
+const cfg = {
+  box: {
+    vercelVcpus: 2,
+    vercelTimeoutMs: 2_700_000,
+    vercelNetworkPolicy: 'strict',
+    e2bTimeoutMs: 120_000,
+  },
+} as unknown as EffectiveConfig;
+
+describe('cloudSizingProviderOptions', () => {
+  it('threads the e2b session timeout for e2b boxes', () => {
+    expect(cloudSizingProviderOptions('e2b', cfg)).toEqual({ timeoutMs: 120_000 });
+  });
+
+  it('threads vcpus / timeout / network policy for vercel boxes', () => {
+    expect(cloudSizingProviderOptions('vercel', cfg)).toEqual({
+      vcpus: 2,
+      timeoutMs: 2_700_000,
+      networkPolicy: 'strict',
+    });
+  });
+
+  it('returns nothing for providers without sizing overrides', () => {
+    expect(cloudSizingProviderOptions('docker', cfg)).toEqual({});
+    expect(cloudSizingProviderOptions('hetzner', cfg)).toEqual({});
+    expect(cloudSizingProviderOptions('daytona', cfg)).toEqual({});
+  });
+});

--- a/apps/web/content/docs/configuration.mdx
+++ b/apps/web/content/docs/configuration.mdx
@@ -172,6 +172,7 @@ See [teleport a project](/docs/teleport-a-project), [environment](/docs/environm
 | `box.vercelVcpus` | int | `2` | vCPUs (RAM is coupled at 2048 MB/vCPU); only 1/2/4/8 are accepted |
 | `box.vercelTimeoutMs` | int | `2700000` (45 min) | max session length before auto-snapshot; persistent mode auto-resumes |
 | `box.vercelNetworkPolicy` | string | empty (`allow-all`) | egress lock: `allow-all`, `deny-all`, or a comma-separated domain allowlist (`github.com,*.npmjs.org`) |
+| `box.e2bTimeoutMs` | int | `2700000` (45 min) | session timeout a new `--provider e2b` box is created with before E2B auto-pauses it on inactivity; the host keepalive holds it open while the agent works (Hobby caps total session at ~1 h) |
 
 See [Vercel](/docs/vercel).
 

--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -562,8 +562,10 @@ brief:
   `attach-helper.cjs`, which `Sandbox.connect`s, opens a `pty.create({ cols,
   rows, onData })` stream, and bridges stdin / stdout / `SIGWINCH` to the
   host TTY. The helper caps `timeoutMs` at **55 minutes** to leave headroom
-  under E2B's 1-hour platform session cap on Hobby (longer sessions need a
-  mid-session `Sandbox.setTimeout` keepalive — deferred).
+  under E2B's 1-hour platform session cap on Hobby. This caps only the live
+  PTY connection — the **box lifetime** is held open independently by the
+  `cloud-keepalive` loop (see §3, "Session keepalive") while the agent works,
+  so after 55 min the attach drops but the box stays alive; just reattach.
 - **Checkpoints are id-addressed (same shape as Vercel).** The provider
   overrides `checkpoint.create` to call `Sandbox.createSnapshot(sandboxId,
   { name })`, store the returned `snapshotId` in the cloud-checkpoint

--- a/docs/e2b_backlog.md
+++ b/docs/e2b_backlog.md
@@ -318,16 +318,22 @@ mode … Yes, I accept" gate.
 - **1-hour platform session cap on Hobby.** The attach helper caps
   `timeoutMs` at **55 minutes** (see `packages/sandbox-e2b/src/attach-helper.ts`
   + the staged `apps/cli/runtime/e2b/attach-helper.cjs`) to leave headroom
-  under the platform ceiling. Longer interactive sessions would need a
-  mid-session `Sandbox.setTimeout` keepalive that extends the lease — out
-  of scope for the launch.
+  under the platform ceiling. NOTE: the **box lifetime** keepalive IS done —
+  the host relay's `cloud-keepalive` loop calls `renewTimeout` →
+  `Sandbox.setTimeout` while the in-box agent is working, so a long agent run
+  no longer dies at the create timeout (bounded by the plan's max session: ~1 h
+  on Hobby). What's still capped is the **interactive attach PTY** itself
+  (`pty.create` ≤ 1 h on Hobby) — after 55 min the attach disconnects but the
+  box stays alive and the agent keeps working; just reattach. Extending the live
+  PTY mid-stream remains future work.
 - **Drive harness display quirk** on the e2b shell attach (Task 2 finding).
   A plain `script -q -c …` capture shows the prompt; the headless drive
   harness shows an empty screen. Underlying PTY bridge works.
-- **No `e2bTimeoutMs` config key.** Vercel exposes a parallel for its own
-  SDK; on E2B the timeout is set at `Sandbox.create({ timeout })` time and
-  extended live via `Sandbox.setTimeout`. Could be wired to a per-create
-  config key — not done at launch.
+- **`box.e2bTimeoutMs` config key — DONE.** Mirrors `box.vercelTimeoutMs`:
+  the session timeout a new `--provider e2b` box is created with (default 45 min),
+  threaded via `cloudSizingProviderOptions` (`apps/cli/src/lib/cloud-sizing.ts`)
+  into `create` and the agent-create commands, and recorded as
+  `cloud.sessionTimeoutMs` so the keepalive seeds its tracked deadline precisely.
 - **No `e2bNetworkPolicy` config key — and it CAN be wired (backlog
   correction).** An earlier note here claimed E2B's network knobs are
   "template-level (set at `Template.build()` time)" with "no per-create

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -83,6 +83,7 @@ export interface UserConfig {
     vercelVcpus?: number;
     vercelTimeoutMs?: number;
     vercelNetworkPolicy?: string;
+    e2bTimeoutMs?: number;
     cpMaxBytes?: number;
   };
   checkpoint?: {
@@ -208,6 +209,7 @@ export interface EffectiveConfig {
     vercelVcpus: number;
     vercelTimeoutMs: number;
     vercelNetworkPolicy: string;
+    e2bTimeoutMs: number;
     cpMaxBytes: number;
   };
   checkpoint: {
@@ -354,6 +356,7 @@ export const BUILT_IN_DEFAULTS: EffectiveConfig = {
     vercelVcpus: 2,
     vercelTimeoutMs: 2_700_000,
     vercelNetworkPolicy: '',
+    e2bTimeoutMs: 2_700_000,
     cpMaxBytes: 100 * 1024 * 1024,
   },
   checkpoint: {
@@ -681,6 +684,12 @@ export const KEY_REGISTRY: readonly KeyDescriptor[] = [
     type: 'int',
     description:
       'Max session length (ms) for new --provider vercel boxes before the VM auto-snapshots; persistent mode auto-resumes on the next call. Default 2700000 (45 min, the Hobby ceiling). Vercel-only.',
+  },
+  {
+    key: 'box.e2bTimeoutMs',
+    type: 'int',
+    description:
+      'Session timeout (ms) a new --provider e2b box is created with, before E2B auto-pauses it on inactivity. The host keepalive loop pushes this forward while the agent is working. Default 2700000 (45 min); the Hobby tier caps total session at ~1 h regardless. E2B-only.',
   },
   {
     key: 'box.cpMaxBytes',


### PR DESCRIPTION
## What

E2B (like Vercel) auto-pauses a sandbox after its **session timeout**. The host relay's `cloud-keepalive` loop already pushes that timeout forward while the in-box agent is *working* — but E2B never had a configured/recorded timeout: `create.ts` only threaded `timeoutMs` into `providerOptions` for **vercel**, so an e2b box recorded `cloud.sessionTimeoutMs` as `undefined` (the keepalive fell back to a 45-min *assumption*) and the lifetime wasn't tunable. This adds the parity needed so E2B's "keep alive while the agent works" behaves exactly like Vercel.

## How

- **`box.e2bTimeoutMs`** config key (mirrors `box.vercelTimeoutMs`, default 45 min).
- A shared **`cloudSizingProviderOptions(providerName, cfg)`** helper (`apps/cli/src/lib/cloud-sizing.ts`), used by `agentbox create` **and** the agent-create commands (`claude`/`codex`/`opencode`), so an e2b box records its real session timeout (which seeds the keepalive precisely) regardless of how it was made. Bonus: this also threads **vercel's** sizing through the agent-create path, which it wasn't before.

No keepalive-loop change was needed — it's already generic and E2B implements `renewTimeout` → `Sandbox.setTimeout`.

## Verified live (E2B)

Created an e2b box with a 2-min timeout, drove a `working` agent state:
- relay logged `cloud-keepalive: renewed box <id> (e2b) +5m` **3×** while working;
- the sandbox stayed **alive past its 2-min create timeout** (would've died without it);
- once **idle**, renewals **stopped** (0 in 3 min) — the timer is only held open while working.

`cloud.sessionTimeoutMs` was correctly recorded as `120000` on the box.

## Notes

- Pure host-side + config change — **no box image rebuild or `prepare` needed**.
- Caveat (documented): E2B **Hobby tier ~1 h platform cap** bounds total session regardless of activity; the interactive attach PTY still caps at 55 min (separate from box lifetime — reattach to continue).
- Unit test `apps/cli/test/cloud-sizing.test.ts`; docs updated (`e2b_backlog`, `cloud-providers` §3c, web config reference).

https://claude.ai/code/session_017WPbmdQCPmqSr2iAxtHqXu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Host-side config and CLI `providerOptions` threading only; keepalive behavior is unchanged and scoped to cloud create paths. Mis-set timeouts could shorten or lengthen E2B box lifetime but do not touch auth or data handling.
> 
> **Overview**
> Adds **`box.e2bTimeoutMs`** (default 45 min, E2B-only) so new `--provider e2b` boxes get a tunable create-time session timeout, recorded as **`cloud.sessionTimeoutMs`** for the existing host **`cloud-keepalive`** loop instead of relying on an assumed deadline when that field was missing.
> 
> Introduces **`cloudSizingProviderOptions`** in `apps/cli/src/lib/cloud-sizing.ts` and wires it through **`agentbox create`** plus cloud **`claude` / `codex` / `opencode`** creates. **`create`** replaces inline Vercel-only `providerOptions` with this helper (Vercel vcpus/timeout/network policy unchanged; E2B gains `timeoutMs`). Agent-create paths now pass the same sizing overrides as **`create`**, including Vercel options that were not threaded there before.
> 
> Config types/defaults/schema, unit tests, and docs (`e2b_backlog`, `cloud-providers`, web config reference) are updated to describe E2B box lifetime vs the 55 min attach PTY cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f29810a8218573d5ee5a7f17e0012055baeeeb9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->