### PR TITLE
fix: dashboard attach to e2b agent sessions + nested-symlink claude-config sync

### DIFF
--- a/apps/cli/src/commands/dashboard.ts
+++ b/apps/cli/src/commands/dashboard.ts
@@ -284,6 +284,7 @@ export const dashboardCommand = new Command('dashboard')
           kind: 'attach',
           command: spec.argv[0]!,
           args: spec.argv.slice(1),
+          ...(spec.env ? { env: spec.env } : {}),
           ...(spec.cleanup ? { cleanup: spec.cleanup } : {}),
           mode: which,
           ...(providerSupportsKeepAlive(record.provider) ? { keepAlive: true } : {}),

--- a/apps/cli/src/dashboard/compositor.ts
+++ b/apps/cli/src/dashboard/compositor.ts
@@ -52,6 +52,11 @@ export type RightTarget =
       command: string;
       /** Args passed to `command` (everything after `argv[0]`). */
       args: string[];
+      /** Extra env merged over `process.env` for the spawned attach process.
+       *  Required by providers that pass the inner command / credentials through
+       *  the environment instead of argv (e2b: `AGENTBOX_E2B_INNER_CMD` +
+       *  `E2B_API_KEY`). Dropping it makes the e2b attach helper exit early. */
+      env?: NodeJS.ProcessEnv;
       /** Fires when the PtySession is disposed. Used by daytona to revoke the
        *  ephemeral SSH token its `buildAttach` mints. */
       cleanup?: () => Promise<void>;
