### PR TITLE
Support git-lfs repos in remote (cloud) boxes

### DIFF
--- a/docs/cloud-create-flow.md
+++ b/docs/cloud-create-flow.md
@@ -117,6 +117,38 @@ workspace, **per repo** (root + any 1st-level nested repos):
 If the host workspace **isn't** a git repo, `seedFromTar` just `tar -czf .`
 the whole dir, uploads, extracts. No clone, no branch.
 
+### git-LFS objects
+
+A plain `git clone` populates only commits + pointer files, **never**
+`.git/lfs/objects`. Cloud boxes also have no host credentials and (hetzner)
+locked egress, so an in-box smudge of a missing object would hit the upstream
+LFS endpoint unauthenticated and fail — leaving broken pointers (or aborting
+the seed under `set -e`). Docker sidesteps this via its bind-mounted, shared
+`.git/lfs`; cloud has no bind mount, so the objects are seeded explicitly:
+
+- Between the shallow clone (step 3) and the tar (step 5),
+  `seedCloneLfsObjects` (`workspace-seed.ts`) probes `git lfs ls-files`,
+  best-effort `git lfs fetch origin <ref>` (host holds the creds) to warm the
+  host cache, then **copies only the checkout ref's object blobs** —
+  content-addressed `.git/lfs/objects/aa/bb/<oid>` — into the clone. They ride
+  the existing `workspace.tar.gz`, so the in-box `git checkout` smudges real
+  content with zero box network/creds. Bounded to the working set (not the
+  whole `.git/lfs` cache, which can be GBs) and fully best-effort: a missing
+  oid is left as a pointer, never failing the seed.
+- The checkpoint-restore **delta** path (`tryReseedRepoDelta`) ships only the
+  oids the delta introduces (`target \ checkpointTip`) as a small
+  `agentbox-delta-lfs.tar.gz`, extracted into the box's `.git` before the
+  reset.
+- Each cloud base image installs `git-lfs` + `git lfs install --system` (the
+  provider install scripts; daytona inherits it from `Dockerfile.box`) so the
+  filter is registered — without it the checkout silently skips smudge, since
+  cloud boxes have no bind-mounted `~/.gitconfig`.
+
+Out of scope (today): push-back of box-created LFS objects and lazy on-demand
+`git lfs pull` of objects beyond the seeded working set — both need a relay
+LFS transport. For docker, push-back already works as an emergent property of
+the shared `.git/lfs` + host-side `git push`.
+
 ## First time vs. next time
 
 | | First time | Subsequent boxes |

