### PR TITLE
feat(codex): dev-mode local marketplace + live skill symlink

### DIFF
--- a/apps/cli/src/commands/install-codex.ts
+++ b/apps/cli/src/commands/install-codex.ts
@@ -100,9 +100,13 @@ function symlinkStagedSkills(
     }
     if (!versionDir || !existsSync(versionDir)) {
       const children = existsSync(pluginRoot) ? readdirSync(pluginRoot) : [];
-      if (children.length === 1) versionDir = join(pluginRoot, children[0]!);
+      versionDir = children.length === 1 ? join(pluginRoot, children[0]!) : undefined;
     }
-    if (!versionDir) return { linked: 0, error: 'staged plugin dir not found' };
+    // Bail unless we resolved a real staged dir — never mkdir/symlink into a
+    // non-existent manifest-version path (that would orphan a tree Codex ignores).
+    if (!versionDir || !existsSync(versionDir)) {
+      return { linked: 0, error: 'staged plugin dir not found' };
+    }
 
     const skillsDir = join(bundle, 'skills');
     if (!existsSync(skillsDir)) return { linked: 0 };
@@ -381,8 +385,11 @@ export async function installCodexPlugin(
 
     // 3) Dev: symlink the staged skill file(s) to the working tree so skill edits
     // are live on the next Codex restart (no re-stage). Manifest/command changes
-    // still need a re-run of `agentbox install codex`.
-    if (devRoot && result.pluginInstalled) {
+    // still need a re-run of `agentbox install codex`. Run whenever a staged dir
+    // exists — not only on add.status === 0: a non-zero `plugin add` is treated as
+    // "already installed" and leaves a staged cache we still want symlinked
+    // (symlinkStagedSkills bails cleanly if nothing is staged).
+    if (devRoot) {
       const sym = symlinkStagedSkills(devRoot, env);
       result.skillsSymlinked = sym.linked > 0;
       if (sym.linked === 0 && !opts.quiet) {

--- a/apps/cli/src/commands/install-codex.ts
+++ b/apps/cli/src/commands/install-codex.ts
@@ -16,28 +16,147 @@
  * delimited managed block ONLY when no `plugins."agentbox@agentbox"` table exists
  * yet. If the user/TUI already wrote that table (enabled or disabled), we respect
  * it and drop our managed block (a second table would be a TOML parse error).
+ *
+ * Dev vs published: from a source checkout (see {@link resolveDevRepoRoot}) the
+ * marketplace is the LOCAL repo root instead of the GitHub slug, so `plugin add`
+ * stages from the working tree; we then symlink the staged per-skill SKILL.md
+ * back to the repo so skill edits go live on the next Codex restart (no re-stage).
+ * Symlinking the *whole* staged dir is NOT viable — Codex re-derives install state
+ * from it and reports the plugin "not installed"; file-level skill symlinks keep
+ * it installed. Manifest/command changes still need a re-run. `--no-dev` forces
+ * the published GitHub path; a published install only ever sees GitHub (the npm
+ * package ships no `plugins/` or `.agents/`).
  */
 
 import { intro, log, note, outro } from '../lib/prompt.js';
+import { resolveDevRepoRoot } from '../lib/source-checkout.js';
 import { Command } from 'commander';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { parse as parseToml } from 'smol-toml';
 
-/** GitHub marketplace source passed to `codex plugin marketplace add`. */
+/** GitHub marketplace source passed to `codex plugin marketplace add` (published). */
 const MARKETPLACE_SOURCE = 'madarco/agentbox';
 /** Marketplace name (from `.agents/plugins/marketplace.json`) and plugin name. */
 const MARKETPLACE_NAME = 'agentbox';
 const PLUGIN_NAME = 'agentbox';
 /** Effective plugin id / config key: `<plugin>@<marketplace>`. */
 const PLUGIN_ID = `${PLUGIN_NAME}@${MARKETPLACE_NAME}`;
+/** Plugin bundle dir within a source checkout, relative to the repo root. */
+const PLUGIN_BUNDLE_REL = join('plugins', 'agentbox');
+
+/**
+ * The marketplace source to register. In a source checkout (unless `--no-dev`)
+ * this is the local repo root — `codex plugin marketplace add <repoRoot>` reads
+ * `.agents/plugins/marketplace.json` and stages the plugin from the working tree,
+ * so dev edits land in Codex without a publish/re-fetch round-trip. On a published
+ * install (or with `--no-dev`) it's the `madarco/agentbox` GitHub slug.
+ */
+export function marketplaceSource(opts: { noDev?: boolean } = {}): {
+  source: string;
+  devRoot: string | null;
+} {
+  const devRoot = opts.noDev ? null : resolveDevRepoRoot();
+  return { source: devRoot ?? MARKETPLACE_SOURCE, devRoot };
+}
+
+/**
+ * After `codex plugin add` stages a *copy* of the bundle into
+ * `~/.codex/plugins/cache/<marketplace>/<plugin>/<version>`, replace the staged
+ * `skills/<name>/SKILL.md` copies with symlinks to the working-tree bundle so a
+ * Codex restart picks up skill edits without a re-stage. We symlink the skill
+ * *files* only, leaving the version dir a real directory — symlinking the whole
+ * dir makes Codex report the plugin "not installed" (it re-derives install state
+ * from the staged dir). Best-effort: any failure leaves the local-sourced copy in
+ * place (still better than GitHub HEAD; a re-run re-stages from the working tree).
+ */
+function symlinkStagedSkills(
+  devRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
+): { linked: number; error?: string } {
+  try {
+    const pluginRoot = join(codexHomeDir(env), 'plugins', 'cache', MARKETPLACE_NAME, PLUGIN_NAME);
+    const bundle = join(devRoot, PLUGIN_BUNDLE_REL);
+    // Resolve the staged version dir: prefer the bundle manifest's version, else
+    // the single staged child.
+    let versionDir: string | undefined;
+    try {
+      const manifest = JSON.parse(
+        readFileSync(join(bundle, '.codex-plugin', 'plugin.json'), 'utf8'),
+      ) as { version?: string };
+      if (manifest.version) versionDir = join(pluginRoot, manifest.version);
+    } catch {
+      // fall through to glob
+    }
+    if (!versionDir || !existsSync(versionDir)) {
+      const children = existsSync(pluginRoot) ? readdirSync(pluginRoot) : [];
+      if (children.length === 1) versionDir = join(pluginRoot, children[0]!);
+    }
+    if (!versionDir) return { linked: 0, error: 'staged plugin dir not found' };
+
+    const skillsDir = join(bundle, 'skills');
+    if (!existsSync(skillsDir)) return { linked: 0 };
+    let linked = 0;
+    for (const name of readdirSync(skillsDir)) {
+      const repoSkill = join(skillsDir, name, 'SKILL.md');
+      if (!existsSync(repoSkill)) continue;
+      const stagedSkill = join(versionDir, 'skills', name, 'SKILL.md');
+      mkdirSync(dirname(stagedSkill), { recursive: true });
+      rmSync(stagedSkill, { force: true });
+      symlinkSync(repoSkill, stagedSkill);
+      linked++;
+    }
+    return { linked };
+  } catch (e) {
+    return { linked: 0, error: (e as Error).message };
+  }
+}
+
+/**
+ * Sync the canonical skill into the Codex bundle copy (dev only) so the staged /
+ * symlinked plugin carries the up-to-date skill. Drives the same script CI uses,
+ * keeping one source of truth for the pairing. Best-effort.
+ */
+function syncBundleSkill(devRoot: string): void {
+  spawnSync('node', [join(devRoot, 'scripts', 'check-plugin-skill-sync.mjs'), '--fix'], {
+    cwd: devRoot,
+    stdio: 'ignore',
+  });
+}
 
 /** `$CODEX_HOME` if set, else `~/.codex`. */
 export function codexHomeDir(env: NodeJS.ProcessEnv = process.env): string {
   const override = env['CODEX_HOME'];
   return override && override.length > 0 ? override : join(homedir(), '.codex');
+}
+
+/**
+ * The `source_type` ("local" | "git" | …) of the currently-registered `agentbox`
+ * marketplace, or `null` if none. Codex refuses `marketplace add` when a same-named
+ * marketplace exists from a different *source type*, so we use this to decide when
+ * to remove-then-add (flipping dev↔published) vs leave it be.
+ */
+function currentMarketplaceType(env: NodeJS.ProcessEnv = process.env): string | null {
+  try {
+    const cfg = readFileSync(codexConfigPath(env), 'utf8');
+    const parsed = parseToml(cfg) as {
+      marketplaces?: Record<string, { source_type?: unknown }>;
+    };
+    const t = parsed.marketplaces?.[MARKETPLACE_NAME]?.source_type;
+    return typeof t === 'string' ? t : null;
+  } catch {
+    return null;
+  }
 }
 
 export function codexConfigPath(env: NodeJS.ProcessEnv = process.env): string {
@@ -158,6 +277,8 @@ export interface InstallCodexOptions {
   force?: boolean;
   dryRun?: boolean;
   quiet?: boolean;
+  /** Force the published GitHub marketplace even inside a source checkout. */
+  noDev?: boolean;
 }
 
 export interface InstallCodexResult {
@@ -167,6 +288,10 @@ export interface InstallCodexResult {
   pluginInstalled: boolean;
   enableStatus?: CodexEnableStatus;
   configPath: string;
+  /** True when staging from the local repo (dev), false for the GitHub source. */
+  dev: boolean;
+  /** True when the staged skill file(s) were symlinked to the working tree (dev only). */
+  skillsSymlinked?: boolean;
 }
 
 /**
@@ -180,11 +305,13 @@ export async function installCodexPlugin(
 ): Promise<InstallCodexResult> {
   const env = process.env;
   const cfgPath = codexConfigPath(env);
+  const { source, devRoot } = marketplaceSource({ noDev: opts.noDev });
   const result: InstallCodexResult = {
     ran: false,
     marketplaceAdded: false,
     pluginInstalled: false,
     configPath: cfgPath,
+    dev: devRoot !== null,
   };
 
   // Gate: Codex must be set up on this host.
@@ -197,8 +324,11 @@ export async function installCodexPlugin(
   if (opts.dryRun) {
     if (!opts.quiet) {
       process.stdout.write(
-        `# would run: ${bin} plugin marketplace add ${MARKETPLACE_SOURCE}\n` +
+        `# would run: ${bin} plugin marketplace add ${source}\n` +
           `# would run: ${bin} plugin add ${PLUGIN_ID}\n` +
+          (devRoot
+            ? `# would symlink the staged skills/*/SKILL.md -> ${join(devRoot, PLUGIN_BUNDLE_REL, 'skills')}/*\n`
+            : '') +
           `# --- appended to ${cfgPath} (only if not already configured) ---\n` +
           `${codexPluginEnableTable()}\n`,
       );
@@ -206,16 +336,33 @@ export async function installCodexPlugin(
     return result;
   }
 
-  // Skip the network re-add when already installed (unless --force): a re-add
-  // would re-enable a plugin the user deliberately disabled. The enable step
-  // below still runs and respects their current choice.
-  const alreadyInstalled = !opts.force && codexPluginInstalled(bin);
+  // Dev: keep the bundle skill copy current before staging from the working tree.
+  if (devRoot) syncBundleSkill(devRoot);
+
+  // A source-type flip (dev local ↔ published git) needs a remove-then-add: Codex
+  // refuses `marketplace add` when a same-named marketplace exists from a different
+  // source type (and exits 0 on that error, so a plain add would silently no-op).
+  const desiredType = devRoot ? 'local' : 'git';
+  const sourceConflict =
+    currentMarketplaceType(env) !== null && currentMarketplaceType(env) !== desiredType;
+
+  // Skip the network re-add when already installed (unless --force / dev / a source
+  // flip): a re-add would re-enable a plugin the user deliberately disabled. The
+  // enable step below still runs and respects their current choice. In dev we always
+  // re-stage so working-tree edits land.
+  const alreadyInstalled =
+    !opts.force && !devRoot && !sourceConflict && codexPluginInstalled(bin);
   if (alreadyInstalled) {
     result.marketplaceAdded = true;
     result.pluginInstalled = true;
   } else {
-    // 1) Register the marketplace (idempotent upsert of [marketplaces.agentbox]).
-    const mkt = spawnSync(bin, ['plugin', 'marketplace', 'add', MARKETPLACE_SOURCE], {
+    // 1) Register the marketplace. Remove the stale entry first when flipping
+    // sources or re-staging in dev (best-effort — harmless if absent; the `enabled`
+    // plugin entry lives elsewhere and survives).
+    if (devRoot || sourceConflict) {
+      spawnSync(bin, ['plugin', 'marketplace', 'remove', MARKETPLACE_NAME], { stdio: 'ignore' });
+    }
+    const mkt = spawnSync(bin, ['plugin', 'marketplace', 'add', source], {
       stdio: 'ignore',
     });
     result.marketplaceAdded = mkt.status === 0;
@@ -231,9 +378,23 @@ export async function installCodexPlugin(
           (detail ? `: ${detail.split('\n')[0]}` : ''),
       );
     }
+
+    // 3) Dev: symlink the staged skill file(s) to the working tree so skill edits
+    // are live on the next Codex restart (no re-stage). Manifest/command changes
+    // still need a re-run of `agentbox install codex`.
+    if (devRoot && result.pluginInstalled) {
+      const sym = symlinkStagedSkills(devRoot, env);
+      result.skillsSymlinked = sym.linked > 0;
+      if (sym.linked === 0 && !opts.quiet) {
+        log.info(
+          `could not symlink the staged Codex skill to the repo (using the local copy instead)` +
+            (sym.error ? `: ${sym.error}` : ''),
+        );
+      }
+    }
   }
 
-  // 3) Enable by default in config.toml (respecting an explicit user choice).
+  // 4) Enable by default in config.toml (respecting an explicit user choice).
   const existing = existsSync(cfgPath) ? readFileSync(cfgPath, 'utf8') : '';
   const { text, status } = upsertCodexPluginEnable(existing, { force: opts.force });
   result.enableStatus = status;
@@ -255,9 +416,15 @@ export const installCodexCommand = new Command('codex')
   )
   .option('--dry-run', 'print the commands and config block without changing anything')
   .option('--force', 're-install and re-enable even if the plugin was disabled')
-  .action(async (opts: { dryRun?: boolean; force?: boolean }) => {
+  .option('--no-dev', 'use the published GitHub marketplace even inside a source checkout')
+  .action(async (opts: { dryRun?: boolean; force?: boolean; dev?: boolean }) => {
     intro('AgentBox Codex plugin');
-    const res = await installCodexPlugin({ force: opts.force, dryRun: opts.dryRun });
+    // commander negatable flag: `--no-dev` sets opts.dev === false.
+    const res = await installCodexPlugin({
+      force: opts.force,
+      dryRun: opts.dryRun,
+      noDev: opts.dev === false,
+    });
     if (!res.ran) {
       outro('Codex not detected on this host (no ~/.codex or `codex` CLI) — skipped.');
       return;
@@ -267,7 +434,12 @@ export const installCodexCommand = new Command('codex')
       return;
     }
     note(
-      `Marketplace: ${res.marketplaceAdded ? 'registered' : 'see warning above'}\n` +
+      `Source:      ${
+        res.dev
+          ? `local repo (dev)${res.skillsSymlinked ? ', skill symlinked — edits live on restart' : ''}`
+          : 'madarco/agentbox (GitHub)'
+      }\n` +
+        `Marketplace: ${res.marketplaceAdded ? 'registered' : 'see warning above'}\n` +
         `Plugin:      ${res.pluginInstalled ? 'installed' : 'add attempted (may already exist)'}\n` +
         `Enabled:     ${
           res.enableStatus === 'added'

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -30,8 +30,8 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { homedir } from 'node:os';
-import { dirname, join, resolve, sep } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { isSourceCheckout, resolveHostSkillsDir } from '../lib/source-checkout.js';
 import {
   formatCompact,
   runProviderChecks,
@@ -214,45 +214,12 @@ function installTargets(): InstallTarget[] {
   ];
 }
 
-/**
- * Locate the bundled `share/host-skills/` directory. This module is bundled
- * into the CLI at `<root>/dist/index.js`; `share/` ships as a sibling of
- * `dist/` in both the dev tree and the published package. The src-tree
- * candidate covers running unbundled (e.g. tsx).
- */
-function resolveHostSkillsDir(): string {
-  const here = dirname(fileURLToPath(import.meta.url));
-  const candidates = [
-    resolve(here, '..', 'share', 'host-skills'),
-    resolve(here, '..', '..', 'share', 'host-skills'),
-  ];
-  for (const c of candidates) {
-    if (existsSync(c)) return c;
-  }
-  throw new Error(`could not locate bundled host skills; tried:\n  ${candidates.join('\n  ')}`);
-}
-
 function isSymlink(target: string): boolean {
   try {
     return lstatSync(target).isSymbolicLink();
   } catch {
     return false;
   }
-}
-
-/**
- * True when the bundled skills resolve inside a source checkout rather than an
- * installed package. Every distribution path — `npm i -g`, pnpm global, the
- * npx cache — lives under a `node_modules` segment; a dev clone
- * (`<repo>/apps/cli/share/host-skills`) does not. We key on the source
- * *location*, not `detectExecutionMethod`, because a global install invoked
- * directly carries no `npm_config_user_agent` and would misreport as `direct`.
- * In a checkout we symlink skills so source edits are picked up live (mirroring
- * the `pnpm register` bin symlink); a published install must copy, since its
- * source dir is transient and a symlink would dangle on upgrade.
- */
-function isSourceCheckout(srcDir: string): boolean {
-  return !srcDir.split(sep).includes('node_modules');
 }
 
 function writableReason(target: string, force: boolean): 'new' | 'managed' | 'forced' | 'skip' {

--- a/apps/cli/src/lib/source-checkout.ts
+++ b/apps/cli/src/lib/source-checkout.ts
@@ -1,0 +1,62 @@
+/**
+ * Source-checkout detection shared by the install commands.
+ *
+ * The CLI is bundled to `<root>/dist/index.js`; `share/` ships as a sibling of
+ * `dist/` in both the dev tree and the published package. We key dev-vs-published
+ * decisions on the *location* of that bundled `share/host-skills` dir: every
+ * distribution path (`npm i -g`, pnpm global, the npx cache) lives under a
+ * `node_modules` segment, a dev clone does not. In a checkout we symlink skills
+ * so source edits are picked up live; a published install must copy.
+ */
+
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Locate the bundled `share/host-skills/` directory. This module is bundled into
+ * the CLI; `share/` is a sibling of `dist/` in both the dev tree and the
+ * published package. The src-tree candidate covers running unbundled (e.g. tsx).
+ */
+export function resolveHostSkillsDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    resolve(here, '..', 'share', 'host-skills'),
+    resolve(here, '..', '..', 'share', 'host-skills'),
+  ];
+  for (const c of candidates) {
+    if (existsSync(c)) return c;
+  }
+  throw new Error(`could not locate bundled host skills; tried:\n  ${candidates.join('\n  ')}`);
+}
+
+/**
+ * True when the bundled skills resolve inside a source checkout rather than an
+ * installed package. We key on the source *location*, not `detectExecutionMethod`,
+ * because a global install invoked directly carries no `npm_config_user_agent` and
+ * would misreport as `direct`.
+ */
+export function isSourceCheckout(srcDir: string): boolean {
+  return !srcDir.split(sep).includes('node_modules');
+}
+
+/**
+ * The repo root when running from a source checkout that still carries the Codex
+ * marketplace sources, else `null`. The published npm package ships `share/` but
+ * NOT `plugins/` or `.agents/`, so this returns `null` for any real install — the
+ * Codex installer falls back to the GitHub marketplace there. `resolveHostSkillsDir`
+ * returns `<root>/apps/cli/share/host-skills`; the repo root is four levels up.
+ */
+export function resolveDevRepoRoot(): string | null {
+  let hostSkillsDir: string;
+  try {
+    hostSkillsDir = resolveHostSkillsDir();
+  } catch {
+    return null;
+  }
+  if (!isSourceCheckout(hostSkillsDir)) return null;
+  const root = resolve(hostSkillsDir, '..', '..', '..', '..');
+  const hasMarketplace = existsSync(join(root, '.agents', 'plugins', 'marketplace.json'));
+  const hasPlugin = existsSync(join(root, 'plugins', 'agentbox'));
+  return hasMarketplace && hasPlugin ? root : null;
+}

--- a/apps/cli/test/install-codex.test.ts
+++ b/apps/cli/test/install-codex.test.ts
@@ -3,8 +3,10 @@ import { parse as parseToml } from 'smol-toml';
 import {
   codexConfigPath,
   codexPluginEnableTable,
+  marketplaceSource,
   upsertCodexPluginEnable,
 } from '../src/commands/install-codex.js';
+import { resolveDevRepoRoot } from '../src/lib/source-checkout.js';
 
 const ID = 'agentbox@agentbox';
 const enabledOf = (text: string) =>
@@ -104,5 +106,21 @@ describe('codexConfigPath', () => {
 describe('codexPluginEnableTable', () => {
   it('is a valid standalone TOML table that enables the plugin', () => {
     expect(enabledOf(codexPluginEnableTable())).toBe(true);
+  });
+});
+
+describe('marketplaceSource', () => {
+  // Tests run from the source checkout, so the default resolves to the local repo.
+  it('points at the local repo root in a source checkout (dev)', () => {
+    const { source, devRoot } = marketplaceSource();
+    expect(devRoot).toBe(resolveDevRepoRoot());
+    expect(devRoot).not.toBeNull();
+    expect(source).toBe(devRoot);
+  });
+
+  it('falls back to the GitHub slug with --no-dev', () => {
+    const { source, devRoot } = marketplaceSource({ noDev: true });
+    expect(devRoot).toBeNull();
+    expect(source).toBe('madarco/agentbox');
   });
 });

--- a/apps/cli/test/source-checkout.test.ts
+++ b/apps/cli/test/source-checkout.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { isSourceCheckout, resolveDevRepoRoot } from '../src/lib/source-checkout.js';
+
+describe('isSourceCheckout', () => {
+  it('is false for any path under node_modules (every distribution path)', () => {
+    expect(isSourceCheckout('/Users/x/node_modules/@madarco/agentbox/share/host-skills')).toBe(
+      false,
+    );
+    expect(isSourceCheckout('/opt/pnpm/global/5/node_modules/.pnpm/x/share')).toBe(false);
+  });
+
+  it('is true for a source clone (no node_modules segment)', () => {
+    expect(isSourceCheckout('/Users/x/Projects/agentbox/apps/cli/share/host-skills')).toBe(true);
+  });
+});
+
+describe('resolveDevRepoRoot', () => {
+  // The test process itself runs from the source checkout, so this exercises the
+  // real dev branch: it must return the repo root that carries the Codex sources.
+  it('returns the repo root carrying the Codex marketplace + plugin', () => {
+    const root = resolveDevRepoRoot();
+    expect(root).not.toBeNull();
+    expect(existsSync(join(root!, '.agents', 'plugins', 'marketplace.json'))).toBe(true);
+    expect(existsSync(join(root!, 'plugins', 'agentbox', '.codex-plugin', 'plugin.json'))).toBe(
+      true,
+    );
+  });
+});

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,6 +8,35 @@
 pnpm build && pnpm lint && pnpm typecheck && pnpm test
 ```
 
+## Host skills + Codex plugin in dev
+
+The `/agentbox` host skills and the Codex plugin are wired so a **source checkout
+reflects your edits without re-publishing**, while a published npm install pulls
+from the GitHub repo. The discriminator is `isSourceCheckout()` /
+`resolveDevRepoRoot()` in `apps/cli/src/lib/source-checkout.ts` — every
+distribution path lives under a `node_modules` segment; a clone does not.
+
+- **Claude / OpenCode skills** — `agentbox install` (or `--skills-only`) symlinks
+  `~/.claude/skills/agentbox-info` → `apps/cli/share/host-skills/agentbox-info/SKILL.md`
+  in a checkout (copies on an npm install). Edit the **canonical**
+  `apps/cli/share/host-skills/agentbox-info/SKILL.md`; it's live immediately.
+- **Codex plugin** — `agentbox install codex` from a checkout points
+  `[marketplaces.agentbox]` at the local repo (`source_type = "local"`) instead of
+  the `madarco/agentbox` GitHub slug, re-syncs the bundle skill copy
+  (`scripts/check-plugin-skill-sync.mjs --fix`), `codex plugin add`s from the
+  working tree, then symlinks the staged `skills/<name>/SKILL.md` back to the repo.
+  Skill edits then go live on the next Codex restart — no re-stage.
+  - Codex re-derives "installed" from the staged dir, so we symlink only the skill
+    *files*, not the whole staged dir (a dir symlink makes Codex report the plugin
+    "not installed").
+  - The Codex bundle keeps a **real copy** of the skill at
+    `plugins/agentbox/skills/agentbox-info/SKILL.md` (Codex won't follow a symlink
+    out of a bundle when it copies on publish). Edit the canonical and run
+    `pnpm check:plugin-skill --fix` to propagate; CI runs `pnpm check:plugin-skill`.
+  - Re-run `agentbox install codex` after **manifest/command** changes (not needed
+    for skill text). Use `agentbox install codex --no-dev` to force the published
+    GitHub path even inside a checkout (it flips the marketplace back to git).
+
 ## Manual end-to-end
 
 Each long-running CLI command tees its output to `~/.agentbox/logs/<command>.log`

--- a/packages/sandbox-daytona/scripts/custom-system-CLAUDE.md
+++ b/packages/sandbox-daytona/scripts/custom-system-CLAUDE.md
@@ -36,4 +36,9 @@ ask the user for confirmation on the wrapper that runs `agentbox claude`;
 deny returns exit 10 (`denied by user`).
 Don't put any timeout on the command, it will run forever and the user will be notified through multiple channels.
 
+If an agentbox.yaml file is present, services and docker containers will be started automatically.
+Check the status with `agentbox-ctl status`.
+
+To view any web services, open the browser to https://<AGENTBOX_BOX_HOST>. The AGENTBOX_BOX_HOST env var is available in the box and the same url will work from the host as well because it is a cloud provided url.
+
 Box identity: /etc/agentbox/box.env and the AGENTBOX_* env vars.

--- a/packages/sandbox-docker/scripts/custom-system-CLAUDE.md
+++ b/packages/sandbox-docker/scripts/custom-system-CLAUDE.md
@@ -35,4 +35,9 @@ ask the user for confirmation on the wrapper that runs `agentbox claude`;
 deny returns exit 10 (`denied by user`). 
 Don't put any timeout on the command, it will run forever and the user will be notified through multiple channels.
 
+If an agentbox.yaml file is present, services and docker containers will be started automatically.
+Check the status with `agentbox-ctl status`.
+
+To view any web services, open the browser to https://<AGENTBOX_BOX_HOST>. The AGENTBOX_BOX_HOST env var is available in the box and the same url will work from the host as well via a local proxy.
+
 Box identity: /etc/agentbox/box.env and the AGENTBOX_* env vars.

--- a/packages/sandbox-e2b/scripts/custom-system-CLAUDE.md
+++ b/packages/sandbox-e2b/scripts/custom-system-CLAUDE.md
@@ -43,4 +43,9 @@ confirmation on the wrapper that runs `agentbox claude`; deny returns exit 10
 (`denied by user`). Don't put any timeout on the command, it will run forever
 and the user will be notified through multiple channels.
 
+If an agentbox.yaml file is present, services and docker containers will be started automatically.
+Check the status with `agentbox-ctl status`, `agentbox-ctl logs <service>`, and `agentbox-ctl restart <service>`.
+
+To view any web services, open the browser to https://<AGENTBOX_BOX_HOST>. The AGENTBOX_BOX_HOST env var is available in the box and the same url will work from the host as well via a local proxy or because is a cloud provided url.
+
 Box identity: /etc/agentbox/box.env and the AGENTBOX_* env vars.

--- a/packages/sandbox-hetzner/scripts/custom-system-CLAUDE.md
+++ b/packages/sandbox-hetzner/scripts/custom-system-CLAUDE.md
@@ -36,4 +36,9 @@ ask the user for confirmation on the wrapper that runs `agentbox claude`;
 deny returns exit 10 (`denied by user`).
 Don't put any timeout on the command, it will run forever and the user will be notified through multiple channels.
 
+If an agentbox.yaml file is present, services and docker containers will be started automatically.
+Check the status with `agentbox-ctl status`.
+
+To view any web services, open the browser to https://<AGENTBOX_BOX_HOST>. The AGENTBOX_BOX_HOST env var is available in the box and the same url will work from the host as well via a local proxy or because is a cloud provided url.
+
 Box identity: /etc/agentbox/box.env and the AGENTBOX_* env vars.

--- a/packages/sandbox-vercel/scripts/custom-system-CLAUDE.md
+++ b/packages/sandbox-vercel/scripts/custom-system-CLAUDE.md
@@ -45,4 +45,9 @@ confirmation on the wrapper that runs `agentbox claude`; deny returns exit 10
 (`denied by user`). Don't put any timeout on the command, it will run forever
 and the user will be notified through multiple channels.
 
+If an agentbox.yaml file is present, services and docker containers will be started automatically.
+Check the status with `agentbox-ctl status`.
+
+To view any web services, open the browser to https://<AGENTBOX_BOX_HOST>. The AGENTBOX_BOX_HOST env var is available in the box and the same url will work from the host as well because it is a cloud provided url.
+
 Box identity: /etc/agentbox/box.env and the AGENTBOX_* env vars.

--- a/plugins/agentbox/assets/icon.svg
+++ b/plugins/agentbox/assets/icon.svg
@@ -1,15 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-label="AgentBox">
-  <rect width="512" height="512" rx="96" fill="#0d1117"/>
-  <!-- back box (parallel) -->
-  <g opacity="0.45">
-    <path d="M150 150 L286 110 L398 150 L262 190 Z" fill="#3b82f6"/>
-    <path d="M150 150 L262 190 L262 318 L150 278 Z" fill="#1e40af"/>
-    <path d="M398 150 L262 190 L262 318 L398 278 Z" fill="#2563eb"/>
-  </g>
-  <!-- front box -->
-  <g>
-    <path d="M114 214 L256 170 L398 214 L256 258 Z" fill="#60a5fa"/>
-    <path d="M114 214 L256 258 L256 402 L114 358 Z" fill="#2563eb"/>
-    <path d="M398 214 L256 258 L256 402 L398 358 Z" fill="#1d4ed8"/>
-  </g>
+<svg width="385" height="382" viewBox="0 0 385 382" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M325 16H59C35.804 16 17 34.804 17 58V324C17 347.196 35.804 366 59 366H325C348.196 366 367 347.196 367 324V58C367 34.804 348.196 16 325 16Z" fill="#F6F6F3" stroke="#161A20" stroke-width="31"/>
+<path d="M255 191H129V317H255V191Z" stroke="#161A20" stroke-width="10"/>
+<path d="M236 210H148V298H236V210Z" fill="#161A20"/>
 </svg>


### PR DESCRIPTION
## What

Makes the Codex plugin reflect working-tree edits in **dev** (source checkout) without a publish/re-fetch round-trip, mirroring how the Claude host skills already symlink in dev. A published npm install is unchanged — it still installs from the `madarco/agentbox` GitHub marketplace.

### Dev (`agentbox install codex` from a checkout)
- Points `[marketplaces.agentbox]` at the **local repo** (`source_type = "local"`) instead of the GitHub slug, so `codex plugin add` stages from the working tree.
- Re-syncs the bundle skill copy (`scripts/check-plugin-skill-sync.mjs --fix`).
- Symlinks the staged **per-skill `SKILL.md`** back to the repo → skill edits go live on the next Codex restart, no re-stage.
- A whole-dir symlink was proven to make Codex report the plugin *"not installed"*, so only the skill files are symlinked (the version dir stays real).
- `--no-dev` forces the published GitHub path; a source-type flip (local ↔ git) is handled by remove-then-add in both directions.

### Shared helper
- New `apps/cli/src/lib/source-checkout.ts`: `isSourceCheckout`, `resolveHostSkillsDir`, `resolveDevRepoRoot` (returns the repo root only in a checkout carrying `.agents/plugins/marketplace.json` + `plugins/agentbox`, else `null`). `install.ts` now imports these (Claude path unchanged).

### Also
- Per-provider box system-prompt note: `agentbox.yaml` services/containers auto-start (`agentbox-ctl status`) and web services are reachable at `https://<AGENTBOX_BOX_HOST>`.

## Verification
- Live against real Codex: marketplace flips to local; staged dir stays real; `SKILL.md` is a symlink; `codex plugin list` shows `installed, enabled`; canonical edit → `--fix` → visible at the path Codex reads. `--no-dev` flips cleanly back to git.
- `pnpm -C apps/cli test` (648 pass), lint, typecheck, and `pnpm check:plugin-skill` all green.
- Docs: `docs/development.md`.

https://claude.ai/code/session_01An9tT8HqjQoGKKVWuYg4bb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly dev-install ergonomics and docs; published npm installs still use GitHub, with best-effort Codex CLI and filesystem side effects gated on Codex being present.
> 
> **Overview**
> **Codex install in a source checkout** now mirrors Claude host skills: `agentbox install codex` registers a **local** marketplace (`source_type = "local"`) instead of `madarco/agentbox`, re-syncs the bundle skill via `check-plugin-skill-sync.mjs --fix`, re-stages from the working tree, and replaces staged `skills/*/SKILL.md` with **symlinks** to the repo (whole-dir symlinks break Codex “installed” detection). **`--no-dev`** forces GitHub; **local ↔ git** flips use marketplace remove-then-add because Codex rejects mixed source types.
> 
> Shared **`source-checkout.ts`** centralizes `resolveHostSkillsDir`, `isSourceCheckout`, and `resolveDevRepoRoot`; **`install.ts`** imports it (Claude symlink behavior unchanged). **`docs/development.md`** documents the dev workflow.
> 
> **Sandbox system prompts** (all providers) now mention `agentbox.yaml` auto-start, `agentbox-ctl status`, and web UI at `https://<AGENTBOX_BOX_HOST>`. **Codex plugin icon** (`icon.svg`) is replaced with a simpler mark.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6964d3a352d2b915d75639c6afbea2d34cb80df. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->