### PR TITLE
fix(creds): fail fast on missing/expired Claude login in non-interactive runs

### DIFF
--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -576,6 +576,7 @@ export const claudeCommand = new Command('claude')
         await assertAgentCredsAvailable({
           agent: 'claude-code',
           image: cfg.effective.box.image,
+          providerName,
         });
       } catch (err) {
         if (err instanceof MissingAgentCredsError) {
@@ -624,6 +625,30 @@ export const claudeCommand = new Command('claude')
     // Resolve auth from host env or the legacy ~/.agentbox/auth.json
     // setup-token (the dormant CI fallback).
     const resolved = await resolveClaudeAuth(process.env);
+
+    // Non-interactive (orchestrator pipe, CI): no TTY to attach or complete an
+    // in-box /login, so fail fast with the same actionable message the prompt
+    // would give instead of booting a box whose agent then silently sits on its
+    // /login screen. `-y` in a real TTY is exempt — that's the documented "boot
+    // and /login inside the box" escape hatch (the user is present). Host-env
+    // auth is exempt too (its presence is the user's explicit choice). The
+    // expiry half of the check is cloud-only — docker boxes refresh in-box.
+    if (!process.stdin.isTTY && resolved.source !== 'host-env') {
+      try {
+        await assertAgentCredsAvailable({
+          agent: 'claude-code',
+          image: cfg.effective.box.image,
+          providerName,
+        });
+      } catch (err) {
+        if (err instanceof MissingAgentCredsError) {
+          log.error(err.message);
+          cmdLog.close();
+          process.exit(2);
+        }
+        throw err;
+      }
+    }
 
     // First-run sign-in offer. Docker seeds every box from the host backup;
     // cloud captures the login to the same backup so the per-box push seeds it

--- a/apps/cli/src/commands/codex.ts
+++ b/apps/cli/src/commands/codex.ts
@@ -476,6 +476,7 @@ export const codexCommand = new Command('codex')
         await assertAgentCredsAvailable({
           agent: 'codex',
           image: cfg.effective.box.image,
+          providerName,
         });
       } catch (err) {
         if (err instanceof MissingAgentCredsError) {

--- a/apps/cli/src/commands/opencode.ts
+++ b/apps/cli/src/commands/opencode.ts
@@ -439,6 +439,7 @@ export const opencodeCommand = new Command('opencode')
         await assertAgentCredsAvailable({
           agent: 'opencode',
           image: cfg.effective.box.image,
+          providerName,
         });
       } catch (err) {
         if (err instanceof MissingAgentCredsError) {

--- a/apps/cli/src/lib/queue/assert-creds.ts
+++ b/apps/cli/src/lib/queue/assert-creds.ts
@@ -3,6 +3,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import {
   hostBackupHasCredentials,
+  hostClaudeBackupExpired,
   OPENCODE_FORWARDED_ENV_KEYS,
   SHARED_CODEX_VOLUME,
   SHARED_OPENCODE_VOLUME,
@@ -33,6 +34,28 @@ export async function claudeAuthAvailable(env: NodeJS.ProcessEnv): Promise<boole
   const resolved = await resolveClaudeAuth(env);
   if (resolved.source !== 'none') return true;
   return hostBackupHasCredentials();
+}
+
+/**
+ * Richer Claude credential verdict for the non-interactive paths. `'missing'`
+ * when nothing can seed a box; `'expired'` when the only credential is a host
+ * backup whose OAuth token is known-expired AND we're on a cloud provider —
+ * cloud's in-box refresh has proven unreliable, whereas docker boxes refresh the
+ * access token themselves, so a stale `expiresAt` is a non-issue there (and
+ * access tokens expire ~hourly, so flagging it on docker would false-fail
+ * constantly). A host-env token (`ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`)
+ * or legacy `auth.json` short-circuits to `'ok'`: it has no expiry concept here.
+ * Mirrors the interactive `maybeRunCloudClaudeLogin` split.
+ */
+export async function claudeCredStatus(
+  env: NodeJS.ProcessEnv,
+  isCloud: boolean,
+): Promise<'ok' | 'missing' | 'expired'> {
+  const resolved = await resolveClaudeAuth(env);
+  if (resolved.source !== 'none') return 'ok';
+  if (!(await hostBackupHasCredentials())) return 'missing';
+  if (isCloud && (await hostClaudeBackupExpired())) return 'expired';
+  return 'ok';
 }
 
 /**
@@ -69,12 +92,15 @@ export async function opencodeAuthAvailable(
 
 const MESSAGES: Record<QueueAgentKind, string> = {
   'claude-code':
-    '-i / --initial-prompt: no Claude credentials on host. Run `agentbox claude login` first (or `agentbox claude` interactively) to seed them, then retry.',
+    'No Claude credentials on host. Run `agentbox claude login` first (or `agentbox claude` interactively) to seed them, then retry.',
   codex:
-    '-i / --initial-prompt: no Codex credentials on host. Run `agentbox codex login` first (or set OPENAI_API_KEY) to seed them, then retry.',
+    'No Codex credentials on host. Run `agentbox codex login` first (or set OPENAI_API_KEY) to seed them, then retry.',
   opencode:
-    '-i / --initial-prompt: no OpenCode credentials on host. Run `agentbox opencode login` first to seed them, then retry.',
+    'No OpenCode credentials on host. Run `agentbox opencode login` first to seed them, then retry.',
 };
+
+const CLAUDE_EXPIRED_MESSAGE =
+  'Your saved Claude login looks expired. Refresh it with `agentbox claude login`, then retry.';
 
 export class MissingAgentCredsError extends Error {
   readonly agent: QueueAgentKind;
@@ -85,10 +111,26 @@ export class MissingAgentCredsError extends Error {
   }
 }
 
+/**
+ * Subclass for the present-but-expired case (Claude on cloud). Extends
+ * {@link MissingAgentCredsError} so the existing `instanceof MissingAgentCredsError`
+ * catches at the call sites still match (→ same fail-fast / exit 2), while callers
+ * and tests can distinguish the reason.
+ */
+export class ExpiredAgentCredsError extends MissingAgentCredsError {
+  constructor(agent: QueueAgentKind, message: string) {
+    super(agent, message);
+    this.name = 'ExpiredAgentCredsError';
+  }
+}
+
 export interface AssertAgentCredsInput {
   agent: QueueAgentKind;
   image: string;
   env?: NodeJS.ProcessEnv;
+  /** Provider for this run; gates the Claude expiry check to cloud (see
+   *  {@link claudeCredStatus}). Omitted/`'docker'` → presence check only. */
+  providerName?: string;
 }
 
 /**
@@ -101,13 +143,16 @@ export interface AssertAgentCredsInput {
  */
 export async function assertAgentCredsAvailable(input: AssertAgentCredsInput): Promise<void> {
   const env = input.env ?? process.env;
-  let ok = false;
   if (input.agent === 'claude-code') {
-    ok = await claudeAuthAvailable(env);
-  } else if (input.agent === 'codex') {
-    ok = await codexAuthAvailable(input.image, env);
-  } else {
-    ok = await opencodeAuthAvailable(input.image, env);
+    const isCloud = input.providerName !== undefined && input.providerName !== 'docker';
+    const status = await claudeCredStatus(env, isCloud);
+    if (status === 'missing') throw new MissingAgentCredsError(input.agent, MESSAGES[input.agent]);
+    if (status === 'expired') throw new ExpiredAgentCredsError(input.agent, CLAUDE_EXPIRED_MESSAGE);
+    return;
   }
+  const ok =
+    input.agent === 'codex'
+      ? await codexAuthAvailable(input.image, env)
+      : await opencodeAuthAvailable(input.image, env);
   if (!ok) throw new MissingAgentCredsError(input.agent, MESSAGES[input.agent]);
 }

--- a/apps/cli/test/assert-creds.test.ts
+++ b/apps/cli/test/assert-creds.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // which `apps/cli/src/auth.ts` reads at load time).
 const sandboxDockerMock = vi.hoisted(() => ({
   hostBackupHasCredentials: vi.fn<() => Promise<boolean>>(),
+  hostClaudeBackupExpired: vi.fn<() => Promise<boolean>>(),
   volumeHasCodexAuth: vi.fn<(volume: string, image: string) => Promise<boolean>>(),
   volumeHasOpencodeAuth: vi.fn<(volume: string, image: string) => Promise<boolean>>(),
 }));
@@ -19,6 +20,7 @@ vi.mock('@agentbox/sandbox-docker', async (importOriginal) => {
   return {
     ...actual,
     hostBackupHasCredentials: sandboxDockerMock.hostBackupHasCredentials,
+    hostClaudeBackupExpired: sandboxDockerMock.hostClaudeBackupExpired,
     volumeHasCodexAuth: sandboxDockerMock.volumeHasCodexAuth,
     volumeHasOpencodeAuth: sandboxDockerMock.volumeHasOpencodeAuth,
   };
@@ -27,9 +29,11 @@ vi.mock('@agentbox/sandbox-docker', async (importOriginal) => {
 const {
   assertAgentCredsAvailable,
   claudeAuthAvailable,
+  claudeCredStatus,
   codexAuthAvailable,
   opencodeAuthAvailable,
   MissingAgentCredsError,
+  ExpiredAgentCredsError,
 } = await import('../src/lib/queue/assert-creds.js');
 
 // Re-import the auth file path AFTER the mock; the module reads STATE_DIR from
@@ -66,6 +70,45 @@ describe('claudeAuthAvailable', () => {
   it('returns false when env empty and backup absent', async () => {
     sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(false);
     expect(await claudeAuthAvailable({})).toBe(false);
+  });
+});
+
+describe('claudeCredStatus', () => {
+  beforeEach(() => {
+    sandboxDockerMock.hostBackupHasCredentials.mockReset();
+    sandboxDockerMock.hostClaudeBackupExpired.mockReset();
+  });
+
+  it('is "missing" when no env and no backup', async () => {
+    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(false);
+    expect(await claudeCredStatus({}, true)).toBe('missing');
+  });
+
+  it('is "ok" when a host-env token is set (expiry not consulted)', async () => {
+    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(false);
+    sandboxDockerMock.hostClaudeBackupExpired.mockResolvedValue(true);
+    expect(await claudeCredStatus({ ANTHROPIC_API_KEY: 'sk-test' }, true)).toBe('ok');
+    expect(sandboxDockerMock.hostClaudeBackupExpired).not.toHaveBeenCalled();
+  });
+
+  it('is "expired" on cloud when the backup token is known-expired', async () => {
+    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
+    sandboxDockerMock.hostClaudeBackupExpired.mockResolvedValue(true);
+    expect(await claudeCredStatus({}, true)).toBe('expired');
+  });
+
+  it('is "ok" on docker even when the backup token is known-expired (in-box refresh)', async () => {
+    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
+    sandboxDockerMock.hostClaudeBackupExpired.mockResolvedValue(true);
+    expect(await claudeCredStatus({}, false)).toBe('ok');
+    // The expiry probe must not even run when the provider is docker.
+    expect(sandboxDockerMock.hostClaudeBackupExpired).not.toHaveBeenCalled();
+  });
+
+  it('is "ok" on cloud when the backup token is present and not expired', async () => {
+    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
+    sandboxDockerMock.hostClaudeBackupExpired.mockResolvedValue(false);
+    expect(await claudeCredStatus({}, true)).toBe('ok');
   });
 });
 
@@ -167,6 +210,7 @@ describe('assertAgentCredsAvailable dispatcher', () => {
 
   beforeEach(async () => {
     sandboxDockerMock.hostBackupHasCredentials.mockReset();
+    sandboxDockerMock.hostClaudeBackupExpired.mockReset();
     sandboxDockerMock.volumeHasCodexAuth.mockReset();
     sandboxDockerMock.volumeHasOpencodeAuth.mockReset();
     homeDir = await mkdtemp(join(tmpdir(), 'agentbox-dispatch-creds-'));
@@ -190,6 +234,40 @@ describe('assertAgentCredsAvailable dispatcher', () => {
     await expect(
       assertAgentCredsAvailable({ agent: 'claude-code', image: IMAGE, env: {} }),
     ).rejects.toBeInstanceOf(MissingAgentCredsError);
+  });
+
+  it('throws ExpiredAgentCredsError for claude on cloud when the backup is expired', async () => {
+    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
+    sandboxDockerMock.hostClaudeBackupExpired.mockResolvedValue(true);
+    try {
+      await assertAgentCredsAvailable({
+        agent: 'claude-code',
+        image: IMAGE,
+        env: {},
+        providerName: 'daytona',
+      });
+      throw new Error('expected to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ExpiredAgentCredsError);
+      // The expired subclass must still satisfy the existing catch at the call sites.
+      expect(err).toBeInstanceOf(MissingAgentCredsError);
+      const e = err as InstanceType<typeof ExpiredAgentCredsError>;
+      expect(e.message).toContain('expired');
+      expect(e.message).toContain('agentbox claude login');
+    }
+  });
+
+  it('does NOT throw for claude on docker when the backup is expired', async () => {
+    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
+    sandboxDockerMock.hostClaudeBackupExpired.mockResolvedValue(true);
+    await expect(
+      assertAgentCredsAvailable({
+        agent: 'claude-code',
+        image: IMAGE,
+        env: {},
+        providerName: 'docker',
+      }),
+    ).resolves.toBeUndefined();
   });
 
   it('error carries the agent kind and a helpful message', async () => {

--- a/apps/web/content/docs/background-and-parallel.mdx
+++ b/apps/web/content/docs/background-and-parallel.mdx
@@ -42,7 +42,7 @@ $ agentbox codex -i "Draft the v0.13 changelog from git log"
 job a1b2c3d4e5f6a1b2c3 queued (2/5 running); log: ~/.agentbox/queue/a1b2c3d4e5f6a1b2c3.log
 ```
 
-Credentials for the chosen agent must already be on the host — the background worker can't do an interactive login. If they're missing, submission fails loud. Authenticate first (see [run an agent](/docs/run-an-agent)).
+Credentials for the chosen agent must already be on the host — the background worker can't do an interactive login. If they're missing — or, on a cloud provider, if your saved Claude login has already expired — submission fails loud (non-zero exit) before any box is created, with an `agentbox <agent> login` hint. The same pre-flight runs for a non-interactive foreground run (e.g. an orchestrating agent piping into `agentbox claude`), so a stale login surfaces as a clean error rather than a box whose agent silently sits on its `/login` screen. Authenticate first (see [run an agent](/docs/run-an-agent)).
 
 On a cloud provider the worker also verifies the seeded session actually came up before reporting success: if the agent exits at launch, or its in-box login is rejected at runtime (the seeded cloud token expires independently of the host session), the job ends in `failed` — `queue show <id>` prints the reason, with an `agentbox <agent> login` hint when it's a credentials problem. Refresh and re-submit.
 

--- a/apps/web/content/docs/run-an-agent.mdx
+++ b/apps/web/content/docs/run-an-agent.mdx
@@ -73,7 +73,7 @@ Auto-approve is safe to default on because the box can't touch your machine — 
 
 ## First-run auth
 
-Credentials are handled on the host and seeded into every box (macOS Keychain doesn't transfer into containers). On the first `agentbox claude` with no credentials — or when a saved login has gone dead and can no longer refresh — AgentBox offers an interactive sign-in that's saved and reused by every future box. Skip it with `-y` (or in CI) and claude will prompt you to `/login` inside the box.
+Credentials are handled on the host and seeded into every box (macOS Keychain doesn't transfer into containers). On the first `agentbox claude` with no credentials — or when a saved login has gone dead and can no longer refresh — AgentBox offers an interactive sign-in that's saved and reused by every future box. Skip it with `-y` in a terminal and claude will prompt you to `/login` inside the box. A genuinely non-interactive run (no TTY — CI, or an orchestrating agent piping in) has no way to complete that login, so it fails fast with an `agentbox claude login` hint instead of leaving a box stuck on its `/login` screen.
 
 ```bash
 agentbox claude login                 # sign in once, reused by every box


### PR DESCRIPTION
## Problem

When the host's saved Claude credentials are missing or expired, the **interactive** create/attach flow re-offers a login. The **non-interactive** paths didn't:

- **`-i` background queue**: the preflight checked only credential *presence* (`hostBackupHasCredentials()`), never expiry. An expired-but-present token sailed through — caught ~10s post-launch on cloud (`verifyDetachedSession`), nowhere on docker.
- **Foreground non-TTY** (an orchestrating agent piping into `agentbox claude`): the login offers early-return on `!process.stdin.isTTY`, so nothing surfaced — the box booted unauthenticated and the agent silently sat on `/login`.

## Fix

Both non-interactive paths now run the same check and **fail fast (exit 2)** with an `agentbox claude login` hint, before any box is created.

- **`apps/cli/src/lib/queue/assert-creds.ts`** — new `claudeCredStatus(env, isCloud)` → `'ok' | 'missing' | 'expired'`, and `ExpiredAgentCredsError extends MissingAgentCredsError` (so existing `instanceof MissingAgentCredsError` catches still match). Expiry is consulted **only on cloud** — docker boxes refresh the access token in-box, and access tokens expire ~hourly, so flagging docker would false-fail constantly. Host-env tokens short-circuit to `'ok'`.
- **`-i` preflight** (claude/codex/opencode) passes `providerName`.
- **claude foreground** — fail fast when there is no TTY and auth isn't host-env. `-y` in a real terminal is left untouched (the documented "boot the box, `/login` inside" escape hatch).
- **Docs** — `background-and-parallel.mdx` and `run-an-agent.mdx` updated.

Mirrors the interactive `maybeRunCloudClaudeLogin` cloud-only expiry split exactly.

## Verification

- Unit: `assert-creds.test.ts` (23) + `cloud-attach.test.ts` (13) green; typecheck + eslint clean.
- Live (throwaway HOME, no real creds touched, no box created):
  - Cloud `-i` + expired backup → exit 2, "looks expired… `agentbox claude login`"
  - Docker `-i` + expired backup → proceeds (in-box refresh)
  - Missing creds (`-i` and foreground non-TTY) → "No Claude credentials…"

## Out of scope

Docker `-i` still has no post-launch verification (cloud does). The pre-flight catches the common expired-access-token case; closing the docker post-launch gap is a separate follow-up.

https://claude.ai/code/session_017WPbmdQCPmqSr2iAxtHqXu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication preflight on common CLI entry points; behavior changes for CI/piped runs and cloud `-i` with stale backups, but scoped checks and existing error handling limit blast radius.
> 
> **Overview**
> Non-interactive Claude runs now **fail before box creation** when host credentials cannot seed the agent, instead of leaving a box stuck on `/login`.
> 
> **`assert-creds`** adds `claudeCredStatus` (`ok` / `missing` / `expired`) and routes Claude through it in `assertAgentCredsAvailable`, with optional **`providerName`**. **Expired** host OAuth backups throw `ExpiredAgentCredsError` (still caught as `MissingAgentCredsError`) **only on cloud** — docker skips expiry because in-box refresh handles hourly access tokens. `-i` preflight for claude/codex/opencode passes `providerName`; error text is generalized beyond the queue-only wording.
> 
> **`agentbox claude`** runs the same assert when **stdin is not a TTY** and auth is not explicit host-env (CI / piped orchestrators). Interactive `-y` in a real terminal is unchanged.
> 
> Docs cover cloud expired-login rejection on `-i`, the non-interactive foreground preflight, and the non-TTY vs `-y` auth behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3134e788290d733504ad29ca18753029ece451ef. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->