### PR TITLE
fix(cloud): preserve multi-line seed prompts in the -i detached launcher

### DIFF
--- a/apps/cli/src/commands/_cloud-attach.ts
+++ b/apps/cli/src/commands/_cloud-attach.ts
@@ -46,12 +46,13 @@ function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
  *   - `exec` so the agent gets PID 2 (Ctrl-c in the agent kills the session
  *     cleanly rather than dropping to bash).
  *
- * When `extraArgs` is non-empty, we base64-encode the argv (one arg per line)
- * and hand the inner shell a small `mapfile`-based launcher that reconstructs
- * the array — see `buildCloudAttachInnerCommand`. Base64 is alphanumeric+`/+=`
- * so it survives every shell-quoting layer (host single-quote, SSH, tmux,
- * bash) untouched, which avoids the 3-layer escaping mess the literal form
- * would otherwise require.
+ * When `extraArgs` is non-empty, we base64-encode each arg individually,
+ * newline-join the tokens, base64 that once more, and hand the inner shell a
+ * small read-loop launcher that reconstructs the array — see
+ * `buildCloudAttachInnerCommand`. Base64 is alphanumeric+`/+=` so it survives
+ * every shell-quoting layer (host single-quote, SSH, tmux, bash) untouched, and
+ * per-arg encoding keeps a newline inside an arg (a multi-line seed prompt) from
+ * being mistaken for an argv separator.
  */
 export interface CloudAgentAttachArgs {
   box: BoxRecord;
@@ -62,9 +63,10 @@ export interface CloudAgentAttachArgs {
   /** Mode label for the wrapper's footer. */
   mode: 'claude' | 'codex' | 'opencode';
   /**
-   * Extra args the user typed after `--`. Passed through to the in-box agent
-   * verbatim via a base64-encoded launcher. Limitation: args containing
-   * literal `\n` aren't supported (none of claude/codex/opencode flags do).
+   * Extra args the user typed after `--`, plus any seed prompt slotted ahead of
+   * them. Passed through to the in-box agent verbatim via a base64-encoded
+   * launcher that preserves each arg's bytes exactly — including embedded
+   * newlines, which a multi-paragraph seed prompt routinely carries.
    */
   extraArgs?: string[];
   /**
@@ -113,32 +115,47 @@ export function buildCloudAttachInnerCommand(binary: string, extraArgs?: string[
   if (!extraArgs || extraArgs.length === 0) {
     return `bash -lc '${agentStartBanner(binary)}exec ${binary}'`;
   }
-  // One arg per line, base64-encoded. The launcher runs `mapfile -t A` against
-  // the decoded stream, then `exec <binary> "${A[@]}"` so each arg lands as
-  // its own argv element — quotes/spaces inside an arg are preserved exactly
-  // because base64 is opaque to every outer shell quoting pass.
-  const blob = Buffer.from(extraArgs.join('\n'), 'utf8').toString('base64');
-  // The decode feeds `mapfile` via a **here-string**, NOT process substitution
-  // (`< <(…)`). Process substitution needs `/dev/fd/N`, and the Vercel Sandbox
-  // (Firecracker microVM, AL2023) has no `/dev/fd` — so `mapfile -t A < <(…)`
-  // fails with `/dev/fd/63: No such file or directory`, A stays empty, and the
+  // Encode EACH arg to its own base64 token, newline-join the tokens, then
+  // base64 that whole list once more into a single opaque `blob`. The launcher
+  // decodes `blob` back to the newline-separated tokens, reads them one per
+  // line, and base64-decodes each into its own argv element before
+  // `exec <binary> "${A[@]}"`.
+  //
+  // Two layers, not one, on purpose: the earlier scheme joined the args with a
+  // single `\n` and split with `mapfile -t`, which conflated "argv separator"
+  // with "a newline INSIDE an arg". A multi-paragraph seed prompt (the `-i`
+  // queue's common case) was shredded into one positional per line, so claude/
+  // codex were launched as `claude "line1" "line2" …` — only the first line
+  // reached the agent and the surplus positionals could abort the launch, so
+  // the detached session died and `verifyDetachedSession` failed the job. Here
+  // the inner newlines live INSIDE a token's base64 payload (base64's alphabet
+  // is `[A-Za-z0-9+/=]` — no newlines), so they never act as a separator; only
+  // the outer per-token newlines split the argv.
+  const blob = Buffer.from(
+    extraArgs.map((a) => Buffer.from(a, 'utf8').toString('base64')).join('\n'),
+    'utf8',
+  ).toString('base64');
+  // The decode feeds the read loop via a **here-string**, NOT process
+  // substitution (`< <(…)`). Process substitution needs `/dev/fd/N`, and the
+  // Vercel Sandbox (Firecracker microVM, AL2023) has no `/dev/fd` — so it would
+  // fail with `/dev/fd/63: No such file or directory`, A stays empty, and the
   // agent launches with no args (the wizard's initial setup prompt is silently
   // dropped). A here-string is backed by a temp file, needs no `/dev/fd`, and
   // works on every backend (docker/daytona/hetzner unaffected). `$(…)` strips
-  // the trailing newline `<<<` re-adds, so mapfile -t yields one element per
-  // arg exactly as the join produced them.
+  // the trailing newline `<<<` re-adds, so the loop yields one element per token
+  // exactly as the join produced them.
   //
   // **bash -lc body MUST be single-quoted, not double-quoted.** When tmux
   // launches the session command, it goes through `/bin/sh -c <cmd>`. If we
   // double-quote, sh's parser sees `"${A[@]}"` and expands it eagerly —
-  // before mapfile ever runs — to the empty string, so claude is invoked as
+  // before the loop ever runs — to the empty string, so claude is invoked as
   // `claude ""` and the wizard's initial prompt is silently dropped. Single
   // quotes are inert in sh's parser: the literal `${A[@]}` (and `$(…)`) reach
   // bash, which runs them AFTER the outer sh layer. The outer shellSingle wrap
   // in renderInnerCommand re-escapes any internal `'` as `'\''`; this body has
   // no single quotes (it uses double quotes around the here-string), so it
   // composes fine.
-  return `bash -lc '${agentStartBanner(binary)}mapfile -t A <<< "$(echo ${blob} | base64 -d)"; exec ${binary} "\${A[@]}"'`;
+  return `bash -lc '${agentStartBanner(binary)}A=(); while IFS= read -r t; do A+=("$(printf %s "$t" | base64 -d)"); done <<< "$(echo ${blob} | base64 -d)"; exec ${binary} "\${A[@]}"'`;
 }
 
 export async function cloudAgentAttach(args: CloudAgentAttachArgs): Promise<void> {

--- a/apps/cli/src/commands/dashboard.ts
+++ b/apps/cli/src/commands/dashboard.ts
@@ -257,7 +257,7 @@ export const dashboardCommand = new Command('dashboard')
       };
 
       // Cloud equivalent of buildDashboardAttachArgv. Reuses the same
-      // base64+mapfile inner-command pattern as `agentbox claude/codex/
+      // base64-launcher inner-command pattern as `agentbox claude/codex/
       // opencode` so positional args (wizard prompts) survive every quoting
       // layer. For `shell`, attach to/create the box's tracked `shell` tmux
       // session so the dashboard's shell pane is the same detachable session
@@ -273,7 +273,7 @@ export const dashboardCommand = new Command('dashboard')
         const sessionName = which;
         const kind = which === 'shell' ? 'shell' : 'agent';
         // `bash -l` for shell — login shell so /etc/profile.d/agentbox.sh
-        // exports AGENTBOX_BOX_* env. For agents, the base64+mapfile launcher
+        // exports AGENTBOX_BOX_* env. For agents, the base64 launcher
         // (extraArgs is always [] from the dashboard — no `--` passthrough).
         const innerCommand = which === 'shell' ? 'bash -l' : buildCloudAttachInnerCommand(which);
         const spec = await provider.buildAttach(record, kind, {

--- a/apps/cli/test/cloud-attach.test.ts
+++ b/apps/cli/test/cloud-attach.test.ts
@@ -17,8 +17,12 @@ import { buildPromptArgs } from '../src/lib/queue/build-prompt-args.js';
 function decodeArgs(cmd: string): string[] {
   const m = /echo ([A-Za-z0-9+/=]+) \| base64 -d/.exec(cmd);
   if (!m) throw new Error(`launcher did not embed a base64 blob: ${cmd}`);
-  const decoded = Buffer.from(m[1]!, 'base64').toString('utf8');
-  return decoded.length === 0 ? [] : decoded.split('\n');
+  // Two layers: the outer blob decodes to newline-joined per-arg base64 tokens;
+  // each token decodes to one argv element (so a newline inside an arg is never
+  // mistaken for an argv separator). Mirrors the in-box read-loop launcher.
+  const payload = Buffer.from(m[1]!, 'base64').toString('utf8');
+  if (payload.length === 0) return [];
+  return payload.split('\n').map((t) => Buffer.from(t, 'base64').toString('utf8'));
 }
 
 describe('buildCloudAttachInnerCommand', () => {
@@ -35,13 +39,13 @@ describe('buildCloudAttachInnerCommand', () => {
   it('prints the start banner before the agent on the args path too', () => {
     const cmd = buildCloudAttachInnerCommand('claude', ['--model', 'sonnet']);
     expect(cmd).toContain('agentbox: starting claude');
-    // banner must precede the mapfile launcher so it paints during cold-start.
-    expect(cmd.indexOf('agentbox: starting')).toBeLessThan(cmd.indexOf('mapfile -t A'));
+    // banner must precede the read-loop launcher so it paints during cold-start.
+    expect(cmd.indexOf('agentbox: starting')).toBeLessThan(cmd.indexOf('while IFS= read -r t'));
   });
 
   it('encodes a single simple arg', () => {
     const cmd = buildCloudAttachInnerCommand('claude', ['--model', 'sonnet']);
-    expect(cmd).toContain('mapfile -t A');
+    expect(cmd).toContain('while IFS= read -r t');
     expect(cmd).toContain('exec claude');
     expect(decodeArgs(cmd)).toEqual(['--model', 'sonnet']);
   });
@@ -50,8 +54,20 @@ describe('buildCloudAttachInnerCommand', () => {
     // Process substitution (`< <(…)`) needs /dev/fd, which the Vercel Sandbox
     // lacks — the launcher must use a here-string so the args survive there.
     const cmd = buildCloudAttachInnerCommand('claude', ['--model', 'sonnet']);
-    expect(cmd).toContain('mapfile -t A <<< "$(');
+    expect(cmd).toContain('done <<< "$(');
     expect(cmd).not.toContain('< <(');
+  });
+
+  it('preserves a multi-line seed prompt as a single argv element', () => {
+    // The `-i` queue's common case: a multi-paragraph prompt. The earlier
+    // newline-join + `mapfile -t` scheme shredded it into one positional per
+    // line, so claude/codex got N positionals and the detached session died at
+    // launch (verifyDetachedSession then failed the job). Per-arg encoding keeps
+    // the whole prompt as one argv element.
+    const prompt = 'Build a kanban board.\n\nRequirements:\n- drag and drop\n- columns';
+    const args = buildPromptArgs('claude-code', prompt, ['--permission-mode=plan']);
+    const cmd = buildCloudAttachInnerCommand('claude', args);
+    expect(decodeArgs(cmd)).toEqual([prompt, '--permission-mode=plan']);
   });
 
   it('preserves args with spaces as a single element', () => {


### PR DESCRIPTION
## Problem

`agentbox <provider> claude -i "<multi-paragraph prompt>"` intermittently failed `verifyDetachedSession` ("agent exited immediately after launch"), while a short `-i "hi"` succeeded. The size was a red herring — **newlines** were the trigger.

## Root cause

`buildCloudAttachInnerCommand` joined the argv with `\n`, base64'd the whole thing, and rebuilt the array in-box with `mapfile -t A` — which splits on newlines. A multi-line seed prompt was therefore split into one positional **per line**:

```
"Build a kanban board.\n\nRequirements:\n- drag and drop"
  → claude "Build a kanban board." "" "Requirements:" "- drag and drop"
```

`claude`/`codex` got N positionals, aborted at launch, the single-window tmux session died, and `verifyDetachedSession` correctly reported the dead session and failed the job. Reproduced on real Linux bash 5 (the box's shell).

## Fix

Encode **each arg to its own base64 token**, newline-join the tokens, then base64 that list once more. The in-box read-loop decodes one token per line into its own argv element — so a newline inside an arg lives inside that token's base64 payload and can't act as a separator. Still a here-string (no `/dev/fd`, so Vercel/E2B safe) and single-quoted body so sh doesn't eagerly expand `"${A[@]}"`.

Verified the round-trip on bash 5: a multi-line prompt comes back as exactly one argv element with flags intact.

## Tests
- New regression test: multi-line seed prompt round-trips as a single argv element.
- Updated `decodeArgs` helper (two-layer) and the `mapfile` → read-loop assertions.
- 14/14 cloud-attach tests pass; build + lint clean.

https://claude.ai/code/session_01RK2TuzwGP2uWp8QWzveRLc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the critical SSH→tmux→bash argv path for all cloud agent attaches with extra args; encoding change is well-tested but any launcher bug would break detached `-i` jobs and interactive `--` passthrough.
> 
> **Overview**
> Fixes **`buildCloudAttachInnerCommand`** so cloud SSH/tmux launches pass argv through intact when a seed prompt contains **embedded newlines** (typical for `agentbox … -i` queue jobs).
> 
> The launcher no longer joins args with `\n` and rebuilds them via **`mapfile -t`** (which treated in-arg newlines as separators). It now **base64-encodes each arg**, newline-joins those tokens, base64-wraps the list again, and uses an in-box **read loop** to decode one argv element per token before `exec`. Here-string decoding and single-quoted `bash -lc` behavior are unchanged (still avoids `/dev/fd` and sh eager expansion).
> 
> **Tests** mirror the two-layer encoding in `decodeArgs` and add a regression that a multi-paragraph prompt round-trips as a single positional. Dashboard comments only reference the updated launcher wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e1fcf1739ed4f75144ab067ee065a33db5f1805. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->