### PR TITLE
Fall back to xterm-256color when the box lacks the host TERM

### DIFF
--- a/packages/sandbox-docker/src/claude.ts
+++ b/packages/sandbox-docker/src/claude.ts
@@ -1079,8 +1079,35 @@ export async function startClaudeSession(opts: StartClaudeSessionOptions): Promi
  * tmux session. Shared by {@link attachClaudeSession} (which `spawnSync`s it
  * directly) and the dashboard command (which hands it to `tmux respawn-pane`).
  */
-export function buildClaudeAttachArgv(container: string, sessionName?: string): string[] {
-  const name = sessionName ?? DEFAULT_CLAUDE_SESSION;
+/**
+ * Shell snippet (run via `sh -c`) that guarantees TERM resolves inside the box
+ * before tmux starts. The box runs Ubuntu, whose terminfo database does not
+ * carry every host terminal: notably `xterm-ghostty`, which was added to
+ * ncurses after 24.04 shipped. Forwarding such a TERM makes `tmux attach` exit
+ * immediately with "missing or unsuitable terminal", which looks like a brief
+ * flash and an instant exit. When the box cannot resolve $TERM, fall back to
+ * xterm-256color, which the image always provides.
+ */
+const TERM_FALLBACK_SNIPPET =
+  'if ! infocmp "$TERM" >/dev/null 2>&1; then TERM=xterm-256color; export TERM; fi; ';
+
+/**
+ * Build the `docker exec` argv that runs an in-box tmux command under `sh -c`
+ * with the TERM guard ({@link TERM_FALLBACK_SNIPPET}) applied first.
+ *
+ * `tmuxScript` is the tmux command line as it should reach tmux (use `\;` for
+ * tmux's own command separator, since a shell now parses it). `positionals` are
+ * bound to "$1", "$2", ... inside the script, so session names are passed as
+ * args rather than interpolated, keeping names with odd characters safe. The
+ * host's TERM is still forwarded via `-e`, so a box that does know it keeps full
+ * fidelity; the guard only downgrades the unknown case.
+ */
+export function buildTermSafeTmuxExec(opts: {
+  container: string;
+  user: string;
+  tmuxScript: string;
+  positionals: string[];
+}): string[] {
   const term = process.env['TERM'] ?? 'xterm-256color';
   return [
     'exec',
@@ -1088,13 +1115,24 @@ export function buildClaudeAttachArgv(container: string, sessionName?: string): 
     '-e',
     `TERM=${term}`,
     '--user',
-    CONTAINER_USER,
-    container,
-    'tmux',
-    'attach',
-    '-t',
-    name,
+    opts.user,
+    opts.container,
+    'sh',
+    '-c',
+    `${TERM_FALLBACK_SNIPPET}${opts.tmuxScript}`,
+    'sh',
+    ...opts.positionals,
   ];
+}
+
+export function buildClaudeAttachArgv(container: string, sessionName?: string): string[] {
+  const name = sessionName ?? DEFAULT_CLAUDE_SESSION;
+  return buildTermSafeTmuxExec({
+    container,
+    user: CONTAINER_USER,
+    tmuxScript: 'exec tmux attach -t "$1"',
+    positionals: [name],
+  });
 }
 
 /**
@@ -1105,46 +1143,28 @@ export function buildClaudeAttachArgv(container: string, sessionName?: string): 
  * attach via a *grouped* sibling session (`<name>-dash`, `tmux new-session -t
  * <name>`): grouped sessions share the same windows/panes (identical live
  * screen + scrollback) but keep independent session options, so `status off`
- * here does not affect a direct `agentbox <agent> attach` to `<name>`. The bare
- * `;` elements are tmux's command separator — node-pty spawns docker without a
- * shell, so they reach tmux verbatim. `new-session -A -d` is a no-op if the
- * grouped session already exists; `attach` runs after `status off` so the
- * footer is gone on first paint.
+ * here does not affect a direct `agentbox <agent> attach` to `<name>`. The
+ * `\;` elements are tmux's command separator, escaped so the wrapping `sh -c`
+ * passes them to tmux verbatim instead of treating them as shell separators.
+ * `new-session -A -d` is a no-op if the grouped session already exists;
+ * `attach` runs after `status off` so the footer is gone on first paint. Runs
+ * under the shared TERM guard ({@link buildTermSafeTmuxExec}) for the same
+ * reason the direct attach builders do.
  */
 export function buildDashboardAttachArgv(
   container: string,
   sessionName?: string,
 ): string[] {
   const name = sessionName ?? DEFAULT_CLAUDE_SESSION;
-  const dash = `${name}-dash`;
-  const term = process.env['TERM'] ?? 'xterm-256color';
-  return [
-    'exec',
-    '-it',
-    '-e',
-    `TERM=${term}`,
-    '--user',
-    CONTAINER_USER,
+  // The grouped sibling session name ("<name>-dash") is derived in-shell from
+  // $1, so the session name stays a single positional that sh never re-parses.
+  return buildTermSafeTmuxExec({
     container,
-    'tmux',
-    'new-session',
-    '-A',
-    '-d',
-    '-s',
-    dash,
-    '-t',
-    name,
-    ';',
-    'set',
-    '-t',
-    dash,
-    'status',
-    'off',
-    ';',
-    'attach',
-    '-t',
-    dash,
-  ];
+    user: CONTAINER_USER,
+    tmuxScript:
+      'dash="$1-dash"; exec tmux new-session -A -d -s "$dash" -t "$1" \\; set -t "$dash" status off \\; attach -t "$dash"',
+    positionals: [name],
+  });
 }
 
 /**

--- a/packages/sandbox-docker/src/codex.ts
+++ b/packages/sandbox-docker/src/codex.ts
@@ -3,7 +3,7 @@ import { readFile, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { execa } from 'execa';
-import { buildTmuxSessionArgs, CONTAINER_USER } from './claude.js';
+import { buildTermSafeTmuxExec, buildTmuxSessionArgs, CONTAINER_USER } from './claude.js';
 import { sanitizeCodexConfigForBox, MINIMAL_TRUSTED_CODEX_CONFIG } from './codex-config.js';
 import { ensureVolume, volumeExists } from './docker.js';
 
@@ -473,20 +473,12 @@ export async function startCodexSession(opts: StartCodexSessionOptions): Promise
  */
 export function buildCodexAttachArgv(container: string, sessionName?: string): string[] {
   const name = sessionName ?? DEFAULT_CODEX_SESSION;
-  const term = process.env['TERM'] ?? 'xterm-256color';
-  return [
-    'exec',
-    '-it',
-    '-e',
-    `TERM=${term}`,
-    '--user',
-    CONTAINER_USER,
+  return buildTermSafeTmuxExec({
     container,
-    'tmux',
-    'attach',
-    '-t',
-    name,
-  ];
+    user: CONTAINER_USER,
+    tmuxScript: 'exec tmux attach -t "$1"',
+    positionals: [name],
+  });
 }
 
 /**

--- a/packages/sandbox-docker/src/opencode.ts
+++ b/packages/sandbox-docker/src/opencode.ts
@@ -3,7 +3,7 @@ import { stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { execa } from 'execa';
-import { buildTmuxSessionArgs, CONTAINER_USER } from './claude.js';
+import { buildTermSafeTmuxExec, buildTmuxSessionArgs, CONTAINER_USER } from './claude.js';
 import { ensureVolume, volumeExists } from './docker.js';
 
 /**
@@ -390,20 +390,12 @@ export async function startOpencodeSession(opts: StartOpencodeSessionOptions): P
  */
 export function buildOpencodeAttachArgv(container: string, sessionName?: string): string[] {
   const name = sessionName ?? DEFAULT_OPENCODE_SESSION;
-  const term = process.env['TERM'] ?? 'xterm-256color';
-  return [
-    'exec',
-    '-it',
-    '-e',
-    `TERM=${term}`,
-    '--user',
-    CONTAINER_USER,
+  return buildTermSafeTmuxExec({
     container,
-    'tmux',
-    'attach',
-    '-t',
-    name,
-  ];
+    user: CONTAINER_USER,
+    tmuxScript: 'exec tmux attach -t "$1"',
+    positionals: [name],
+  });
 }
 
 /**

--- a/packages/sandbox-docker/src/shell-session.ts
+++ b/packages/sandbox-docker/src/shell-session.ts
@@ -1,5 +1,5 @@
 import { execa } from 'execa';
-import { buildTmuxSessionArgs, CONTAINER_USER } from './claude.js';
+import { buildTermSafeTmuxExec, buildTmuxSessionArgs, CONTAINER_USER } from './claude.js';
 
 /** Default tmux session name for `agentbox shell` (the box's first shell). */
 export const DEFAULT_SHELL_SESSION = 'shell';
@@ -191,20 +191,12 @@ export function buildShellSessionAttachArgv(
   user?: string,
 ): string[] {
   const name = sessionName ?? DEFAULT_SHELL_SESSION;
-  const term = process.env['TERM'] ?? 'xterm-256color';
-  return [
-    'exec',
-    '-it',
-    '-e',
-    `TERM=${term}`,
-    '--user',
-    user ?? CONTAINER_USER,
+  return buildTermSafeTmuxExec({
     container,
-    'tmux',
-    'attach',
-    '-t',
-    name,
-  ];
+    user: user ?? CONTAINER_USER,
+    tmuxScript: 'exec tmux attach -t "$1"',
+    positionals: [name],
+  });
 }
 
 /**

--- a/packages/sandbox-docker/test/claude.test.ts
+++ b/packages/sandbox-docker/test/claude.test.ts
@@ -32,9 +32,8 @@ describe('resolveClaudeVolume', () => {
 describe('buildDashboardAttachArgv', () => {
   it('attaches via a grouped sibling session with the inner status bar off', () => {
     const argv = buildDashboardAttachArgv('agentbox-box1');
-    const dash = `${DEFAULT_CLAUDE_SESSION}-dash`;
-    // grouped session created (or no-op) before status is changed, attach last
-    expect(argv).toEqual([
+    // docker exec head, then the tmux command runs under `sh -c` with the TERM guard.
+    expect(argv.slice(0, 7)).toEqual([
       'exec',
       '-it',
       '-e',
@@ -42,34 +41,29 @@ describe('buildDashboardAttachArgv', () => {
       '--user',
       'vscode',
       'agentbox-box1',
-      'tmux',
-      'new-session',
-      '-A',
-      '-d',
-      '-s',
-      dash,
-      '-t',
-      DEFAULT_CLAUDE_SESSION,
-      ';',
-      'set',
-      '-t',
-      dash,
-      'status',
-      'off',
-      ';',
-      'attach',
-      '-t',
-      dash,
     ]);
+    const script = argv[argv.indexOf('-c') + 1]!;
+    expect(script).toContain('infocmp "$TERM"');
+    // grouped session name derived in-shell, created (or no-op) and status off
+    // before attach, attach last.
+    expect(script).toContain('dash="$1-dash"');
+    expect(script).toContain('new-session -A -d -s "$dash" -t "$1"');
+    expect(script).toContain('set -t "$dash" status off');
+    expect(script).toMatch(/attach -t "\$dash"\s*$/);
+    // the base session name is the single positional bound to "$1".
+    expect(argv[argv.length - 1]).toBe(DEFAULT_CLAUDE_SESSION);
   });
 
   it('derives the grouped session from a custom session name', () => {
     const argv = buildDashboardAttachArgv('agentbox-box1', 'codex');
-    expect(argv).toContain('codex');
-    expect(argv).toContain('codex-dash');
-    // never attaches directly to the original session (would show its footer)
-    const attachIdx = argv.lastIndexOf('attach');
-    expect(argv[attachIdx + 2]).toBe('codex-dash');
+    // the base session name is the single positional; the grouped "-dash" name
+    // is derived from it in-shell.
+    expect(argv[argv.length - 1]).toBe('codex');
+    const script = argv[argv.indexOf('-c') + 1]!;
+    expect(script).toContain('dash="$1-dash"');
+    // never attaches directly to the original session (would show its footer).
+    expect(script).toContain('attach -t "$dash"');
+    expect(script).not.toContain('attach -t "$1"');
   });
 });
 

--- a/packages/sandbox-docker/test/codex.test.ts
+++ b/packages/sandbox-docker/test/codex.test.ts
@@ -83,11 +83,16 @@ describe('buildCodexAttachArgv', () => {
     const argv = buildCodexAttachArgv('agentbox-box1');
     expect(argv.slice(0, 2)).toEqual(['exec', '-it']);
     expect(argv).toContain('agentbox-box1');
-    expect(argv.slice(-4)).toEqual(['tmux', 'attach', '-t', DEFAULT_CODEX_SESSION]);
+    // tmux runs under `sh -c` with the TERM guard; the session name is the
+    // final positional bound to "$1" in the script.
+    const script = argv[argv.indexOf('-c') + 1]!;
+    expect(script).toContain('infocmp "$TERM"');
+    expect(script).toContain('exec tmux attach -t "$1"');
+    expect(argv[argv.length - 1]).toBe(DEFAULT_CODEX_SESSION);
   });
 
   it('attaches to a custom session name', () => {
     const argv = buildCodexAttachArgv('agentbox-box1', 'my-codex');
-    expect(argv.slice(-4)).toEqual(['tmux', 'attach', '-t', 'my-codex']);
+    expect(argv[argv.length - 1]).toBe('my-codex');
   });
 });

--- a/packages/sandbox-docker/test/opencode.test.ts
+++ b/packages/sandbox-docker/test/opencode.test.ts
@@ -87,11 +87,16 @@ describe('buildOpencodeAttachArgv', () => {
     const argv = buildOpencodeAttachArgv('agentbox-box1');
     expect(argv.slice(0, 2)).toEqual(['exec', '-it']);
     expect(argv).toContain('agentbox-box1');
-    expect(argv.slice(-4)).toEqual(['tmux', 'attach', '-t', DEFAULT_OPENCODE_SESSION]);
+    // tmux runs under `sh -c` with the TERM guard; the session name is the
+    // final positional bound to "$1" in the script.
+    const script = argv[argv.indexOf('-c') + 1]!;
+    expect(script).toContain('infocmp "$TERM"');
+    expect(script).toContain('exec tmux attach -t "$1"');
+    expect(argv[argv.length - 1]).toBe(DEFAULT_OPENCODE_SESSION);
   });
 
   it('attaches to a custom session name', () => {
     const argv = buildOpencodeAttachArgv('agentbox-box1', 'my-oc');
-    expect(argv.slice(-4)).toEqual(['tmux', 'attach', '-t', 'my-oc']);
+    expect(argv[argv.length - 1]).toBe('my-oc');
   });
 });

--- a/packages/sandbox-docker/test/shell-session.test.ts
+++ b/packages/sandbox-docker/test/shell-session.test.ts
@@ -16,7 +16,12 @@ describe('buildShellSessionAttachArgv', () => {
     expect(argv).toContain('--user');
     expect(argv[argv.indexOf('--user') + 1]).toBe('vscode');
     expect(argv).toContain('agentbox-smoke');
-    expect(argv.slice(-4)).toEqual(['tmux', 'attach', '-t', DEFAULT_SHELL_SESSION]);
+    // tmux runs under `sh -c` with the TERM guard; the session name is the
+    // final positional bound to "$1" in the script.
+    const script = argv[argv.indexOf('-c') + 1]!;
+    expect(script).toContain('infocmp "$TERM"');
+    expect(script).toContain('exec tmux attach -t "$1"');
+    expect(argv[argv.length - 1]).toBe(DEFAULT_SHELL_SESSION);
     // TERM is forwarded so tmux declares true-color / hyperlink support.
     expect(argv).toContain('-e');
   });
@@ -24,7 +29,7 @@ describe('buildShellSessionAttachArgv', () => {
   it('honors a custom session name and user', () => {
     const argv = buildShellSessionAttachArgv('agentbox-smoke', 'shell-work', 'root');
     expect(argv[argv.indexOf('--user') + 1]).toBe('root');
-    expect(argv.slice(-2)).toEqual(['-t', 'shell-work']);
+    expect(argv[argv.length - 1]).toBe('shell-work');
   });
 });
 


### PR DESCRIPTION
Attaching to a box's tmux session (`agentbox claude/codex/opencode attach`, the tmux-backed `agentbox shell`, and the dashboard's right pane) forwarded the host's TERM into the box as-is. When the box's Ubuntu terminfo database has no entry for that terminal (for example xterm-ghostty, which ncurses only added after 24.04 shipped), `tmux attach` exits immediately with "missing or unsuitable terminal", so the attach appears to flash for an instant and quit.

One widely used terminal app this affects is ghostty.

Run the in-box tmux command under `sh -c` and, when `infocmp "$TERM"` cannot resolve the forwarded TERM, fall back to xterm-256color (always present in the image) before exec'ing tmux. The host TERM is still forwarded, so a box that does recognize it keeps full fidelity. Centralized in `buildTermSafeTmuxExec` and reused by every attach-argv builder.