--- a/packages/sandbox-cloud/src/git-identity.ts
+++ b/packages/sandbox-cloud/src/git-identity.ts
@@ -27,6 +27,12 @@ const FALLBACK_EMAIL = 'agentbox@users.noreply.github.com';
  * user.name`), so a repo-local override is honored just like a normal local
  * commit would. Sets `--global` for the box's agent user (cloud `exec` runs as
  * that user), which is where the in-box merge / agent commits look it up.
+ *
+ * Note: the git-lfs `filter.lfs.*` config is intentionally NOT seeded here — it
+ * is registered system-wide in each base image (`git lfs install --system`, see
+ * the provider install scripts / Dockerfile.box), so an LFS checkout smudges
+ * without any per-box config. The objects themselves are seeded host-side by
+ * `seedCloneLfsObjects` in workspace-seed.ts.
  */
 export async function seedGitIdentity(
   backend: CloudBackend,

--- a/packages/sandbox-cloud/src/workspace-seed.ts
+++ b/packages/sandbox-cloud/src/workspace-seed.ts
@@ -1,7 +1,7 @@
 import { execa } from 'execa';
-import { mkdtemp, rm, stat } from 'node:fs/promises';
+import { copyFile, mkdir, mkdtemp, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import type { CloudBackend, CloudHandle, ResyncResult } from '@agentbox/core';
 import { detectGitRepos } from '@agentbox/sandbox-core';
 import { bashScript, quoteShellArgv } from './shell.js';
@@ -381,7 +381,11 @@ async function seedFromGitClone(args: SeedFromGitCloneArgs): Promise<RepoSeedCon
     // --use-branch reuses the named branch directly; otherwise --from-branch
     // (or nothing) picks the fork base. Either way it pins the clone's HEAD.
     const cloneBranch = args.useBranch ?? args.fromBranch;
+    const lfsRef = cloneBranch ?? 'HEAD';
     await runShallowClone(args.hostRepo, cloneDir, initialDepth, stashRefCreated, cloneBranch);
+    // Pack the checkout ref's LFS objects into the clone's .git/lfs BEFORE the
+    // tar so the in-box checkout smudges real content (no box network/creds).
+    await seedCloneLfsObjects(args.hostRepo, cloneDir, lfsRef, log);
     await tarCloneDir(cloneDir, tarPath);
     if (adaptive && initialDepth !== null) {
       const size = await safeFileSize(tarPath);
@@ -393,6 +397,8 @@ async function seedFromGitClone(args: SeedFromGitCloneArgs): Promise<RepoSeedCon
         await rm(cloneDir, { recursive: true, force: true });
         await rm(tarPath, { force: true });
         await runShallowClone(args.hostRepo, cloneDir, LARGE_BUNDLE_DEPTH, stashRefCreated, cloneBranch);
+        // Fresh cloneDir from the rebuild — re-seed its LFS objects too.
+        await seedCloneLfsObjects(args.hostRepo, cloneDir, lfsRef, log);
         await tarCloneDir(cloneDir, tarPath);
       }
     }
@@ -502,6 +508,7 @@ async function seedFromGitClone(args: SeedFromGitCloneArgs): Promise<RepoSeedCon
 
 const DELTA_TARGET_REF = 'refs/agentbox-delta/target';
 const REMOTE_DELTA_BUNDLE = '/tmp/agentbox-delta.bundle';
+const REMOTE_DELTA_LFS = '/tmp/agentbox-delta-lfs.tar.gz';
 const SHA_RE = /^[0-9a-f]{40}$/;
 
 /**
@@ -552,6 +559,7 @@ async function tryReseedRepoDelta(args: SeedFromGitCloneArgs): Promise<RepoSeedC
   const stage = await mkdtemp(join(tmpdir(), 'agentbox-delta-'));
   const bundlePath = join(stage, 'delta.bundle');
   const untrackedTarPath = join(stage, 'untracked.tar.gz');
+  const deltaLfsTarPath = join(stage, 'delta-lfs.tar.gz');
   // --use-branch reuses the committed tip; no host uncommitted carry-over.
   const stashSha =
     args.useBranch || args.skipCarryOver ? null : await safeStashCreate(args.hostRepo);
@@ -595,6 +603,21 @@ async function tryReseedRepoDelta(args: SeedFromGitCloneArgs): Promise<RepoSeedC
     if (untrackedSize > 0) {
       await args.backend.uploadFile(args.handle, untrackedTarPath, REMOTE_UNTRACKED_TAR);
     }
+    // Ship the LFS objects the delta introduces (oids in target but not in the
+    // checkpoint tip the box already holds), so the post-restore checkout
+    // smudges new LFS files to real content. Bounded + best-effort.
+    const deltaLfsSize = await maybeBuildDeltaLfsTar(
+      args.hostRepo,
+      target,
+      checkpointTip,
+      deltaLfsTarPath,
+    );
+    if (deltaLfsSize > 0) {
+      await args.backend.uploadFile(args.handle, deltaLfsTarPath, REMOTE_DELTA_LFS);
+      log(
+        `checkpoint restore: ${args.workspaceDir}: ${String(deltaLfsSize)} B of new git-lfs objects`,
+      );
+    }
     log(
       needTarget
         ? `checkpoint restore: ${args.workspaceDir}: delta bundle (${checkpointTip.slice(0, 8)}..${target.slice(0, 8)})`
@@ -624,18 +647,26 @@ async function tryReseedRepoDelta(args: SeedFromGitCloneArgs): Promise<RepoSeedC
       hasUntracked: untrackedSize > 0,
       detectConflicts: true,
     });
+    // Extract the delta's new LFS objects into the box's object store BEFORE the
+    // checkout/reset smudges them. `.git/lfs/objects/aa/bb/<oid>` layout is
+    // preserved by the tar so they land content-addressed.
+    const lfsStep =
+      deltaLfsSize > 0
+        ? `tar -C ${quoteShellArgv([`${args.workspaceDir}/.git`])} -xzf ${quoteShellArgv([REMOTE_DELTA_LFS])}`
+        : ': # no delta lfs objects';
     const SUDO = `if command -v sudo >/dev/null 2>&1; then SUDO='sudo -n'; else SUDO=''; fi`;
     const script = [
       `set -euo pipefail`,
       `cd /tmp`,
       SUDO,
       fetchStep,
+      lfsStep,
       checkoutStep,
       `git -C ${wd} reset --hard ${quoteShellArgv([target])}`,
       setOrigin,
       ...carryOverSteps,
       `git -C ${wd} update-ref -d ${quoteShellArgv([DELTA_TARGET_REF])} || true`,
-      `rm -f ${quoteShellArgv([REMOTE_DELTA_BUNDLE])}`,
+      `rm -f ${quoteShellArgv([REMOTE_DELTA_BUNDLE])} ${quoteShellArgv([REMOTE_DELTA_LFS])}`,
     ].join('\n');
     const r = await args.backend.exec(args.handle, bashScript(script));
     if (r.exitCode !== 0) {
@@ -704,6 +735,130 @@ async function tarCloneDir(cloneDir: string, outPath: string): Promise<void> {
   await execa('tar', ['-C', cloneDir, '-czf', outPath, '.'], {
     env: { ...process.env, COPYFILE_DISABLE: '1' },
   });
+}
+
+const LFS_OID_RE = /^[0-9a-f]{64}$/;
+
+/** Content-addressed path of an LFS object inside a `.git/` dir: `lfs/objects/aa/bb/<oid>`. */
+export function lfsObjectRelPath(oid: string): string {
+  return join('lfs', 'objects', oid.slice(0, 2), oid.slice(2, 4), oid);
+}
+
+/**
+ * The set of LFS object oids reachable from `ref` in `hostRepo`. Empty when the
+ * repo doesn't use LFS, `ref` is unknown, or git-lfs isn't installed on the host
+ * (all best-effort — never throws). `git lfs ls-files --long` prints
+ * "<oid> <* or -> <path>" per tracked blob.
+ */
+async function lfsOidsForRef(hostRepo: string, ref: string): Promise<string[]> {
+  const listed = await execa('git', ['-C', hostRepo, 'lfs', 'ls-files', '--long', ref], {
+    reject: false,
+  });
+  if (listed.exitCode !== 0) return [];
+  const oids = listed.stdout
+    .split('\n')
+    .map((l) => l.trim().split(/\s+/)[0] ?? '')
+    .filter((o) => LFS_OID_RE.test(o));
+  return [...new Set(oids)];
+}
+
+/**
+ * Pack the LFS objects reachable from `ref` into the shallow clone's
+ * `.git/lfs/objects/` BEFORE it's tarred, so the in-box `git checkout` smudges
+ * real content instead of leaving pointer files. Docker gets this for free via
+ * its bind-mounted shared `.git/lfs`; cloud has no bind mount, so we copy the
+ * content-addressed blobs into the clone where they ride the existing workspace
+ * tar (no box network / credentials needed at checkout).
+ *
+ * Bounded + best-effort, mirroring the docker provider's `prefetchHostLfs`:
+ *   - probe `git lfs ls-files` → a non-LFS repo does nothing, no log noise.
+ *   - `git lfs fetch origin <ref>` (host holds the creds) warms the host cache.
+ *   - copy ONLY the ref's oids (not the whole `.git/lfs` cache, which can be
+ *     GBs) into the clone. A missing oid (fetch failed / offline) is left as a
+ *     pointer — the box still seeds, just without that object's content.
+ */
+async function seedCloneLfsObjects(
+  hostRepo: string,
+  cloneDir: string,
+  ref: string,
+  log: (line: string) => void,
+): Promise<void> {
+  // Cheap probe so the overwhelmingly common non-LFS repo does nothing and logs
+  // nothing. Empty stdout or non-zero exit (no git-lfs binary / not LFS) → skip.
+  const tracked = await execa('git', ['-C', hostRepo, 'lfs', 'ls-files', '-n', ref], {
+    reject: false,
+  });
+  if (tracked.exitCode !== 0 || tracked.stdout.trim().length === 0) return;
+
+  // Warm the host object cache for the checkout ref (uses the host's creds).
+  const fetched = await execa('git', ['-C', hostRepo, 'lfs', 'fetch', 'origin', ref], {
+    reject: false,
+  });
+  if (fetched.exitCode !== 0) {
+    const msg = (fetched.stderr || fetched.stdout || `exit ${String(fetched.exitCode ?? '?')}`)
+      .trim()
+      .split('\n')[0];
+    log(`git-lfs prefetch for ${ref} skipped (best-effort, continuing): ${msg}`);
+  }
+
+  const oids = await lfsOidsForRef(hostRepo, ref);
+  let copied = 0;
+  for (const oid of oids) {
+    const rel = lfsObjectRelPath(oid);
+    const dst = join(cloneDir, '.git', rel);
+    try {
+      await mkdir(dirname(dst), { recursive: true });
+      await copyFile(join(hostRepo, '.git', rel), dst);
+      copied++;
+    } catch {
+      // Object isn't in the host cache (fetch missed / offline) — leave the
+      // pointer; the box surfaces it as a pointer rather than failing the seed.
+    }
+  }
+  if (copied > 0) log(`seeded ${String(copied)} git-lfs object(s) for ${ref} into clone`);
+}
+
+/**
+ * Tar the LFS objects that the checkpoint restore's delta introduces — the oids
+ * reachable from `target` but not from `checkpointTip` (which the box already
+ * has from when it was first seeded). Preserves the `lfs/objects/aa/bb/<oid>`
+ * layout so an in-box `tar -x` into `<workspaceDir>/.git` lands them in the
+ * box's object store. Returns the tar size (0 when there's nothing to ship, so
+ * the caller can skip the upload + extract). Best-effort; never throws.
+ */
+async function maybeBuildDeltaLfsTar(
+  hostRepo: string,
+  target: string,
+  checkpointTip: string,
+  outPath: string,
+): Promise<number> {
+  const targetOids = await lfsOidsForRef(hostRepo, target);
+  if (targetOids.length === 0) return 0;
+  const have = new Set(await lfsOidsForRef(hostRepo, checkpointTip));
+  const deltaOids = targetOids.filter((o) => !have.has(o));
+  if (deltaOids.length === 0) return 0;
+
+  // Warm the host cache for the target ref, then keep only the oids whose blob
+  // actually exists on disk (a missed fetch just ships fewer objects).
+  await execa('git', ['-C', hostRepo, 'lfs', 'fetch', 'origin', target], { reject: false });
+  const gitDir = join(hostRepo, '.git');
+  const relPaths: string[] = [];
+  for (const oid of deltaOids) {
+    const rel = lfsObjectRelPath(oid);
+    try {
+      await stat(join(gitDir, rel));
+      relPaths.push(rel);
+    } catch {
+      // not present — skip
+    }
+  }
+  if (relPaths.length === 0) return 0;
+  const tar = await execa('tar', ['-C', gitDir, '-czf', outPath, ...relPaths], {
+    env: { ...process.env, COPYFILE_DISABLE: '1' },
+    reject: false,
+  });
+  if (tar.exitCode !== 0) return 0;
+  return safeFileSize(outPath);
 }
 
 async function safeFileSize(path: string): Promise<number> {

--- a/packages/sandbox-cloud/test/workspace-seed.test.ts
+++ b/packages/sandbox-cloud/test/workspace-seed.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { buildCarryOverSteps, parseSeedConflicts } from '../src/workspace-seed.js';
+import { buildCarryOverSteps, lfsObjectRelPath, parseSeedConflicts } from '../src/workspace-seed.js';
+
+describe('lfsObjectRelPath', () => {
+  it('maps an oid to git-lfs content-addressed storage (aa/bb/<oid>)', () => {
+    const oid = 'dfbd78a3ce7887c4d9033fd78e690be2c1096a7dfc2194e3cd7030ccd51aa267';
+    // This layout is load-bearing: the host-side copy and the in-box tar extract
+    // must agree so the in-box smudge finds the object with no network.
+    expect(lfsObjectRelPath(oid)).toBe(`lfs/objects/df/bd/${oid}`);
+  });
+});
 
 describe('parseSeedConflicts', () => {
   it('extracts + dedupes merge-conflict and overlay-skip markers', () => {

--- a/packages/sandbox-daytona/src/prepare.ts
+++ b/packages/sandbox-daytona/src/prepare.ts
@@ -177,6 +177,10 @@ export async function prepareDaytona(opts: PrepareOptions): Promise<PrepareResul
   }
 
   try {
+    // git-lfs (binary + `git lfs install --system`) is inherited for free from
+    // Dockerfile.box, so an in-box checkout of an LFS repo smudges real content.
+    // No daytona-specific overlay step is needed; the host-side object seeding
+    // lives in sandbox-cloud's workspace-seed (seedCloneLfsObjects).
     let image: Image = Image.fromDockerfile(ctx.dockerfile);
 
     // Overlay the daytona-specific /etc/claude-code/CLAUDE.md on top of the

--- a/packages/sandbox-e2b/scripts/build-template.sh
+++ b/packages/sandbox-e2b/scripts/build-template.sh
@@ -54,6 +54,7 @@ apt-get update -y -q
 apt-get install -y -q --no-install-recommends \
   ca-certificates \
   git \
+  git-lfs \
   tar \
   gzip \
   curl \
@@ -131,6 +132,15 @@ step "git system-wide safe.directory"
 git config --system --add safe.directory '*' 2>/dev/null || true
 sudo -u vscode -H git config --global --add safe.directory '*' 2>/dev/null || true
 done_ "git system-wide safe.directory"
+
+step "git-lfs system filter"
+# Register filter.lfs.* system-wide (and for vscode) so an in-box checkout of an
+# LFS repo smudges instead of writing pointer files. Cloud boxes have no
+# bind-mounted ~/.gitconfig, so --system is the only place the filter lives.
+# --skip-repo never touches a checkout at bake time.
+git lfs install --system --skip-repo 2>/dev/null || true
+sudo -u vscode -H git lfs install --skip-repo 2>/dev/null || true
+done_ "git-lfs system filter"
 
 step "agentbox-ctl install"
 install -m 0755 /tmp/agentbox-ctl /usr/local/bin/agentbox-ctl

--- a/packages/sandbox-hetzner/scripts/install-box.sh
+++ b/packages/sandbox-hetzner/scripts/install-box.sh
@@ -69,6 +69,7 @@ apt-get install -y --no-install-recommends \
   python3-venv \
   build-essential \
   git \
+  git-lfs \
   tmux \
   vim \
   libcap2-bin \
@@ -133,6 +134,14 @@ done_ "corepack cache dir (vscode-owned, prevents first-use ENOENT)"
 step "git system-wide safe.directory"
 git config --system --add safe.directory '*'
 done_ "git system-wide safe.directory"
+
+step "git-lfs system filter"
+# Register filter.lfs.* in /etc/gitconfig so an in-box checkout of an LFS repo
+# smudges instead of writing pointer files. Unlike docker, cloud boxes have no
+# bind-mounted ~/.gitconfig, so --system is the only place the filter lives.
+# --skip-repo keeps install from touching a checkout at bake time.
+git lfs install --system --skip-repo
+done_ "git-lfs system filter"
 
 step "docker + iptables for in-VPS DinD"
 apt-get install -y --no-install-recommends \

--- a/packages/sandbox-vercel/scripts/provision.sh
+++ b/packages/sandbox-vercel/scripts/provision.sh
@@ -144,6 +144,26 @@ git config --system --add safe.directory '*' 2>/dev/null || true
 sudo -u vscode -H git config --global --add safe.directory '*' 2>/dev/null || true
 done_ "git system-wide safe.directory"
 
+step "git-lfs (binary + system filter)"
+# Not in the atomic base dnf transaction on purpose: AL2023 may not carry
+# git-lfs in its default repos, and a missing package would abort the whole
+# (atomic) base install. Best-effort here — try dnf, then git-lfs's official
+# packagecloud rpm repo as a fallback. If both miss, LFS repos degrade to
+# pointer files rather than breaking the bake.
+if ! command -v git-lfs >/dev/null 2>&1; then
+  dnf install -y -q git-lfs 2>/dev/null || {
+    curl -fsSL https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | bash 2>&1 | tail -3 || true
+    dnf install -y -q git-lfs 2>&1 | tail -3 || true
+  }
+fi
+# Register filter.lfs.* in the (Vercel-relocated /opt/git/etc) system gitconfig
+# AND for vscode, so an in-box checkout of an LFS repo smudges instead of writing
+# pointers. Cloud boxes have no bind-mounted ~/.gitconfig, so this is the only
+# place the filter lives. --skip-repo never touches a checkout at bake time.
+git lfs install --system --skip-repo 2>/dev/null || true
+sudo -u vscode -H git lfs install --skip-repo 2>/dev/null || true
+done_ "git-lfs (binary + system filter)"
+
 step "agentbox-ctl install"
 install -m 0755 /tmp/agentbox-ctl /usr/local/bin/agentbox-ctl
 done_ "agentbox-ctl install"


### PR DESCRIPTION
Extends the docker git-lfs fix (#112) to the cloud providers — **daytona, hetzner, vercel, e2b**. Targets `nightly` because it builds directly on #112 (which is only on nightly).

## Problem

Cloud boxes seed `/workspace` from a host-side shallow `git clone --no-checkout file://<hostRepo>` → tar `.git/` → upload → in-box `git checkout`. A plain clone never populates `.git/lfs/objects`, and cloud boxes have no host git credentials (and, on hetzner, locked egress). So an LFS-tracked repo either checked out with broken pointer files or failed the seed outright (the in-box smudge hits the upstream LFS endpoint unauthenticated → error under `set -e`). Docker dodges this via its bind-mounted, shared `.git/lfs`; cloud has no bind mount.