@@ -604,6 +609,7 @@ export class Compositor {
         () => this.scheduleRender(),
         (id) => this.onSessionExit(id),
         target.cleanup,
+        target.env,
       );
       if (keepAlive) {
         // A re-resolve can replace an existing pooled entry for this box.

--- a/apps/cli/src/dashboard/pty-session.ts
+++ b/apps/cli/src/dashboard/pty-session.ts
@@ -124,6 +124,7 @@ export class PtySession {
     onRenderable: () => void,
     onExit: (boxId: string) => void,
     cleanup?: () => Promise<void>,
+    env?: NodeJS.ProcessEnv,
   ) {
     this.boxId = boxId;
     this.keepAlive = keepAlive;
@@ -140,7 +141,10 @@ export class PtySession {
       name: 'xterm-256color',
       cols,
       rows,
-      env: process.env,
+      // Merge provider-supplied env over the host env. e2b's attach helper
+      // reads the inner tmux command + API key from here (passed via env, not
+      // argv); without the merge the helper exits before attaching.
+      env: env ? { ...process.env, ...env } : process.env,
     });
     this.pty.onData((d) => {
       // Always feed the parser so the headless buffer stays current even while

--- a/packages/sandbox-docker/src/claude.ts
+++ b/packages/sandbox-docker/src/claude.ts
@@ -144,8 +144,15 @@ function isUnder(parent: string, child: string): boolean {
  *    at `/.agents`). The referent then has "no referent" inside the box — e.g. a
  *    dev's `~/.claude/skills/*` symlinked into an agentbox source checkout.
  *
- * Crosses into subdirs; doesn't follow symlinks (the whole point is to test
- * them rather than traverse them).
+ * A symlinked directory whose target IS reachable can still hide an unsyncable
+ * link one level down: `~/.claude/skills/<name>` -> `~/.agents/skills/<name>`
+ * (reachable) whose `SKILL.md` is an ABSOLUTE link into a repo checkout (not
+ * mounted). rsync's `--copy-unsafe-links` dereferences the reachable dir link
+ * and descends into it, then aborts on the nested absolute link. So when a
+ * symlink resolves into a reachable tree we recurse into the resolved target,
+ * reporting nested findings under the symlink's path as rsync transfers it
+ * (the link name in `root`, not the resolved `~/.agents` path). `seen` guards
+ * against symlink cycles.
  */
 export async function findUnsyncableSymlinks(
   root: string,
@@ -163,32 +170,43 @@ export async function findUnsyncableSymlinks(
     }),
   );
   const unsyncable: string[] = [];
-  async function walk(dir: string): Promise<void> {
+  const seen = new Set<string>();
+  // `realDir` is the filesystem directory to read; `virtualDir` is its path as
+  // rsync sees it under `root` (they diverge once we follow a symlinked dir).
+  async function walk(realDir: string, virtualDir: string): Promise<void> {
+    if (seen.has(realDir)) return;
+    seen.add(realDir);
     let entries;
     try {
-      entries = await readdir(dir, { withFileTypes: true });
+      entries = await readdir(realDir, { withFileTypes: true });
     } catch {
       return;
     }
     for (const ent of entries) {
-      const full = join(dir, ent.name);
+      const realFull = join(realDir, ent.name);
+      const virtualFull = virtualDir ? join(virtualDir, ent.name) : ent.name;
       if (ent.isSymbolicLink()) {
         let real: string;
         try {
-          real = await realpath(full);
+          real = await realpath(realFull);
         } catch {
-          unsyncable.push(relative(root, full)); // broken on the host
+          unsyncable.push(virtualFull); // broken on the host
           continue;
         }
         if (!reachable.some((r) => isUnder(r, real))) {
-          unsyncable.push(relative(root, full)); // target not mounted in the box
+          unsyncable.push(virtualFull); // target not mounted in the box
+          continue;
         }
+        // Reachable target: rsync will dereference + descend, so check inside
+        // it too for nested unsyncable links, keyed to the symlink's path.
+        const st = await stat(real).catch(() => null);
+        if (st?.isDirectory()) await walk(real, virtualFull);
       } else if (ent.isDirectory()) {
-        await walk(full);
+        await walk(realFull, virtualFull);
       }
     }
   }
-  await walk(root);
+  await walk(root, '');
   return unsyncable;
 }
 

--- a/packages/sandbox-docker/src/claude.ts
+++ b/packages/sandbox-docker/src/claude.ts
@@ -151,8 +151,11 @@ function isUnder(parent: string, child: string): boolean {
  * and descends into it, then aborts on the nested absolute link. So when a
  * symlink resolves into a reachable tree we recurse into the resolved target,
  * reporting nested findings under the symlink's path as rsync transfers it
- * (the link name in `root`, not the resolved `~/.agents` path). `seen` guards
- * against symlink cycles.
+ * (the link name in `root`, not the resolved `~/.agents` path). An ancestry
+ * guard (`onPath`) blocks symlink cycles without suppressing the same resolved
+ * dir reached under a *different* virtual prefix — e.g. two skills symlinked to
+ * one shared target must each report their nested unsyncable link, or rsync
+ * still aborts on the prefix we skipped.
  */
 export async function findUnsyncableSymlinks(
   root: string,
@@ -170,40 +173,47 @@ export async function findUnsyncableSymlinks(
     }),
   );
   const unsyncable: string[] = [];
-  const seen = new Set<string>();
+  // Resolved dirs currently on the recursion path. Guards against symlink
+  // cycles (a link pointing at an ancestor) while still allowing the same dir
+  // to be re-walked under a different virtual prefix once this branch unwinds.
+  const onPath = new Set<string>();
   // `realDir` is the filesystem directory to read; `virtualDir` is its path as
   // rsync sees it under `root` (they diverge once we follow a symlinked dir).
   async function walk(realDir: string, virtualDir: string): Promise<void> {
-    if (seen.has(realDir)) return;
-    seen.add(realDir);
-    let entries;
+    if (onPath.has(realDir)) return;
+    onPath.add(realDir);
     try {
-      entries = await readdir(realDir, { withFileTypes: true });
-    } catch {
-      return;
-    }
-    for (const ent of entries) {
-      const realFull = join(realDir, ent.name);
-      const virtualFull = virtualDir ? join(virtualDir, ent.name) : ent.name;
-      if (ent.isSymbolicLink()) {
-        let real: string;
-        try {
-          real = await realpath(realFull);
-        } catch {
-          unsyncable.push(virtualFull); // broken on the host
-          continue;
-        }
-        if (!reachable.some((r) => isUnder(r, real))) {
-          unsyncable.push(virtualFull); // target not mounted in the box
-          continue;
-        }
-        // Reachable target: rsync will dereference + descend, so check inside
-        // it too for nested unsyncable links, keyed to the symlink's path.
-        const st = await stat(real).catch(() => null);
-        if (st?.isDirectory()) await walk(real, virtualFull);
-      } else if (ent.isDirectory()) {
-        await walk(realFull, virtualFull);
+      let entries;
+      try {
+        entries = await readdir(realDir, { withFileTypes: true });
+      } catch {
+        return;
       }
+      for (const ent of entries) {
+        const realFull = join(realDir, ent.name);
+        const virtualFull = virtualDir ? join(virtualDir, ent.name) : ent.name;
+        if (ent.isSymbolicLink()) {
+          let real: string;
+          try {
+            real = await realpath(realFull);
+          } catch {
+            unsyncable.push(virtualFull); // broken on the host
+            continue;
+          }
+          if (!reachable.some((r) => isUnder(r, real))) {
+            unsyncable.push(virtualFull); // target not mounted in the box
+            continue;
+          }
+          // Reachable target: rsync will dereference + descend, so check inside
+          // it too for nested unsyncable links, keyed to the symlink's path.
+          const st = await stat(real).catch(() => null);
+          if (st?.isDirectory()) await walk(real, virtualFull);
+        } else if (ent.isDirectory()) {
+          await walk(realFull, virtualFull);
+        }
+      }
+    } finally {
+      onPath.delete(realDir);
     }
   }
   await walk(root, '');

--- a/packages/sandbox-docker/test/find-unsyncable-symlinks.test.ts
+++ b/packages/sandbox-docker/test/find-unsyncable-symlinks.test.ts
@@ -1,0 +1,73 @@
+import { mkdir, mkdtemp, symlink, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { findUnsyncableSymlinks } from '../src/claude.js';
+
+// findUnsyncableSymlinks pre-scans the host trees for symlinks the in-container
+// rsync (run with --copy-unsafe-links) can't dereference, so they can be
+// --exclude'd before the sync aborts with exit 23 ("symlink has no referent").
+describe('findUnsyncableSymlinks', () => {
+  let dir: string;
+  let claudeRoot: string;
+  let agentsRoot: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'unsyncable-'));
+    claudeRoot = join(dir, '.claude');
+    agentsRoot = join(dir, '.agents');
+    await mkdir(claudeRoot, { recursive: true });
+    await mkdir(agentsRoot, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('flags a symlink whose target is outside every reachable root', async () => {
+    await mkdir(join(claudeRoot, 'skills', 'foo'), { recursive: true });
+    await writeFile(join(dir, 'outside.md'), 'x');
+    await symlink(join(dir, 'outside.md'), join(claudeRoot, 'skills', 'foo', 'SKILL.md'));
+
+    const out = await findUnsyncableSymlinks(claudeRoot, [claudeRoot, agentsRoot]);
+    expect(out).toEqual(['skills/foo/SKILL.md']);
+  });
+
+  it('flags a symlink broken on the host', async () => {
+    await mkdir(join(claudeRoot, 'debug'), { recursive: true });
+    await symlink(join(claudeRoot, 'debug', 'gone.log'), join(claudeRoot, 'debug', 'latest'));
+
+    const out = await findUnsyncableSymlinks(claudeRoot, [claudeRoot, agentsRoot]);
+    expect(out).toEqual(['debug/latest']);
+  });
+
+  it('keeps a symlink whose target is inside a reachable root', async () => {
+    await mkdir(join(agentsRoot, 'skills', 'ok'), { recursive: true });
+    await writeFile(join(agentsRoot, 'skills', 'ok', 'SKILL.md'), 'x');
+    await mkdir(join(claudeRoot, 'skills'), { recursive: true });
+    // ~/.claude/skills/ok -> ~/.agents/skills/ok (a reachable tree)
+    await symlink(join(agentsRoot, 'skills', 'ok'), join(claudeRoot, 'skills', 'ok'));
+
+    const out = await findUnsyncableSymlinks(claudeRoot, [claudeRoot, agentsRoot]);
+    expect(out).toEqual([]);
+  });
+
+  // The regression: a reachable symlinked dir hides an unsyncable link one level
+  // down. rsync dereferences the reachable dir link and descends, then aborts on
+  // the nested absolute link — so the pre-scan must recurse and report it under
+  // the symlink's transfer path (skills/agentbox/SKILL.md), not the resolved
+  // ~/.agents path.
+  it('flags a nested unsyncable link reached through a reachable symlinked dir', async () => {
+    await mkdir(join(agentsRoot, 'skills', 'agentbox'), { recursive: true });
+    await writeFile(join(dir, 'repo-skill.md'), 'x');
+    await symlink(
+      join(dir, 'repo-skill.md'),
+      join(agentsRoot, 'skills', 'agentbox', 'SKILL.md'),
+    );
+    await mkdir(join(claudeRoot, 'skills'), { recursive: true });
+    await symlink(join(agentsRoot, 'skills', 'agentbox'), join(claudeRoot, 'skills', 'agentbox'));
+
+    const out = await findUnsyncableSymlinks(claudeRoot, [claudeRoot, agentsRoot]);
+    expect(out).toEqual(['skills/agentbox/SKILL.md']);
+  });
+});

--- a/packages/sandbox-docker/test/find-unsyncable-symlinks.test.ts
+++ b/packages/sandbox-docker/test/find-unsyncable-symlinks.test.ts
@@ -70,4 +70,29 @@ describe('findUnsyncableSymlinks', () => {
     const out = await findUnsyncableSymlinks(claudeRoot, [claudeRoot, agentsRoot]);
     expect(out).toEqual(['skills/agentbox/SKILL.md']);
   });
+
+  // Two symlinks resolving to the SAME shared dir must each report the nested
+  // unsyncable link under their own transfer prefix — a global visited set keyed
+  // by the resolved path would skip the second, leaving rsync to abort on it.
+  it('reports a shared nested link under every virtual prefix that reaches it', async () => {
+    await mkdir(join(agentsRoot, 'skills', 'shared'), { recursive: true });
+    await writeFile(join(dir, 'repo-skill.md'), 'x');
+    await symlink(join(dir, 'repo-skill.md'), join(agentsRoot, 'skills', 'shared', 'SKILL.md'));
+    await mkdir(join(claudeRoot, 'skills'), { recursive: true });
+    await symlink(join(agentsRoot, 'skills', 'shared'), join(claudeRoot, 'skills', 'foo'));
+    await symlink(join(agentsRoot, 'skills', 'shared'), join(claudeRoot, 'skills', 'bar'));
+
+    const out = await findUnsyncableSymlinks(claudeRoot, [claudeRoot, agentsRoot]);
+    expect(out.sort()).toEqual(['skills/bar/SKILL.md', 'skills/foo/SKILL.md']);
+  });
+
+  // A symlink pointing back at an ancestor must not loop forever.
+  it('terminates on a symlink cycle into an ancestor', async () => {
+    await mkdir(join(claudeRoot, 'a', 'b'), { recursive: true });
+    // ~/.claude/a/b/loop -> ~/.claude/a (an ancestor, reachable)
+    await symlink(join(claudeRoot, 'a'), join(claudeRoot, 'a', 'b', 'loop'));
+
+    const out = await findUnsyncableSymlinks(claudeRoot, [claudeRoot, agentsRoot]);
+    expect(out).toEqual([]);
+  });
 });


