### PR TITLE
fix(cloud): start the agent session on --no-attach

### DIFF
--- a/apps/cli/src/commands/_cloud-agent-create.ts
+++ b/apps/cli/src/commands/_cloud-agent-create.ts
@@ -23,7 +23,7 @@ import { makeProgressReporter } from '../lib/progress.js';
 import { printLaunchRecap } from '../lib/launch-recap.js';
 import { buildPromptArgs } from '../lib/queue/build-prompt-args.js';
 import { buildResyncWarning } from '../lib/resync-warning.js';
-import { cloudAgentAttach } from './_cloud-attach.js';
+import { cloudAgentAttach, cloudAgentStartDetached } from './_cloud-attach.js';
 
 export interface CloudAgentCreateArgs {
   /** Pre-resolved provider (from `providerForCreate`). */
@@ -42,11 +42,11 @@ export interface CloudAgentCreateArgs {
   verbose?: boolean;
   /** Where to open the attached session; forwarded to `cloudAgentAttach`. */
   openIn?: AttachOpenIn;
-  /** When `false`, create the cloud box and skip the agent attach (background
-   *  mode). Defaults to `true`. On cloud providers the agent's tmux session is
-   *  created lazily by `cloudAgentAttach`; with `attach: false` the session
-   *  isn't started yet — a later `agentbox <agent> attach <box>` starts it on
-   *  first attach. */
+  /** When `false`, create the cloud box and start the agent in a detached tmux
+   *  session (background mode) but don't attach the host terminal — mirrors the
+   *  docker path, where the session is always created and only the terminal
+   *  attach is skipped. A later `agentbox <agent> attach <box>` finds the
+   *  running session and attaches to it. Defaults to `true`. */
   attach?: boolean;
   /**
    * Hook fired AFTER the box is provisioned and BEFORE the agent attach starts
@@ -118,6 +118,15 @@ export async function cloudAgentCreate(args: CloudAgentCreateArgs): Promise<void
       attaching: args.attach !== false,
     });
     if (args.attach === false) {
+      // Background mode: start the agent in a detached tmux session (and verify
+      // it stayed up) without attaching the host terminal — matches docker,
+      // where the session is always created and only the attach is skipped.
+      await cloudAgentStartDetached({
+        box: result.record,
+        binary: args.binary,
+        sessionName: args.sessionName,
+        extraArgs,
+      });
       return;
     }
     await cloudAgentAttach({

--- a/apps/cli/src/commands/_cloud-attach.ts
+++ b/apps/cli/src/commands/_cloud-attach.ts
@@ -419,7 +419,20 @@ export async function cloudAgentStartDetached(args: {
   if (state !== 'running') {
     box = await provider.start(box);
   }
-  const command = buildCloudAttachInnerCommand(args.binary, args.extraArgs);
+  // With no user args, resume the box's recorded session instead of launching
+  // fresh — same as the interactive `cloudAgentAttach` path. Matters for a
+  // background `agentbox <agent> start <box> --no-attach` (and idle-resumed
+  // creates): the box already has a claude/codex session to reopen. The `-i`
+  // queue path always seeds a prompt, so extraArgs is non-empty and this no-ops.
+  let extraArgs = args.extraArgs;
+  if (
+    (!extraArgs || extraArgs.length === 0) &&
+    (args.binary === 'claude' || args.binary === 'codex')
+  ) {
+    const resume = await agentResumeArgs(provider, box, args.binary);
+    if (resume) extraArgs = resume;
+  }
+  const command = buildCloudAttachInnerCommand(args.binary, extraArgs);
   const { exitCode, stderr } = await startDetachedSession(
     provider,
     box,

--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -54,7 +54,7 @@ import {
   NO_ATTACH_HELP,
   resolveAttachInOption,
 } from './_attach-in.js';
-import { cloudAgentAttach } from './_cloud-attach.js';
+import { cloudAgentAttach, cloudAgentStartDetached } from './_cloud-attach.js';
 import { cloudAgentCreate } from './_cloud-agent-create.js';
 import { runCarryGate, runQueuedCarryGate } from '../lib/carry-gate.js';
 import { FromBranchError, UseBranchError, resolveBranchSelection } from '../lib/from-branch.js';
@@ -1410,12 +1410,6 @@ const claudeStartCommand = new Command('start')
         }
       }
       if ((box.provider ?? 'docker') !== 'docker') {
-        if (opts.attach === false) {
-          outro(
-            `--no-attach: cloud agent sessions are started lazily on attach. Run: agentbox claude attach ${reattachRef(box)}`,
-          );
-          return;
-        }
         const cfg = await loadEffectiveConfig(box.workspacePath, {
           cliOverrides: {
             ...(attachIn ? { attach: { openIn: attachIn } } : {}),
@@ -1438,10 +1432,23 @@ const claudeStartCommand = new Command('start')
             throw err;
           }
         }
+        const sessionName = opts.sessionName ?? 'claude';
+        if (opts.attach === false) {
+          // Background mode: start the detached session (matches docker) instead
+          // of deferring the agent until the next attach.
+          await cloudAgentStartDetached({
+            box,
+            binary: 'claude',
+            sessionName,
+            extraArgs: effectiveClaudeArgs,
+          });
+          outro(`--no-attach: claude started in background. Attach: agentbox claude attach ${reattachRef(box)}`);
+          return;
+        }
         await cloudAgentAttach({
           box,
           binary: 'claude',
-          sessionName: opts.sessionName ?? 'claude',
+          sessionName,
           mode: 'claude',
           extraArgs: effectiveClaudeArgs,
           openIn: hostAwareOpenIn(cfg),

--- a/apps/cli/src/commands/codex.ts
+++ b/apps/cli/src/commands/codex.ts
@@ -56,7 +56,7 @@ import {
   NO_ATTACH_HELP,
   resolveAttachInOption,
 } from './_attach-in.js';
-import { cloudAgentAttach } from './_cloud-attach.js';
+import { cloudAgentAttach, cloudAgentStartDetached } from './_cloud-attach.js';
 import { cloudAgentCreate } from './_cloud-agent-create.js';
 import { runCarryGate, runQueuedCarryGate } from '../lib/carry-gate.js';
 import { FromBranchError, UseBranchError, resolveBranchSelection } from '../lib/from-branch.js';
@@ -1044,12 +1044,6 @@ const codexStartCommand = new Command('start')
         }
       }
       if ((box.provider ?? 'docker') !== 'docker') {
-        if (opts.attach === false) {
-          outro(
-            `--no-attach: cloud agent sessions are started lazily on attach. Run: agentbox codex attach ${reattachRef(box)}`,
-          );
-          return;
-        }
         const cfg = await loadEffectiveConfig(box.workspacePath, {
           cliOverrides: {
             ...(attachIn ? { attach: { openIn: attachIn } } : {}),
@@ -1072,10 +1066,23 @@ const codexStartCommand = new Command('start')
             throw err;
           }
         }
+        const sessionName = opts.sessionName ?? 'codex';
+        if (opts.attach === false) {
+          // Background mode: start the detached session (matches docker) instead
+          // of deferring the agent until the next attach.
+          await cloudAgentStartDetached({
+            box,
+            binary: 'codex',
+            sessionName,
+            extraArgs: effectiveCodexArgs,
+          });
+          outro(`--no-attach: codex started in background. Attach: agentbox codex attach ${reattachRef(box)}`);
+          return;
+        }
         await cloudAgentAttach({
           box,
           binary: 'codex',
-          sessionName: opts.sessionName ?? 'codex',
+          sessionName,
           mode: 'codex',
           extraArgs: effectiveCodexArgs,
           openIn: hostAwareOpenIn(cfg),

--- a/apps/cli/src/commands/opencode.ts
+++ b/apps/cli/src/commands/opencode.ts
@@ -53,7 +53,7 @@ import {
   NO_ATTACH_HELP,
   resolveAttachInOption,
 } from './_attach-in.js';
-import { cloudAgentAttach } from './_cloud-attach.js';
+import { cloudAgentAttach, cloudAgentStartDetached } from './_cloud-attach.js';
 import { cloudAgentCreate } from './_cloud-agent-create.js';
 import { runCarryGate, runQueuedCarryGate } from '../lib/carry-gate.js';
 import { FromBranchError, UseBranchError, resolveBranchSelection } from '../lib/from-branch.js';
@@ -886,19 +886,28 @@ const opencodeStartCommand = new Command('start')
         }
       }
       if ((box.provider ?? 'docker') !== 'docker') {
-        if (opts.attach === false) {
-          outro(
-            `--no-attach: cloud agent sessions are started lazily on attach. Run: agentbox opencode attach ${reattachRef(box)}`,
-          );
-          return;
-        }
         const cfg = await loadEffectiveConfig(box.workspacePath, {
           cliOverrides: attachIn ? { attach: { openIn: attachIn } } : {},
         });
+        const sessionName = opts.sessionName ?? 'opencode';
+        if (opts.attach === false) {
+          // Background mode: start the detached session (matches docker) instead
+          // of deferring the agent until the next attach.
+          await cloudAgentStartDetached({
+            box,
+            binary: 'opencode',
+            sessionName,
+            extraArgs: effectiveOpencodeArgs,
+          });
+          outro(
+            `--no-attach: opencode started in background. Attach: agentbox opencode attach ${reattachRef(box)}`,
+          );
+          return;
+        }
         await cloudAgentAttach({
           box,
           binary: 'opencode',
-          sessionName: opts.sessionName ?? 'opencode',
+          sessionName,
           mode: 'opencode',
           extraArgs: effectiveOpencodeArgs,
           openIn: hostAwareOpenIn(cfg),


### PR DESCRIPTION
## Problem

On cloud providers (daytona/hetzner/vercel/e2b), `agentbox claude`/`codex`/`opencode --no-attach` and `agentbox fork` (which maps background mode to `--no-attach`) created the box but **never started the agent**. The agent's tmux session is created lazily by the attach step, so skipping attach skipped the agent entirely — the box came up empty.

This contradicts the documented `--no-attach` behavior: *"create the box and start the agent session, but do not attach (background mode)."* Docker was always correct (it creates the session before the attach check).

## Root cause

The bare commands and `fork` funnel into `cloudAgentCreate`, which returned early on `attach === false` before any session was created. The three `<agent> start` subcommands had the same gap and even printed *"cloud agent sessions are started lazily on attach"* and returned without starting anything.

## Fix

- `_cloud-agent-create.ts` — on `attach === false`, call `cloudAgentStartDetached(...)` (the same helper the `-i` queue worker uses) to start a detached tmux session and verify it stayed up (fail-loud on immediate exit / credential rejection), instead of returning early.
- `claude.ts` / `codex.ts` / `opencode.ts` `start` subcommand cloud branches — resolve args (skip-perms, resume teleport) first, then start the detached session in background mode rather than printing the lazy no-op message.

Cloud now matches docker on every path. No docs change needed — the `--no-attach` help text already describes the now-correct behavior.

## Verification

- `typecheck` + `lint` clean; `cloud-attach` / `attach-parse` tests pass (18/18).
- **Docker** `--no-attach` (regression guard): box created, `claude` tmux session live with the TUI running.
- **E2B** `--no-attach` (the previously broken path): box created, process exits 0, `tmux has-session -t claude` confirms a live, logged-in Claude TUI — where before it produced an empty box.

https://claude.ai/code/session_01PTY4KwAeZdAVvgSWxjpYfs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cloud session startup on create/start paths for all three agents; wrong behavior could leave boxes running without agents or fail loudly on credential issues, but scope is limited to `--no-attach` and reuses an existing helper.
> 
> **Overview**
> **Cloud `--no-attach` now starts the agent in a detached tmux session** instead of leaving the box empty until attach. Behavior matches Docker: the session is created up front; only the host terminal attach is skipped.
> 
> `cloudAgentCreate` no longer returns early when `attach === false`; it calls **`cloudAgentStartDetached`** (same helper as the `-i` queue worker) to launch and verify the session.
> 
> The **claude**, **codex**, and **opencode** `start` subcommands on non-docker boxes follow the same pattern: resolve args (skip-perms, resume teleport where applicable), then **`cloudAgentStartDetached`** on `--no-attach`, with updated outro text instead of the old “lazy on attach” message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 512397c4f55cb2adc3bab6afb1d64cd8c5687313. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->