## Scope

Read/seed parity with docker — LFS repos check out with **real content** at create **and** checkpoint-restore. Push-back of box-created LFS objects and lazy on-demand `git lfs pull` are intentionally **out of scope** (both need a relay LFS transport; follow-up). For docker, push-back already works as an emergent property of the shared `.git/lfs` + host-side `git push`.

## Layer 1 — base images (git-lfs binary + system filter)

- **hetzner** (`install-box.sh`) / **e2b** (`build-template.sh`): add `git-lfs` to the package list + `git lfs install --system --skip-repo`.
- **vercel** (`provision.sh`): git-lfs as a **separate best-effort step** (not the atomic base dnf transaction — AL2023 may not carry it; falls back to the git-lfs packagecloud rpm repo) + system filter.
- **daytona**: inherits git-lfs from `Dockerfile.box` (#112) — comment only.
- `--system` is required: cloud boxes have no bind-mounted `~/.gitconfig` carrying `filter.lfs.process`.

## Layer 2 — host-side working-set seeding (`sandbox-cloud/workspace-seed.ts`)

- **`seedCloneLfsObjects`**: probe `git lfs ls-files`, best-effort `git lfs fetch origin <ref>` (host holds the creds), then copy **only the checkout ref's** content-addressed object blobs (`.git/lfs/objects/aa/bb/<oid>`) into the clone so they ride the existing `workspace.tar.gz`. The in-box checkout then smudges real content with zero box network/creds. Bounded to the working set; best-effort (missing oid → pointer, never fails the seed). Wired into both `seedFromGitClone` call sites (incl. the adaptive-depth rebuild).
- **Checkpoint-restore delta path**: ships only the oids the delta introduces (`target \ checkpointTip`) as `agentbox-delta-lfs.tar.gz`, extracted into the box's `.git` before the reset.

## Verification — live cloud e2e ✅

Re-baked (`agentbox prepare -f`) and created a box on each provider against the ssh LFS fixture (`../agentbox-test-repo`, `sample.bin` oid `fc270de147…`), then asserted in-box. **All three pass identically** — `sample.bin` is real 524288-byte content (not a pointer), sha256 == the host oid, `git lfs ls-files` shows it downloaded, system filter registered, git status clean:

| Provider | git-lfs in image | seed log | in-box sha256 | result |
|---|---|---|---|---|
| **e2b** | 3.3.0 (Debian apt) | `seeded 1 git-lfs object(s) for HEAD` | `fc270de147…` ✓ | real content |
| **hetzner** | 3.4.1 (Ubuntu apt) | seeded ✓ | `fc270de147…` ✓ | real content |
| **vercel** | dnf (AL2023 — no packagecloud fallback needed) | `seeded 1 git-lfs object(s) for HEAD` | `fc270de147…` ✓ | real content |

- **daytona** not run (no creds in this env), but it shares the exact same code path — git-lfs inherited from `Dockerfile.box` + the same host-side `seedCloneLfsObjects`.
- Also a local A/B PoC (unreachable origin) confirming the credential-less checkout fails *without* the fix and smudges real content *with* it.
- Build + lint + 77 unit tests green (added a `lfsObjectRelPath` path-layout test).

https://claude.ai/code/session_01PTY4KwAeZdAVvgSWxjpYfs