### PR TITLE
fix(cloud): surface masked -i session-start failures + herdr concurrent-tab reliability

### DIFF
--- a/apps/cli/src/commands/_cloud-attach.ts
+++ b/apps/cli/src/commands/_cloud-attach.ts
@@ -285,15 +285,17 @@ export async function cloudAgentAttach(args: CloudAgentAttachArgs): Promise<void
 /**
  * Create + configure the agent's tmux session running `command` without
  * attaching (the `detached` buildAttach mode). Shared by the new-tab attach
- * pre-start and the background (`-i`) queue worker. `runDetached` swallows the
- * exit code; a real launch failure surfaces on the subsequent attach.
+ * pre-start and the background (`-i`) queue worker. Returns the session-create
+ * command's exit code + stderr so the queue worker can fail the job when the
+ * session was never created; the new-tab pre-start ignores the result (a real
+ * launch failure surfaces on the subsequent attach).
  */
 async function startDetachedSession(
   provider: Provider,
   box: BoxRecord,
   sessionName: string,
   command: string,
-): Promise<void> {
+): Promise<{ exitCode: number; stderr: string }> {
   if (!provider.buildAttach) {
     throw new Error(`provider '${provider.name}' does not support detached sessions`);
   }
@@ -303,9 +305,76 @@ async function startDetachedSession(
     detached: true,
   });
   try {
-    await runDetached(spec.argv, spec.env);
+    return await runDetached(spec.argv, spec.env);
   } finally {
     if (spec.cleanup) await spec.cleanup();
+  }
+}
+
+/**
+ * Markers an agent prints to its TUI when its in-box credentials are rejected.
+ * The seeded cloud login can be stale (it expires independently of the host
+ * session — `agentbox <agent> login` refreshes it), in which case the agent
+ * launches, draws, then sits on an auth error doing no work. Scraping the pane
+ * for these turns that otherwise-silent dead-end into an actionable failure.
+ */
+const AGENT_AUTH_FAILURE =
+  /Please run \/login|Invalid authentication credentials|API Error: 401|Invalid API key|\bUnauthorized\b/i;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * After a detached pre-start, confirm the agent's tmux session actually came up
+ * and stayed up. `tmux new-session -d` creates the session synchronously, so a
+ * session that's already gone — or vanishes within the settle window — means the
+ * agent process exited immediately at launch (the single-window session dies
+ * with it). This is the exact silent failure the `-i` queue path hit on cloud
+ * providers: the box was created and the job reported "done", but no session was
+ * ever running. We also scrape the pane for credential-rejection markers, the
+ * most common cause of a session that's technically alive but doing nothing.
+ * Throws an actionable error so the caller surfaces it (queue worker → failed
+ * job; restore → logged) instead of masking it.
+ */
+export async function verifyDetachedSession(
+  provider: Provider,
+  box: BoxRecord,
+  sessionName: string,
+  binary: string,
+  opts: { windowMs?: number; pollMs?: number } = {},
+): Promise<void> {
+  const windowMs = opts.windowMs ?? 10_000;
+  const pollMs = opts.pollMs ?? 2_000;
+  const q = `'${sessionName.replace(/'/g, `'\\''`)}'`;
+  // One round-trip per tick: bail (exit 7) if the session is gone, else echo the
+  // pane so we can sniff for an auth dead-end.
+  const probe = `tmux has-session -t ${q} 2>/dev/null || exit 7; tmux capture-pane -p -t ${q} 2>/dev/null`;
+  const deadline = Date.now() + windowMs;
+  for (;;) {
+    let pane = '';
+    try {
+      const r = await provider.exec(box, ['bash', '-lc', probe], { user: 'vscode' });
+      if (r.exitCode === 7) {
+        throw new Error(
+          `agent '${binary}' exited immediately after launch in box ${box.name} — the session did not stay up. ` +
+            `Attach to inspect: agentbox ${binary} attach ${box.name}`,
+        );
+      }
+      pane = r.stdout;
+    } catch (err) {
+      // Re-throw our own diagnosis; a transport-level probe error is NOT proof
+      // of death (don't false-fail on a flaky exec) — keep polling.
+      if (err instanceof Error && err.message.startsWith(`agent '${binary}'`)) throw err;
+    }
+    if (AGENT_AUTH_FAILURE.test(pane)) {
+      throw new Error(
+        `box ${binary} credentials were rejected — the agent launched but printed an auth error, so no work will run. ` +
+          `Refresh them with \`agentbox ${binary} login\`, then re-run.`,
+      );
+    }
+    if (Date.now() >= deadline) break;
+    await sleep(pollMs);
   }
 }
 
