### PR TITLE
feat(box): land interactive SSH/login shells in /workspace

### DIFF
--- a/packages/sandbox-docker/Dockerfile.box
+++ b/packages/sandbox-docker/Dockerfile.box
@@ -510,6 +510,15 @@ RUN printf '%s\n' \
         '  . /etc/agentbox/box.env' \
         '  set +a' \
         'fi' \
+        '# Land interactive login shells in the workspace (remote-host integrations,' \
+        '# plain `ssh <box>`); interactive-only and only when still at $HOME.' \
+        'case $- in' \
+        '  *i*)' \
+        '    if [ "$PWD" = "$HOME" ] && [ -d /workspace ]; then' \
+        '      cd /workspace' \
+        '    fi' \
+        '    ;;' \
+        'esac' \
         > /etc/profile.d/agentbox.sh \
     && chmod 0644 /etc/profile.d/agentbox.sh
 

--- a/packages/sandbox-e2b/scripts/build-template.sh
+++ b/packages/sandbox-e2b/scripts/build-template.sh
@@ -244,6 +244,18 @@ export DISABLE_AUTOUPDATER=${DISABLE_AUTOUPDATER:-1}
 export DISPLAY=${DISPLAY:-:1}
 export AGENT_BROWSER_EXECUTABLE_PATH=${AGENT_BROWSER_EXECUTABLE_PATH:-/usr/local/bin/chromium}
 export BROWSER=${BROWSER:-/usr/local/bin/agentbox-open}
+# Land interactive login shells in the workspace, so remote-host integrations
+# (Codex app, VS Code Remote-SSH, plain `ssh <box>`) open in the project instead
+# of $HOME. Interactive-only so scp/sftp and `ssh box <cmd>` are untouched; only
+# when still at $HOME so a caller-chosen dir (e.g. agentbox's tmux `-c /workspace`)
+# is never overridden.
+case $- in
+  *i*)
+    if [ "$PWD" = "$HOME" ] && [ -d /workspace ]; then
+      cd /workspace
+    fi
+    ;;
+esac
 PROFILE
 chmod 0644 /etc/profile.d/agentbox.sh
 done_ "login-shell shim (/etc/profile.d/agentbox.sh)"

--- a/packages/sandbox-hetzner/scripts/install-box.sh
+++ b/packages/sandbox-hetzner/scripts/install-box.sh
@@ -290,6 +290,18 @@ export LC_ALL=${LC_ALL:-en_US.UTF-8}
 export DISPLAY=${DISPLAY:-:1}
 export AGENT_BROWSER_EXECUTABLE_PATH=${AGENT_BROWSER_EXECUTABLE_PATH:-/usr/local/bin/chromium}
 export BROWSER=${BROWSER:-/usr/local/bin/agentbox-open}
+# Land interactive login shells in the workspace, so remote-host integrations
+# (Codex app, VS Code Remote-SSH, plain `ssh <box>`) open in the project instead
+# of $HOME. Interactive-only so scp/sftp and `ssh box <cmd>` are untouched; only
+# when still at $HOME so a caller-chosen dir (e.g. agentbox's tmux `-c /workspace`)
+# is never overridden.
+case $- in
+  *i*)
+    if [ "$PWD" = "$HOME" ] && [ -d /workspace ]; then
+      cd /workspace
+    fi
+    ;;
+esac
 PROFILE
 chmod 0644 /etc/profile.d/agentbox.sh
 done_ "login-shell shim (/etc/profile.d/agentbox.sh)"

--- a/packages/sandbox-vercel/scripts/provision.sh
+++ b/packages/sandbox-vercel/scripts/provision.sh
@@ -269,6 +269,18 @@ export DISABLE_AUTOUPDATER=${DISABLE_AUTOUPDATER:-1}
 export DISPLAY=${DISPLAY:-:1}
 export AGENT_BROWSER_EXECUTABLE_PATH=${AGENT_BROWSER_EXECUTABLE_PATH:-/usr/local/bin/chromium}
 export BROWSER=${BROWSER:-/usr/local/bin/agentbox-open}
