### PR TITLE
feat(claude): headless `agentbox claude login` for non-interactive use

### DIFF
--- a/apps/cli/src/commands/_claude-login-worker.ts
+++ b/apps/cli/src/commands/_claude-login-worker.ts
@@ -198,7 +198,10 @@ export const claudeLoginWorkerCommand = new Command('_claude-login-worker')
     disposers.push(() => clearTimeout(urlTimer));
 
     const codeTimer = setTimeout(() => {
-      if (finished || cur.phase === 'done' || cur.phase === 'error') return;
+      // Only abort while we're still WAITING for a code. Never kill an in-flight
+      // exchange (`exchanging`) — a code submitted near the deadline, or a slow
+      // token-exchange + credential warm-up, must be allowed to finish.
+      if (finished || (cur.phase !== 'starting' && cur.phase !== 'awaiting-code')) return;
       log.write('no code within timeout; aborting');
       setState({ phase: 'error', error: 'timed out waiting for a code (10 min) — run login again' });
       cleanExit(1);

--- a/apps/cli/src/commands/_claude-login-worker.ts
+++ b/apps/cli/src/commands/_claude-login-worker.ts
@@ -1,0 +1,207 @@
+/**
+ * Internal worker for the headless `agentbox claude login` flow. Hidden from
+ * `--help`. The foreground `agentbox claude login` (non-TTY or `--headless`)
+ * spawns this detached; it holds the single live `claude auth login` process —
+ * required because the PKCE verifier that mints the auth URL must also exchange
+ * the pasted code, so the URL-printer and the code-exchanger have to be one
+ * process. It drives that process under a node-pty, publishes the auth URL into
+ * the session's `state.json`, waits for the `--code` call to drop a `code`
+ * file, feeds it in, and on success runs the same warm-up + host-backup sync the
+ * interactive login does. See lib/claude-login-session.ts for the IPC contract.
+ */
+import { Command } from 'commander';
+import {
+  buildClaudeLoginRunArgv,
+  SHARED_CLAUDE_VOLUME,
+  syncClaudeCredentials,
+  volumeClaudeCredentials,
+  warmUpClaudeCredentials,
+} from '@agentbox/sandbox-docker';
+import { openCommandLog } from '../lib/log-file.js';
+import { loadPtyBackend } from '../pty/pty-backend.js';
+import {
+  extractOAuthUrl,
+  readLoginRequest,
+  takeLoginCode,
+  writeLoginState,
+  type LoginState,
+} from '../lib/claude-login-session.js';
+
+const URL_TIMEOUT_MS = 60_000;
+const CODE_TIMEOUT_MS = 10 * 60_000;
+const POLL_MS = 500;
+// After a code is submitted, a line that looks like a rejection means claude
+// re-prompted rather than exited — so we drop back to awaiting-code and let the
+// user retry against the same (still-valid) PKCE verifier.
+const INVALID_CODE = /invalid|incorrect|not a valid|try again|expired|rejected/i;
+const BUF_CAP = 64 * 1024;
+
+/** Last meaningful line of buffered output, stripped of escapes and clamped. */
+function tailOf(buf: string): string {
+  const clean = buf
+    .replace(new RegExp('\\u001b\\[[0-9;?]*[ -\\/]*[@-~]', 'g'), '')
+    .replace(/\r/g, '');
+  const lines = clean.split('\n').map((l) => l.trim()).filter((l) => l.length > 0);
+  const tail = lines.slice(-2).join(' ');
+  return tail.length > 240 ? tail.slice(-240) : tail;
+}
+
+export const claudeLoginWorkerCommand = new Command('_claude-login-worker')
+  .description('internal: drive `claude auth login` under a pty for headless login (do not invoke directly)')
+  .argument('<id>', 'login session id (~/.agentbox/claude-login/<id>/)')
+  .action(async (id: string) => {
+    const log = openCommandLog(`claude-login-${id}`);
+    log.write(`worker pid=${String(process.pid)} starting for session ${id}`);
+
+    const base = { pid: process.pid, createdAt: new Date().toISOString() };
+    let cur: Omit<LoginState, 'updatedAt'> = { ...base, phase: 'starting' };
+    const setState = (patch: Partial<Omit<LoginState, 'updatedAt' | 'pid' | 'createdAt'>>): void => {
+      cur = { ...cur, ...patch };
+      writeLoginState(id, cur);
+    };
+
+    const req = readLoginRequest(id);
+    if (!req) {
+      log.write(`FATAL: no request.json for session ${id}`);
+      setState({ phase: 'error', error: 'internal: missing login request' });
+      log.close();
+      process.exit(64);
+    }
+
+    const backend = await loadPtyBackend();
+    if (!backend) {
+      log.write('FATAL: node-pty backend unavailable');
+      setState({ phase: 'error', error: 'pty-unavailable: the node-pty prebuild is not installed' });
+      log.close();
+      process.exit(1);
+    }
+
+    // No method flags → default to the subscription paste-code flow (the one
+    // that prints a URL and reads a single code line). Respect an explicit
+    // method the user forwarded (e.g. --console / --sso).
+    const methodArgs = req.extraArgs.length > 0 ? req.extraArgs : ['--claudeai'];
+    const dockerArgv = buildClaudeLoginRunArgv({
+      volume: SHARED_CLAUDE_VOLUME,
+      image: req.image,
+      extraArgs: methodArgs,
+    });
+    log.write(`spawning: docker ${dockerArgv.join(' ')}`);
+
+    let buf = '';
+    let urlPublished = false;
+    let lastError: string | undefined;
+    let finished = false;
+    const disposers: Array<() => void> = [];
+
+    const pty = backend.ptySpawn('docker', dockerArgv, {
+      name: 'xterm-256color',
+      cols: 200,
+      rows: 50,
+      env: process.env,
+    });
+
+    const cleanExit = (code: number): void => {
+      finished = true;
+      for (const d of disposers) d();
+      try {
+        pty.kill();
+      } catch {
+        /* already gone */
+      }
+      log.close();
+      process.exit(code);
+    };
+
+    for (const sig of ['SIGTERM', 'SIGINT'] as const) {
+      process.on(sig, () => {
+        if (finished) return;
+        log.write(`received ${sig}; aborting`);
+        setState({ phase: 'error', error: `login worker terminated (${sig})` });
+        cleanExit(1);
+      });
+    }
+
+    // Poll for the code file; only consume one while we're actually waiting for it.
+    const codePoll = setInterval(() => {
+      if (finished || cur.phase !== 'awaiting-code') return;
+      const code = takeLoginCode(id);
+      if (code) {
+        log.write('received code; submitting to login');
+        setState({ phase: 'exchanging' });
+        pty.write(code + '\r');
+      }
+    }, POLL_MS);
+    disposers.push(() => clearInterval(codePoll));
+
+    pty.onData((d: string) => {
+      buf += d;
+      if (buf.length > BUF_CAP) buf = buf.slice(-BUF_CAP);
+      log.raw(d);
+      if (!urlPublished) {
+        const url = extractOAuthUrl(buf);
+        if (url) {
+          // Leave the no-URL guard timer to expire harmlessly; its callback
+          // re-checks `urlPublished` and bails.
+          urlPublished = true;
+          log.write(`published auth url: ${url}`);
+          setState({ phase: 'awaiting-code', url });
+        }
+        return;
+      }
+      if (cur.phase === 'exchanging' && INVALID_CODE.test(d)) {
+        lastError = 'the code was not accepted — paste a fresh one';
+        log.write('code rejected; back to awaiting-code');
+        setState({ phase: 'awaiting-code', lastError });
+      }
+    });
+
+    pty.onExit(({ exitCode }: { exitCode: number }) => {
+      if (finished) return;
+      log.write(`login process exited code=${String(exitCode)}`);
+      void (async () => {
+        let creds = { present: false, hasRefreshToken: false };
+        try {
+          creds = await volumeClaudeCredentials(SHARED_CLAUDE_VOLUME, req.image);
+        } catch {
+          /* treat as no-creds */
+        }
+        if (exitCode === 0 && creds.hasRefreshToken) {
+          const warm = await warmUpClaudeCredentials(SHARED_CLAUDE_VOLUME, req.image, {
+            onProgress: (l) => log.write(l),
+          });
+          await syncClaudeCredentials(
+            { volume: SHARED_CLAUDE_VOLUME },
+            { image: req.image, isolate: false },
+          );
+          setState({ phase: 'done', warmed: warm.warmed });
+          cleanExit(0);
+          return;
+        }
+        const tail = tailOf(buf);
+        let error =
+          exitCode === 0
+            ? 'login exited without writing credentials'
+            : `login exited with code ${String(exitCode)}`;
+        if (lastError) error = lastError;
+        if (tail) error += ` — ${tail}`;
+        setState({ phase: 'error', error, exitCode });
+        cleanExit(1);
+      })();
+    });
+
+    const urlTimer = setTimeout(() => {
+      if (urlPublished || finished) return;
+      log.write('no auth URL within timeout');
+      setState({ phase: 'error', error: 'login never printed an auth URL (see the worker log)' });
+      cleanExit(1);
+    }, URL_TIMEOUT_MS);
+    disposers.push(() => clearTimeout(urlTimer));
+
+    const codeTimer = setTimeout(() => {
+      if (finished || cur.phase === 'done' || cur.phase === 'error') return;
+      log.write('no code within timeout; aborting');
+      setState({ phase: 'error', error: 'timed out waiting for a code (10 min) — run login again' });
+      cleanExit(1);
+    }, CODE_TIMEOUT_MS);
+    disposers.push(() => clearTimeout(codeTimer));
+  });

--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -576,6 +576,7 @@ export const claudeCommand = new Command('claude')
         await assertAgentCredsAvailable({
           agent: 'claude-code',
           image: cfg.effective.box.image,
+          providerName,
         });
       } catch (err) {
         if (err instanceof MissingAgentCredsError) {
@@ -624,6 +625,30 @@ export const claudeCommand = new Command('claude')
     // Resolve auth from host env or the legacy ~/.agentbox/auth.json
     // setup-token (the dormant CI fallback).
     const resolved = await resolveClaudeAuth(process.env);
+
+    // Non-interactive (orchestrator pipe, CI): no TTY to attach or complete an
+    // in-box /login, so fail fast with the same actionable message the prompt
+    // would give instead of booting a box whose agent then silently sits on its
+    // /login screen. `-y` in a real TTY is exempt — that's the documented "boot
+    // and /login inside the box" escape hatch (the user is present). Host-env
+    // auth is exempt too (its presence is the user's explicit choice). The
+    // expiry half of the check is cloud-only — docker boxes refresh in-box.
+    if (!process.stdin.isTTY && resolved.source !== 'host-env') {
+      try {
+        await assertAgentCredsAvailable({
+          agent: 'claude-code',
+          image: cfg.effective.box.image,
+          providerName,
+        });
+      } catch (err) {
+        if (err instanceof MissingAgentCredsError) {
+          log.error(err.message);
+          cmdLog.close();
+          process.exit(2);
+        }
+        throw err;
+      }
+    }
 
     // First-run sign-in offer. Docker seeds every box from the host backup;
     // cloud captures the login to the same backup so the per-box push seeds it

--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -88,11 +88,13 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { loadPtyBackend } from '../pty/pty-backend.js';
 import {
   cleanupStaleSessions,
+  findLiveSession,
   findPendingSession,
   readLoginState,
   selectLoginMode,
   writeLoginCode,
   writeLoginRequest,
+  writeLoginState,
   type LoginState,
 } from '../lib/claude-login-session.js';
 
@@ -1481,12 +1483,19 @@ async function startHeadlessLogin(args: string[]): Promise<void> {
     process.exit(1);
   }
   cleanupStaleSessions();
-  // Only one live session at a time — re-surface an existing one rather than
-  // stranding a second worker on a URL nobody will read.
-  const existing = findPendingSession();
+  // Only one live session at a time. Match ANY non-terminal live session (incl.
+  // a worker still in `starting`, before its URL is published) so a second
+  // `--headless` can't slip through and spawn a duplicate worker.
+  const existing = findLiveSession();
   if (existing) {
-    log.info('A login is already pending; finish it (or wait for it to expire):');
-    printAwaitingCode(existing.state);
+    if (existing.state.phase === 'awaiting-code' && existing.state.url) {
+      log.info('A login is already pending; finish it (or wait for it to expire):');
+      printAwaitingCode(existing.state);
+    } else {
+      log.info(
+        'A login is already in progress; wait for it to print its URL, then finish with `agentbox claude login --code <CODE>`.',
+      );
+    }
     return;
   }
 
@@ -1518,8 +1527,17 @@ async function startHeadlessLogin(args: string[]): Promise<void> {
     env: process.env,
   });
   child.unref();
+  // Publish a `starting` state with the worker pid immediately, so a concurrent
+  // `--headless` sees a live session and won't spawn a second worker during the
+  // window before the worker itself writes any state.
+  if (typeof child.pid === 'number') {
+    writeLoginState(id, { phase: 'starting', pid: child.pid, createdAt: new Date().toISOString() });
+  }
 
-  const deadline = Date.now() + 30_000;
+  // Wait past the worker's own no-URL deadline (60s) so we observe its verdict
+  // (awaiting-code or a published error) instead of giving up while it's still
+  // working and missing the URL it later prints.
+  const deadline = Date.now() + 65_000;
   for (;;) {
     const st = readLoginState(id);
     if (st?.phase === 'awaiting-code' && st.url) {

--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -81,6 +81,20 @@ import { runWrappedAttach } from '../wrapped-pty/index.js';
 import { pasteHostClipboardImage, uploadImageFileToBox } from '../lib/paste-image.js';
 import { clipboardCaptureAvailable } from '../lib/host-clipboard.js';
 import { handleLifecycleError } from './_errors.js';
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { loadPtyBackend } from '../pty/pty-backend.js';
+import {
+  cleanupStaleSessions,
+  findPendingSession,
+  readLoginState,
+  selectLoginMode,
+  writeLoginCode,
+  writeLoginRequest,
+  type LoginState,
+} from '../lib/claude-login-session.js';
 
 /** Project an agent-create options struct down to what the queue worker needs. */
 function pickCreateOpts(opts: ClaudeCreateOptions): import('@agentbox/relay').QueueJobCreateOpts {
@@ -1442,21 +1456,162 @@ const claudeStartCommand = new Command('start')
     }
   });
 
+function printAwaitingCode(st: LoginState): void {
+  const url = st.url ?? '';
+  log.info('To finish signing in, open this URL in a browser and approve access:');
+  process.stdout.write(`\n  ${url}\n\n`);
+  log.info('Then run:  agentbox claude login --code <CODE>');
+  // Stable, greppable marker so an orchestrating agent can grab the URL
+  // deterministically regardless of how the prose above is worded.
+  process.stdout.write(`AGENTBOX_LOGIN_URL=${url}\n`);
+}
+
+/**
+ * Headless login (non-TTY / `--headless`): spawn the detached worker that holds
+ * the live `claude auth login`, wait for it to publish the auth URL, print it +
+ * the `--code` follow-up, and return while the worker keeps waiting. A second
+ * `agentbox claude login --code <CODE>` ({@link deliverLoginCode}) finishes it.
+ */
+async function startHeadlessLogin(args: string[]): Promise<void> {
+  // node-pty drives the login; without the prebuild there is no headless path.
+  if (!(await loadPtyBackend())) {
+    log.error(
+      'Headless login needs the node-pty prebuild, which is not installed. Run `agentbox claude login` from an interactive terminal instead.',
+    );
+    process.exit(1);
+  }
+  cleanupStaleSessions();
+  // Only one live session at a time — re-surface an existing one rather than
+  // stranding a second worker on a URL nobody will read.
+  const existing = findPendingSession();
+  if (existing) {
+    log.info('A login is already pending; finish it (or wait for it to expire):');
+    printAwaitingCode(existing.state);
+    return;
+  }
+
+  const cfg = await loadEffectiveConfig(process.cwd());
+  const image = cfg.effective.box.image;
+  const s = spinner();
+  s.start('preparing sandbox image');
+  await ensureImage(image, { onProgress: (line) => s.message(clampSpinnerLine(line)) });
+  s.stop('image ready');
+
+  const id = randomUUID().slice(0, 8);
+  writeLoginRequest(id, {
+    image,
+    extraArgs: args,
+    cwd: process.cwd(),
+    createdAt: new Date().toISOString(),
+  });
+
+  // This foreground process IS the CLI entry, so argv[1] is the right script to
+  // re-exec for the worker; AGENTBOX_CLI_ENTRY wins if a wrapper set it.
+  const entry = process.env.AGENTBOX_CLI_ENTRY ?? process.argv[1];
+  if (!entry || !existsSync(entry)) {
+    log.error('could not resolve the agentbox CLI entry to spawn the login worker');
+    process.exit(1);
+  }
+  const child = spawn(process.execPath, [entry, '_claude-login-worker', id], {
+    detached: true,
+    stdio: 'ignore',
+    env: process.env,
+  });
+  child.unref();
+
+  const deadline = Date.now() + 30_000;
+  for (;;) {
+    const st = readLoginState(id);
+    if (st?.phase === 'awaiting-code' && st.url) {
+      printAwaitingCode(st);
+      return;
+    }
+    if (st?.phase === 'error') {
+      log.error(`login could not start: ${st.error ?? 'unknown error'}`);
+      process.exit(1);
+    }
+    if (Date.now() > deadline) {
+      log.error(`timed out waiting for the login URL — see ~/.agentbox/logs/claude-login-${id}.log`);
+      process.exit(1);
+    }
+    await sleep(400);
+  }
+}
+
+/** Deliver an OAuth code to the pending headless login session and report the outcome. */
+async function deliverLoginCode(code: string): Promise<void> {
+  cleanupStaleSessions();
+  const pending = findPendingSession();
+  if (!pending) {
+    log.error(
+      'No pending login is waiting for a code. Start one first with `agentbox claude login` (or --headless).',
+    );
+    process.exit(1);
+  }
+  const { id } = pending;
+  const submittedAt = Date.now();
+  writeLoginCode(id, code);
+
+  const s = spinner();
+  s.start('completing sign-in');
+  const deadline = Date.now() + 120_000;
+  for (;;) {
+    const st = readLoginState(id);
+    if (st?.phase === 'done') {
+      s.stop(st.warmed ? 'credentials ready' : 'signed in (credential check incomplete)');
+      outro('signed in — credentials saved for future boxes');
+      return;
+    }
+    if (st?.phase === 'error') {
+      s.stop('sign-in failed');
+      log.error(st.error ?? 'login failed');
+      process.exit(1);
+    }
+    // Worker reverted to awaiting-code after our submit → the code was rejected;
+    // the session stays valid so a corrected `--code` can retry it.
+    if (st?.phase === 'awaiting-code' && st.lastError && Date.parse(st.updatedAt) >= submittedAt) {
+      s.stop('code rejected');
+      log.error(`${st.lastError}. Run \`agentbox claude login --code <CODE>\` again with a fresh code.`);
+      process.exit(1);
+    }
+    if (Date.now() > deadline) {
+      s.stop('sign-in timed out');
+      log.error('timed out completing sign-in — see the login worker log under ~/.agentbox/logs/');
+      process.exit(1);
+    }
+    await sleep(500);
+  }
+}
+
 const claudeLoginCommand = new Command('login')
   .description(
-    'Sign in to Claude for use in sandboxes (forwards args to `claude auth login`, e.g. --sso, --console). Runs in a throwaway container against the shared claude-config volume — usable before the first `agentbox claude`.',
+    'Sign in to Claude for use in sandboxes (forwards args to `claude auth login`, e.g. --sso, --console). Runs in a throwaway container against the shared claude-config volume — usable before the first `agentbox claude`. Non-interactive (no TTY) or `--headless`: prints the auth URL, then finish with `--code <CODE>`.',
   )
   .argument(
     '[args...]',
     'extra args forwarded to `claude auth login`; place after `--`, e.g. `agentbox claude login -- --sso`',
   )
-  .action(async (args: string[]) => {
-    intro('Signing in to Claude...');
-    if (!process.stdin.isTTY) {
-      log.error('`agentbox claude login` needs an interactive terminal.');
-      process.exit(1);
-    }
+  .option(
+    '--headless',
+    'drive login without a terminal: print the auth URL, then finish with `--code` (auto-selected when stdin is not a TTY)',
+  )
+  .option('--code <code>', 'deliver the OAuth code to a pending headless login session')
+  .action(async (args: string[], opts: { headless?: boolean; code?: string }) => {
+    const mode = selectLoginMode({
+      isTTY: !!process.stdin.isTTY,
+      headless: !!opts.headless,
+      code: typeof opts.code === 'string',
+    });
     try {
+      if (mode === 'code') {
+        await deliverLoginCode(opts.code as string);
+        return;
+      }
+      if (mode === 'headless') {
+        await startHeadlessLogin(args);
+        return;
+      }
+      intro('Signing in to Claude...');
       const cfg = await loadEffectiveConfig(process.cwd());
       const image = cfg.effective.box.image;
 

--- a/apps/cli/src/commands/codex.ts
+++ b/apps/cli/src/commands/codex.ts
@@ -476,6 +476,7 @@ export const codexCommand = new Command('codex')
         await assertAgentCredsAvailable({
           agent: 'codex',
           image: cfg.effective.box.image,
+          providerName,
         });
       } catch (err) {
         if (err instanceof MissingAgentCredsError) {

--- a/apps/cli/src/commands/opencode.ts
+++ b/apps/cli/src/commands/opencode.ts
@@ -439,6 +439,7 @@ export const opencodeCommand = new Command('opencode')
         await assertAgentCredsAvailable({
           agent: 'opencode',
           image: cfg.effective.box.image,
+          providerName,
         });
       } catch (err) {
         if (err instanceof MissingAgentCredsError) {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -50,6 +50,7 @@ import { pruneCommand } from './commands/prune.js';
 import { queueCommand } from './commands/queue.js';
 import { relayCommand } from './commands/relay.js';
 import { runQueuedJobCommand } from './commands/_run-queued-job.js';
+import { claudeLoginWorkerCommand } from './commands/_claude-login-worker.js';
 import { herdrCommand } from './commands/herdr.js';
 import { screenCommand } from './commands/screen.js';
 import { shellCommand } from './commands/shell.js';
@@ -111,6 +112,9 @@ program.addCommand(relayCommand);
 // Internal worker spawned by the relay's queue scheduler. Hidden from
 // `--help` (it shows nothing user-facing — see _run-queued-job.ts).
 program.addCommand(runQueuedJobCommand, { hidden: true });
+// Internal worker that drives `claude auth login` under a pty for the headless
+// (non-TTY / --headless) login flow. Hidden — see _claude-login-worker.ts.
+program.addCommand(claudeLoginWorkerCommand, { hidden: true });
 // Internal entry points invoked by the Herdr plugin (`agentbox install herdr`).
 program.addCommand(herdrCommand, { hidden: true });
 program.addCommand(daytonaCommand);
@@ -140,6 +144,7 @@ const FIRST_RUN_EXEMPT = new Set([
   'help',
   'relay',
   '_run-queued-job',
+  '_claude-login-worker',
   'drive',
   'screen',
 ]);

--- a/apps/cli/src/lib/claude-login-session.ts
+++ b/apps/cli/src/lib/claude-login-session.ts
@@ -172,6 +172,23 @@ export function findPendingSession(): { id: string; state: LoginState } | null {
 }
 
 /**
+ * Any live (worker-alive) session in a non-terminal phase — including `starting`
+ * (URL not published yet) and `exchanging`. The start guard uses THIS, not
+ * {@link findPendingSession}: blocking only on `awaiting-code` would let a second
+ * `--headless` slip through during the brief `starting` window and spawn a
+ * duplicate worker, breaking the single-session PKCE assumption.
+ */
+export function findLiveSession(): { id: string; state: LoginState } | null {
+  for (const id of listSessions()) {
+    const state = readLoginState(id);
+    if (state && state.phase !== 'done' && state.phase !== 'error' && pidAlive(state.pid)) {
+      return { id, state };
+    }
+  }
+  return null;
+}
+
+/**
  * Reap finished/dead/old session dirs. Removed when: the worker pid is dead and
  * the phase isn't terminal (crash), the phase is terminal and older than 5 min,
  * or the state is missing/older than 15 min (stuck/abandoned).

--- a/apps/cli/src/lib/claude-login-session.ts
+++ b/apps/cli/src/lib/claude-login-session.ts
@@ -1,0 +1,236 @@
+/**
+ * State + IPC for the headless (`--headless` / non-TTY) `agentbox claude login`
+ * flow. The login is a PKCE OAuth flow, so the process that prints the auth URL
+ * must be the same one that exchanges the pasted code — it can't be split across
+ * two independent CLI invocations. So a detached worker holds the live login
+ * process while two short foreground calls coordinate with it through files
+ * under `~/.agentbox/claude-login/<id>/`:
+ *
+ *   request.json  start → worker   { image, extraArgs, cwd, createdAt }
+ *   state.json    worker → polls   { phase, url?, pid, ... } (atomically replaced)
+ *   code          --code → worker  the pasted OAuth code (atomically created)
+ *
+ * All writers write a temp file then `rename` over the target (atomic on the
+ * same filesystem); readers tolerate a transient ENOENT mid-rename.
+ */
+import {
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export type LoginPhase = 'starting' | 'awaiting-code' | 'exchanging' | 'done' | 'error';
+
+export interface LoginState {
+  phase: LoginPhase;
+  /** OAuth URL the user must approve; present from `awaiting-code` onward. */
+  url?: string;
+  /** Worker pid — readers use it to tell a live session from a crashed one. */
+  pid: number;
+  createdAt: string;
+  updatedAt: string;
+  /** Warm-up result (the sacrificial first-request absorb), set on `done`. */
+  warmed?: boolean;
+  /** A recoverable problem (e.g. a rejected code) — session stays usable. */
+  lastError?: string;
+  /** A terminal failure reason, set with phase `error`. */
+  error?: string;
+  /** Login process exit code, when it exited. */
+  exitCode?: number;
+}
+
+export interface LoginRequest {
+  image: string;
+  extraArgs: string[];
+  cwd: string;
+  createdAt: string;
+}
+
+export type LoginMode = 'code' | 'headless' | 'interactive';
+
+/**
+ * Pick the login flavor from the invocation shape. `--code` always means
+ * "deliver a code to a pending session". Otherwise a real TTY gets today's
+ * fully-interactive flow; anything non-interactive (orchestrator pipe, CI) or
+ * an explicit `--headless` gets the two-call worker flow.
+ */
+export function selectLoginMode(o: {
+  isTTY: boolean;
+  headless: boolean;
+  code: boolean;
+}): LoginMode {
+  if (o.code) return 'code';
+  if (o.headless || !o.isTTY) return 'headless';
+  return 'interactive';
+}
+
+/** `~/.agentbox` honoring `AGENTBOX_HOME` (mirrors lib/log-file.ts). */
+function stateDir(): string {
+  return process.env.AGENTBOX_HOME ?? join(homedir(), '.agentbox');
+}
+export function loginRootDir(): string {
+  return join(stateDir(), 'claude-login');
+}
+export function loginSessionDir(id: string): string {
+  return join(loginRootDir(), id);
+}
+
+function atomicWrite(path: string, data: string): void {
+  const tmp = `${path}.tmp.${String(process.pid)}.${String(Date.now())}`;
+  writeFileSync(tmp, data, { mode: 0o600 });
+  renameSync(tmp, path);
+}
+
+function readJsonWithRetry<T>(path: string): T | null {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      return JSON.parse(readFileSync(path, 'utf8')) as T;
+    } catch {
+      // A read that races a rename can see ENOENT or a partial file; retry once.
+    }
+  }
+  return null;
+}
+
+export function writeLoginRequest(id: string, req: LoginRequest): void {
+  mkdirSync(loginSessionDir(id), { recursive: true });
+  atomicWrite(join(loginSessionDir(id), 'request.json'), JSON.stringify(req));
+}
+export function readLoginRequest(id: string): LoginRequest | null {
+  return readJsonWithRetry<LoginRequest>(join(loginSessionDir(id), 'request.json'));
+}
+
+export function writeLoginState(id: string, state: Omit<LoginState, 'updatedAt'>): void {
+  mkdirSync(loginSessionDir(id), { recursive: true });
+  const full: LoginState = { ...state, updatedAt: new Date().toISOString() };
+  atomicWrite(join(loginSessionDir(id), 'state.json'), JSON.stringify(full));
+}
+export function readLoginState(id: string): LoginState | null {
+  return readJsonWithRetry<LoginState>(join(loginSessionDir(id), 'state.json'));
+}
+
+export function writeLoginCode(id: string, code: string): void {
+  mkdirSync(loginSessionDir(id), { recursive: true });
+  atomicWrite(join(loginSessionDir(id), 'code'), code.trim());
+}
+/** Read and consume the pasted code (deleting it so a retry can deliver a new one). */
+export function takeLoginCode(id: string): string | null {
+  const path = join(loginSessionDir(id), 'code');
+  try {
+    const code = readFileSync(path, 'utf8').trim();
+    try {
+      unlinkSync(path);
+    } catch {
+      /* already gone */
+    }
+    return code.length > 0 ? code : null;
+  } catch {
+    return null;
+  }
+}
+
+export function pidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM means the process exists but we can't signal it — still alive.
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+export function listSessions(): string[] {
+  try {
+    return readdirSync(loginRootDir(), { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * The single live session still waiting for a code (worker process alive). The
+ * normal flow only ever has one; if a future caller starts several, the first
+ * live one wins and the caller can disambiguate with `--session`.
+ */
+export function findPendingSession(): { id: string; state: LoginState } | null {
+  for (const id of listSessions()) {
+    const state = readLoginState(id);
+    if (state && state.phase === 'awaiting-code' && pidAlive(state.pid)) {
+      return { id, state };
+    }
+  }
+  return null;
+}
+
+/**
+ * Reap finished/dead/old session dirs. Removed when: the worker pid is dead and
+ * the phase isn't terminal (crash), the phase is terminal and older than 5 min,
+ * or the state is missing/older than 15 min (stuck/abandoned).
+ */
+export function cleanupStaleSessions(now: number = Date.now()): void {
+  const TERMINAL_MAX_AGE = 5 * 60_000;
+  const STUCK_MAX_AGE = 15 * 60_000;
+  for (const id of listSessions()) {
+    const dir = loginSessionDir(id);
+    const state = readLoginState(id);
+    let stale = false;
+    if (!state) {
+      stale = true;
+    } else {
+      const age = now - Date.parse(state.updatedAt);
+      const terminal = state.phase === 'done' || state.phase === 'error';
+      if (terminal) {
+        stale = age > TERMINAL_MAX_AGE;
+      } else if (!pidAlive(state.pid)) {
+        stale = true;
+      } else {
+        stale = age > STUCK_MAX_AGE;
+      }
+    }
+    if (stale) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
+}
+
+// Strip CSI (color/cursor) escapes only. OSC hyperlinks (OSC 8) embed the URL
+// itself, so leaving them in lets the URL regex still match inside them. Built
+// via RegExp(string) so the ESC byte and the `/` intermediate stay unambiguous.
+const CSI = new RegExp('\\u001b\\[[0-9;?]*[ -\\/]*[@-~]', 'g');
+// Match an OAuth approval URL on any current Claude/Anthropic auth host
+// (claude.com/cai/oauth/…, claude.ai, console.anthropic.com) and REQUIRE the
+// literal `oauth` in the path/query so an unrelated claude.com link can't
+// match. The char class excludes whitespace, quotes/brackets, and control bytes
+// (so an OSC-8 hyperlink's trailing BEL terminates the match cleanly).
+const URL_BODY = "[^\\s'\"`<>)\\]\\u0000-\\u001f]";
+const OAUTH_URL = new RegExp(
+  `https?://(?:claude\\.com|claude\\.ai|console\\.anthropic\\.com)/${URL_BODY}*oauth${URL_BODY}*`,
+  'i',
+);
+
+/**
+ * Pull the OAuth approval URL out of accumulated (possibly ANSI-styled) login
+ * output. Claude's `--claudeai` paste-code flow prints a
+ * `https://claude.ai/oauth/authorize?...` (or console.anthropic.com) link. We
+ * strip color escapes first, then match the first such URL; surrounding
+ * quotes/brackets and trailing punctuation are trimmed.
+ */
+export function extractOAuthUrl(text: string): string | null {
+  const clean = text.replace(CSI, '');
+  const m = clean.match(OAUTH_URL);
+  if (!m) return null;
+  return m[0].replace(/["'`)\]>]+$/, '').replace(/[.,;]+$/, '');
+}

--- a/apps/cli/src/lib/queue/assert-creds.ts
+++ b/apps/cli/src/lib/queue/assert-creds.ts
@@ -3,6 +3,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import {
   hostBackupHasCredentials,
+  hostClaudeBackupExpired,
   OPENCODE_FORWARDED_ENV_KEYS,
   SHARED_CODEX_VOLUME,
   SHARED_OPENCODE_VOLUME,
@@ -33,6 +34,28 @@ export async function claudeAuthAvailable(env: NodeJS.ProcessEnv): Promise<boole
   const resolved = await resolveClaudeAuth(env);
   if (resolved.source !== 'none') return true;
   return hostBackupHasCredentials();
+}
+
+/**
+ * Richer Claude credential verdict for the non-interactive paths. `'missing'`
+ * when nothing can seed a box; `'expired'` when the only credential is a host
+ * backup whose OAuth token is known-expired AND we're on a cloud provider —
+ * cloud's in-box refresh has proven unreliable, whereas docker boxes refresh the
+ * access token themselves, so a stale `expiresAt` is a non-issue there (and
+ * access tokens expire ~hourly, so flagging it on docker would false-fail
+ * constantly). A host-env token (`ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`)
+ * or legacy `auth.json` short-circuits to `'ok'`: it has no expiry concept here.
+ * Mirrors the interactive `maybeRunCloudClaudeLogin` split.
+ */
+export async function claudeCredStatus(
+  env: NodeJS.ProcessEnv,
+  isCloud: boolean,
+): Promise<'ok' | 'missing' | 'expired'> {
+  const resolved = await resolveClaudeAuth(env);
+  if (resolved.source !== 'none') return 'ok';
+  if (!(await hostBackupHasCredentials())) return 'missing';
+  if (isCloud && (await hostClaudeBackupExpired())) return 'expired';
+  return 'ok';
 }
 
 /**
@@ -69,12 +92,15 @@ export async function opencodeAuthAvailable(
 
 const MESSAGES: Record<QueueAgentKind, string> = {
   'claude-code':
-    '-i / --initial-prompt: no Claude credentials on host. Run `agentbox claude login` first (or `agentbox claude` interactively) to seed them, then retry.',
+    'No Claude credentials on host. Run `agentbox claude login` first (or `agentbox claude` interactively) to seed them, then retry.',
   codex:
-    '-i / --initial-prompt: no Codex credentials on host. Run `agentbox codex login` first (or set OPENAI_API_KEY) to seed them, then retry.',
+    'No Codex credentials on host. Run `agentbox codex login` first (or set OPENAI_API_KEY) to seed them, then retry.',
   opencode:
-    '-i / --initial-prompt: no OpenCode credentials on host. Run `agentbox opencode login` first to seed them, then retry.',
+    'No OpenCode credentials on host. Run `agentbox opencode login` first to seed them, then retry.',
 };
+
+const CLAUDE_EXPIRED_MESSAGE =
+  'Your saved Claude login looks expired. Refresh it with `agentbox claude login`, then retry.';
 
 export class MissingAgentCredsError extends Error {
   readonly agent: QueueAgentKind;
@@ -85,10 +111,26 @@ export class MissingAgentCredsError extends Error {
   }
 }
 
+/**
+ * Subclass for the present-but-expired case (Claude on cloud). Extends
+ * {@link MissingAgentCredsError} so the existing `instanceof MissingAgentCredsError`
+ * catches at the call sites still match (→ same fail-fast / exit 2), while callers
+ * and tests can distinguish the reason.
+ */
+export class ExpiredAgentCredsError extends MissingAgentCredsError {
+  constructor(agent: QueueAgentKind, message: string) {
+    super(agent, message);
+    this.name = 'ExpiredAgentCredsError';
+  }
+}
+
 export interface AssertAgentCredsInput {
   agent: QueueAgentKind;
   image: string;
   env?: NodeJS.ProcessEnv;
+  /** Provider for this run; gates the Claude expiry check to cloud (see
+   *  {@link claudeCredStatus}). Omitted/`'docker'` → presence check only. */
+  providerName?: string;
 }
 
 /**
@@ -101,13 +143,16 @@ export interface AssertAgentCredsInput {
  */
 export async function assertAgentCredsAvailable(input: AssertAgentCredsInput): Promise<void> {
   const env = input.env ?? process.env;
-  let ok = false;
   if (input.agent === 'claude-code') {
-    ok = await claudeAuthAvailable(env);
-  } else if (input.agent === 'codex') {
-    ok = await codexAuthAvailable(input.image, env);
-  } else {
-    ok = await opencodeAuthAvailable(input.image, env);
+    const isCloud = input.providerName !== undefined && input.providerName !== 'docker';
+    const status = await claudeCredStatus(env, isCloud);
+    if (status === 'missing') throw new MissingAgentCredsError(input.agent, MESSAGES[input.agent]);
+    if (status === 'expired') throw new ExpiredAgentCredsError(input.agent, CLAUDE_EXPIRED_MESSAGE);
+    return;
   }
+  const ok =
+    input.agent === 'codex'
+      ? await codexAuthAvailable(input.image, env)
+      : await opencodeAuthAvailable(input.image, env);
   if (!ok) throw new MissingAgentCredsError(input.agent, MESSAGES[input.agent]);
 }

--- a/apps/cli/test/assert-creds.test.ts
+++ b/apps/cli/test/assert-creds.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // which `apps/cli/src/auth.ts` reads at load time).
 const sandboxDockerMock = vi.hoisted(() => ({
   hostBackupHasCredentials: vi.fn<() => Promise<boolean>>(),
+  hostClaudeBackupExpired: vi.fn<() => Promise<boolean>>(),
   volumeHasCodexAuth: vi.fn<(volume: string, image: string) => Promise<boolean>>(),
   volumeHasOpencodeAuth: vi.fn<(volume: string, image: string) => Promise<boolean>>(),
 }));
@@ -19,6 +20,7 @@ vi.mock('@agentbox/sandbox-docker', async (importOriginal) => {
   return {
     ...actual,
     hostBackupHasCredentials: sandboxDockerMock.hostBackupHasCredentials,
+    hostClaudeBackupExpired: sandboxDockerMock.hostClaudeBackupExpired,
     volumeHasCodexAuth: sandboxDockerMock.volumeHasCodexAuth,
     volumeHasOpencodeAuth: sandboxDockerMock.volumeHasOpencodeAuth,
   };
@@ -27,9 +29,11 @@ vi.mock('@agentbox/sandbox-docker', async (importOriginal) => {
 const {
   assertAgentCredsAvailable,
   claudeAuthAvailable,
+  claudeCredStatus,
   codexAuthAvailable,
   opencodeAuthAvailable,
   MissingAgentCredsError,
+  ExpiredAgentCredsError,
 } = await import('../src/lib/queue/assert-creds.js');
 
 // Re-import the auth file path AFTER the mock; the module reads STATE_DIR from
@@ -66,6 +70,45 @@ describe('claudeAuthAvailable', () => {
   it('returns false when env empty and backup absent', async () => {
     sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(false);
     expect(await claudeAuthAvailable({})).toBe(false);
+  });
+});
+
+describe('claudeCredStatus', () => {
+  beforeEach(() => {
+    sandboxDockerMock.hostBackupHasCredentials.mockReset();
+    sandboxDockerMock.hostClaudeBackupExpired.mockReset();
+  });
+
+  it('is "missing" when no env and no backup', async () => {
+    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(false);
+    expect(await claudeCredStatus({}, true)).toBe('missing');
+  });
+
+  it('is "ok" when a host-env token is set (expiry not consulted)', async () => {
+    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(false);
+    sandboxDockerMock.hostClaudeBackupExpired.mockResolvedValue(true);
+    expect(await claudeCredStatus({ ANTHROPIC_API_KEY: 'sk-test' }, true)).toBe('ok');
+    expect(sandboxDockerMock.hostClaudeBackupExpired).not.toHaveBeenCalled();
+  });
+
+  it('is "expired" on cloud when the backup token is known-expired', async () => {
+    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
+    sandboxDockerMock.hostClaudeBackupExpired.mockResolvedValue(true);
+    expect(await claudeCredStatus({}, true)).toBe('expired');
+  });
+
+  it('is "ok" on docker even when the backup token is known-expired (in-box refresh)', async () => {
+    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
+    sandboxDockerMock.hostClaudeBackupExpired.mockResolvedValue(true);
+    expect(await claudeCredStatus({}, false)).toBe('ok');
+    // The expiry probe must not even run when the provider is docker.
+    expect(sandboxDockerMock.hostClaudeBackupExpired).not.toHaveBeenCalled();
+  });
+
+  it('is "ok" on cloud when the backup token is present and not expired', async () => {
+    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
+    sandboxDockerMock.hostClaudeBackupExpired.mockResolvedValue(false);
+    expect(await claudeCredStatus({}, true)).toBe('ok');
   });
 });
 
@@ -167,6 +210,7 @@ describe('assertAgentCredsAvailable dispatcher', () => {
 
   beforeEach(async () => {
     sandboxDockerMock.hostBackupHasCredentials.mockReset();
+    sandboxDockerMock.hostClaudeBackupExpired.mockReset();
     sandboxDockerMock.volumeHasCodexAuth.mockReset();
     sandboxDockerMock.volumeHasOpencodeAuth.mockReset();
     homeDir = await mkdtemp(join(tmpdir(), 'agentbox-dispatch-creds-'));
@@ -190,6 +234,40 @@ describe('assertAgentCredsAvailable dispatcher', () => {
     await expect(
       assertAgentCredsAvailable({ agent: 'claude-code', image: IMAGE, env: {} }),
     ).rejects.toBeInstanceOf(MissingAgentCredsError);
+  });
+
+  it('throws ExpiredAgentCredsError for claude on cloud when the backup is expired', async () => {
+    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
+    sandboxDockerMock.hostClaudeBackupExpired.mockResolvedValue(true);
+    try {
+      await assertAgentCredsAvailable({
+        agent: 'claude-code',
+        image: IMAGE,
+        env: {},
+        providerName: 'daytona',
+      });
+      throw new Error('expected to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ExpiredAgentCredsError);
+      // The expired subclass must still satisfy the existing catch at the call sites.
+      expect(err).toBeInstanceOf(MissingAgentCredsError);
+      const e = err as InstanceType<typeof ExpiredAgentCredsError>;
+      expect(e.message).toContain('expired');
+      expect(e.message).toContain('agentbox claude login');
+    }
+  });
+
+  it('does NOT throw for claude on docker when the backup is expired', async () => {
+    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
+    sandboxDockerMock.hostClaudeBackupExpired.mockResolvedValue(true);
+    await expect(
+      assertAgentCredsAvailable({
+        agent: 'claude-code',
+        image: IMAGE,
+        env: {},
+        providerName: 'docker',
+      }),
+    ).resolves.toBeUndefined();
   });
 
   it('error carries the agent kind and a helpful message', async () => {

--- a/apps/cli/test/claude-login-session.test.ts
+++ b/apps/cli/test/claude-login-session.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   cleanupStaleSessions,
   extractOAuthUrl,
+  findLiveSession,
   findPendingSession,
   loginSessionDir,
   readLoginState,
@@ -125,6 +126,21 @@ describe('login session state IPC', () => {
   it('does not return a done/error session as pending', () => {
     writeLoginState('done', { phase: 'done', pid: process.pid, createdAt: 'T' });
     expect(findPendingSession()).toBeNull();
+  });
+
+  it('findLiveSession matches a live `starting` session (before its URL) but findPendingSession does not', () => {
+    writeLoginState('boot', { phase: 'starting', pid: process.pid, createdAt: 'T' });
+    expect(findPendingSession()).toBeNull(); // no URL yet → not deliverable
+    expect(findLiveSession()?.id).toBe('boot'); // but it IS live → blocks a 2nd worker
+  });
+
+  it('findLiveSession matches a live `exchanging` session but ignores dead/terminal ones', () => {
+    writeLoginState('xchg', { phase: 'exchanging', url: 'u', pid: process.pid, createdAt: 'T' });
+    expect(findLiveSession()?.id).toBe('xchg');
+    writeLoginState('xchg', { phase: 'done', pid: process.pid, createdAt: 'T' });
+    expect(findLiveSession()).toBeNull(); // terminal → not live
+    writeLoginState('xchg', { phase: 'exchanging', url: 'u', pid: DEAD_PID, createdAt: 'T' });
+    expect(findLiveSession()).toBeNull(); // dead worker → not live
   });
 });
 

--- a/apps/cli/test/claude-login-session.test.ts
+++ b/apps/cli/test/claude-login-session.test.ts
@@ -1,0 +1,160 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  cleanupStaleSessions,
+  extractOAuthUrl,
+  findPendingSession,
+  loginSessionDir,
+  readLoginState,
+  selectLoginMode,
+  takeLoginCode,
+  writeLoginCode,
+  writeLoginRequest,
+  writeLoginState,
+} from '../src/lib/claude-login-session.js';
+
+const DEAD_PID = 2 ** 30; // astronomically unlikely to be a live process
+
+describe('selectLoginMode', () => {
+  it('--code always wins, even with a TTY', () => {
+    expect(selectLoginMode({ isTTY: true, headless: false, code: true })).toBe('code');
+    expect(selectLoginMode({ isTTY: false, headless: true, code: true })).toBe('code');
+  });
+  it('non-TTY (no code) → headless', () => {
+    expect(selectLoginMode({ isTTY: false, headless: false, code: false })).toBe('headless');
+  });
+  it('explicit --headless in a TTY → headless', () => {
+    expect(selectLoginMode({ isTTY: true, headless: true, code: false })).toBe('headless');
+  });
+  it('plain TTY → interactive', () => {
+    expect(selectLoginMode({ isTTY: true, headless: false, code: false })).toBe('interactive');
+  });
+});
+
+describe('extractOAuthUrl', () => {
+  it('pulls a plain claude.ai oauth URL out of surrounding prose', () => {
+    expect(extractOAuthUrl('Open https://claude.ai/oauth/authorize?code=1&x=2 to continue')).toBe(
+      'https://claude.ai/oauth/authorize?code=1&x=2',
+    );
+  });
+  it('handles a console.anthropic.com host', () => {
+    expect(extractOAuthUrl('go: https://console.anthropic.com/oauth/authorize?a=b now')).toBe(
+      'https://console.anthropic.com/oauth/authorize?a=b',
+    );
+  });
+  it('handles the current claude.com/cai/oauth host and stops at a trailing CR', () => {
+    const cr = String.fromCharCode(13);
+    const line = `visit: https://claude.com/cai/oauth/authorize?code=true&state=hKXe${cr}Paste code here`;
+    expect(extractOAuthUrl(line)).toBe(
+      'https://claude.com/cai/oauth/authorize?code=true&state=hKXe',
+    );
+  });
+  it('does not match an unrelated claude.com link (no oauth in path)', () => {
+    expect(extractOAuthUrl('see https://claude.com/pricing for details')).toBeNull();
+  });
+  it('strips ANSI color codes around the URL', () => {
+    const esc = String.fromCharCode(27);
+    const styled = `${esc}[36mhttps://claude.ai/oauth/authorize?foo=bar${esc}[0m`;
+    expect(extractOAuthUrl(styled)).toBe('https://claude.ai/oauth/authorize?foo=bar');
+  });
+  it('stops at the BEL of an OSC-8 hyperlink (no swallowing trailing text)', () => {
+    const esc = String.fromCharCode(27);
+    const bel = String.fromCharCode(7);
+    const osc = `${esc}]8;;https://claude.ai/oauth/authorize?h=1${bel}click here${esc}]8;;${bel}`;
+    expect(extractOAuthUrl(osc)).toBe('https://claude.ai/oauth/authorize?h=1');
+  });
+  it('trims trailing punctuation', () => {
+    expect(extractOAuthUrl('URL: https://claude.ai/oauth/authorize?z=9.')).toBe(
+      'https://claude.ai/oauth/authorize?z=9',
+    );
+  });
+  it('does not treat literal [brackets] in prose as escapes', () => {
+    expect(extractOAuthUrl('config [debug] mode; see https://claude.ai/oauth/x?y=1')).toBe(
+      'https://claude.ai/oauth/x?y=1',
+    );
+  });
+  it('returns null when there is no matching URL', () => {
+    expect(extractOAuthUrl('nothing here, just [brackets] and https://example.com/x')).toBeNull();
+  });
+});
+
+describe('login session state IPC', () => {
+  let home: string;
+  const origHome = process.env['AGENTBOX_HOME'];
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), 'agentbox-login-'));
+    process.env['AGENTBOX_HOME'] = home;
+  });
+  afterEach(async () => {
+    if (origHome === undefined) delete process.env['AGENTBOX_HOME'];
+    else process.env['AGENTBOX_HOME'] = origHome;
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it('round-trips request + state and never leaves a temp file', async () => {
+    writeLoginRequest('s1', { image: 'img:1', extraArgs: ['--claudeai'], cwd: '/w', createdAt: 'T' });
+    writeLoginState('s1', { phase: 'awaiting-code', url: 'https://claude.ai/oauth/x', pid: process.pid, createdAt: 'T' });
+    const st = readLoginState('s1');
+    expect(st?.phase).toBe('awaiting-code');
+    expect(st?.url).toBe('https://claude.ai/oauth/x');
+    expect(st?.updatedAt).toBeTypeOf('string');
+    const entries = (await import('node:fs/promises')).readdir(loginSessionDir('s1'));
+    expect((await entries).some((f) => f.includes('.tmp.'))).toBe(false);
+  });
+
+  it('takeLoginCode reads and consumes the code', () => {
+    writeLoginCode('s2', '  abc123  ');
+    expect(takeLoginCode('s2')).toBe('abc123');
+    expect(takeLoginCode('s2')).toBeNull(); // consumed
+    expect(existsSync(join(loginSessionDir('s2'), 'code'))).toBe(false);
+  });
+
+  it('findPendingSession returns only a live awaiting-code session', () => {
+    // dead worker → ignored even though it is awaiting-code
+    writeLoginState('dead', { phase: 'awaiting-code', url: 'https://claude.ai/oauth/d', pid: DEAD_PID, createdAt: 'T' });
+    expect(findPendingSession()).toBeNull();
+    // live worker → found
+    writeLoginState('live', { phase: 'awaiting-code', url: 'https://claude.ai/oauth/l', pid: process.pid, createdAt: 'T' });
+    expect(findPendingSession()?.id).toBe('live');
+  });
+
+  it('does not return a done/error session as pending', () => {
+    writeLoginState('done', { phase: 'done', pid: process.pid, createdAt: 'T' });
+    expect(findPendingSession()).toBeNull();
+  });
+});
+
+describe('cleanupStaleSessions', () => {
+  let home: string;
+  const origHome = process.env['AGENTBOX_HOME'];
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), 'agentbox-login-clean-'));
+    process.env['AGENTBOX_HOME'] = home;
+  });
+  afterEach(async () => {
+    if (origHome === undefined) delete process.env['AGENTBOX_HOME'];
+    else process.env['AGENTBOX_HOME'] = origHome;
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it('reaps a crashed worker (dead pid, non-terminal phase)', () => {
+    writeLoginState('crash', { phase: 'awaiting-code', url: 'u', pid: DEAD_PID, createdAt: 'T' });
+    cleanupStaleSessions();
+    expect(existsSync(loginSessionDir('crash'))).toBe(false);
+  });
+
+  it('reaps an old terminal session but keeps a fresh live one', () => {
+    // Fresh live awaiting-code (updatedAt = now) → kept.
+    writeLoginState('live', { phase: 'awaiting-code', url: 'u', pid: process.pid, createdAt: 'T' });
+    // Old done session → reaped (its updatedAt is now, so advance the clock past TERMINAL_MAX_AGE).
+    writeLoginState('olddone', { phase: 'done', pid: process.pid, createdAt: 'T' });
+    cleanupStaleSessions(Date.now() + 6 * 60_000);
+    expect(existsSync(loginSessionDir('olddone'))).toBe(false);
+    expect(existsSync(loginSessionDir('live'))).toBe(true);
+  });
+});

--- a/apps/web/content/docs/background-and-parallel.mdx
+++ b/apps/web/content/docs/background-and-parallel.mdx
@@ -42,7 +42,7 @@ $ agentbox codex -i "Draft the v0.13 changelog from git log"
 job a1b2c3d4e5f6a1b2c3 queued (2/5 running); log: ~/.agentbox/queue/a1b2c3d4e5f6a1b2c3.log
 ```
 
-Credentials for the chosen agent must already be on the host — the background worker can't do an interactive login. If they're missing, submission fails loud. Authenticate first (see [run an agent](/docs/run-an-agent)).
+Credentials for the chosen agent must already be on the host — the background worker can't do an interactive login. If they're missing — or, on a cloud provider, if your saved Claude login has already expired — submission fails loud (non-zero exit) before any box is created, with an `agentbox <agent> login` hint. The same pre-flight runs for a non-interactive foreground run (e.g. an orchestrating agent piping into `agentbox claude`), so a stale login surfaces as a clean error rather than a box whose agent silently sits on its `/login` screen. Authenticate first (see [run an agent](/docs/run-an-agent)).
 
 On a cloud provider the worker also verifies the seeded session actually came up before reporting success: if the agent exits at launch, or its in-box login is rejected at runtime (the seeded cloud token expires independently of the host session), the job ends in `failed` — `queue show <id>` prints the reason, with an `agentbox <agent> login` hint when it's a credentials problem. Refresh and re-submit.
 

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -27,7 +27,7 @@ agentbox codex
 agentbox opencode
 ```
 
-The agent-agnostic `agentbox attach [box]` reattaches to whichever agent session is running in the box (it prompts when more than one is live). It never auto-starts: when nothing is running it prints a warning and exits non-zero. Each agent command also exposes its own `attach` / `start` / `login` subcommands: per-agent `attach` reattaches *and* starts a session if none is running (never re-syncs config), `start` (re)starts a session in an existing box (rsyncs host config unless `--no-sync-config`), and `login` runs that agent's auth flow.
+The agent-agnostic `agentbox attach [box]` reattaches to whichever agent session is running in the box (it prompts when more than one is live). It never auto-starts: when nothing is running it prints a warning and exits non-zero. Each agent command also exposes its own `attach` / `start` / `login` subcommands: per-agent `attach` reattaches *and* starts a session if none is running (never re-syncs config), `start` (re)starts a session in an existing box (rsyncs host config unless `--no-sync-config`), and `login` runs that agent's auth flow. `claude login` is interactive in a terminal; with no TTY (or `--headless`) it prints the OAuth approval URL — including a greppable `AGENTBOX_LOGIN_URL=` marker — and you finish with `agentbox claude login --code <CODE>`, so an orchestrating agent can drive the sign-in. See [first-run auth](/docs/run-an-agent#headless-sign-in-no-terminal--from-an-orchestrating-agent).
 
 ```bash
 # Create a box and drop into a shell once it's ready

--- a/apps/web/content/docs/run-an-agent.mdx
+++ b/apps/web/content/docs/run-an-agent.mdx
@@ -73,7 +73,7 @@ Auto-approve is safe to default on because the box can't touch your machine — 
 
 ## First-run auth
 
-Credentials are handled on the host and seeded into every box (macOS Keychain doesn't transfer into containers). On the first `agentbox claude` with no credentials — or when a saved login has gone dead and can no longer refresh — AgentBox offers an interactive sign-in that's saved and reused by every future box. Skip it with `-y` (or in CI) and claude will prompt you to `/login` inside the box.
+Credentials are handled on the host and seeded into every box (macOS Keychain doesn't transfer into containers). On the first `agentbox claude` with no credentials — or when a saved login has gone dead and can no longer refresh — AgentBox offers an interactive sign-in that's saved and reused by every future box. Skip it with `-y` in a terminal and claude will prompt you to `/login` inside the box. A genuinely non-interactive run (no TTY — CI, or an orchestrating agent piping in) has no way to complete that login, so it fails fast with an `agentbox claude login` hint instead of leaving a box stuck on its `/login` screen.
 
 ```bash
 agentbox claude login                 # sign in once, reused by every box

--- a/apps/web/content/docs/run-an-agent.mdx
+++ b/apps/web/content/docs/run-an-agent.mdx
@@ -87,6 +87,33 @@ $ agentbox claude
 ✔ Signed in with your Claude subscription — saved for future boxes.
 ```
 
+### Headless sign-in (no terminal / from an orchestrating agent)
+
+`agentbox claude login` normally needs a terminal to paste the OAuth code into.
+When there's no TTY (an orchestrating agent running `! agentbox claude login`, or
+CI) it switches to a two-call flow automatically — force it anywhere with
+`--headless`:
+
+```bash
+agentbox claude login --headless        # prints the approval URL, returns immediately
+# → open the URL, approve, copy the code, then:
+agentbox claude login --code <CODE>     # completes the sign-in
+```
+
+The first call backgrounds the live login (the OAuth code must be exchanged by
+the same process that minted the URL, so it stays resident) and prints the URL
+both as friendly text and as a stable, greppable marker line:
+
+```console
+AGENTBOX_LOGIN_URL=https://claude.com/cai/oauth/authorize?...
+```
+
+An orchestrating agent can grab the URL with `grep -o 'AGENTBOX_LOGIN_URL=.*'`,
+hand it to you to approve, then finish with `--code`. A rejected code keeps the
+session alive so you can retry `--code` with a corrected one; an unattended
+session expires after 10 minutes. (Needs the optional `node-pty` prebuild — the
+same one `dashboard` uses; without it, sign in from a terminal instead.)
+
 Setting `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` (Claude) or `OPENAI_API_KEY` (Codex) on the host forwards it into the box and skips the sign-in offer. Host `~/.claude` stays the source of truth — every `create` / `claude` syncs it in, so skills, plugins, MCP, and login flow into the next box. Cloud providers capture the login to `~/.agentbox` and push it in on create — see [hetzner](/docs/hetzner), [daytona](/docs/daytona), and [vercel](/docs/vercel).
 
 <Callout title="TIP">


### PR DESCRIPTION
## Problem

`agentbox claude login` runs `claude auth login` interactively in a throwaway docker container and **hard-errors without a TTY**. So an orchestrating Claude Code (`! agentbox claude login`) or CI can't sign in when the box's Claude login expires.

The login is a **PKCE** flow: the process that prints the auth URL generates the code_verifier and must be the same one that exchanges the pasted code — it can't be split across two independent CLI invocations.

## Solution

A two-call protocol backed by a persistent **detached worker** that holds the live login process:

```bash
agentbox claude login --headless        # auto-selected when stdin is not a TTY
# → prints the approval URL + a greppable `AGENTBOX_LOGIN_URL=` marker, returns immediately
agentbox claude login --code <CODE>     # delivers the code, completes + warms up
```

A real terminal keeps today's fully-interactive flow unchanged.

- **`lib/claude-login-session.ts`** (new) — file-based state/IPC under `~/.agentbox/claude-login/<id>/` (atomic temp+rename writes), OAuth-URL extraction (handles the current `claude.com/cai/oauth` host plus `claude.ai` / `console.anthropic.com`, tolerant of ANSI color + OSC-8 hyperlinks), live-session discovery, stale-session reaping, and the pure `selectLoginMode` branch selector.
- **`_claude-login-worker.ts`** (new, hidden) — drives `claude auth login` under node-pty, publishes the URL into `state.json`, waits for the `code` file, feeds it in, and on success reuses the existing `warmUpClaudeCredentials` + `syncClaudeCredentials`. A rejected code keeps the session alive for a retry; URL/code timeouts (60s / 10min) and SIGTERM clean up.
- **`claude.ts` `login`** — branches via `selectLoginMode`; fails gracefully when the optional node-pty prebuild is missing.
- Hidden `_claude-login-worker` registered in `index.ts` (+ first-run exempt).

Cloud providers reuse this unchanged (login always runs in a throwaway docker container to capture the token to `~/.agentbox`).

## Verification

Live end-to-end on docker (creds backup sha identical before/after — starting login is non-destructive):
- `--headless` (piped, non-TTY) → prints the real `claude.com/cai/oauth/authorize?...` URL + `AGENTBOX_LOGIN_URL=` marker, exits 0; worker stays resident in `awaiting-code`.
- bogus `--code` → claude rejects ("Invalid code"), worker reverts to `awaiting-code` and stays alive, foreground reports "code rejected" (retryable).
- second `--headless` while pending → re-surfaces the existing session (no 2nd worker).
- `--code` with no pending session → clean error, exit 1.
- 19 new unit tests (`claude-login-session.test.ts`) + full 618-test suite green; eslint + tsc clean.

## Note

Stacked on #107 (non-interactive creds fail-fast); shows both commits until #107 merges, then auto-trims. Claude-only (codex/opencode login flows differ — follow-up).

https://claude.ai/code/session_017WPbmdQCPmqSr2iAxtHqXu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth login, detached workers, and credential gating for foreground/queue/cloud paths; mistakes could block launches or mishandle tokens, though behavior is covered by new unit tests.
> 
> **Overview**
> Adds **headless Claude sign-in** so CI and orchestrating agents can authenticate without a TTY. `agentbox claude login` now auto-selects headless when stdin is not a TTY (or with `--headless`): it prints the OAuth URL plus a greppable `AGENTBOX_LOGIN_URL=` line and returns while a **detached worker** keeps the live PKCE `claude auth login` process. Finish with `agentbox claude login --code <CODE>`; rejected codes can be retried on the same session.
> 
> New **`claude-login-session`** file IPC under `~/.agentbox/claude-login/<id>/` and a hidden **`_claude-login-worker`** (node-pty + docker login, warm-up, credential sync). Interactive terminal login is unchanged.
> 
> **Credential pre-flight** is tightened: `assertAgentCredsAvailable` takes `providerName`, treats **expired Claude backups as failures on cloud only** (`ExpiredAgentCredsError`), and **`agentbox claude` without a TTY** fails fast when creds are missing/expired (host-env auth exempt). Queue `-i` paths pass `providerName` for Claude/codex/opencode. Docs updated for headless login and non-interactive fail-fast behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45360af5195a8a5ef3057b5c006ac9526063ef90. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->