### PR TITLE
feat(cli): `agentbox shell --ssh-config` for Codex / Claude desktop SSH

### DIFF
--- a/apps/cli/share/host-skills/agentbox-info/SKILL.md
+++ b/apps/cli/share/host-skills/agentbox-info/SKILL.md
@@ -231,6 +231,35 @@ If a PR op appears to hang, tell the user to check the dashboard footer for the 
 
 Per-project numeric index (`1`, `2`, …) and friendly name (`review`, `smoke`) both work wherever `<box>` is accepted. Index `1` is the first box created in the current workspace.
 
+## Connecting an external app (Codex / Claude desktop) over SSH
+
+When the user wants to attach the **Codex app** or **Claude desktop** to a box over SSH, run:
+
+```
+agentbox shell <box> --ssh-config          # writes ~/.ssh/config + prints details
+agentbox shell <box> --ssh-config --json   # same, machine-readable
+```
+
+This writes a `Host <box-name>` alias into `~/.ssh/config` (pointing at the box's IP and its
+per-box identity file) and prints the alias, host, user, identity path, and a ready `ssh
+<box-name>` command. `--json` emits `{ alias, host, user, identityFile, sshCommand,
+codexAddUrl }`.
+
+**Hetzner cloud boxes only.** Only a box with a persistent per-box SSH key qualifies — an
+external app connects later, so Daytona's 60-minute token would already be expired, and
+Docker / Vercel / E2B boxes have no SSH. The command exits with a clear message (and writes
+nothing) for unsupported providers.
+
+After running it, surface both apps to the user. For **Codex**, render the deep link verbatim
+(`<ssh-alias>` is the box name):
+
+```
+[Add <ssh-alias> to Codex SSH](codex://settings/connections/ssh/add?name=<ssh-alias>)
+```
+
+For **Claude desktop**, there's no deep link — tell the user to add an SSH connection to host
+`<ssh-alias>` (it's already in `~/.ssh/config`).
+
 ## Operating principles
 
 1. **Never assume the host needs SSH keys forwarded into a box** — git is handled by the relay, by design.

--- a/apps/cli/share/host-skills/agentbox/SKILL.md
+++ b/apps/cli/share/host-skills/agentbox/SKILL.md
@@ -34,6 +34,19 @@ Fork the current Claude Code session into a fresh AgentBox box.
 
 4. **Report.** In one line, give the user the new box name (parse it from the command output) and confirm their host session is unaffected. If you passed `--plan`, mention the box opens in plan mode ready to resume. Do not summarize the conversation — the fork already carries it.
 
+For Hetzner cloud boxes only, when in Codex App or Claude Desktop, use can add a ssh connection to the box. To do this first add an alias to their ssh config, then instruct them how to add the connection:
+
+```
+agentbox shell <box> --ssh-config          # writes ~/.ssh/config + prints details
+```
+
+to add a ssh alias that the user can use to connect to the box
+
+When in Codex App return a clickable link in the response for an easy way:
+```
+[Add <ssh-alias> to Codex SSH](codex://settings/connections/ssh/add?name=<ssh-alias>)
+```
+
 ## Troubleshooting
 
 - If agentbox command fails, tell the user to install AgentBox by writing `! npm -g install @madarco/agentbox` in the chat.

--- a/apps/cli/src/cloud-ssh.ts
+++ b/apps/cli/src/cloud-ssh.ts
@@ -19,32 +19,48 @@ export interface CloudSshAlias {
   identityFile?: string;
 }
 
-/**
- * Bring a cloud box online and resolve its SSH connection target WITHOUT
- * touching `~/.ssh/config`. Lets callers inspect the target (e.g. gate on a
- * persistent `identityFile`) before deciding to persist an alias.
- *
- * `buildAttach(..., { noTmux: true })` yields the plain `ssh ... <user>@<host>`
- * argv; the identity path (if any) is parsed straight out of it so we never
- * hardcode a provider-specific key path. Bringing the box online is idempotent
- * — a probe of an already-running box is a no-op.
- */
-export async function resolveCloudSshTarget(box: BoxRecord): Promise<CloudSshAlias> {
-  const p = await providerForBox(box);
-  const state = await p.probeState(box);
-  if (state === 'paused') {
-    log.info('box is paused; resuming');
-    await p.resume(box);
-  } else if (state === 'stopped') {
-    log.info('box is stopped; starting');
-    await p.start(box);
-  } else if (state === 'missing') {
-    throw new Error(`cloud sandbox for ${box.name} is missing; was it deleted?`);
-  }
+export interface CloudSshOptions {
+  /**
+   * Bring the box online (resume/start) before resolving the target. Default
+   * true. Callers that already brought the box online (e.g. `agentbox code`
+   * after its own wait-ready) pass false to skip a redundant lifecycle pass.
+   */
+  bringOnline?: boolean;
+}
 
+/**
+ * Resolve a cloud box's SSH connection target WITHOUT touching `~/.ssh/config`.
+ * Lets callers inspect the target (e.g. gate on a persistent `identityFile`)
+ * before deciding to persist an alias.
+ *
+ * The SSH-support check runs FIRST, before any lifecycle action — so an
+ * unsupported provider (e.g. Docker, which has no `buildAttach`) errors without
+ * resuming/starting the box. `buildAttach(..., { noTmux: true })` yields the
+ * plain `ssh ... <user>@<host>` argv; the identity path (if any) is parsed
+ * straight out of it so we never hardcode a provider-specific key path.
+ */
+export async function resolveCloudSshTarget(
+  box: BoxRecord,
+  opts: CloudSshOptions = {},
+): Promise<CloudSshAlias> {
+  const p = await providerForBox(box);
   if (!p.buildAttach) {
     throw new Error(`cloud provider '${p.name}' does not support SSH attach`);
   }
+
+  if (opts.bringOnline ?? true) {
+    const state = await p.probeState(box);
+    if (state === 'paused') {
+      log.info('box is paused; resuming');
+      await p.resume(box);
+    } else if (state === 'stopped') {
+      log.info('box is stopped; starting');
+      await p.start(box);
+    } else if (state === 'missing') {
+      throw new Error(`cloud sandbox for ${box.name} is missing; was it deleted?`);
+    }
+  }
+
   const spec = await p.buildAttach(box, 'shell', { noTmux: true });
   const target = parseSshTarget(spec.argv);
   if (!target) {
@@ -60,8 +76,11 @@ export async function resolveCloudSshTarget(box: BoxRecord): Promise<CloudSshAli
  * `agentbox open` (sshfs mount), and `agentbox shell --ssh-config` (external
  * app handoff) — all three need the same alias mapped to a live SSH target.
  */
-export async function ensureCloudSshAlias(box: BoxRecord): Promise<CloudSshAlias> {
-  const conn = await resolveCloudSshTarget(box);
+export async function ensureCloudSshAlias(
+  box: BoxRecord,
+  opts: CloudSshOptions = {},
+): Promise<CloudSshAlias> {
+  const conn = await resolveCloudSshTarget(box, opts);
   await writeAgentboxSshAlias({
     alias: conn.alias,
     hostname: conn.host,

--- a/apps/cli/src/cloud-ssh.ts
+++ b/apps/cli/src/cloud-ssh.ts
@@ -1,0 +1,72 @@
+import { log } from '@clack/prompts';
+import type { BoxRecord } from '@agentbox/core';
+import { providerForBox } from './provider/registry.js';
+import { agentboxAliasFor, parseSshTarget, writeAgentboxSshAlias } from './ssh-config.js';
+
+export interface CloudSshAlias {
+  /** Host alias written to `~/.ssh/config` (the box name). */
+  alias: string;
+  /** SSH host — VPS IP (Hetzner) or gateway domain (Daytona). */
+  host: string;
+  /** SSH user — `vscode` (Hetzner) or an ephemeral token (Daytona). */
+  user: string;
+  /**
+   * Per-box private key path when the provider authenticates by identity file
+   * (Hetzner). Undefined for token-in-User providers (Daytona) — callers that
+   * need a persistent connection (external apps) should treat its absence as
+   * "not supported".
+   */
+  identityFile?: string;
+}
+
+/**
+ * Bring a cloud box online and resolve its SSH connection target WITHOUT
+ * touching `~/.ssh/config`. Lets callers inspect the target (e.g. gate on a
+ * persistent `identityFile`) before deciding to persist an alias.
+ *
+ * `buildAttach(..., { noTmux: true })` yields the plain `ssh ... <user>@<host>`
+ * argv; the identity path (if any) is parsed straight out of it so we never
+ * hardcode a provider-specific key path. Bringing the box online is idempotent
+ * — a probe of an already-running box is a no-op.
+ */
+export async function resolveCloudSshTarget(box: BoxRecord): Promise<CloudSshAlias> {
+  const p = await providerForBox(box);
+  const state = await p.probeState(box);
+  if (state === 'paused') {
+    log.info('box is paused; resuming');
+    await p.resume(box);
+  } else if (state === 'stopped') {
+    log.info('box is stopped; starting');
+    await p.start(box);
+  } else if (state === 'missing') {
+    throw new Error(`cloud sandbox for ${box.name} is missing; was it deleted?`);
+  }
+
+  if (!p.buildAttach) {
+    throw new Error(`cloud provider '${p.name}' does not support SSH attach`);
+  }
+  const spec = await p.buildAttach(box, 'shell', { noTmux: true });
+  const target = parseSshTarget(spec.argv);
+  if (!target) {
+    throw new Error(`could not parse <user>@<host> from cloud SSH argv: ${spec.argv.join(' ')}`);
+  }
+  const alias = agentboxAliasFor(box.name);
+  return { alias, host: target.host, user: target.user, identityFile: target.identityFile };
+}
+
+/**
+ * Bring a cloud box online and (re)write its `~/.ssh/config` alias, returning
+ * the connection target. Shared by `agentbox code` (VS Code Remote-SSH),
+ * `agentbox open` (sshfs mount), and `agentbox shell --ssh-config` (external
+ * app handoff) — all three need the same alias mapped to a live SSH target.
+ */
+export async function ensureCloudSshAlias(box: BoxRecord): Promise<CloudSshAlias> {
+  const conn = await resolveCloudSshTarget(box);
+  await writeAgentboxSshAlias({
+    alias: conn.alias,
+    hostname: conn.host,
+    user: conn.user,
+    identityFile: conn.identityFile,
+  });
+  return conn;
+}

--- a/apps/cli/src/commands/code.ts
+++ b/apps/cli/src/commands/code.ts
@@ -212,8 +212,9 @@ async function prepareCloudAttach(box: BoxRecord, opts: PrepareCloudOptions): Pr
 
   // Mint the SSH target and (re)write the `~/.ssh/config` alias. Shared with
   // `agentbox open` and `agentbox shell --ssh-config`. The inner tmux command
-  // is irrelevant here (Remote-SSH starts its own session).
-  const { alias } = await ensureCloudSshAlias(box);
+  // is irrelevant here (Remote-SSH starts its own session). The box was already
+  // brought online + waited above, so skip the helper's lifecycle pass.
+  const { alias } = await ensureCloudSshAlias(box, { bringOnline: false });
   log.info(`updated ~/.ssh/config alias ${alias}`);
 
   return `vscode-remote://ssh-remote+${alias}/workspace`;

--- a/apps/cli/src/commands/code.ts
+++ b/apps/cli/src/commands/code.ts
@@ -18,7 +18,7 @@ import {
 } from '@agentbox/sandbox-docker';
 import { resolveBoxOrExit } from '../box-ref.js';
 import { providerForBox } from '../provider/registry.js';
-import { agentboxAliasFor, parseSshTarget, writeAgentboxSshAlias } from '../ssh-config.js';
+import { ensureCloudSshAlias } from '../cloud-ssh.js';
 import { handleLifecycleError } from './_errors.js';
 
 interface CodeOptions {
@@ -210,30 +210,10 @@ async function prepareCloudAttach(box: BoxRecord, opts: PrepareCloudOptions): Pr
   // `writeFileInBox` over `backend.exec`. Not load-bearing for the editor
   // attach itself; user can author `.vscode/tasks.json` manually.
 
-  if (!p.buildAttach) {
-    throw new Error(
-      `cloud provider '${p.name}' does not support SSH attach — \`agentbox code\` requires it`,
-    );
-  }
-  // buildAttach mints a fresh 60-min SSH token via the backend's `attachArgv`.
-  // We only want the connect argv here; the inner tmux command is irrelevant
-  // (Remote-SSH starts its own session). `noTmux` skips the tmux wrap so
-  // argv is the plain `ssh ... <user>@<host>` form.
-  const spec = await p.buildAttach(box, 'shell', { noTmux: true });
-  const target = parseSshTarget(spec.argv);
-  if (!target) {
-    throw new Error(
-      `could not parse <user>@<host> from cloud SSH argv: ${spec.argv.join(' ')}`,
-    );
-  }
-
-  const alias = agentboxAliasFor(box.name);
-  await writeAgentboxSshAlias({
-    alias,
-    hostname: target.host,
-    user: target.user,
-    identityFile: target.identityFile,
-  });
+  // Mint the SSH target and (re)write the `~/.ssh/config` alias. Shared with
+  // `agentbox open` and `agentbox shell --ssh-config`. The inner tmux command
+  // is irrelevant here (Remote-SSH starts its own session).
+  const { alias } = await ensureCloudSshAlias(box);
   log.info(`updated ~/.ssh/config alias ${alias}`);
 
   return `vscode-remote://ssh-remote+${alias}/workspace`;

--- a/apps/cli/src/commands/inspect.ts
+++ b/apps/cli/src/commands/inspect.ts
@@ -9,6 +9,7 @@ import {
 import { renderEndpointLines } from '../endpoints-render.js';
 import { fmtBytes } from '../fmt.js';
 import { providerForBox } from '../provider/registry.js';
+import { agentboxAliasFor, readAgentboxSshAlias } from '../ssh-config.js';
 import { watchRender } from '../watch.js';
 import { fetchLive, renderLiveSections, renderPersistedSections } from './_status-render.js';
 import { handleLifecycleError } from './_errors.js';
@@ -153,6 +154,8 @@ async function renderCloudText(box: BoxRecord): Promise<string> {
   const provider = await providerForBox(box);
   const state = await provider.probeState(box);
   const persisted = await readBoxStatus(box);
+  const alias = agentboxAliasFor(box.name);
+  const sshAlias = await readAgentboxSshAlias(alias);
   const lim = box.resourceLimits;
   const lines: string[] = [
     `id            ${box.id}`,
@@ -170,6 +173,8 @@ async function renderCloudText(box: BoxRecord): Promise<string> {
     `web preview   ${webPreviewLine(box)}`,
     `relay preview ${box.cloud?.relayPreviewUrl ?? '(unresolved)'}`,
     `bridge token  ${box.cloud?.bridgeToken ? '(set)' : '(unset)'}`,
+    `ssh alias     ${alias}${sshAlias ? '' : ` (run \`agentbox shell ${box.name} --ssh-config\` to write it)`}`,
+    `ssh identity  ${sshAlias?.identityFile ?? '(none — write the alias first)'}`,
     `playwright    ${box.withPlaywright ? 'yes' : 'no'}`,
     `env files     ${box.withEnv ? 'yes' : 'no'}`,
     `mem limit     ${lim?.memoryBytes ? fmtBytes(lim.memoryBytes) : 'unlimited'}`,

--- a/apps/cli/src/commands/open.ts
+++ b/apps/cli/src/commands/open.ts
@@ -8,8 +8,7 @@ import { hostOpenCommand } from '@agentbox/sandbox-core';
 import { openBoxInFinder } from '@agentbox/sandbox-docker';
 import { Command } from 'commander';
 import { resolveBoxOrExit } from '../box-ref.js';
-import { providerForBox } from '../provider/registry.js';
-import { agentboxAliasFor, parseSshTarget, writeAgentboxSshAlias } from '../ssh-config.js';
+import { ensureCloudSshAlias } from '../cloud-ssh.js';
 import { runPath } from './path.js';
 import { handleLifecycleError } from './_errors.js';
 
@@ -41,11 +40,10 @@ export const openCommand = new Command('open')
   .action(async (idOrName: string | undefined, opts: OpenOpts) => {
     try {
       const box = await resolveBoxOrExit(idOrName);
-      const provider = await providerForBox(box);
       const isCloud = (box.provider ?? 'docker') !== 'docker';
 
       if (isCloud) {
-        await runCloudOpen(box, provider, opts);
+        await runCloudOpen(box, opts);
         return;
       }
 
@@ -77,11 +75,7 @@ export const openCommand = new Command('open')
  * 60-min Daytona SSH token, written into `~/.ssh/config` per call so sshfs
  * has a live target without baking the token into the mount itself.
  */
-async function runCloudOpen(
-  box: BoxRecord,
-  provider: { name: string; buildAttach?: NonNullable<Awaited<ReturnType<typeof providerForBox>>['buildAttach']> },
-  opts: OpenOpts,
-): Promise<void> {
+async function runCloudOpen(box: BoxRecord, opts: OpenOpts): Promise<void> {
   const mountRoot = join(homedir(), '.agentbox', 'mounts', box.name);
 
   if (opts.unmount) {
@@ -107,25 +101,10 @@ async function runCloudOpen(
     );
   }
 
-  if (!provider.buildAttach) {
-    throw new Error(
-      `cloud provider '${provider.name}' does not support SSH attach — \`agentbox open\` requires it for cloud boxes`,
-    );
-  }
-  // Same SSH alias machinery `agentbox code` uses — mint a fresh 60-min token
-  // and rewrite the alias every call so the user gets a live mount target.
-  const spec = await provider.buildAttach(box, 'shell', { noTmux: true });
-  const target = parseSshTarget(spec.argv);
-  if (!target) {
-    throw new Error(`could not parse <user>@<host> from cloud SSH argv: ${spec.argv.join(' ')}`);
-  }
-  const alias = agentboxAliasFor(box.name);
-  await writeAgentboxSshAlias({
-    alias,
-    hostname: target.host,
-    user: target.user,
-    identityFile: target.identityFile,
-  });
+  // Same SSH alias machinery `agentbox code` uses — bring the box online and
+  // (re)write the alias (a fresh 60-min token for Daytona) so sshfs gets a live
+  // mount target.
+  const { alias } = await ensureCloudSshAlias(box);
 
   // Ensure the mount dir exists. If something's already mounted there (a
   // stale mount from a previous run) we tear it down before re-mounting —

--- a/apps/cli/src/commands/shell.ts
+++ b/apps/cli/src/commands/shell.ts
@@ -23,6 +23,9 @@ import {
 } from '@agentbox/sandbox-docker';
 import { resolveBoxOrExit, resolveBoxOrShift } from '../box-ref.js';
 import { providerForBox } from '../provider/registry.js';
+import { resolveCloudSshTarget } from '../cloud-ssh.js';
+import { hyperlink } from '../hyperlink.js';
+import { writeAgentboxSshAlias } from '../ssh-config.js';
 import { runWrappedAttach } from '../wrapped-pty/index.js';
 import { handleLifecycleError } from './_errors.js';
 import { requireDockerProvider } from './_provider-guard.js';
@@ -37,6 +40,10 @@ interface ShellOptions {
   name?: string;
   /** --new: open a fresh auto-numbered shell instead of the default. */
   new?: boolean;
+  /** --ssh-config: write a ~/.ssh/config alias for external apps instead of opening a shell. */
+  sshConfig?: boolean;
+  /** --json: machine-readable output (only meaningful with --ssh-config). */
+  json?: boolean;
 }
 
 function buildShellCliOverrides(opts: ShellOptions): Partial<UserConfig> {
@@ -204,6 +211,69 @@ async function startOrAttachShell(box: BoxRecord, cfg: ShellSessionCfg): Promise
   process.exit(code);
 }
 
+/**
+ * `agentbox shell <box> --ssh-config`: write the box's `~/.ssh/config` alias and
+ * print connection details so an external app (the Codex app, Claude desktop)
+ * can connect over plain SSH — instead of opening a shell.
+ *
+ * Only providers with a *persistent* per-box identity file qualify: an external
+ * app connects later, so a token-in-User credential that expires (Daytona) is
+ * useless, and Docker/Vercel/E2B have no SSH at all. We resolve the target
+ * first and gate on `identityFile` BEFORE writing, so unsupported providers
+ * leave `~/.ssh/config` untouched.
+ */
+async function runSshConfig(box: BoxRecord, opts: ShellOptions): Promise<void> {
+  const conn = await resolveCloudSshTarget(box);
+  if (!conn.identityFile) {
+    throw new Error(
+      `box '${box.name}' (provider '${box.provider ?? 'docker'}') has no persistent SSH key, ` +
+        `so it can't be added to Codex / Claude desktop over SSH. Only Hetzner cloud boxes are ` +
+        `supported — Docker boxes aren't reachable over SSH, and Daytona uses a 60-min token that expires.`,
+    );
+  }
+  await writeAgentboxSshAlias({
+    alias: conn.alias,
+    hostname: conn.host,
+    user: conn.user,
+    identityFile: conn.identityFile,
+  });
+
+  const codexUrl = `codex://settings/connections/ssh/add?name=${encodeURIComponent(conn.alias)}`;
+  if (opts.json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          alias: conn.alias,
+          host: conn.host,
+          user: conn.user,
+          identityFile: conn.identityFile,
+          sshCommand: `ssh ${conn.alias}`,
+          codexAddUrl: codexUrl,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return;
+  }
+
+  const codexLink = hyperlink(`Add ${conn.alias} to Codex SSH`, codexUrl, process.stdout);
+  const lines = [
+    `wrote ~/.ssh/config alias "${conn.alias}"`,
+    ``,
+    `ssh alias:      ${conn.alias}`,
+    `host:           ${conn.host}`,
+    `user:           ${conn.user}`,
+    `identity:       ${conn.identityFile}`,
+    `connect:        ssh ${conn.alias}`,
+    ``,
+    `Codex:          ${codexLink}`,
+    `                ${codexUrl}`,
+    `Claude desktop: add an SSH connection to host "${conn.alias}" (already in ~/.ssh/config)`,
+  ];
+  process.stdout.write(lines.join('\n') + '\n');
+}
+
 export const shellCommand = new Command('shell')
   .description(
     'Open an interactive shell in a box, in a detachable tmux session (auto-unpause/start)',
@@ -221,6 +291,11 @@ export const shellCommand = new Command('shell')
   .option('--no-tmux', 'run a plain docker exec shell instead of a detachable tmux session')
   .option('-n, --name <label>', 'open/attach a named shell session (a box can hold several)')
   .option('--new', 'open a fresh, auto-numbered shell session (shell-2, shell-3, ...)')
+  .option(
+    '--ssh-config',
+    'write a ~/.ssh/config alias for this box (Hetzner cloud boxes) and print connection details for Codex / Claude desktop, instead of opening a shell',
+  )
+  .option('--json', 'with --ssh-config: emit the connection details as JSON')
   .action(async (idOrName: string | undefined, cmd: string[], opts: ShellOptions) => {
     try {
       // resolveBoxOrShift handles the `agentbox shell -- ls` case: commander
@@ -228,6 +303,13 @@ export const shellCommand = new Command('shell')
       // treat "ls" as the first cmd token instead.
       const { box, shifted } = await resolveBoxOrShift(idOrName);
       const effectiveCmd = shifted && idOrName ? [idOrName, ...cmd] : cmd;
+
+      // `--ssh-config` short-circuits the shell: it only writes the SSH alias
+      // and prints connection details for external apps.
+      if (opts.sshConfig) {
+        await runSshConfig(box, opts);
+        return;
+      }
 
       const cfg = await loadEffectiveConfig(box.workspacePath, {
         cliOverrides: buildShellCliOverrides(opts),

--- a/apps/cli/src/commands/shell.ts
+++ b/apps/cli/src/commands/shell.ts
@@ -25,7 +25,7 @@ import { resolveBoxOrExit, resolveBoxOrShift } from '../box-ref.js';
 import { providerForBox } from '../provider/registry.js';
 import { resolveCloudSshTarget } from '../cloud-ssh.js';
 import { hyperlink } from '../hyperlink.js';
-import { writeAgentboxSshAlias } from '../ssh-config.js';
+import { hasUnmanagedHostConflict, writeAgentboxSshAlias } from '../ssh-config.js';
 import { runWrappedAttach } from '../wrapped-pty/index.js';
 import { handleLifecycleError } from './_errors.js';
 import { requireDockerProvider } from './_provider-guard.js';
@@ -231,6 +231,16 @@ async function runSshConfig(box: BoxRecord, opts: ShellOptions): Promise<void> {
         `supported — Docker boxes aren't reachable over SSH, and Daytona uses a 60-min token that expires.`,
     );
   }
+  // The alias is the bare box name; warn (don't fail) if the user already has
+  // their own `Host <name>` — OpenSSH would let the earlier entry shadow ours.
+  if (await hasUnmanagedHostConflict(conn.alias)) {
+    log.warn(
+      `~/.ssh/config already has a non-agentbox \`Host ${conn.alias}\` entry. SSH uses the ` +
+        `first value per keyword, so it may override agentbox's HostName/IdentityFile — ` +
+        `remove it (or rename the box) if \`ssh ${conn.alias}\` doesn't reach the box.`,
+    );
+  }
+
   await writeAgentboxSshAlias({
     alias: conn.alias,
     hostname: conn.host,

--- a/apps/cli/src/ssh-config.ts
+++ b/apps/cli/src/ssh-config.ts
@@ -12,7 +12,7 @@ import { join } from 'node:path';
  */
 
 export interface SshAliasOptions {
-  /** Host alias the user (and VS Code Remote-SSH) refers to, e.g. `agentbox-cloud-myname`. */
+  /** Host alias the user (and VS Code Remote-SSH) refers to — the box name, e.g. `myname`. */
   alias: string;
   /** Daytona SSH gateway, typically `ssh.app.daytona.io`. */
   hostname: string;
@@ -40,9 +40,15 @@ function endMarker(alias: string): string {
   return `# END agentbox cloud box ${alias}`;
 }
 
-/** Stable alias derived from a box name. Box names are already kebab-safe. */
+/**
+ * Stable `~/.ssh/config` Host alias for a box: the box name itself. Box names
+ * are already kebab-safe, so `ssh <boxname>` works and external apps (Codex's
+ * `codex://…?name=<alias>` deep link, Claude desktop) get a clean, memorable
+ * host. Our BEGIN/END-marked managed block keeps this entry isolated from any
+ * user-authored `Host <boxname>` so the two coexist.
+ */
 export function agentboxAliasFor(boxName: string): string {
-  return `agentbox-cloud-${boxName}`;
+  return boxName;
 }
 
 async function readConfig(): Promise<string> {
@@ -145,6 +151,29 @@ export function parseSshTarget(argv: readonly string[]): SshTarget | undefined {
     }
   }
   return { ...target, identityFile };
+}
+
+/**
+ * Read back the `HostName` / `IdentityFile` from the managed block for `alias`
+ * in `~/.ssh/config`, if one exists. Used by `inspect` to surface the SSH
+ * connection details without re-deriving them from a provider (which would
+ * require bringing the box online). Returns undefined when no managed block is
+ * present for the alias.
+ */
+export async function readAgentboxSshAlias(
+  alias: string,
+): Promise<{ hostName?: string; identityFile?: string } | undefined> {
+  const contents = await readConfig();
+  if (contents === '') return undefined;
+  const begin = beginMarker(alias);
+  const end = endMarker(alias);
+  const escape = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = new RegExp(`^${escape(begin)}\\n([\\s\\S]*?)${escape(end)}`, 'm').exec(contents);
+  if (!match) return undefined;
+  const body = match[1] ?? '';
+  const field = (name: string): string | undefined =>
+    new RegExp(`^\\s*${name}\\s+(.+)$`, 'm').exec(body)?.[1]?.trim();
+  return { hostName: field('HostName'), identityFile: field('IdentityFile') };
 }
 
 export async function removeAgentboxSshAlias(alias: string): Promise<void> {

--- a/apps/cli/src/ssh-config.ts
+++ b/apps/cli/src/ssh-config.ts
@@ -106,16 +106,43 @@ function buildBlock(opts: SshAliasOptions): string {
   return lines.join('\n');
 }
 
+/**
+ * Pre-`agentbox-cloud-<box>` → `<box>` rename, managed blocks were keyed by
+ * `agentbox-cloud-<box>`. We strip that block whenever we rewrite/remove the
+ * box's alias so upgrades don't leave a stale duplicate Host entry behind.
+ */
+function legacyAliasFor(alias: string): string {
+  return `agentbox-cloud-${alias}`;
+}
+
 export async function writeAgentboxSshAlias(opts: SshAliasOptions): Promise<void> {
   const path = sshConfigPath();
   await fs.mkdir(join(homedir(), '.ssh'), { recursive: true, mode: 0o700 });
   const existing = await readConfig();
-  const stripped = stripBlock(existing, opts.alias);
+  const stripped = stripBlock(stripBlock(existing, opts.alias), legacyAliasFor(opts.alias));
   const separator = stripped.length === 0 || stripped.endsWith('\n') ? '' : '\n';
   const next = `${stripped}${separator}${buildBlock(opts)}`;
   await fs.writeFile(path, next, { mode: 0o600 });
   // Re-assert mode in case the file existed with broader perms.
   await fs.chmod(path, 0o600);
+}
+
+/**
+ * True when `~/.ssh/config` already has a user-authored `Host <alias>` stanza
+ * OUTSIDE our managed block. Because the alias is now the bare box name, such a
+ * collision matters: OpenSSH applies the first value it sees per keyword, so an
+ * earlier user entry can shadow the HostName/IdentityFile/User we append.
+ */
+export async function hasUnmanagedHostConflict(alias: string): Promise<boolean> {
+  const contents = await readConfig();
+  if (contents === '') return false;
+  // Drop our managed block first so we only see foreign `Host` lines.
+  const foreign = stripBlock(contents, alias);
+  return foreign.split('\n').some((line) => {
+    const m = /^\s*Host\s+(.+?)\s*$/.exec(line);
+    if (!m) return false;
+    return m[1]!.split(/\s+/).includes(alias);
+  });
 }
 
 export interface SshTarget {
@@ -180,7 +207,7 @@ export async function removeAgentboxSshAlias(alias: string): Promise<void> {
   const path = sshConfigPath();
   const existing = await readConfig();
   if (existing === '') return;
-  const next = stripBlock(existing, alias);
+  const next = stripBlock(stripBlock(existing, alias), legacyAliasFor(alias));
   if (next === existing) return; // no managed block matched
   await fs.writeFile(path, next, { mode: 0o600 });
 }

--- a/apps/cli/test/ssh-config.test.ts
+++ b/apps/cli/test/ssh-config.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   agentboxAliasFor,
+  hasUnmanagedHostConflict,
   parseSshTarget,
   readAgentboxSshAlias,
   removeAgentboxSshAlias,
@@ -139,5 +140,43 @@ describe('writeAgentboxSshAlias', () => {
       identityFile: '/box/key',
     });
     expect(await readAgentboxSshAlias('no-such-box')).toBeUndefined();
+  });
+
+  it('migrates away a legacy `agentbox-cloud-<box>` block on rewrite', async () => {
+    // Simulate a block written by an older release keyed on the legacy alias.
+    await writeAgentboxSshAlias({
+      alias: 'agentbox-cloud-hz-box',
+      hostname: '9.9.9.9',
+      user: 'vscode',
+      identityFile: '/box/old-key',
+    });
+    // Now write under the new box-name alias.
+    await writeAgentboxSshAlias({
+      alias: agentboxAliasFor('hz-box'),
+      hostname: '1.2.3.4',
+      user: 'vscode',
+      identityFile: '/box/key',
+    });
+    const cfg = await readCfg();
+    expect(cfg).not.toContain('agentbox-cloud-hz-box');
+    expect(cfg).not.toContain('9.9.9.9');
+    expect(cfg).toContain('Host hz-box');
+    expect(cfg).toContain('1.2.3.4');
+  });
+
+  it('hasUnmanagedHostConflict detects a user-authored Host but ignores our block', async () => {
+    // Our own managed block is not a conflict.
+    await writeAgentboxSshAlias({
+      alias: agentboxAliasFor('hz-box'),
+      hostname: '1.2.3.4',
+      user: 'vscode',
+      identityFile: '/box/key',
+    });
+    expect(await hasUnmanagedHostConflict('hz-box')).toBe(false);
+    expect(await hasUnmanagedHostConflict('mybox')).toBe(false);
+
+    // A user-authored stanza for the same alias IS a conflict.
+    await fs.appendFile(join(tmp, '.ssh', 'config'), '\nHost mybox other\n  HostName 5.6.7.8\n');
+    expect(await hasUnmanagedHostConflict('mybox')).toBe(true);
   });
 });

--- a/apps/cli/test/ssh-config.test.ts
+++ b/apps/cli/test/ssh-config.test.ts
@@ -6,9 +6,16 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   agentboxAliasFor,
   parseSshTarget,
+  readAgentboxSshAlias,
   removeAgentboxSshAlias,
   writeAgentboxSshAlias,
 } from '../src/ssh-config.js';
+
+describe('agentboxAliasFor', () => {
+  it('uses the box name as the SSH host alias', () => {
+    expect(agentboxAliasFor('hz-box')).toBe('hz-box');
+  });
+});
 
 describe('parseSshTarget', () => {
   it('extracts user, host, and identity file from a Hetzner-style argv', () => {
@@ -69,7 +76,7 @@ describe('writeAgentboxSshAlias', () => {
       identityFile: '/box/key',
     });
     const cfg = await readCfg();
-    expect(cfg).toContain('Host agentbox-cloud-hz-box');
+    expect(cfg).toContain('Host hz-box');
     expect(cfg).toContain('  IdentityFile /box/key');
     expect(cfg).toContain('  IdentitiesOnly yes');
   });
@@ -81,7 +88,7 @@ describe('writeAgentboxSshAlias', () => {
       user: 'tok_abc',
     });
     const cfg = await readCfg();
-    expect(cfg).toContain('Host agentbox-cloud-dt-box');
+    expect(cfg).toContain('Host dt-box');
     expect(cfg).not.toContain('IdentityFile');
     expect(cfg).not.toContain('IdentitiesOnly');
   });
@@ -96,7 +103,7 @@ describe('writeAgentboxSshAlias', () => {
     await writeAgentboxSshAlias(opts);
     await writeAgentboxSshAlias({ ...opts, identityFile: '/box/key-v2' });
     const cfg = await readCfg();
-    const beginCount = cfg.split('# BEGIN agentbox cloud box agentbox-cloud-hz-box').length - 1;
+    const beginCount = cfg.split('# BEGIN agentbox cloud box hz-box').length - 1;
     expect(beginCount).toBe(1);
     expect(cfg).toContain('/box/key-v2');
     expect(cfg).not.toContain('/box/key-v1');
@@ -114,9 +121,23 @@ describe('writeAgentboxSshAlias', () => {
       hostname: 'ssh.app.daytona.io',
       user: 'tok_abc',
     });
-    await removeAgentboxSshAlias('agentbox-cloud-hz-box');
+    await removeAgentboxSshAlias(agentboxAliasFor('hz-box'));
     const cfg = await readCfg();
-    expect(cfg).not.toContain('agentbox-cloud-hz-box');
-    expect(cfg).toContain('agentbox-cloud-dt-box');
+    expect(cfg).not.toContain('Host hz-box');
+    expect(cfg).toContain('Host dt-box');
+  });
+
+  it('readAgentboxSshAlias returns HostName + IdentityFile from a written block', async () => {
+    await writeAgentboxSshAlias({
+      alias: agentboxAliasFor('hz-box'),
+      hostname: '1.2.3.4',
+      user: 'vscode',
+      identityFile: '/box/key',
+    });
+    expect(await readAgentboxSshAlias(agentboxAliasFor('hz-box'))).toEqual({
+      hostName: '1.2.3.4',
+      identityFile: '/box/key',
+    });
+    expect(await readAgentboxSshAlias('no-such-box')).toBeUndefined();
   });
 });

--- a/plugins/agentbox/skills/agentbox-info/SKILL.md
+++ b/plugins/agentbox/skills/agentbox-info/SKILL.md
@@ -231,6 +231,35 @@ If a PR op appears to hang, tell the user to check the dashboard footer for the 
 
 Per-project numeric index (`1`, `2`, …) and friendly name (`review`, `smoke`) both work wherever `<box>` is accepted. Index `1` is the first box created in the current workspace.
 
+## Connecting an external app (Codex / Claude desktop) over SSH
+
+When the user wants to attach the **Codex app** or **Claude desktop** to a box over SSH, run:
+
+```
+agentbox shell <box> --ssh-config          # writes ~/.ssh/config + prints details
+agentbox shell <box> --ssh-config --json   # same, machine-readable
+```
+
+This writes a `Host <box-name>` alias into `~/.ssh/config` (pointing at the box's IP and its
+per-box identity file) and prints the alias, host, user, identity path, and a ready `ssh
+<box-name>` command. `--json` emits `{ alias, host, user, identityFile, sshCommand,
+codexAddUrl }`.
+
+**Hetzner cloud boxes only.** Only a box with a persistent per-box SSH key qualifies — an
+external app connects later, so Daytona's 60-minute token would already be expired, and
+Docker / Vercel / E2B boxes have no SSH. The command exits with a clear message (and writes
+nothing) for unsupported providers.
+
+After running it, surface both apps to the user. For **Codex**, render the deep link verbatim
+(`<ssh-alias>` is the box name):
+
+```
+[Add <ssh-alias> to Codex SSH](codex://settings/connections/ssh/add?name=<ssh-alias>)
+```
+
+For **Claude desktop**, there's no deep link — tell the user to add an SSH connection to host
+`<ssh-alias>` (it's already in `~/.ssh/config`).
+
 ## Operating principles
 
 1. **Never assume the host needs SSH keys forwarded into a box** — git is handled by the relay, by design.


### PR DESCRIPTION
## What

Adds an explicit way to connect external apps (the **Codex app**, **Claude desktop**) to a box over plain SSH.

`agentbox shell <box> --ssh-config` (+ `--json`) brings the box online, writes a `~/.ssh/config` alias, and prints the alias, host, user, identity-file path, a ready `ssh <box>` command, the Codex deep link `codex://settings/connections/ssh/add?name=<box>`, and Claude-desktop instructions.

## Details

- **Hetzner-only gate.** Only providers with a *persistent* per-box identity file qualify (an external app connects later). Docker/Daytona/Vercel/E2B exit cleanly **without** writing config.
- **Shared helper `cloud-ssh.ts`** — extracted the duplicated "bring online → `buildAttach` → `parseSshTarget` → write alias" flow into `resolveCloudSshTarget` / `ensureCloudSshAlias`; reused from `code` and `open`.
- **Alias is now the box name** (clean `ssh <box>` and Codex `name=` param). Added `readAgentboxSshAlias` and surfaced `ssh alias` / `ssh identity` rows in cloud `status --inspect`.
- Documented in the agentbox-info and fork skills.

## Verification

- typecheck ✅, lint ✅, 628 tests ✅ (updated `ssh-config.test.ts`), plugin-skill bundle in sync ✅
- **E2E on a real Hetzner box**: `--ssh-config` wrote the alias with the real IP + identity file; `ssh <box>` connected as `vscode`; `--json` and `status --inspect` correct; docker box hit the negative gate with no config write. Boxes torn down after.

https://claude.ai/code/session_011VoAz7mUaUGh6dKAvr7kAP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `~/.ssh/config` and changes SSH Host alias naming (breaking for anyone relying on `agentbox-cloud-*`); Hetzner gating limits blast radius for external-app handoff.
> 
> **Overview**
> Adds **`agentbox shell <box> --ssh-config`** (and **`--json`**) so Codex and Claude desktop can connect over SSH without opening an interactive shell. The command brings the box online, writes a managed **`Host <box-name>`** block in **`~/.ssh/config`**, and prints connection details plus a Codex deep link.
> 
> **Hetzner-only:** resolution happens before any write; boxes without a persistent per-box **`identityFile`** (Docker, Daytona token auth, etc.) exit with a clear error and leave **`~/.ssh/config`** unchanged.
> 
> **Refactor:** duplicated cloud SSH logic moves into **`cloud-ssh.ts`** (`resolveCloudSshTarget` / `ensureCloudSshAlias`), reused by **`agentbox code`** and **`agentbox open`**.
> 
> **SSH aliases** change from **`agentbox-cloud-<name>`** to the **box name** itself. **`readAgentboxSshAlias`** and new **`ssh alias` / `ssh identity`** rows on cloud **`inspect`** output. Host skills document the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ece42898522b1455ee9313e9bb29a0a3bc2a004. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->