+# Land interactive login shells in the workspace, so remote-host integrations
+# (Codex app, VS Code Remote-SSH, plain `ssh <box>`) open in the project instead
+# of $HOME. Interactive-only so scp/sftp and `ssh box <cmd>` are untouched; only
+# when still at $HOME so a caller-chosen dir (e.g. agentbox's tmux `-c /workspace`)
+# is never overridden.
+case $- in
+  *i*)
+    if [ "$PWD" = "$HOME" ] && [ -d /workspace ]; then
+      cd /workspace
+    fi
+    ;;
+esac
 PROFILE
 chmod 0644 /etc/profile.d/agentbox.sh
 done_ "login-shell shim (/etc/profile.d/agentbox.sh)"


### PR DESCRIPTION
## Problem

Adding a box as a remote host (Codex app, VS Code Remote-SSH, or plain `ssh <box>`) opened the session in `/home/vscode` instead of the project at `/workspace`, forcing the user to navigate there every time.

SSH config has **no start-directory directive**. The only client-side option — `RemoteCommand cd /workspace && exec $SHELL -l` — would break the *shared* agentbox Host block for scp/sftp (`agentbox open` sshfs) and VS Code's remote bootstrap (`agentbox code`). So the fix is server-side.

## Change

Make interactive login shells `cd /workspace` via the existing `/etc/profile.d/agentbox.sh` shim every box already installs:

```sh
case $- in
  *i*)
    if [ "$PWD" = "$HOME" ] && [ -d /workspace ]; then
      cd /workspace
    fi
    ;;
esac
```

Guarded so it's safe:
- **interactive-only** (`case $- in *i*`) → scp/sftp and `ssh box <cmd>` are untouched
- **only when at `$HOME`** → never overrides a caller-chosen dir (agentbox's own tmux `-c /workspace` stays a no-op)
- **`-d /workspace`** → never cd into a missing dir

Applied to all provider login-shell shims for consistency: `hetzner` (install-box.sh), `vercel` (provision.sh), `e2b` (build-template.sh), and the canonical `docker` Dockerfile.box (regenerated runtime copy follows on build).

## E2E results (live Hetzner)

Re-baked the Hetzner snapshot with the updated `install-box.sh`, created a real box (`sshdir`), and verified against the live VPS:

| # | Check | Result |
|---|-------|--------|
| 1 | **Interactive login shell** (Codex-app / VS Code Remote-SSH / plain `ssh sshdir`) | Lands in **`/workspace`** — prompt `vscode@...:/workspace$`, `pwd` -> `/workspace` |
| 2 | Non-interactive `ssh sshdir pwd` | Stays in `/home/vscode` — guard skips (`$-` = `hBc`, no `i`) |
| 3 | `scp file sshdir:/workspace/` (sftp subsystem) | Succeeds; file read back |

Box destroyed and Hetzner VPS/firewall/SSH-alias cleanup confirmed (no orphans). Also syntax-checked the generated shim under both `bash -n` and `sh -n`.

https://claude.ai/code/session_01An9tT8HqjQoGKKVWuYg4bb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shell startup-only change with explicit interactive and PWD guards; no auth or application logic touched. Effect is limited to new image/template bakes until providers are refreshed.
> 
> **Overview**
> Interactive **login shells** now **`cd /workspace`** when the session still starts in **`$HOME`**, so Remote-SSH, Codex remote hosts, and plain **`ssh <box>`** open in the project tree instead of **`/home/vscode`**.
> 
> The behavior is added to the existing **`/etc/profile.d/agentbox.sh`** shim across **docker**, **hetzner**, **vercel**, and **e2b** bake/install paths. Guards keep it **interactive-only** (`case $- in *i*)`), require **`PWD` = `$HOME`**, and **`[ -d /workspace ]`** so **`scp`/`sftp`**, **`ssh box <cmd>`**, and callers that already pick a working directory are unchanged.
> 
> **Existing boxes** need a **re-bake/rebuild** of the base image or template for the shim update to apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8c64f4731be42ab894d865b72e1e65ea5ba4e42. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->