### PR TITLE
Cloud: fall back to xterm-256color when the box lacks the host TERM

### DIFF
--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -48,6 +48,7 @@ import {
   portlessGetUrl,
   portlessUnalias,
   registerBoxWithRelay,
+  TERM_FALLBACK_SNIPPET,
 } from '@agentbox/sandbox-docker';
 import {
   ensureAgentVolumesForCloud,
@@ -1425,6 +1426,15 @@ function makeCloudCheckpoint(backend: CloudBackend): ProviderCheckpoint {
  * starts the session in the box's workspace dir so claude/codex/opencode
  * see /workspace as their cwd (otherwise tmux inherits the SSH login
  * shell's $HOME and the agents prompt for workspace-trust).
+ *
+ * The command is prefixed with the shared {@link TERM_FALLBACK_SNIPPET} (same
+ * guard the docker provider applies): hetzner/daytona forward the host TERM
+ * over `ssh -t`, and vercel/e2b forward it via their attach builders, so a
+ * host TERM the box's terminfo doesn't carry (e.g. xterm-ghostty on Ubuntu)
+ * would otherwise make `tmux attach` exit immediately ("missing or unsuitable
+ * terminal"). The guard downgrades the unknown case to xterm-256color before
+ * tmux runs, and is a no-op (`infocmp` missing → also downgrades) when the box
+ * lacks `infocmp`, so it never regresses the providers that hardcoded TERM.
  */
 export function renderInnerCommand(kind: AttachKind, opts?: BuildAttachOptions): string {
   const sessionName = opts?.sessionName ?? defaultSessionName(kind);
@@ -1448,8 +1458,8 @@ export function renderInnerCommand(kind: AttachKind, opts?: BuildAttachOptions):
   // `detached`: create + configure the session but don't attach. Used to
   // pre-start a session with its full launch command before a new-tab attach
   // re-invokes `agentbox <agent> attach` (which carries no launch args).
-  if (opts?.detached) return lines.join('; ');
-  return [...lines, `exec tmux attach -t ${sessionQ}`].join('; ');
+  if (opts?.detached) return TERM_FALLBACK_SNIPPET + lines.join('; ');
+  return TERM_FALLBACK_SNIPPET + [...lines, `exec tmux attach -t ${sessionQ}`].join('; ');
 }
 
 function defaultSessionName(kind: AttachKind): string {

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -1436,6 +1436,20 @@ function makeCloudCheckpoint(backend: CloudBackend): ProviderCheckpoint {
  * tmux runs, and is a no-op (`infocmp` missing → also downgrades) when the box
  * lacks `infocmp`, so it never regresses the providers that hardcoded TERM.
  */
+/**
+ * The host TERM to forward into a cloud box, sanitized to a safe terminfo
+ * name. A terminal name is `[A-Za-z0-9][A-Za-z0-9._+-]*`; anything else (a
+ * space, a shell metacharacter) is rejected to `xterm-256color` because the
+ * vercel provider interpolates this into a `bash -lc` prelude — an unquoted,
+ * attacker-shaped TERM could otherwise split the export or inject a command.
+ * The box's terminfo is the real filter anyway: renderInnerCommand's guard
+ * downgrades any forwarded TERM the box doesn't actually carry.
+ */
+export function hostTermForCloud(): string {
+  const t = process.env['TERM'];
+  return t && /^[A-Za-z0-9][A-Za-z0-9._+-]*$/.test(t) ? t : 'xterm-256color';
+}
+
 export function renderInnerCommand(kind: AttachKind, opts?: BuildAttachOptions): string {
   const sessionName = opts?.sessionName ?? defaultSessionName(kind);
   const fallback = opts?.command ?? defaultCommand(kind, opts);

--- a/packages/sandbox-cloud/src/index.ts
+++ b/packages/sandbox-cloud/src/index.ts
@@ -3,6 +3,7 @@ export {
   CLOUD_WORKSPACE_DIR,
   createCloudProvider,
   emptyCloudStats,
+  hostTermForCloud,
   renderInnerCommand,
   type CreateCloudProviderOptions,
 } from './cloud-provider.js';

--- a/packages/sandbox-cloud/test/render-inner-command.test.ts
+++ b/packages/sandbox-cloud/test/render-inner-command.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderInnerCommand } from '../src/index.js';
+
+// The TERM guard is shared with the docker provider (TERM_FALLBACK_SNIPPET).
+// hetzner/daytona forward the host TERM over `ssh -t`, and vercel/e2b forward
+// it via their attach builders, so the inner tmux command must downgrade an
+// unrecognized TERM before tmux runs — otherwise `tmux attach` flash-quits.
+const GUARD = 'infocmp "$TERM"';
+
+describe('renderInnerCommand TERM guard', () => {
+  it('prefixes the interactive attach with the TERM fallback guard', () => {
+    const cmd = renderInnerCommand('shell');
+    expect(cmd).toContain(GUARD);
+    // guard runs before any tmux invocation
+    expect(cmd.indexOf(GUARD)).toBeLessThan(cmd.indexOf('tmux'));
+    expect(cmd).toMatch(/exec tmux attach -t/);
+  });
+
+  it('prefixes the agent attach with the guard too', () => {
+    const cmd = renderInnerCommand('agent', { command: 'exec claude' });
+    expect(cmd).toContain(GUARD);
+    expect(cmd.indexOf(GUARD)).toBeLessThan(cmd.indexOf('tmux'));
+  });
+
+  it('guards the detached pre-start (no attach) as well', () => {
+    const cmd = renderInnerCommand('agent', { command: 'exec claude', detached: true });
+    expect(cmd).toContain(GUARD);
+    // detached only creates/configures the session; it never attaches.
+    expect(cmd).not.toContain('exec tmux attach');
+  });
+
+  it('does not inject the guard into the tmux-less paths (logs / noTmux)', () => {
+    expect(renderInnerCommand('logs', { service: 'web' })).not.toContain(GUARD);
+    expect(renderInnerCommand('shell', { noTmux: true })).not.toContain(GUARD);
+  });
+});

--- a/packages/sandbox-cloud/test/render-inner-command.test.ts
+++ b/packages/sandbox-cloud/test/render-inner-command.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
-import { renderInnerCommand } from '../src/index.js';
+import { hostTermForCloud, renderInnerCommand } from '../src/index.js';
 
 // The TERM guard is shared with the docker provider (TERM_FALLBACK_SNIPPET).
 // hetzner/daytona forward the host TERM over `ssh -t`, and vercel/e2b forward
@@ -33,5 +33,33 @@ describe('renderInnerCommand TERM guard', () => {
   it('does not inject the guard into the tmux-less paths (logs / noTmux)', () => {
     expect(renderInnerCommand('logs', { service: 'web' })).not.toContain(GUARD);
     expect(renderInnerCommand('shell', { noTmux: true })).not.toContain(GUARD);
+  });
+});
+
+describe('hostTermForCloud', () => {
+  const orig = process.env['TERM'];
+  afterEach(() => {
+    if (orig === undefined) delete process.env['TERM'];
+    else process.env['TERM'] = orig;
+  });
+
+  it('passes through a well-formed terminfo name', () => {
+    for (const t of ['xterm-256color', 'screen-256color', 'tmux-256color', 'xterm-ghostty']) {
+      process.env['TERM'] = t;
+      expect(hostTermForCloud()).toBe(t);
+    }
+  });
+
+  it('falls back to xterm-256color when TERM is unset', () => {
+    delete process.env['TERM'];
+    expect(hostTermForCloud()).toBe('xterm-256color');
+  });
+
+  it('rejects an unsafe TERM (spaces / shell metacharacters) to the safe default', () => {
+    // these would otherwise break out of the vercel `bash -lc` prelude
+    for (const t of ['xterm; rm -rf /', 'foo bar', '$(whoami)', 'a`id`', '']) {
+      process.env['TERM'] = t;
+      expect(hostTermForCloud()).toBe('xterm-256color');
+    }
   });
 });

--- a/packages/sandbox-docker/src/claude.ts
+++ b/packages/sandbox-docker/src/claude.ts
@@ -1088,7 +1088,7 @@ export async function startClaudeSession(opts: StartClaudeSessionOptions): Promi
  * flash and an instant exit. When the box cannot resolve $TERM, fall back to
  * xterm-256color, which the image always provides.
  */
-const TERM_FALLBACK_SNIPPET =
+export const TERM_FALLBACK_SNIPPET =
   'if ! infocmp "$TERM" >/dev/null 2>&1; then TERM=xterm-256color; export TERM; fi; ';
 
 /**

--- a/packages/sandbox-docker/src/index.ts
+++ b/packages/sandbox-docker/src/index.ts
@@ -10,6 +10,7 @@ export {
   buildClaudeMounts,
   buildTmuxSessionArgs,
   buildTmuxConfigShellSnippet,
+  TERM_FALLBACK_SNIPPET,
   buildShellArgv,
   CLAUDE_FORWARDED_ENV_KEYS,
   ClaudeSessionError,

--- a/packages/sandbox-e2b/src/attach-helper.ts
+++ b/packages/sandbox-e2b/src/attach-helper.ts
@@ -142,7 +142,10 @@ async function main(): Promise<void> {
     envs: {
       LANG: 'C.UTF-8',
       LC_ALL: 'C.UTF-8',
-      TERM: 'xterm-256color',
+      // Forwarded from the host by build-attach.ts. The inner command's TERM
+      // guard (renderInnerCommand) downgrades to xterm-256color when the box's
+      // terminfo lacks it, so an exotic host TERM never breaks the attach.
+      TERM: process.env.AGENTBOX_HOST_TERM || 'xterm-256color',
     },
     // Long-lived. We don't want the SDK reaping the PTY mid-session.
     timeoutMs: 55 * 60_000,

--- a/packages/sandbox-e2b/src/build-attach.ts
+++ b/packages/sandbox-e2b/src/build-attach.ts
@@ -24,7 +24,7 @@ import {
   type BoxRecord,
   type BuildAttachOptions,
 } from '@agentbox/core';
-import { renderInnerCommand } from '@agentbox/sandbox-cloud';
+import { hostTermForCloud, renderInnerCommand } from '@agentbox/sandbox-cloud';
 import { resolveApiKey } from './sdk.js';
 
 const SELF = dirname(fileURLToPath(import.meta.url));
@@ -76,7 +76,7 @@ export async function buildE2bAttach(
   // it, so pass it explicitly). The helper sets it on the in-box PTY; the
   // renderInnerCommand TERM guard downgrades to xterm-256color when the box's
   // terminfo doesn't carry it (e.g. xterm-ghostty), matching the docker path.
-  const hostTerm = process.env['TERM'] ?? 'xterm-256color';
+  const hostTerm = hostTermForCloud();
 
   const argv = [
     process.execPath,

--- a/packages/sandbox-e2b/src/build-attach.ts
+++ b/packages/sandbox-e2b/src/build-attach.ts
@@ -72,6 +72,11 @@ export async function buildE2bAttach(
 
   const apiKey = resolveApiKey();
   const inner = renderInnerCommand(kind, opts);
+  // Forward the host's TERM (the helper has no host env once node-pty spawns
+  // it, so pass it explicitly). The helper sets it on the in-box PTY; the
+  // renderInnerCommand TERM guard downgrades to xterm-256color when the box's
+  // terminfo doesn't carry it (e.g. xterm-ghostty), matching the docker path.
+  const hostTerm = process.env['TERM'] ?? 'xterm-256color';
 
   const argv = [
     process.execPath,
@@ -93,6 +98,7 @@ export async function buildE2bAttach(
     env: {
       E2B_API_KEY: apiKey,
       AGENTBOX_E2B_INNER_CMD: inner,
+      AGENTBOX_HOST_TERM: hostTerm,
     },
   };
 }

--- a/packages/sandbox-e2b/test/build-attach.test.ts
+++ b/packages/sandbox-e2b/test/build-attach.test.ts
@@ -57,6 +57,7 @@ describe('buildE2bAttach', () => {
     expect(spec.env).toEqual({
       E2B_API_KEY: 'e2b_test_key',
       AGENTBOX_E2B_INNER_CMD: 'INNER(agent)',
+      AGENTBOX_HOST_TERM: process.env['TERM'] ?? 'xterm-256color',
     });
   });
 

--- a/packages/sandbox-e2b/test/build-attach.test.ts
+++ b/packages/sandbox-e2b/test/build-attach.test.ts
@@ -11,6 +11,7 @@ vi.mock('../src/sdk.js', () => ({
 }));
 vi.mock('@agentbox/sandbox-cloud', () => ({
   renderInnerCommand: (kind: string) => `INNER(${kind})`,
+  hostTermForCloud: () => 'xterm-256color',
 }));
 vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
@@ -57,7 +58,7 @@ describe('buildE2bAttach', () => {
     expect(spec.env).toEqual({
       E2B_API_KEY: 'e2b_test_key',
       AGENTBOX_E2B_INNER_CMD: 'INNER(agent)',
-      AGENTBOX_HOST_TERM: process.env['TERM'] ?? 'xterm-256color',
+      AGENTBOX_HOST_TERM: 'xterm-256color',
     });
   });
 

--- a/packages/sandbox-vercel/src/build-attach.ts
+++ b/packages/sandbox-vercel/src/build-attach.ts
@@ -29,7 +29,7 @@ import {
   type BoxRecord,
   type BuildAttachOptions,
 } from '@agentbox/core';
-import { renderInnerCommand } from '@agentbox/sandbox-cloud';
+import { hostTermForCloud, renderInnerCommand } from '@agentbox/sandbox-cloud';
 import { detectSbx } from './sbx-cli.js';
 import { ensureFreshCredentials, resolveCredentials } from './sdk.js';
 
@@ -65,8 +65,9 @@ export async function buildVercelAttach(
   // provider) so a box that carries that terminfo renders at full fidelity;
   // renderInnerCommand's TERM guard downgrades to xterm-256color when it
   // doesn't, so an exotic host TERM (e.g. xterm-ghostty) never breaks attach.
-  const hostTerm = process.env['TERM'] ?? 'xterm-256color';
-  const envPrelude = `export LANG=C.UTF-8 LC_ALL=C.UTF-8 TERM=${hostTerm}; `;
+  // hostTermForCloud sanitizes to a safe terminfo name — required because this
+  // value is interpolated into the bash -lc prelude below.
+  const envPrelude = `export LANG=C.UTF-8 LC_ALL=C.UTF-8 TERM=${hostTermForCloud()}; `;
   const inner = envPrelude + renderInnerCommand(kind, opts);
 
   const argv = [

--- a/packages/sandbox-vercel/src/build-attach.ts
+++ b/packages/sandbox-vercel/src/build-attach.ts
@@ -61,9 +61,12 @@ export async function buildVercelAttach(
   // `sbx exec` (unlike `ssh -t`) forwards neither TERM nor the locale, so the
   // box session lands in TERM=unknown + an ASCII (POSIX) locale — tmux then
   // collapses Claude Code's Unicode glyphs (logo, spinner, box-drawing) to `_`.
-  // Force a UTF-8 locale + a 256color TERM (matching the host PTY wrapper) so
-  // the tmux server + the agent it spawns render correctly.
-  const envPrelude = 'export LANG=C.UTF-8 LC_ALL=C.UTF-8 TERM=xterm-256color; ';
+  // Force a UTF-8 locale and forward the host's TERM (matching the docker
+  // provider) so a box that carries that terminfo renders at full fidelity;
+  // renderInnerCommand's TERM guard downgrades to xterm-256color when it
+  // doesn't, so an exotic host TERM (e.g. xterm-ghostty) never breaks attach.
+  const hostTerm = process.env['TERM'] ?? 'xterm-256color';
+  const envPrelude = `export LANG=C.UTF-8 LC_ALL=C.UTF-8 TERM=${hostTerm}; `;
   const inner = envPrelude + renderInnerCommand(kind, opts);
 
   const argv = [

--- a/packages/sandbox-vercel/test/build-attach.test.ts
+++ b/packages/sandbox-vercel/test/build-attach.test.ts
@@ -11,15 +11,16 @@ vi.mock('../src/sdk.js', () => ({
 }));
 vi.mock('@agentbox/sandbox-cloud', () => ({
   renderInnerCommand: (kind: string) => `INNER(${kind})`,
+  hostTermForCloud: () => 'xterm-256color',
 }));
 
 const { buildVercelAttach } = await import('../src/build-attach.js');
 import type { BoxRecord } from '@agentbox/core';
 
 // The attach inner is prefixed with a UTF-8/TERM prelude (sbx forwards neither).
-// TERM is now the host's TERM (renderInnerCommand's guard handles fallback).
-const HOST_TERM = process.env['TERM'] ?? 'xterm-256color';
-const PRELUDE = `export LANG=C.UTF-8 LC_ALL=C.UTF-8 TERM=${HOST_TERM}; `;
+// TERM comes from hostTermForCloud (mocked to xterm-256color here); the
+// renderInnerCommand guard handles the box-side fallback.
+const PRELUDE = 'export LANG=C.UTF-8 LC_ALL=C.UTF-8 TERM=xterm-256color; ';
 
 function boxWith(sandboxId: string | undefined): BoxRecord {
   return {

--- a/packages/sandbox-vercel/test/build-attach.test.ts
+++ b/packages/sandbox-vercel/test/build-attach.test.ts
@@ -17,7 +17,9 @@ const { buildVercelAttach } = await import('../src/build-attach.js');
 import type { BoxRecord } from '@agentbox/core';
 
 // The attach inner is prefixed with a UTF-8/TERM prelude (sbx forwards neither).
-const PRELUDE = 'export LANG=C.UTF-8 LC_ALL=C.UTF-8 TERM=xterm-256color; ';
+// TERM is now the host's TERM (renderInnerCommand's guard handles fallback).
+const HOST_TERM = process.env['TERM'] ?? 'xterm-256color';
+const PRELUDE = `export LANG=C.UTF-8 LC_ALL=C.UTF-8 TERM=${HOST_TERM}; `;
 
 function boxWith(sandboxId: string | undefined): BoxRecord {
   return {


### PR DESCRIPTION
Ports the docker TERM-fallback fix (#113) to the **cloud providers** — daytona, hetzner, vercel, e2b. Targets `nightly` (where #113 landed).

## Problem

The shared `renderInnerCommand` (`packages/sandbox-cloud/src/cloud-provider.ts`) builds the in-box tmux attach command for **all four** cloud providers, and had no TERM guard:

- **hetzner / daytona** attach over `ssh -t`, which forwards the host TERM as-is. When the box's Ubuntu terminfo lacks that TERM (e.g. `xterm-ghostty`, added to ncurses after 24.04 shipped), `tmux attach` exits immediately with *"missing or unsuitable terminal"* — the same flash-and-quit #113 fixed for docker. **This was the live bug.**
- **vercel / e2b** hardcoded `TERM=xterm-256color`, so they never hit the bug but also dropped host-terminal fidelity.

## Fix

- Export `TERM_FALLBACK_SNIPPET` from `sandbox-docker` (single source of truth) and prepend it in `renderInnerCommand` before the tmux commands — **one change covers all four providers**. The guard is a no-op when the box already knows `$TERM`, and safely downgrades to `xterm-256color` when it doesn't (or when `infocmp` is absent), so it never regresses the providers that hardcoded TERM.
- Forward the host TERM on **vercel** (`build-attach` envPrelude) and **e2b** (`build-attach` → `AGENTBOX_HOST_TERM` → `attach-helper` PTY env) so a box that carries the host terminfo renders at full fidelity, matching docker. hetzner/daytona already forward via `ssh -t`.

## Notes

- **Host-side only — no base-image rebake needed.** The guard relies on `infocmp`/ncurses, already present in every base image; and the fallback is safe even if it weren't.
- Build + lint + typecheck green. Added a cloud guard test (`render-inner-command.test.ts`) and updated the vercel/e2b `build-attach` assertions. docker 297 / cloud 81 / vercel 82 / e2b 16 tests pass.

## Verification status

Unit-tested + statically verified. Live cloud e2e (create a hetzner/vercel box, attach with `TERM=xterm-ghostty`, confirm it renders instead of flash-quitting) is cheap here since no rebake is required — can run on request.

https://claude.ai/code/session_01PTY4KwAeZdAVvgSWxjpYfs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only interactive attach command strings and TERM env wiring; behavior is defensive (fallback to xterm-256color) with new unit tests and no security or data-path impact.
> 
> **Overview**
> Fixes **flash-and-quit** cloud attaches when the host forwards a `TERM` the box’s Ubuntu terminfo does not know (e.g. `xterm-ghostty` over Hetzner/Daytona `ssh -t`).
> 
> **Shared guard:** `TERM_FALLBACK_SNIPPET` is **exported** from `@agentbox/sandbox-docker` and **prepended** to `renderInnerCommand` for every tmux path (interactive attach and detached pre-start). It runs `infocmp` and downgrades to `xterm-256color` when needed; **logs** and **noTmux** are unchanged.
> 
> **Host TERM forwarding:** Vercel’s attach prelude and E2B (`AGENTBOX_HOST_TERM` → in-box PTY) now set **`TERM` from the host** instead of always `xterm-256color`, with the same guard handling unknown terms.
> 
> New unit coverage in `render-inner-command.test.ts`; Vercel/E2B attach tests updated for the new prelude/env.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 051af1babcb3af6155c25a9fec2d86d62dbde37e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->