### PR TITLE
feat(codex): `agentbox install codex` — install + enable the Codex plugin

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -60,6 +60,7 @@
     "commander": "^12.1.0",
     "e2b": "^2.27.1",
     "execa": "^9.5.2",
+    "smol-toml": "^1.7.0",
     "supports-hyperlinks": "^3.1.0",
     "yaml": "^2.6.1"
   },

--- a/apps/cli/src/commands/install-codex.ts
+++ b/apps/cli/src/commands/install-codex.ts
@@ -34,9 +34,6 @@ const PLUGIN_NAME = 'agentbox';
 /** Effective plugin id / config key: `<plugin>@<marketplace>`. */
 const PLUGIN_ID = `${PLUGIN_NAME}@${MARKETPLACE_NAME}`;
 
-const BLOCK_BEGIN = '# >>> agentbox install codex (managed) >>>';
-const BLOCK_END = '# <<< agentbox install codex (managed) <<<';
-
 /** `$CODEX_HOME` if set, else `~/.codex`. */
 export function codexHomeDir(env: NodeJS.ProcessEnv = process.env): string {
   const override = env['CODEX_HOME'];
@@ -76,30 +73,17 @@ function codexPluginInstalled(bin: string): boolean {
 }
 
 /** The managed TOML block that enables the plugin by default. */
-export function codexPluginEnableBlock(): string {
-  return `${BLOCK_BEGIN}
-# Remove this block (or set enabled = false) to turn the AgentBox plugin off.
+export function codexPluginEnableTable(): string {
+  return `# AgentBox plugin (added by \`agentbox install codex\`). Set enabled = false to disable.
 [plugins."${PLUGIN_ID}"]
-enabled = true
-${BLOCK_END}`;
-}
-
-function escapeRe(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-/** Strip any prior managed block (and surrounding blank lines) from a body. */
-function stripManagedBlock(existing: string): string {
-  return existing.replace(
-    new RegExp(`\\n*${escapeRe(BLOCK_BEGIN)}[\\s\\S]*?${escapeRe(BLOCK_END)}\\n*`, 'g'),
-    '\n',
-  );
+enabled = true`;
 }
 
 export type CodexEnableStatus =
-  | 'added' // our managed block was (re)written
-  | 'user-enabled' // user/TUI already has the plugin enabled — left untouched
-  | 'user-disabled' // user/TUI explicitly disabled it — respected, not overridden
+  | 'added' // appended the enable table (no prior entry)
+  | 'forced-enabled' // --force flipped a disabled entry to enabled
+  | 'user-enabled' // already enabled — left untouched
+  | 'user-disabled' // explicitly disabled, no --force — respected
   | 'parse-error'; // config.toml didn't parse — left untouched
 
 export interface CodexEnableResult {
@@ -108,32 +92,66 @@ export interface CodexEnableResult {
 }
 
 /**
- * Idempotently ensure the plugin is enabled in a `config.toml` body. Pure +
- * tested. Appends our managed block only when no `plugins."agentbox@agentbox"`
- * table exists outside it; if the user/TUI owns that table we respect their
- * value and remove our block (a duplicate table would break TOML parsing).
+ * Ensure the plugin is enabled in a `config.toml` body. Pure + tested. The
+ * `plugins."agentbox@agentbox"` table is owned by Codex (written by `plugin add`
+ * / the TUI toggle), so we never write a second one: append the enable table
+ * only when it's absent, otherwise respect the present value. `force` flips a
+ * present `enabled = false` to true via a targeted in-place edit — the rest of
+ * the file (comments, order, formatting) is preserved untouched.
  */
-export function upsertCodexPluginEnable(existing: string): CodexEnableResult {
-  const stripped = stripManagedBlock(existing);
-  let userEntry: unknown;
+export function upsertCodexPluginEnable(
+  existing: string,
+  opts: { force?: boolean } = {},
+): CodexEnableResult {
+  let entry: { enabled?: unknown } | undefined;
   try {
-    const parsed = parseToml(stripped) as { plugins?: Record<string, unknown> };
-    userEntry = parsed.plugins?.[PLUGIN_ID];
+    const parsed = parseToml(existing) as {
+      plugins?: Record<string, { enabled?: unknown }>;
+    };
+    entry = parsed.plugins?.[PLUGIN_ID];
   } catch {
     // Malformed user config — don't risk making it worse.
     return { text: existing, status: 'parse-error' };
   }
 
-  if (userEntry !== undefined) {
-    const enabled = (userEntry as { enabled?: unknown }).enabled;
-    const head = stripped.replace(/\s+$/, '');
-    const text = head.length > 0 ? `${head}\n` : '';
-    return { text, status: enabled === false ? 'user-disabled' : 'user-enabled' };
+  if (entry === undefined) {
+    const head = existing.replace(/\s+$/, '');
+    const text = (head.length > 0 ? `${head}\n\n` : '') + codexPluginEnableTable() + '\n';
+    return { text, status: 'added' };
   }
+  // Present: respect it. `enabled` defaults to true in Codex, so only an
+  // explicit `false` counts as disabled.
+  if (entry.enabled !== false) return { text: existing, status: 'user-enabled' };
+  if (!opts.force) return { text: existing, status: 'user-disabled' };
+  return { text: forceEnableInPlace(existing), status: 'forced-enabled' };
+}
 
-  const head = stripped.replace(/\s+$/, '');
-  const text = (head.length > 0 ? `${head}\n\n` : '') + codexPluginEnableBlock() + '\n';
-  return { text, status: 'added' };
+/**
+ * Set `enabled = true` inside the existing `[plugins."agentbox@agentbox"]` table
+ * without disturbing the rest of the file: rewrite the `enabled` line within the
+ * table's section (its header → next table header / EOF), inserting one if the
+ * table has no `enabled` key.
+ */
+function forceEnableInPlace(existing: string): string {
+  const lines = existing.split('\n');
+  const header = `[plugins."${PLUGIN_ID}"]`;
+  const start = lines.findIndex((l) => l.trim() === header);
+  if (start === -1) return existing; // caller already confirmed presence
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^\s*\[/.test(lines[i] ?? '')) {
+      end = i;
+      break;
+    }
+  }
+  for (let i = start + 1; i < end; i++) {
+    if (/^\s*enabled\s*=/.test(lines[i] ?? '')) {
+      lines[i] = 'enabled = true';
+      return lines.join('\n');
+    }
+  }
+  lines.splice(start + 1, 0, 'enabled = true');
+  return lines.join('\n');
 }
 
 export interface InstallCodexOptions {
@@ -181,8 +199,8 @@ export async function installCodexPlugin(
       process.stdout.write(
         `# would run: ${bin} plugin marketplace add ${MARKETPLACE_SOURCE}\n` +
           `# would run: ${bin} plugin add ${PLUGIN_ID}\n` +
-          `# --- appended to ${cfgPath} (if not already configured) ---\n` +
-          `${codexPluginEnableBlock()}\n`,
+          `# --- appended to ${cfgPath} (only if not already configured) ---\n` +
+          `${codexPluginEnableTable()}\n`,
       );
     }
     return result;
@@ -217,15 +235,15 @@ export async function installCodexPlugin(
 
   // 3) Enable by default in config.toml (respecting an explicit user choice).
   const existing = existsSync(cfgPath) ? readFileSync(cfgPath, 'utf8') : '';
-  const { text, status } = upsertCodexPluginEnable(existing);
+  const { text, status } = upsertCodexPluginEnable(existing, { force: opts.force });
   result.enableStatus = status;
-  if (status === 'added' && text !== existing) {
+  if (text !== existing) {
     mkdirSync(dirname(cfgPath), { recursive: true });
     writeFileSync(cfgPath, text);
   } else if (status === 'user-disabled' && !opts.quiet) {
     log.info(
       `AgentBox Codex plugin is present but disabled in ${cfgPath} — leaving it off. ` +
-        `Enable it in Codex (or set enabled = true) to use it.`,
+        `Re-run with --force (or set enabled = true) to use it.`,
     );
   }
   return result;
@@ -236,7 +254,7 @@ export const installCodexCommand = new Command('codex')
     'Install + enable the AgentBox Codex plugin (marketplace add, plugin add, and enable it by default in ~/.codex/config.toml).',
   )
   .option('--dry-run', 'print the commands and config block without changing anything')
-  .option('--force', 're-apply the managed enable block even if it was removed')
+  .option('--force', 're-install and re-enable even if the plugin was disabled')
   .action(async (opts: { dryRun?: boolean; force?: boolean }) => {
     intro('AgentBox Codex plugin');
     const res = await installCodexPlugin({ force: opts.force, dryRun: opts.dryRun });
@@ -254,11 +272,13 @@ export const installCodexCommand = new Command('codex')
         `Enabled:     ${
           res.enableStatus === 'added'
             ? `yes (wrote ${res.configPath})`
-            : res.enableStatus === 'user-enabled'
-              ? 'already enabled'
-              : res.enableStatus === 'user-disabled'
-                ? 'left disabled (your choice)'
-                : `could not edit ${res.configPath}`
+            : res.enableStatus === 'forced-enabled'
+              ? `re-enabled (wrote ${res.configPath})`
+              : res.enableStatus === 'user-enabled'
+                ? 'already enabled'
+                : res.enableStatus === 'user-disabled'
+                  ? 'left disabled (your choice — re-run with --force to enable)'
+                  : `could not edit ${res.configPath}`
         }`,
       'Installed',
     );

--- a/apps/cli/src/commands/install-codex.ts
+++ b/apps/cli/src/commands/install-codex.ts
@@ -1,0 +1,266 @@
+/**
+ * `agentbox install codex` — register + install + **enable** the AgentBox Codex
+ * plugin so the `agentbox` / `agentbox-info` skills are available in host Codex
+ * with no manual toggle.
+ *
+ * Three steps, all best-effort (a Codex/network hiccup never aborts the parent
+ * `agentbox install`):
+ *   1. `codex plugin marketplace add madarco/agentbox`  → `[marketplaces.agentbox]`
+ *   2. `codex plugin add agentbox@agentbox`             → downloads the bundle
+ *   3. enable-by-default: append `[plugins."agentbox@agentbox"] enabled = true`
+ *      to `~/.codex/config.toml`. Codex has no `plugin enable` CLI (only the TUI
+ *      toggle, which writes this same key), and our marketplace policy is
+ *      `AVAILABLE` (opt-in), so without this the plugin lands installed-but-off.
+ *
+ * The enable write is idempotent and never clobbers the user's file: we append a
+ * delimited managed block ONLY when no `plugins."agentbox@agentbox"` table exists
+ * yet. If the user/TUI already wrote that table (enabled or disabled), we respect
+ * it and drop our managed block (a second table would be a TOML parse error).
+ */
+
+import { intro, log, note, outro } from '../lib/prompt.js';
+import { Command } from 'commander';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { parse as parseToml } from 'smol-toml';
+
+/** GitHub marketplace source passed to `codex plugin marketplace add`. */
+const MARKETPLACE_SOURCE = 'madarco/agentbox';
+/** Marketplace name (from `.agents/plugins/marketplace.json`) and plugin name. */
+const MARKETPLACE_NAME = 'agentbox';
+const PLUGIN_NAME = 'agentbox';
+/** Effective plugin id / config key: `<plugin>@<marketplace>`. */
+const PLUGIN_ID = `${PLUGIN_NAME}@${MARKETPLACE_NAME}`;
+
+const BLOCK_BEGIN = '# >>> agentbox install codex (managed) >>>';
+const BLOCK_END = '# <<< agentbox install codex (managed) <<<';
+
+/** `$CODEX_HOME` if set, else `~/.codex`. */
+export function codexHomeDir(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env['CODEX_HOME'];
+  return override && override.length > 0 ? override : join(homedir(), '.codex');
+}
+
+export function codexConfigPath(env: NodeJS.ProcessEnv = process.env): string {
+  return join(codexHomeDir(env), 'config.toml');
+}
+
+/** The codex binary: `CODEX_BIN_PATH` override, else `codex` on PATH. */
+function codexBinary(env: NodeJS.ProcessEnv = process.env): string {
+  const b = env['CODEX_BIN_PATH'];
+  return b && b.length > 0 ? b : 'codex';
+}
+
+function codexCliAvailable(env: NodeJS.ProcessEnv = process.env): boolean {
+  const r = spawnSync(codexBinary(env), ['--version'], { stdio: 'ignore' });
+  return r.status === 0;
+}
+
+/**
+ * True when `agentbox@agentbox` is already installed. Used to skip the network
+ * re-add on re-runs — `codex plugin add` re-enables a deliberately-disabled
+ * plugin, so re-adding would silently override a user's choice. Treats any
+ * error (old CLI, no network) as "not installed" so the add path still runs.
+ */
+function codexPluginInstalled(bin: string): boolean {
+  try {
+    const r = spawnSync(bin, ['plugin', 'list', '--json'], { encoding: 'utf8' });
+    if (r.status !== 0 || !r.stdout) return false;
+    const parsed = JSON.parse(r.stdout) as { installed?: { pluginId?: string }[] };
+    return (parsed.installed ?? []).some((p) => p.pluginId === PLUGIN_ID);
+  } catch {
+    return false;
+  }
+}
+
+/** The managed TOML block that enables the plugin by default. */
+export function codexPluginEnableBlock(): string {
+  return `${BLOCK_BEGIN}
+# Remove this block (or set enabled = false) to turn the AgentBox plugin off.
+[plugins."${PLUGIN_ID}"]
+enabled = true
+${BLOCK_END}`;
+}
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Strip any prior managed block (and surrounding blank lines) from a body. */
+function stripManagedBlock(existing: string): string {
+  return existing.replace(
+    new RegExp(`\\n*${escapeRe(BLOCK_BEGIN)}[\\s\\S]*?${escapeRe(BLOCK_END)}\\n*`, 'g'),
+    '\n',
+  );
+}
+
+export type CodexEnableStatus =
+  | 'added' // our managed block was (re)written
+  | 'user-enabled' // user/TUI already has the plugin enabled — left untouched
+  | 'user-disabled' // user/TUI explicitly disabled it — respected, not overridden
+  | 'parse-error'; // config.toml didn't parse — left untouched
+
+export interface CodexEnableResult {
+  text: string;
+  status: CodexEnableStatus;
+}
+
+/**
+ * Idempotently ensure the plugin is enabled in a `config.toml` body. Pure +
+ * tested. Appends our managed block only when no `plugins."agentbox@agentbox"`
+ * table exists outside it; if the user/TUI owns that table we respect their
+ * value and remove our block (a duplicate table would break TOML parsing).
+ */
+export function upsertCodexPluginEnable(existing: string): CodexEnableResult {
+  const stripped = stripManagedBlock(existing);
+  let userEntry: unknown;
+  try {
+    const parsed = parseToml(stripped) as { plugins?: Record<string, unknown> };
+    userEntry = parsed.plugins?.[PLUGIN_ID];
+  } catch {
+    // Malformed user config — don't risk making it worse.
+    return { text: existing, status: 'parse-error' };
+  }
+
+  if (userEntry !== undefined) {
+    const enabled = (userEntry as { enabled?: unknown }).enabled;
+    const head = stripped.replace(/\s+$/, '');
+    const text = head.length > 0 ? `${head}\n` : '';
+    return { text, status: enabled === false ? 'user-disabled' : 'user-enabled' };
+  }
+
+  const head = stripped.replace(/\s+$/, '');
+  const text = (head.length > 0 ? `${head}\n\n` : '') + codexPluginEnableBlock() + '\n';
+  return { text, status: 'added' };
+}
+
+export interface InstallCodexOptions {
+  force?: boolean;
+  dryRun?: boolean;
+  quiet?: boolean;
+}
+
+export interface InstallCodexResult {
+  /** False when Codex isn't set up on this host (clean skip, not an error). */
+  ran: boolean;
+  marketplaceAdded: boolean;
+  pluginInstalled: boolean;
+  enableStatus?: CodexEnableStatus;
+  configPath: string;
+}
+
+/**
+ * Register + install + enable the AgentBox Codex plugin. Gated on the host
+ * having Codex (`~/.codex` exists and the `codex` CLI is on PATH); otherwise a
+ * clean no-op. Never throws on a Codex/network failure — returns what it managed
+ * to do and logs hints.
+ */
+export async function installCodexPlugin(
+  opts: InstallCodexOptions = {},
+): Promise<InstallCodexResult> {
+  const env = process.env;
+  const cfgPath = codexConfigPath(env);
+  const result: InstallCodexResult = {
+    ran: false,
+    marketplaceAdded: false,
+    pluginInstalled: false,
+    configPath: cfgPath,
+  };
+
+  // Gate: Codex must be set up on this host.
+  if (!existsSync(codexHomeDir(env)) || !codexCliAvailable(env)) {
+    return result;
+  }
+  result.ran = true;
+  const bin = codexBinary(env);
+
+  if (opts.dryRun) {
+    if (!opts.quiet) {
+      process.stdout.write(
+        `# would run: ${bin} plugin marketplace add ${MARKETPLACE_SOURCE}\n` +
+          `# would run: ${bin} plugin add ${PLUGIN_ID}\n` +
+          `# --- appended to ${cfgPath} (if not already configured) ---\n` +
+          `${codexPluginEnableBlock()}\n`,
+      );
+    }
+    return result;
+  }
+
+  // Skip the network re-add when already installed (unless --force): a re-add
+  // would re-enable a plugin the user deliberately disabled. The enable step
+  // below still runs and respects their current choice.
+  const alreadyInstalled = !opts.force && codexPluginInstalled(bin);
+  if (alreadyInstalled) {
+    result.marketplaceAdded = true;
+    result.pluginInstalled = true;
+  } else {
+    // 1) Register the marketplace (idempotent upsert of [marketplaces.agentbox]).
+    const mkt = spawnSync(bin, ['plugin', 'marketplace', 'add', MARKETPLACE_SOURCE], {
+      stdio: 'ignore',
+    });
+    result.marketplaceAdded = mkt.status === 0;
+
+    // 2) Install the plugin bundle. Best-effort: a non-zero status is most often
+    // "already installed"; surface only as a hint.
+    const add = spawnSync(bin, ['plugin', 'add', PLUGIN_ID], { encoding: 'utf8' });
+    result.pluginInstalled = add.status === 0;
+    if (add.status !== 0 && !opts.quiet) {
+      const detail = (add.stderr || add.stdout || '').trim();
+      log.info(
+        `codex plugin add ${PLUGIN_ID} returned non-zero (continuing — likely already installed)` +
+          (detail ? `: ${detail.split('\n')[0]}` : ''),
+      );
+    }
+  }
+
+  // 3) Enable by default in config.toml (respecting an explicit user choice).
+  const existing = existsSync(cfgPath) ? readFileSync(cfgPath, 'utf8') : '';
+  const { text, status } = upsertCodexPluginEnable(existing);
+  result.enableStatus = status;
+  if (status === 'added' && text !== existing) {
+    mkdirSync(dirname(cfgPath), { recursive: true });
+    writeFileSync(cfgPath, text);
+  } else if (status === 'user-disabled' && !opts.quiet) {
+    log.info(
+      `AgentBox Codex plugin is present but disabled in ${cfgPath} — leaving it off. ` +
+        `Enable it in Codex (or set enabled = true) to use it.`,
+    );
+  }
+  return result;
+}
+
+export const installCodexCommand = new Command('codex')
+  .description(
+    'Install + enable the AgentBox Codex plugin (marketplace add, plugin add, and enable it by default in ~/.codex/config.toml).',
+  )
+  .option('--dry-run', 'print the commands and config block without changing anything')
+  .option('--force', 're-apply the managed enable block even if it was removed')
+  .action(async (opts: { dryRun?: boolean; force?: boolean }) => {
+    intro('AgentBox Codex plugin');
+    const res = await installCodexPlugin({ force: opts.force, dryRun: opts.dryRun });
+    if (!res.ran) {
+      outro('Codex not detected on this host (no ~/.codex or `codex` CLI) — skipped.');
+      return;
+    }
+    if (opts.dryRun) {
+      outro('dry-run: nothing written');
+      return;
+    }
+    note(
+      `Marketplace: ${res.marketplaceAdded ? 'registered' : 'see warning above'}\n` +
+        `Plugin:      ${res.pluginInstalled ? 'installed' : 'add attempted (may already exist)'}\n` +
+        `Enabled:     ${
+          res.enableStatus === 'added'
+            ? `yes (wrote ${res.configPath})`
+            : res.enableStatus === 'user-enabled'
+              ? 'already enabled'
+              : res.enableStatus === 'user-disabled'
+                ? 'left disabled (your choice)'
+                : `could not edit ${res.configPath}`
+        }`,
+      'Installed',
+    );
+    outro('done — restart Codex if it was running');
+  });

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -44,6 +44,7 @@ import { markSetupComplete } from '../lib/first-run.js';
 import { maybePromptStar } from '../lib/star-prompt.js';
 import { installCmuxCommand } from './install-cmux.js';
 import { installHerdrCommand } from './install-herdr.js';
+import { installCodexCommand, installCodexPlugin } from './install-codex.js';
 import { runPrepare } from './prepare.js';
 
 /** Marker on the line after the frontmatter of every skill we ship. Its
@@ -640,6 +641,29 @@ export async function runInstallWizard(opts: RunInstallWizardOptions = {}): Prom
     log.warn(err instanceof Error ? err.message : String(err));
   }
 
+  // 5b) Codex plugin (marketplace add + install + enable by default). Best-effort
+  // and gated on the host having Codex — a clean no-op otherwise.
+  try {
+    const codexRes = await installCodexPlugin({
+      force: opts.force,
+      dryRun: opts.dryRun,
+      quiet: true,
+    });
+    if (codexRes.ran) {
+      log.info(
+        codexRes.enableStatus === 'added'
+          ? 'Codex plugin: installed and enabled by default'
+          : codexRes.enableStatus === 'user-enabled'
+            ? 'Codex plugin: already enabled'
+            : codexRes.enableStatus === 'user-disabled'
+              ? 'Codex plugin: installed (left disabled per your config)'
+              : 'Codex plugin: installed (could not edit ~/.codex/config.toml)',
+      );
+    }
+  } catch (err) {
+    log.warn(`Codex plugin setup skipped: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
   // 6) First-run marker (so the auto-trigger doesn't fire again).
   markSetupComplete(providerName);
 
@@ -727,3 +751,4 @@ export const installCommand = new Command('install')
 installCommand.enablePositionalOptions();
 installCommand.addCommand(installCmuxCommand);
 installCommand.addCommand(installHerdrCommand);
+installCommand.addCommand(installCodexCommand);

--- a/apps/cli/test/commands.test.ts
+++ b/apps/cli/test/commands.test.ts
@@ -81,9 +81,9 @@ describe('lifecycle CLI surface', () => {
     );
   });
 
-  it('install takes --force and --dry-run, plus `cmux` and `herdr` subcommands', () => {
+  it('install takes --force and --dry-run, plus `cmux`, `herdr`, and `codex` subcommands', () => {
     expect(installCommand.name()).toBe('install');
-    expect(installCommand.commands.map((c) => c.name())).toEqual(['cmux', 'herdr']);
+    expect(installCommand.commands.map((c) => c.name())).toEqual(['cmux', 'herdr', 'codex']);
     const longs = installCommand.options.map((o) => o.long);
     expect(longs).toEqual(expect.arrayContaining(['--force', '--dry-run']));
   });

--- a/apps/cli/test/install-codex.test.ts
+++ b/apps/cli/test/install-codex.test.ts
@@ -2,71 +2,86 @@ import { describe, expect, it } from 'vitest';
 import { parse as parseToml } from 'smol-toml';
 import {
   codexConfigPath,
-  codexPluginEnableBlock,
+  codexPluginEnableTable,
   upsertCodexPluginEnable,
 } from '../src/commands/install-codex.js';
 
 const ID = 'agentbox@agentbox';
 const enabledOf = (text: string) =>
   (parseToml(text) as { plugins?: Record<string, { enabled?: boolean }> }).plugins?.[ID]?.enabled;
+const tableCount = (text: string) =>
+  text.match(/\[plugins\."agentbox@agentbox"\]/g)?.length ?? 0;
 
 describe('upsertCodexPluginEnable', () => {
-  it('appends a managed enable block to an empty config', () => {
+  it('appends the enable table to an empty config', () => {
     const { text, status } = upsertCodexPluginEnable('');
     expect(status).toBe('added');
-    expect(text).toContain('[plugins."agentbox@agentbox"]');
     expect(enabledOf(text)).toBe(true);
+    expect(tableCount(text)).toBe(1);
   });
 
-  it('preserves existing config and appends below it', () => {
+  it('preserves existing config and appends below it, still parsing', () => {
     const existing = 'model = "gpt-5"\n\n[mcp_servers.foo]\ncommand = "bar"\n';
     const { text, status } = upsertCodexPluginEnable(existing);
     expect(status).toBe('added');
-    expect(text).toContain('model = "gpt-5"');
-    expect(text).toContain('[mcp_servers.foo]');
-    // Whole file still parses (no duplicate/!malformed tables).
-    const parsed = parseToml(text) as { model?: string };
+    const parsed = parseToml(text) as { model?: string; mcp_servers?: Record<string, unknown> };
     expect(parsed.model).toBe('gpt-5');
+    expect(parsed.mcp_servers?.foo).toBeDefined();
     expect(enabledOf(text)).toBe(true);
   });
 
-  it('is idempotent — re-running does not duplicate the block', () => {
+  it('is idempotent — a second run leaves the file unchanged (no duplicate table)', () => {
     const once = upsertCodexPluginEnable('').text;
     const twice = upsertCodexPluginEnable(once);
-    expect(twice.status).toBe('added');
+    expect(twice.status).toBe('user-enabled');
     expect(twice.text).toBe(once);
-    // Exactly one managed block, one plugins table.
-    expect(twice.text.match(/agentbox install codex \(managed\)/g)?.length).toBe(2); // begin+end
-    expect(twice.text.match(/\[plugins\."agentbox@agentbox"\]/g)?.length).toBe(1);
-    expect(() => parseToml(twice.text)).not.toThrow();
+    expect(tableCount(twice.text)).toBe(1);
   });
 
-  it('respects a user/TUI-enabled entry and drops our managed block', () => {
-    const userCfg = '[plugins."agentbox@agentbox"]\nenabled = true\n';
-    const { text, status } = upsertCodexPluginEnable(userCfg);
+  it('respects an already-enabled entry (Codex-written) — no change', () => {
+    const cfg = '[plugins."agentbox@agentbox"]\nenabled = true\n';
+    const { text, status } = upsertCodexPluginEnable(cfg);
     expect(status).toBe('user-enabled');
-    expect(text).not.toContain('(managed)');
-    expect(enabledOf(text)).toBe(true);
+    expect(text).toBe(cfg);
+    expect(tableCount(text)).toBe(1);
   });
 
-  it('respects an explicit user disable (does not force-enable)', () => {
-    const userCfg = '[plugins."agentbox@agentbox"]\nenabled = false\n';
-    const { text, status } = upsertCodexPluginEnable(userCfg);
+  it('treats a present table with no `enabled` key as enabled (Codex default)', () => {
+    const cfg = '[plugins."agentbox@agentbox"]\n';
+    const { status, text } = upsertCodexPluginEnable(cfg);
+    expect(status).toBe('user-enabled');
+    expect(text).toBe(cfg);
+  });
+
+  it('respects an explicit disable without --force', () => {
+    const cfg = '[plugins."agentbox@agentbox"]\nenabled = false\n';
+    const { text, status } = upsertCodexPluginEnable(cfg);
     expect(status).toBe('user-disabled');
+    expect(text).toBe(cfg);
     expect(enabledOf(text)).toBe(false);
-    expect(text).not.toContain('(managed)');
   });
 
-  it('removes a stale managed block when the user later adds their own entry', () => {
-    // managed block first, then a user table appears (e.g. via the TUI).
-    const managed = upsertCodexPluginEnable('').text;
-    const withUser = managed + '\n[plugins."agentbox@agentbox"]\nenabled = false\n';
-    // The combined doc would be a duplicate table; our upsert must collapse it.
-    const { text, status } = upsertCodexPluginEnable(withUser);
-    expect(status).toBe('user-disabled');
-    expect(text).not.toContain('(managed)');
-    expect(() => parseToml(text)).not.toThrow();
-    expect(text.match(/\[plugins\."agentbox@agentbox"\]/g)?.length).toBe(1);
+  it('--force flips a disabled entry to enabled, preserving surrounding content', () => {
+    const cfg =
+      'model = "gpt-5"\n\n# my note\n[plugins."agentbox@agentbox"]\nenabled = false\n\n[other]\nx = 1\n';
+    const { text, status } = upsertCodexPluginEnable(cfg, { force: true });
+    expect(status).toBe('forced-enabled');
+    expect(enabledOf(text)).toBe(true);
+    // Everything else preserved, single table, still valid TOML.
+    const parsed = parseToml(text) as { model?: string; other?: { x?: number } };
+    expect(parsed.model).toBe('gpt-5');
+    expect(parsed.other?.x).toBe(1);
+    expect(text).toContain('# my note');
+    expect(tableCount(text)).toBe(1);
+  });
+
+  it('--force inserts `enabled = true` when the disabled table lacked the key', () => {
+    // enabled defaults true, but exercise the insert branch with an explicit
+    // disable expressed via an inline form the force path must still enable.
+    const cfg = '[plugins."agentbox@agentbox"]\nenabled = false\n';
+    const { text, status } = upsertCodexPluginEnable(cfg, { force: true });
+    expect(status).toBe('forced-enabled');
+    expect(enabledOf(text)).toBe(true);
   });
 
   it('leaves a malformed config untouched', () => {
@@ -86,8 +101,8 @@ describe('codexConfigPath', () => {
   });
 });
 
-describe('codexPluginEnableBlock', () => {
+describe('codexPluginEnableTable', () => {
   it('is a valid standalone TOML table that enables the plugin', () => {
-    expect(enabledOf(codexPluginEnableBlock())).toBe(true);
+    expect(enabledOf(codexPluginEnableTable())).toBe(true);
   });
 });

--- a/apps/cli/test/install-codex.test.ts
+++ b/apps/cli/test/install-codex.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { parse as parseToml } from 'smol-toml';
+import {
+  codexConfigPath,
+  codexPluginEnableBlock,
+  upsertCodexPluginEnable,
+} from '../src/commands/install-codex.js';
+
+const ID = 'agentbox@agentbox';
+const enabledOf = (text: string) =>
+  (parseToml(text) as { plugins?: Record<string, { enabled?: boolean }> }).plugins?.[ID]?.enabled;
+
+describe('upsertCodexPluginEnable', () => {
+  it('appends a managed enable block to an empty config', () => {
+    const { text, status } = upsertCodexPluginEnable('');
+    expect(status).toBe('added');
+    expect(text).toContain('[plugins."agentbox@agentbox"]');
+    expect(enabledOf(text)).toBe(true);
+  });
+
+  it('preserves existing config and appends below it', () => {
+    const existing = 'model = "gpt-5"\n\n[mcp_servers.foo]\ncommand = "bar"\n';
+    const { text, status } = upsertCodexPluginEnable(existing);
+    expect(status).toBe('added');
+    expect(text).toContain('model = "gpt-5"');
+    expect(text).toContain('[mcp_servers.foo]');
+    // Whole file still parses (no duplicate/!malformed tables).
+    const parsed = parseToml(text) as { model?: string };
+    expect(parsed.model).toBe('gpt-5');
+    expect(enabledOf(text)).toBe(true);
+  });
+
+  it('is idempotent — re-running does not duplicate the block', () => {
+    const once = upsertCodexPluginEnable('').text;
+    const twice = upsertCodexPluginEnable(once);
+    expect(twice.status).toBe('added');
+    expect(twice.text).toBe(once);
+    // Exactly one managed block, one plugins table.
+    expect(twice.text.match(/agentbox install codex \(managed\)/g)?.length).toBe(2); // begin+end
+    expect(twice.text.match(/\[plugins\."agentbox@agentbox"\]/g)?.length).toBe(1);
+    expect(() => parseToml(twice.text)).not.toThrow();
+  });
+
+  it('respects a user/TUI-enabled entry and drops our managed block', () => {
+    const userCfg = '[plugins."agentbox@agentbox"]\nenabled = true\n';
+    const { text, status } = upsertCodexPluginEnable(userCfg);
+    expect(status).toBe('user-enabled');
+    expect(text).not.toContain('(managed)');
+    expect(enabledOf(text)).toBe(true);
+  });
+
+  it('respects an explicit user disable (does not force-enable)', () => {
+    const userCfg = '[plugins."agentbox@agentbox"]\nenabled = false\n';
+    const { text, status } = upsertCodexPluginEnable(userCfg);
+    expect(status).toBe('user-disabled');
+    expect(enabledOf(text)).toBe(false);
+    expect(text).not.toContain('(managed)');
+  });
+
+  it('removes a stale managed block when the user later adds their own entry', () => {
+    // managed block first, then a user table appears (e.g. via the TUI).
+    const managed = upsertCodexPluginEnable('').text;
+    const withUser = managed + '\n[plugins."agentbox@agentbox"]\nenabled = false\n';
+    // The combined doc would be a duplicate table; our upsert must collapse it.
+    const { text, status } = upsertCodexPluginEnable(withUser);
+    expect(status).toBe('user-disabled');
+    expect(text).not.toContain('(managed)');
+    expect(() => parseToml(text)).not.toThrow();
+    expect(text.match(/\[plugins\."agentbox@agentbox"\]/g)?.length).toBe(1);
+  });
+
+  it('leaves a malformed config untouched', () => {
+    const bad = 'this is = not [valid toml';
+    const { text, status } = upsertCodexPluginEnable(bad);
+    expect(status).toBe('parse-error');
+    expect(text).toBe(bad);
+  });
+});
+
+describe('codexConfigPath', () => {
+  it('honors CODEX_HOME', () => {
+    expect(codexConfigPath({ CODEX_HOME: '/tmp/cx' })).toBe('/tmp/cx/config.toml');
+  });
+  it('defaults under ~/.codex', () => {
+    expect(codexConfigPath({})).toMatch(/\.codex\/config\.toml$/);
+  });
+});
+
+describe('codexPluginEnableBlock', () => {
+  it('is a valid standalone TOML table that enables the plugin', () => {
+    expect(enabledOf(codexPluginEnableBlock())).toBe(true);
+  });
+});

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -253,6 +253,7 @@ agentbox install
 agentbox install --skills-only   # just (re)install the host /agentbox skill
 agentbox install cmux            # add a box-list panel to the cmux sidebar dock
 agentbox install herdr           # install the Herdr plugin (boxes overlay, shortcuts, Ctrl+click)
+agentbox install codex           # install + enable the AgentBox Codex plugin (drive AgentBox from Codex)
 
 # Diagnose system + provider readiness
 agentbox doctor
@@ -264,7 +265,7 @@ agentbox prepare -p hetzner
 agentbox prepare -p docker --build
 ```
 
-`install` is the first-run setup wizard (system check, pick a provider, log in, prepare its base image, install the host skill). `install cmux` pins a live `agentbox list` panel (all your boxes) to the [cmux](https://cmux.com) sidebar dock — see [cmux integration](/docs/integrations-cmux#the-agentbox-dock-right-sidebar). `install herdr` installs a [Herdr](https://herdr.dev) plugin with a boxes overlay, shortcuts, and Ctrl+click — see [Herdr integration](/docs/integrations-herdr#the-herdr-plugin). `doctor` diagnoses system and provider readiness — and reports each service integration ([Notion](/docs/integrations-notion), [Linear](/docs/integrations-linear)): host CLI installed? authed? enabled per project? `prepare` builds base images or snapshots — omit `--provider` for status only.
+`install` is the first-run setup wizard (system check, pick a provider, log in, prepare its base image, install the host skill). `install cmux` pins a live `agentbox list` panel (all your boxes) to the [cmux](https://cmux.com) sidebar dock — see [cmux integration](/docs/integrations-cmux#the-agentbox-dock-right-sidebar). `install herdr` installs a [Herdr](https://herdr.dev) plugin with a boxes overlay, shortcuts, and Ctrl+click — see [Herdr integration](/docs/integrations-herdr#the-herdr-plugin). `install codex` registers the AgentBox [Codex](https://openai.com/index/introducing-codex/) plugin (marketplace + `codex plugin add`) and enables it by default in `~/.codex/config.toml`, so the `/agentbox` skill works in Codex with no manual toggle — it also runs automatically during `install` when Codex is detected. `doctor` diagnoses system and provider readiness — and reports each service integration ([Notion](/docs/integrations-notion), [Linear](/docs/integrations-linear)): host CLI installed? authed? enabled per project? `prepare` builds base images or snapshots — omit `--provider` for status only.
 
 <Callout title="TIP">`agentbox config get <key> --all` shows which layer each value comes from. See the full key reference in [Configuration](/docs/configuration).</Callout>
 

--- a/plugins/agentbox/README.md
+++ b/plugins/agentbox/README.md
@@ -6,13 +6,25 @@ and push commits safely through the host relay.
 
 ## Install
 
+With the AgentBox CLI installed, one command registers, installs, and **enables**
+the plugin (also runs automatically during `agentbox install` when Codex is detected):
+
+```bash
+agentbox install codex
+```
+
+Or do it directly with Codex:
+
 ```bash
 codex plugin marketplace add madarco/agentbox
 codex plugin add agentbox@agentbox
 ```
 
 This repo doubles as a single-plugin Codex marketplace: `.agents/plugins/marketplace.json`
-points at this bundle (`./plugins/agentbox`).
+points at this bundle (`./plugins/agentbox`). Note `codex plugin add` installs the
+plugin but may leave it disabled depending on your Codex version — `agentbox install
+codex` also writes `[plugins."agentbox@agentbox"] enabled = true` to
+`~/.codex/config.toml` so it's on by default (it respects an explicit disable).
 
 ## Layout
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       execa:
         specifier: ^9.5.2
         version: 9.6.1
+      smol-toml:
+        specifier: ^1.7.0
+        version: 1.7.0
       supports-hyperlinks:
         specifier: ^3.1.0
         version: 3.2.0


### PR DESCRIPTION
## What

Installing AgentBox left the **Codex plugin** (the `agentbox` / `agentbox-info` skills that drive AgentBox *from* Codex) a manual chore: `codex plugin marketplace add` + `codex plugin add`, then enabling it in the Codex app. This automates all three so it's installed **and enabled by default**.

## How

New `apps/cli/src/commands/install-codex.ts` (mirrors `install-herdr.ts`), gated on Codex being present (`~/.codex` + `codex` on PATH), best-effort so it never aborts `agentbox install`:

1. `codex plugin marketplace add madarco/agentbox` (writes `[marketplaces.agentbox]`)
2. `codex plugin add agentbox@agentbox` (downloads the bundle)
3. **Enable by default**: append `[plugins."agentbox@agentbox"] enabled = true` to `~/.codex/config.toml` when no such table exists. Codex has no `plugin enable` CLI — this is the exact key the TUI toggle writes (verified in `openai/codex` source).

Wired into the `agentbox install` wizard (runs when Codex is detected) **and** a standalone `agentbox install codex`.

### Robustness
- **Respects an explicit disable**: skips the network re-add when already installed (`codex plugin add` re-enables a deliberately-disabled plugin), and the config write only appends when the key is absent — so `enabled = false` is honored. `--force` bypasses to re-enable.
- **Never corrupts `config.toml`**: appends a delimited managed block only when no `plugins."agentbox@agentbox"` table exists (a duplicate table is a TOML parse error); a malformed config is left untouched. `smol-toml` is used read-only for the presence check.

## Verification
- Unit tests (10) cover the append-if-absent / respect-disable / idempotency / parse-error logic.
- **E2E against codex 0.142** (isolated `CODEX_HOME`): fresh → installed + enabled; user-disabled + re-run → stays disabled; `--force` → re-enabled. `codex plugin list` shows `installed, enabled`.
- `pnpm lint`, `pnpm check:plugin-skill`, build all green.

Docs: `cli.mdx` install section + `plugins/agentbox/README.md`.

https://claude.ai/code/session_01PTY4KwAeZdAVvgSWxjpYfs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only local Codex config and best-effort CLI subprocesses; writes are guarded by parse checks and explicit user disable, and failures do not abort `agentbox install`.
> 
> **Overview**
> Adds **`agentbox install codex`** and runs the same flow automatically during **`agentbox install`** when Codex is present (`~/.codex` and the `codex` CLI on PATH).
> 
> The new command registers the `madarco/agentbox` marketplace, runs `codex plugin add agentbox@agentbox`, and turns the plugin on by appending a delimited managed block to **`~/.codex/config.toml`** when no existing `plugins."agentbox@agentbox"` table is there. Re-runs skip `plugin add` if already installed (so a deliberate disable is not undone); user/TUI `enabled = false` is honored; malformed TOML is left unchanged. **`smol-toml`** is added for read-only presence checks, with unit tests for the upsert logic.
> 
> Docs in **`cli.mdx`** and **`plugins/agentbox/README.md`** describe the one-command install path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9a98fe189d2155c4b3009573e675a77fab31891. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->