@@ -334,23 +403,47 @@ export async function cloudAgentStartDetached(args: {
     box = await provider.start(box);
   }
   const command = buildCloudAttachInnerCommand(args.binary, args.extraArgs);
-  await startDetachedSession(provider, box, args.sessionName, command);
+  const { exitCode, stderr } = await startDetachedSession(
+    provider,
+    box,
+    args.sessionName,
+    command,
+  );
+  if (exitCode !== 0) {
+    const detail = stderr.trim().slice(0, 500);
+    throw new Error(
+      `failed to start the ${args.binary} session in box ${box.name} (exit ${String(exitCode)})` +
+        (detail ? `: ${detail}` : ''),
+    );
+  }
+  await verifyDetachedSession(provider, box, args.sessionName, args.binary);
 }
 
 /**
  * Run an attach-style argv non-interactively to completion (used for the
- * `detached` session pre-start). stdio is ignored — the remote command only
- * creates + configures the tmux session and exits; there's nothing to show.
- * Resolves on exit regardless of code (a non-zero here shouldn't block the
- * subsequent attach, which surfaces any real failure to the user).
+ * `detached` session pre-start). The remote command only creates + configures
+ * the tmux session and exits, so stdout is dropped — but stderr and the exit
+ * code are captured: the E2B helper's `--detached` path runs the session-create
+ * command via the SDK and exits with its code, so a non-zero here is the only
+ * signal that the session was never created (e.g. a transient SDK connect/exec
+ * failure). Callers decide whether to surface it — the queue worker fails the
+ * job, the new-tab pre-start ignores it (the subsequent attach re-creates the
+ * session anyway). Resolves on exit regardless of code (never rejects).
  */