### PR DESCRIPTION
Two related sandbox-attach / config-sync fixes, found while testing the dashboard against an e2b box.

## 1. Dashboard can't attach to e2b agent sessions (`fix(e2b)`)

The dashboard built its attach `RightTarget` from `spec.argv` only and **dropped `spec.env`**. e2b (no SSH) passes the inner tmux command + API key through the environment (`AGENTBOX_E2B_INNER_CMD`, `E2B_API_KEY`), so the attach helper exited immediately with `attach-helper: AGENTBOX_E2B_INNER_CMD env is required` and the right pane stayed blank — for claude, codex, and opencode.

Fix: thread `spec.env` through `RightTarget` → `PtySession` → the pty spawn, merging over `process.env` (the same merge the CLI attach path at `_cloud-attach.ts` already does). No-op for docker; also hardens vercel, which previously relied on its auth token being ambient in `process.env`.

Verified live on an e2b box via the drive harness: claude / codex / opencode all attach in the dashboard (right pane streams each session, footer shows the mode).

## 2. claude-config sync aborts on a nested unsyncable symlink (`fix(docker)`)

`ensureClaudeVolume`'s in-container rsync (`--copy-unsafe-links`) aborted with **exit 23 — "symlink has no referent"** when `~/.claude/skills/<name>` is a symlink into a reachable tree (`~/.agents`) whose `SKILL.md` is an **absolute** link into a repo checkout not mounted in the helper container:

