### PR TITLE
fix(ctl): make the in-box ctl-daemon launch idempotent (stop the pile-up)

### DIFF
--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -322,9 +322,11 @@ export function createCloudProvider(
   // portless aliases, persist the record, relaunch the in-box daemons
   // (ctl daemon -> in-box bridge + the agentbox.yaml tasks/services, dockerd,
   // VNC), and re-register with the host relay. Shared by `start()` (after
-  // `backend.start`) and `resume()` (after `backend.resume`) so EVERY wake path
-  // brings the box fully back, not just attach. Idempotent — the `launch*`
-  // helpers no-op when the daemon is already alive.
+  // `backend.start`), `resume()` (after `backend.resume`), and `reconnect()`
+  // (no power-cycle) so EVERY wake/recover path brings the box fully back, not
+  // just attach. Idempotent — `launchCloudCtlDaemon`/dockerd/VNC skip the spawn
+  // when a healthy instance is already serving (so a host-only `reconnect` on a
+  // live box doesn't pile up duplicate daemons).
   async function reEnsureCloudBox(box: BoxRecord, h: CloudHandle): Promise<BoxRecord> {
     // Preview URLs (and their tokens) can rotate across stop/start — refresh
     // the web + relay preview URLs and persist so `agentbox url` and the

--- a/packages/sandbox-cloud/src/ctl-launch.ts
+++ b/packages/sandbox-cloud/src/ctl-launch.ts
@@ -68,6 +68,21 @@ export async function launchCloudCtlDaemon(args: LaunchCloudCtlArgs): Promise<vo
     boxEnvFile.push(`AGENTBOX_WEB_PROXY_PORT=${quoteShellArgv([String(args.webProxyPort)])}`);
   if (args.boxHost) boxEnvFile.push(`AGENTBOX_BOX_HOST=${quoteShellArgv([args.boxHost])}`);
 
+  // Port the in-box daemon serves the box-relay `/healthz` on (it binds
+  // AGENTBOX_BOX_RELAY_PORT, default 8788). We pass relayUrl as
+  // `http://127.0.0.1:8788`, so derive the port from it; fall back to 8788.
+  const boxRelayPort = (() => {
+    if (args.relayUrl) {
+      try {
+        const p = new URL(args.relayUrl).port;
+        if (p) return Number.parseInt(p, 10);
+      } catch {
+        // unparseable URL → default
+      }
+    }
+    return 8788;
+  })();
+
   // nohup + & detaches the daemon from the exec channel; logs go to the file
   // the daemon already uses for Docker boxes so debugging is uniform.
   // /run and /var/log are root-owned — the non-root sandbox user needs sudo
@@ -77,6 +92,17 @@ export async function launchCloudCtlDaemon(args: LaunchCloudCtlArgs): Promise<vo
   // by the image's /etc/profile.d/agentbox.sh shim.
   const script = [
     `set -e`,
+    // Idempotent: if a healthy ctl daemon is already serving the box relay,
+    // leave it — it already has the right env (relayUrl/token are stable across
+    // a host-only reconnect), and a fresh spawn would just fail to bind :PORT
+    // and linger as an orphan. Only a real sandbox restart kills the daemon, in
+    // which case the probe fails and we (re)launch. Without this, every
+    // start/resume/recover leaked another idle daemon. node is guaranteed
+    // present (it runs agentbox-ctl); curl may not be.
+    `if node -e 'require("http").get("http://127.0.0.1:${String(boxRelayPort)}/healthz",r=>process.exit(r.statusCode===200?0:1)).on("error",()=>process.exit(1))' 2>/dev/null; then`,
+    `  echo "agentbox-ctl daemon already healthy on :${String(boxRelayPort)}; skipping launch"`,
+    `  exit 0`,
+    `fi`,
     `if command -v sudo >/dev/null 2>&1; then SUDO='sudo -n'; else SUDO=''; fi`,
     `$SUDO mkdir -p /run/agentbox /var/log/agentbox /etc/agentbox`,
     `$SUDO chown "$(id -un):$(id -gn)" /run/agentbox /var/log/agentbox`,

--- a/packages/sandbox-cloud/test/ctl-launch.test.ts
+++ b/packages/sandbox-cloud/test/ctl-launch.test.ts
@@ -54,6 +54,34 @@ describe('launchCloudCtlDaemon', () => {
     expect(script).toContain('AGENTBOX_WEB_PROXY_PORT=8080');
   });
 
+  it('guards the spawn with a /healthz probe before launching (idempotent)', async () => {
+    const script = await launchScript(undefined);
+    const guardIdx = script.indexOf('/healthz');
+    const spawnIdx = script.indexOf('agentbox-ctl daemon >>');
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(spawnIdx).toBeGreaterThan(-1);
+    // The skip-guard must run BEFORE the daemon spawn, else it can't prevent it.
+    expect(guardIdx).toBeLessThan(spawnIdx);
+    expect(script).toContain('skipping launch');
+    // Default box-relay port when no relayUrl is supplied.
+    expect(script).toContain('127.0.0.1:8788/healthz');
+  });
+
+  it('probes the box-relay port parsed from relayUrl', async () => {
+    const backend = makeMockCloudBackend();
+    const handle = await backend.provision({ name: 'b', image: 'i' });
+    backend.clearCalls();
+    await launchCloudCtlDaemon({
+      backend,
+      handle,
+      boxId: 'id-1',
+      boxName: 'mybox',
+      relayUrl: 'http://127.0.0.1:9999',
+    });
+    const exec = backend.calls.find((c) => c.method === 'exec');
+    expect(exec!.args[1] as string).toContain('127.0.0.1:9999/healthz');
+  });
+
   it('omits AGENTBOX_BOX_HOST when unset (engine falls back to derive)', async () => {
     const script = await launchScript(undefined);
     expect(script).not.toContain('AGENTBOX_BOX_HOST=');

--- a/packages/sandbox-docker/src/ctl.ts
+++ b/packages/sandbox-docker/src/ctl.ts
@@ -31,7 +31,18 @@ export async function launchCtlDaemon(
   // after a crash. The log dir is pre-created in the image (Dockerfile.box
   // mkdir+chown vscode); `mkdir -p` is a cheap belt-and-braces. `exec` lets
   // the shell replace itself with the daemon for a clean process tree.
-  const wrapped = `mkdir -p ${CTL_DAEMON_LOG.replace(/\/[^/]*$/, '')} && exec agentbox-ctl daemon >>${CTL_DAEMON_LOG} 2>&1`;
+  //
+  // Idempotent: skip the spawn when a daemon is already running — a normal
+  // `start` runs on a freshly-started container (daemon dead, so this no-ops),
+  // but `reconnect` (and `start` on an already-running container) would
+  // otherwise launch a duplicate. Anchor the pattern at end-of-cmdline so it
+  // matches the daemon (`node …/agentbox-ctl daemon`) but not this `sh -c`
+  // wrapper, whose argv ends in the log redirect, not "daemon".
+  const logDir = CTL_DAEMON_LOG.replace(/\/[^/]*$/, '');
+  const wrapped =
+    `mkdir -p ${logDir} && ` +
+    `{ pgrep -f 'agentbox-ctl daemon$' >/dev/null 2>&1 && exit 0; }; ` +
+    `exec agentbox-ctl daemon >>${CTL_DAEMON_LOG} 2>&1`;
   const result = await execInBox(container, ['sh', '-c', wrapped], {
     user: 'vscode',
     detach: true,


### PR DESCRIPTION
## Problem

A live cloud box accumulated many `agentbox-ctl daemon` processes (a Hetzner box had 9), only the oldest actually serving the box-relay port `:8788`; the rest were orphaned idle node processes.

`launchCloudCtlDaemon` spawns the daemon **unconditionally** on every create / start / unpause / resume / **recover** (via `reEnsureCloudBox`). The daemon has no singleton guard — when `:8788` is already bound it catches `EADDRINUSE` and keeps running — so each relaunch leaks another idle daemon. `agentbox recover`, which targets *already-running* boxes, hit this every single time. (It is **not** `agentbox attach` — attach never launches a daemon.)

## Fix

- **Cloud** (`ctl-launch.ts`): guard the spawn with a liveness probe — if a healthy daemon already serves the box relay's `/healthz` (port parsed from `relayUrl`, default 8788), skip the launch. It already has the right env (stable across a host-only reconnect); only a real sandbox restart kills it (probe fails → relaunch). Probe via `node` (guaranteed present; `curl` may not be).
- **Docker parity** (`ctl.ts`): same idea with `pgrep -f 'agentbox-ctl daemon$'` (end-anchored so it matches the daemon, not the `sh -c` wrapper). Docker doesn't pile up today because the daemon dies with the container, but the new docker `reconnect` runs `startBox` on a possibly-running container and would otherwise double-launch.
- Corrected the stale "Idempotent — the launch* helpers no-op" comment in `reEnsureCloudBox` to match reality.

## Verification

- Unit: assert the cloud script contains the `/healthz` skip-guard *before* the spawn, and the probe port is parsed from `relayUrl`.
- Live (Hetzner box): ran `recover --no-attach` **twice** — daemon count stayed flat, `:8788` still healthy on the original pid.
- `pnpm typecheck && lint && test` green.

Note: this prevents *new* pile-up; existing orphans in a long-lived box clear on its next real restart. Out of scope: `recover --adopt` against a box with a *foreign* daemon (different token) needs force-replace — tracked as a follow-up.

https://claude.ai/code/session_01Ja5HgEjwyER5BhhFCpPUup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes in-box daemon startup on every start/resume/recover/reconnect path; mis-probes could skip needed relaunches, though fresh sandbox boots still relaunch when health checks fail.
> 
> **Overview**
> **Stops duplicate `agentbox-ctl daemon` processes** when `reEnsureCloudBox` runs on an already-live box (notably `recover` / `reconnect`), where each unconditional spawn could leave orphaned Node processes after `EADDRINUSE` on the box-relay port.
> 
> **Cloud** (`ctl-launch.ts`): before `nohup agentbox-ctl daemon`, the launch script probes `http://127.0.0.1:<port>/healthz` via `node` (port from `relayUrl`, default **8788**). A 200 skips the spawn; only a dead/missing daemon proceeds to mkdir, `box.env`, and launch.
> 
> **Docker** (`ctl.ts`): same idea with `pgrep -f 'agentbox-ctl daemon$'` so `reconnect` / start on a running container does not double-launch.
> 
> Comments in `reEnsureCloudBox` now state that wake paths include **`reconnect()`** and that ctl/dockerd/VNC launches are idempotent when already healthy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56fe054fc0fd8f13e17bbc025732f1c7b3ceee86. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->