-function runDetached(argv: string[], env?: Record<string, string>): Promise<void> {
+function runDetached(
+  argv: string[],
+  env?: Record<string, string>,
+): Promise<{ exitCode: number; stderr: string }> {
   return new Promise((resolve) => {
     const child = spawn(argv[0]!, argv.slice(1), {
-      stdio: 'ignore',
+      stdio: ['ignore', 'ignore', 'pipe'],
       env: env ? { ...process.env, ...env } : process.env,
     });
-    child.on('error', () => resolve());
-    child.on('exit', () => resolve());
+    let stderr = '';
+    child.stderr?.on('data', (c: Buffer) => {
+      stderr += c.toString('utf8');
+    });
+    child.on('error', (err) => resolve({ exitCode: 1, stderr: stderr + String(err.message ?? err) }));
+    child.on('exit', (code) => resolve({ exitCode: code ?? 0, stderr }));
   });
 }

--- a/apps/cli/src/terminal/herdr-socket.ts
+++ b/apps/cli/src/terminal/herdr-socket.ts
@@ -54,10 +54,19 @@ export function herdrSend(
 }
 
 /**
- * Send a Herdr request and resolve the first response line's `result`. Resolves
- * `null` on any error (no socket, refused connect, error reply, timeout) so
- * callers can fall back. Used by the spawn paths, which need the created
- * pane id echoed back.
+ * Send a Herdr request and resolve the reply's `result`. Resolves `null` on any
+ * error (no socket, refused connect, error reply, timeout) so callers can fall
+ * back. Used by the spawn paths, which need the created pane id echoed back.
+ *
+ * Reply correlation matters under concurrency: when several boxes' queue
+ * workers each open a Herdr connection and ask it to create a tab at once,
+ * Herdr can push a notification (a focus/layout event) onto the connection
+ * *before* the RPC reply. The old "take the first line with a `result`" logic
+ * mis-read that notification as the answer and reported "gave no pane id" even
+ * though the tab was created. We now scan line-by-line and consume only the line
+ * carrying OUR request `id` (an id-less reply is still accepted, so a
+ * non-compliant Herdr that omits the echo doesn't regress), skipping
+ * notifications (no `result`/`error`) and any other request's reply.
  */
 export function herdrRequest(
   method: string,
@@ -67,11 +76,13 @@ export function herdrRequest(
 ): Promise<Record<string, unknown> | null> {
   const sock = herdrSocketPath(env);
   if (!sock) return Promise.resolve(null);
+  const id = nextId();
   return new Promise((resolve) => {
     let settled = false;
     const done = (value: Record<string, unknown> | null): void => {
       if (settled) return;
       settled = true;
+      clearTimeout(timer);
       try {
         client.destroy();
       } catch {
@@ -93,26 +104,36 @@ export function herdrRequest(
     client.on('close', () => done(null));
     client.on('connect', () => {
       try {
-        client.write(`${JSON.stringify({ id: nextId(), method, params })}\n`);
+        client.write(`${JSON.stringify({ id, method, params })}\n`);
       } catch {
         done(null);
       }
     });
     client.on('data', (chunk: Buffer) => {
       buf += chunk.toString('utf8');
-      const nl = buf.indexOf('\n');
-      if (nl === -1) return;
-      const line = buf.slice(0, nl);
-      try {
-        const msg = JSON.parse(line) as { result?: unknown; error?: unknown };
+      let nl: number;
+      // Drain every complete line; ignore anything that isn't our reply and
+      // keep reading until the matching id arrives or the timeout fires.
+      while ((nl = buf.indexOf('\n')) !== -1) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        if (line.trim().length === 0) continue;
+        let msg: { id?: unknown; result?: unknown; error?: unknown };
+        try {
+          msg = JSON.parse(line) as typeof msg;
+        } catch {
+          continue; // partial/garbage line — wait for more data
+        }
+        // Notifications (method+params, no result/error) aren't replies — skip.
+        if (!('result' in msg) && !('error' in msg)) continue;
+        // A reply for a different request on this connection — not ours.
+        if (msg.id !== undefined && msg.id !== id) continue;
         if (msg.error || typeof msg.result !== 'object' || msg.result === null) {
           done(null);
         } else {
-          clearTimeout(timer);
           done(msg.result as Record<string, unknown>);
         }
-      } catch {
-        done(null);
+        return;
       }
     });
   });

--- a/apps/cli/src/terminal/host.ts
+++ b/apps/cli/src/terminal/host.ts
@@ -374,20 +374,29 @@ function extractHerdrPaneId(result: Record<string, unknown> | null): string | un
  */
 async function spawnInHerdr(args: SpawnInNewTerminalArgs): Promise<SpawnInNewTerminalResult> {
   const env = args.env;
+  // Creating a pane/tab/workspace is heavier than a query and gets slower when
+  // several queue workers fan out tabs at once (the `-i` concurrency case), so
+  // give the create a wider window than the default 2s before falling back.
+  const CREATE_TIMEOUT_MS = 6000;
   let result: Record<string, unknown> | null;
   let noteKind: string;
   if (args.mode === 'split') {
     const params: Record<string, unknown> = { direction: 'right', ratio: 0.5 };
     if (args.herdrTargetPane) params['pane_id'] = args.herdrTargetPane;
-    result = await herdrRequest('pane.split', params, env);
+    result = await herdrRequest('pane.split', params, env, CREATE_TIMEOUT_MS);
     noteKind = 'Herdr split';
   } else if (args.mode === 'tab') {
     const params: Record<string, unknown> = {};
     if (args.herdrTargetWorkspace) params['workspace_id'] = args.herdrTargetWorkspace;
-    result = await herdrRequest('tab.create', params, env);
+    result = await herdrRequest('tab.create', params, env, CREATE_TIMEOUT_MS);
     noteKind = 'Herdr tab';
   } else {
-    result = await herdrRequest('workspace.create', { cwd: args.cwd, label: args.title }, env);
+    result = await herdrRequest(
+      'workspace.create',
+      { cwd: args.cwd, label: args.title },
+      env,
+      CREATE_TIMEOUT_MS,
+    );
     noteKind = 'Herdr workspace';
   }
 

--- a/apps/cli/test/cloud-attach.test.ts
+++ b/apps/cli/test/cloud-attach.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { buildCloudAttachInnerCommand } from '../src/commands/_cloud-attach.js';
+import type { BoxRecord, ExecResult, Provider } from '@agentbox/core';
+import {
+  buildCloudAttachInnerCommand,
+  verifyDetachedSession,
+} from '../src/commands/_cloud-attach.js';
 import { buildPromptArgs } from '../src/lib/queue/build-prompt-args.js';
 
 /**
@@ -87,5 +91,60 @@ describe('buildCloudAttachInnerCommand', () => {
     const args = buildPromptArgs('claude-code', 'fix the failing test', ['--permission-mode=plan']);
     const cmd = buildCloudAttachInnerCommand('claude', args);
     expect(decodeArgs(cmd)).toEqual(['fix the failing test', '--permission-mode=plan']);
+  });
+});
+
+/**
+ * `verifyDetachedSession` is what turns a silent cloud `-i` failure (box created,
+ * job reports "done", but the seeded agent session never came up) into a thrown,
+ * surfaced error. A fake provider drives the `tmux has-session`/`capture-pane`
+ * probe so we exercise the three outcomes without a real sandbox.
+ */
+describe('verifyDetachedSession', () => {
+  const box = { name: 'kanban-buttons' } as BoxRecord;
+  const fakeProvider = (exec: (argv: string[]) => ExecResult): Provider =>
+    ({ exec: (_b: BoxRecord, argv: string[]) => Promise.resolve(exec(argv)) }) as unknown as Provider;
+
+  it('throws "exited immediately" when the session is gone (probe exits 7)', async () => {
+    const provider = fakeProvider(() => ({ exitCode: 7, stdout: '', stderr: '' }));
+    await expect(
+      verifyDetachedSession(provider, box, 'claude', 'claude', { windowMs: 0 }),
+    ).rejects.toThrow(/exited immediately after launch/);
+  });
+
+  it('throws an actionable login hint when the pane shows an auth rejection', async () => {
+    const provider = fakeProvider(() => ({
+      exitCode: 0,
+      stdout: '❯ build a kanban board\n● Please run /login · API Error: 401 Invalid authentication credentials',
+      stderr: '',
+    }));
+    await expect(
+      verifyDetachedSession(provider, box, 'claude', 'claude', { windowMs: 0 }),
+    ).rejects.toThrow(/credentials were rejected.*agentbox claude login/s);
+  });
+
+  it('resolves for a live, authenticated session', async () => {
+    const provider = fakeProvider(() => ({
+      exitCode: 0,
+      stdout: '❯ build a kanban board\n● Working on it...',
+      stderr: '',
+    }));
+    await expect(
+      verifyDetachedSession(provider, box, 'claude', 'claude', { windowMs: 0 }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('does not false-fail on a transient probe error (keeps polling)', async () => {
+    let calls = 0;
+    const provider = fakeProvider(() => {
+      calls++;
+      if (calls === 1) throw new Error('transport blip');
+      return { exitCode: 0, stdout: 'all good', stderr: '' };
+    });
+    // windowMs large enough for a second tick; pollMs tiny so the test is fast.
+    await expect(
+      verifyDetachedSession(provider, box, 'claude', 'claude', { windowMs: 30, pollMs: 1 }),
+    ).resolves.toBeUndefined();
+    expect(calls).toBeGreaterThan(1);
   });
 });

--- a/apps/cli/test/herdr-socket.test.ts
+++ b/apps/cli/test/herdr-socket.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import net from 'node:net';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { herdrRequest } from '../src/terminal/herdr-socket.js';
+
+/**
+ * Spins up a throwaway UNIX-socket "Herdr" whose per-connection handler is
+ * supplied by each test, so we can exercise the JSON-RPC correlation logic
+ * (notifications, out-of-order ids, slow replies) without a real Herdr.
+ */
+function fakeHerdr(
+  onLine: (line: Record<string, unknown>, sock: net.Socket) => void,
+): { path: string; close: () => Promise<void> } {
+  const dir = mkdtempSync(join(tmpdir(), 'herdr-sock-'));
+  const path = join(dir, 'h.sock');
+  const server = net.createServer((sock) => {
+    let buf = '';
+    sock.on('data', (c) => {
+      buf += c.toString('utf8');
+      let nl: number;
+      while ((nl = buf.indexOf('\n')) !== -1) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        if (line.trim().length === 0) continue;
+        onLine(JSON.parse(line) as Record<string, unknown>, sock);
+      }
+    });
+    sock.on('error', () => {});
+  });
+  server.listen(path);
+  return {
+    path,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => {
+          rmSync(dir, { recursive: true, force: true });
+          resolve();
+        });
+      }),
+  };
+}
+
+describe('herdrRequest', () => {
+  let herdr: { path: string; close: () => Promise<void> } | undefined;
+  const env = (path: string): NodeJS.ProcessEnv => ({ HERDR_SOCKET_PATH: path });
+
+  afterEach(async () => {
+    await herdr?.close();
+    herdr = undefined;
+  });
+
+  it('returns null when no socket is configured', async () => {
+    expect(await herdrRequest('tab.create', {}, {})).toBeNull();
+  });
+
+  it('resolves the matching reply by id', async () => {
+    herdr = fakeHerdr((req, sock) => {
+      sock.write(`${JSON.stringify({ id: req.id, result: { root_pane: { pane_id: 'w1:p2' } } })}\n`);
+    });
+    const r = await herdrRequest('tab.create', {}, env(herdr.path));
+    expect(r).toEqual({ root_pane: { pane_id: 'w1:p2' } });
+  });
+
+  it('skips a notification pushed before the reply (the concurrency bug)', async () => {
+    // Herdr emits a focus/layout notification first, then the actual reply.
+    herdr = fakeHerdr((req, sock) => {
+      sock.write(`${JSON.stringify({ method: 'layout.changed', params: { foo: 1 } })}\n`);
+      sock.write(`${JSON.stringify({ id: req.id, result: { pane_id: 'w3:p7' } })}\n`);
+    });
+    const r = await herdrRequest('tab.create', {}, env(herdr.path));
+    expect(r).toEqual({ pane_id: 'w3:p7' });
+  });
+
+  it("skips another request's reply (different id) and waits for ours", async () => {
+    herdr = fakeHerdr((req, sock) => {
+      sock.write(`${JSON.stringify({ id: 'someone-else:99', result: { pane_id: 'x:p1' } })}\n`);
+      sock.write(`${JSON.stringify({ id: req.id, result: { pane_id: 'ours:p1' } })}\n`);
+    });
+    const r = await herdrRequest('tab.create', {}, env(herdr.path));
+    expect(r).toEqual({ pane_id: 'ours:p1' });
+  });
+
+  it('accepts an id-less reply (non-compliant Herdr) without regressing', async () => {
+    herdr = fakeHerdr((_req, sock) => {
+      sock.write(`${JSON.stringify({ result: { pane_id: 'noid:p1' } })}\n`);
+    });
+    const r = await herdrRequest('tab.create', {}, env(herdr.path));
+    expect(r).toEqual({ pane_id: 'noid:p1' });
+  });
+
+  it('returns null on an error reply', async () => {
+    herdr = fakeHerdr((req, sock) => {
+      sock.write(`${JSON.stringify({ id: req.id, error: { message: 'busy' } })}\n`);
+    });
+    expect(await herdrRequest('tab.create', {}, env(herdr.path))).toBeNull();
+  });
+
+  it('times out (returns null) when no matching reply ever arrives', async () => {
+    herdr = fakeHerdr((_req, sock) => {
+      // Only ever send notifications — never our reply.
+      sock.write(`${JSON.stringify({ method: 'noise' })}\n`);
+    });
+    expect(await herdrRequest('tab.create', {}, env(herdr.path), 150)).toBeNull();
+  });
+
+  it('handles a reply split across two data chunks', async () => {
+    herdr = fakeHerdr((req, sock) => {
+      const full = JSON.stringify({ id: req.id, result: { pane_id: 'split:p1' } });
+      const mid = Math.floor(full.length / 2);
+      sock.write(full.slice(0, mid));
+      setTimeout(() => sock.write(`${full.slice(mid)}\n`), 20);
+    });
+    const r = await herdrRequest('tab.create', {}, env(herdr.path));
+    expect(r).toEqual({ pane_id: 'split:p1' });
+  });
+});

--- a/apps/web/content/docs/background-and-parallel.mdx
+++ b/apps/web/content/docs/background-and-parallel.mdx
@@ -44,6 +44,8 @@ job a1b2c3d4e5f6a1b2c3 queued (2/5 running); log: ~/.agentbox/queue/a1b2c3d4e5f6
 
 Credentials for the chosen agent must already be on the host — the background worker can't do an interactive login. If they're missing, submission fails loud. Authenticate first (see [run an agent](/docs/run-an-agent)).
 
+On a cloud provider the worker also verifies the seeded session actually came up before reporting success: if the agent exits at launch, or its in-box login is rejected at runtime (the seeded cloud token expires independently of the host session), the job ends in `failed` — `queue show <id>` prints the reason, with an `agentbox <agent> login` hint when it's a credentials problem. Refresh and re-submit.
+
 By default a queued run opens nothing — attach later with `agentbox attach <box>`. To have the box pop open automatically the moment its worker finishes creating it, set [`queue.openIn`](/docs/configuration#queue--autopause) to `split`, `window`, or `tab` (when you submit from inside tmux, cmux, or iTerm2). The relay opens an attached terminal onto the box for you — no need to watch for it to come up.
 
 <Callout type="warn" title="NOT PRINT MODE">

--- a/docs/e2b_backlog.md
+++ b/docs/e2b_backlog.md
@@ -424,6 +424,32 @@ mode … Yes, I accept" gate.
   relay and can launch boxes on other providers, so they can fully smoke-test.
 
 ## Changelog
+- 2026-06-23: **Fix: cloud `-i` background jobs reported `done` even when the
+  seeded agent session never came up (all cloud providers).** The `-i` queue
+  worker's cloud path (`runCloudJob` → `cloudAgentStartDetached` → `runDetached`
+  in `apps/cli/src/commands/_cloud-attach.ts`) spawned the detached session-start
+  helper with `stdio: 'ignore'` and resolved on **any** exit, discarding the
+  exit code and stderr — so a helper failure (a transient SDK connect/exec error,
+  the agent crashing at launch, or stale in-box credentials) was invisible and
+  the job still wrote `status: done`. The only error that surfaced was the
+  unrelated best-effort `queue.openIn` step (e.g. `herdr tab gave no pane id`),
+  which misled diagnosis toward openIn even though session start is independent of
+  it. Fixes: (1) `runDetached` now captures the exit code + stderr; (2)
+  `cloudAgentStartDetached` throws (→ failed job with reason) when the
+  session-create command exits non-zero; (3) new `verifyDetachedSession` polls
+  `tmux has-session` after start — a session that's already gone means the agent
+  exited immediately at launch (the exact "no tmux session running" symptom) —
+  and best-effort-scrapes the pane for credential-rejection markers (`Please run
+  /login` / `API Error: 401` / …), failing the job with an actionable `agentbox
+  <agent> login` hint. Both callers handle the throw correctly: the queue worker
+  marks the job failed; `restoreAgentSessions` (resume-on-restart) catches +
+  logs. Cloud-wide (daytona/hetzner/vercel/e2b). Verified live on e2b: a job
+  whose box claude creds had lapsed now reports `failed` with the login hint
+  instead of a false `done`; a healthy job still reports `done` with a live
+  session. Unit-tested in `test/cloud-attach.test.ts`. The seeded in-box claude
+  OAuth token is a point-in-time snapshot that expires independently of the host
+  session (see `docs` note on box-cred expiry) — `agentbox claude login` re-seeds
+  it; this fix makes that condition discoverable instead of silent.
 - 2026-06-23: **Fix: cloud create with a relative `-w` path failed the git-clone
   workspace seed (all cloud providers).** `agentbox create --provider e2b -w
   ../repo` died with `git clone … 'file://../repo' … fatal: '/repo' does not

--- a/docs/terminal-integration.md
+++ b/docs/terminal-integration.md
@@ -292,7 +292,18 @@ design is the inverse: we **proxy state transparently** and let Herdr do the res
   notifications) and `herdrRequest` (request/response, for spawn). Everything is
   best-effort — a missing/erroring socket never breaks the attach. Keyed on
   `HERDR_ENV=1` + `HERDR_SOCKET_PATH` + `HERDR_PANE_ID` (`herdrStatusActive`), so
-  it works even when a tmux is nested inside Herdr.
+  it works even when a tmux is nested inside Herdr. **Reply correlation:**
+  `herdrRequest` consumes only the line carrying its own request `id`, skipping
+  notifications and other replies that Herdr may push onto the connection first
+  (an id-less reply is still accepted, so a non-compliant Herdr doesn't regress).
+  This is what made the `-i` queue's concurrent `tab.create` fan-out flaky —
+  several boxes opening tabs at once raced a layout/focus notification ahead of
+  the reply, and the old "take the first `result` line" logic mis-read it as
+  "gave no pane id" even though the tab was created. Pane/tab/workspace *creates*
+  also use a wider 6s timeout (vs the 2s default) since they're slower under that
+  fan-out. (Note: queued session start is independent of `openIn` — a failed
+  `openIn` no longer means no session; see `cloud-create-flow` / the `-i`
+  worker.)
 
 ## Herdr plugin (`agentbox install herdr` + `herdr-plugin/`)
 


### PR DESCRIPTION
## Problem

Running `agentbox claude -i "<prompt>" --provider e2b -n <name> --max-running 3` (background queue, fan-out) created the boxes but the seeded agent session never came up — and the job still reported `done`. The only visible error was an unrelated best-effort `queue.openIn` line (`herdr tab gave no pane id`), which misled diagnosis toward openIn.

Two independent bugs:

1. **Masked session-start failure (all cloud providers).** The `-i` queue worker's cloud path (`runCloudJob` → `cloudAgentStartDetached` → `runDetached`) spawned the detached session-start helper with `stdio: 'ignore'` and resolved on *any* exit, discarding the exit code + stderr. A helper failure (transient SDK connect/exec error, the agent crashing at launch, or stale in-box credentials) was therefore invisible and the job wrote `status: done` with no agent session running. Session start is **independent** of `openIn` — proven live: a no-openIn run still starts the session.

2. **Herdr `tab.create` flaky under concurrency.** `herdrRequest` took the *first* JSON-RPC line with a `result` as the reply, ignoring the request `id`. Under concurrent fan-out, Herdr pushes a layout/focus notification onto the connection before the actual reply; the old logic mis-read it and reported `gave no pane id` even though the tab was created.

## Fixes

**Cloud session start (`apps/cli/src/commands/_cloud-attach.ts`)**
- `runDetached` captures exit code + stderr (was: discarded).
- `cloudAgentStartDetached` throws (→ failed job with reason) when the session-create command exits non-zero.
- new `verifyDetachedSession` polls `tmux has-session` after start (a vanished session = agent exited at launch — the exact "no tmux session" symptom) and best-effort-scrapes the pane for credential-rejection markers, failing with an actionable `agentbox <agent> login` hint.
- Both callers handle the throw: queue worker → failed job; `restoreAgentSessions` → caught + logged. Cloud-wide (daytona/hetzner/vercel/e2b).

**Herdr (`apps/cli/src/terminal/herdr-socket.ts`, `host.ts`)**
- `herdrRequest` consumes only the reply carrying its own request `id`, skipping notifications and other replies (an id-less reply is still accepted, so a non-compliant Herdr doesn't regress). Drains multiple buffered lines; tolerates a reply split across chunks.
- pane/tab/workspace creates use a 6s timeout (was 2s default) since they're slower under the fan-out.

## Verification

- Live on e2b: a job whose box claude creds had lapsed now reports `failed` with the login hint instead of a false `done`; a healthy job still reports `done` with a live session.
- Unit tests: 4 new in `cloud-attach.test.ts` (verifyDetachedSession outcomes), 8 new in `herdr-socket.test.ts` (id-correlation incl. the notification-before-reply concurrency case, split chunks, timeout).
- Full suite 591 pass / 1 skip; lint, typecheck, build clean.

Discovered root cause of the user's no-work boxes: the seeded in-box claude OAuth token was 401-rejected at runtime (it expires independently of the host session; `agentbox claude login` re-seeds it). This change makes that condition discoverable instead of silent.

https://claude.ai/code/session_01RK2TuzwGP2uWp8QWzveRLc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes background queue success criteria for all cloud providers and Herdr terminal spawning under concurrency; failures may surface that were previously silent false positives.
> 
> **Overview**
> Cloud **`-i`** jobs no longer report **`done`** when the seeded agent session never actually started. **`runDetached`** now returns exit code and stderr; **`cloudAgentStartDetached`** fails the job on non-zero session-create and runs new **`verifyDetachedSession`** (tmux liveness + pane scrape for auth errors with **`agentbox <agent> login`** hints). The new-tab pre-start path still ignores create failures; the queue worker surfaces them.
> 
> **Herdr** **`herdrRequest`** correlates replies by request **`id`** instead of taking the first **`result`** line, fixing concurrent **`tab.create`** fan-out mis-reading notifications as “gave no pane id”. Pane/tab/workspace creates use a **6s** timeout under load.
> 
> Docs note cloud session verification on **`-i`**; unit tests cover **`verifyDetachedSession`** and **`herdrRequest`** correlation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f86cc9229106f8f4b0a2fa77c812f0610087b70. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->