```
~/.claude/skills/agentbox        -> ../../.agents/skills/agentbox        (reachable)
~/.agents/skills/agentbox/SKILL.md -> /abs/repo/.../SKILL.md             (NOT mounted)
```

`findUnsyncableSymlinks` didn't descend symlinked dirs, so it missed the nested absolute link — while rsync *does* dereference the reachable dir link and then chokes on it. (A sibling real-dir skill survived only because the scan descended into it normally.)

Fix: recurse into a symlink's resolved target when it lands in a reachable root, reporting nested findings under the symlink's transfer path (so the `--exclude` actually matches), with a `seen` set guarding cycles. Benefits both callers (claude agent-config sync + `~/.agents` sync).

Verified: the real `ensureClaudeVolume` rsync against the live host `~/.claude` now syncs cleanly; added unit coverage for the nested case (4 tests, incl. the regression).

## Tests

- New `packages/sandbox-docker/test/find-unsyncable-symlinks.test.ts` (4 cases).
- Full `@agentbox/sandbox-docker` suite (295) and CLI typecheck pass.

https://claude.ai/code/session_01PTY4KwAeZdAVvgSWxjpYfs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized dashboard PTY env plumbing and pre-sync symlink scanning; no auth or data-model changes, with new test coverage for the docker path.
> 
> **Overview**
> **Dashboard cloud attach** now forwards `buildAttach`’s `spec.env` through `RightTarget` into `PtySession`, merging it over `process.env` when spawning the PTY—matching the CLI cloud attach path. **e2b** needs `AGENTBOX_E2B_INNER_CMD` and `E2B_API_KEY` in the environment (not argv); without that merge the attach helper exits and the right pane stays blank.
> 
> **Claude config host→volume sync** improves `findUnsyncableSymlinks`: when a symlink under `~/.claude` points into a reachable tree (e.g. `~/.agents`), the walker now **recurses into the resolved directory** and reports nested broken/out-of-mount links under the **rsync transfer path** (not the resolved target path), with a `seen` set for cycles. That prevents rsync `--copy-unsafe-links` from hitting exit 23 on a nested absolute `SKILL.md` link after dereferencing a reachable skill dir symlink.
> 
> Adds **unit tests** for the symlink scanner (including the nested regression).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94130459d556ebcbf0bb5b430cb55de1c5f206a2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->