### PR TITLE
fix(codex): drop heavy host-only artifacts from codex config staging

### DIFF
--- a/packages/sandbox-docker/src/codex.ts
+++ b/packages/sandbox-docker/src/codex.ts
@@ -221,18 +221,32 @@ export async function ensureCodexVolume(
       // resumes at /workspace (Codex reads the cwd from state_*.sqlite's threads
       // index, which it backfills from the box's rollouts) and the host's
       // cross-project Codex history doesn't leak into the box.
-      // The trailing `rm -rf` purges any state DBs a PREVIOUS sync (before these
+      // The trailing `rm -rf` purges anything a PREVIOUS sync (before these
       // excludes) already copied into the shared volume — rsync without
       // --delete only adds/updates. The globs are no-ops with `-f` when absent,
       // and never touch box-owned `sessions/` (the teleported rollouts) or
       // `hooks.json`.
+      // Heavy host-only artifacts are also excluded (mirrors CODEX_RSYNC_EXCLUDES
+      // in host-stage.ts): `packages` (macOS standalone release binaries — the
+      // in-box codex is npm-installed), `plugins/.plugin-appserver` (the
+      // platform-specific plugin app-server runtime), `computer-use` (the macOS
+      // `Codex Computer Use.app` bundle), `archived_sessions` (host history), and
+      // the regenerable caches (`.tmp`, `tmp`, `cache`, `vendor_imports`,
+      // `sqlite`, `models_cache.json`). Without these the shared volume balloons
+      // to ~1.5 GB and every create's rsync crawls.
       'rsync -a --exclude=sessions --exclude=log --exclude=history.jsonl --exclude=hooks.json' +
         skillsExclude +
         ' --exclude=state_*.sqlite* --exclude=logs_*.sqlite* --exclude=session_index.jsonl' +
         ' --exclude=external_agent_session_imports.json --exclude=shell_snapshots' +
+        ' --exclude=packages --exclude=plugins/.plugin-appserver --exclude=computer-use' +
+        ' --exclude=archived_sessions --exclude=.tmp --exclude=tmp --exclude=cache' +
+        ' --exclude=vendor_imports --exclude=sqlite --exclude=models_cache.json' +
         ' /src/ /dst/' +
         ' && rm -rf /dst/state_*.sqlite* /dst/logs_*.sqlite* /dst/session_index.jsonl' +
         ' /dst/external_agent_session_imports.json /dst/shell_snapshots' +
+        ' /dst/packages /dst/plugins/.plugin-appserver /dst/computer-use' +
+        ' /dst/archived_sessions /dst/.tmp /dst/tmp /dst/cache' +
+        ' /dst/vendor_imports /dst/sqlite /dst/models_cache.json' +
         skillsPurge +
         ' && chown -R 1000:1000 /dst',
     ]);

--- a/packages/sandbox-docker/src/host-stage.ts
+++ b/packages/sandbox-docker/src/host-stage.ts
@@ -471,6 +471,20 @@ const CODEX_RSYNC_EXCLUDES = [
   '--exclude=models_cache.json',
   '--exclude=installation_id',
   '--exclude=version.json',
+  // Heavy host-only artifacts that are useless inside a Linux box and balloon
+  // the staged tarball (~800 MB on a real host) — without these the codex
+  // static scp/extract during prepare crawls. `packages/standalone` is the
+  // macOS aarch64 standalone release binaries (the in-box codex is npm-installed
+  // anyway); `plugins/.plugin-appserver` is the platform-specific plugin
+  // app-server runtime; `computer-use` is the macOS `Codex Computer Use.app`
+  // bundle. `archived_sessions` is host session history, not config (mirrors the
+  // `sessions` exclude). (`plugins/cache`, the marketplace download cache, is
+  // already dropped by the generic `--exclude=cache` above.) This shrinks the
+  // staged codex tarball from ~800 MB to ~0.5 MB.
+  '--exclude=packages',
+  '--exclude=plugins/.plugin-appserver',
+  '--exclude=computer-use',
+  '--exclude=archived_sessions',
 ];
 
 const CODEX_KEYCHAIN_WARNING =


### PR DESCRIPTION
## Problem

Host `~/.codex` is ~1.1 GB and was synced into boxes almost whole — ~800 MB of it is **macOS-host artifacts useless in a Linux box**:

| Dir | Size | What |
|---|---|---|
| `packages/standalone` | 485M | macOS aarch64 Codex release binaries (in-box codex is npm-installed) |
| `plugins/.plugin-appserver` | 238M | platform-specific plugin app-server runtime |
| `computer-use` | 57M | `Codex Computer Use.app` macOS bundle |
| `.tmp` | 213M | plugin marketplace cache (regenerable) |
| `archived_sessions`, `tmp`, `cache`, `vendor_imports`, `sqlite`, `models_cache.json` | — | host history / regenerable caches |

This made the `scp codex static` step during cloud `prepare` (and the docker volume sync on every create) crawl.

## Fix

Exclude the heavy host-only dirs from **both** codex staging paths:
- **Cloud bake** (`CODEX_RSYNC_EXCLUDES`, `host-stage.ts`) — used by hetzner/vercel/e2b/daytona `stageCodexStaticForUpload`.
- **Docker volume sync** (`codex.ts`, the `agentbox-codex-config` rsync) — plus the matching `rm -rf` purge so existing shared volumes get trimmed on the next sync.

Config / auth / skills / prompts / rules / memories / plugins are still synced, so codex keeps working.

## Verification

- **Cloud (dry-run):** staged codex tarball **820 MB → 482 KB** (121 files; config.toml/skills/prompts kept).
- **Docker (live e2e):** fresh box from `../agentbox-test-repo-gh` — `~/.codex` **1.5 GB → 59 MB**, all junk dirs purged, kept config intact, and `codex exec` returned a real `PONG`. All 297 `sandbox-docker` tests pass.
- Cloud live-validation on Hetzner was blocked by an unrelated, sustained Cloudflare 403 on the datacenter IP (the claude-installer issue from #123) preventing a fresh bake; the change's correctness is covered by the dry-run + the docker live test (which exercises a superset of the same trimmed file set).

https://claude.ai/code/session_019m5WHxP4vmsoXaHUhQdY9e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow rsync/staging filter changes with no auth or config semantics changes; only drops host artifacts that are useless in-box.
> 
> **Overview**
> Stops copying macOS-only and regenerable bulk from the host `~/.codex` into Linux sandboxes, which had been inflating cloud prepare tarballs and Docker `agentbox-codex-config` syncs to hundreds of MB or ~1.5 GB.
> 
> **Cloud prepare** (`CODEX_RSYNC_EXCLUDES` in `host-stage.ts`) now skips `packages`, `plugins/.plugin-appserver`, `computer-use`, and `archived_sessions`, alongside existing cache/runtime excludes.
> 
> **Docker volume sync** (`ensureCodexVolume` in `codex.ts`) applies the same rsync excludes and extends the post-sync `rm -rf` purge so volumes that already absorbed those paths get trimmed on the next create. Config, auth, skills, prompts, and other real settings still sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3f71936c877b514a502939c8d2c1547c73b335e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->