### PR TITLE
Support git-lfs repos in the box

### DIFF
--- a/packages/sandbox-docker/Dockerfile.box
+++ b/packages/sandbox-docker/Dockerfile.box
@@ -68,6 +68,7 @@ RUN apt-get update \
         python3-venv \
         build-essential \
         git \
+        git-lfs \
         tmux \
         vim \
         libcap2-bin \
@@ -111,6 +112,18 @@ RUN mkdir -p /home/vscode/.cache/node/corepack \
 # explicit allowlist. /etc/gitconfig is system-wide and unaffected by the RO
 # bind-mount of ~/.gitconfig from the host.
 RUN git config --system --add safe.directory '*'
+
+# git-lfs (installed above) must register its filter.lfs.* hooks, otherwise a
+# checkout of an LFS-tracked repo skips smudge/clean entirely. More to the
+# point: the host's ~/.gitconfig is bind-mounted RO into the box and a user who
+# ran `git lfs install` on the host has `filter.lfs.process = git-lfs
+# filter-process` in it. The in-container `git worktree add` (seedWorkspace)
+# then spawns that filter on checkout, so the `git-lfs` binary has to be on
+# PATH or the add dies with "git-lfs: not found / the remote end hung up
+# unexpectedly". `--system` writes /etc/gitconfig (the host-config bind only
+# covers ~/.gitconfig), so repos that declare LFS purely via .gitattributes
+# resolve too. `--skip-repo` keeps it from touching any checkout at build time.
+RUN git lfs install --system --skip-repo
 
 # Docker-in-Docker. dockerd inside the box lets the agent run
 # `docker build`/`docker run` in its own namespace without exposing the host

--- a/packages/sandbox-docker/src/in-box-git.ts
+++ b/packages/sandbox-docker/src/in-box-git.ts
@@ -251,6 +251,54 @@ export async function bindWorktrees(
 }
 
 /**
+ * Best-effort host-side `git lfs fetch` of the LFS objects reachable from
+ * `baseRef`, BEFORE the in-box `git worktree add` checkout smudges them.
+ *
+ * Why host-side: the box has no access to the host's git credentials (the
+ * git-shim only relays push/pull/fetch/clone, and git-lfs uses its own HTTP
+ * transfer), so an in-box smudge of an object that isn't cached yet would
+ * reach the network unauthenticated and fail. The host *does* have creds, and
+ * `.git/lfs/objects/` is part of the bind-mounted `.git/` shared with the box.
+ * So we fetch here, the objects land in the shared store, and the in-box
+ * checkout resolves every object from cache with zero box network or creds.
+ *
+ * Quiet and safe: we first probe `git lfs ls-files` so the overwhelmingly
+ * common non-LFS repo does nothing and logs nothing. Any failure (no git-lfs
+ * on the host, no `origin`, offline, private without creds) is logged and
+ * swallowed, so create proceeds and the in-box checkout still resolves
+ * whatever is already cached. Mirrors the host-side, best-effort style of
+ * `collectRepoCarryOver`.
+ */
+async function prefetchHostLfs(
+  hostMainRepo: string,
+  baseRef: string,
+  log: (line: string) => void,
+): Promise<void> {
+  // Probe whether this repo tracks anything with LFS (ls-files defaults to
+  // HEAD). Empty output or a non-zero exit (no git-lfs binary, not LFS) → no
+  // work to do, and crucially no log noise on the common non-LFS path.
+  const tracked = await execa('git', ['-C', hostMainRepo, 'lfs', 'ls-files', '-n'], {
+    reject: false,
+  });
+  if (tracked.exitCode !== 0 || tracked.stdout.trim().length === 0) return;
+
+  // `origin` matches the convention used by from-branch.ts; a repo with a
+  // differently-named remote just falls through to the best-effort skip below.
+  const remote = 'origin';
+  const fetched = await execa('git', ['-C', hostMainRepo, 'lfs', 'fetch', remote, baseRef], {
+    reject: false,
+  });
+  if (fetched.exitCode === 0) {
+    log(`prefetched git-lfs objects for ${baseRef} into shared .git/lfs (host ${remote})`);
+  } else {
+    const msg = (fetched.stderr || fetched.stdout || `exit ${String(fetched.exitCode ?? '?')}`)
+      .trim()
+      .split('\n')[0];
+    log(`git-lfs prefetch for ${baseRef} skipped (best-effort, continuing): ${msg}`);
+  }
+}
+
+/**
  * Materialize each per-box git worktree *inside* the container against the
  * bind-mounted `.git/`, then replay the host's uncommitted state (stash +
  * untracked) into it. Runs as `vscode` (the in-container user) so files in
@@ -298,6 +346,10 @@ export async function seedWorkspace(opts: SeedWorkspaceOptions): Promise<void> {
     // stderr is surfaced verbatim below. fork (default): create a fresh
     // branch with `-b` from `fromBranch ?? HEAD` (root only; nested → HEAD).
     const baseRef = r.repo.kind === 'root' ? (opts.fromBranch ?? 'HEAD') : 'HEAD';
+    // Pull the checkout's LFS objects into the shared (bind-mounted) .git/lfs
+    // cache host-side first, so the in-box smudge below never reaches the
+    // network without the host's credentials. Best-effort; never aborts.
+    await prefetchHostLfs(main, baseRef, log);
     const addArgs = r.reuseBranch
       ? ['worktree', 'add', wt, r.branch]
       : ['worktree', 'add', '-b', r.branch, wt, baseRef];
@@ -523,6 +575,10 @@ export async function regenerateRestoredWorktrees(opts: {
   ].join('\n');
   for (const p of opts.plans) {
     const baseRef = p.kind === 'root' ? (opts.fromBranch ?? 'HEAD') : 'HEAD';
+    // Same as seedWorkspace: the restore script's `reset --hard HEAD` smudges
+    // LFS files in-box, so pull their objects into the shared .git/lfs
+    // host-side first. Best-effort; never aborts the restore.
+    await prefetchHostLfs(p.hostMainRepo, baseRef, log);
     const metaDir = `${p.hostMainRepo}/.git/worktrees/${fsSafeBranch(p.freshBranch)}`;
     const r = await execa(
       'docker',


### PR DESCRIPTION
Box creation failed for any repo whose host ~/.gitconfig configures the git-lfs filter (filter.lfs.process = git-lfs filter-process, set by `git lfs install`). The box image installs git but not git-lfs, and the host ~/.gitconfig is bind-mounted RO into the box, so the in-container `git worktree add` (seedWorkspace) spawned the filter on checkout and died:

    git-lfs filter-process: 1: git-lfs: not found
    fatal: the remote end hung up unexpectedly

Two changes:

- Dockerfile.box: install git-lfs and `git lfs install --system` so the filter binary resolves on PATH. --system writes /etc/gitconfig (the host-config bind only covers ~/.gitconfig), so repos that declare LFS purely via .gitattributes resolve too.

- in-box-git.ts: before the in-box `git worktree add` checkout (and the checkpoint-restore `reset --hard`), best-effort `git lfs fetch` the base ref host-side. The host has the credentials and .git/lfs/objects is part of the bind-mounted .git shared with the box, so the in-box smudge then resolves every object from cache with no box-side network or credentials. A non-LFS repo is a silent no-op; any failure is logged and swallowed so create never aborts.