### PR TITLE
refactor(provider): central PROVIDERS table + loader map to streamline adding a provider

### DIFF
--- a/apps/cli/src/commands/checkpoint.ts
+++ b/apps/cli/src/commands/checkpoint.ts
@@ -10,7 +10,7 @@ import {
   setConfigValue,
   unsetConfigValue,
 } from '@agentbox/config';
-import type { ProviderKind } from '@agentbox/config';
+import { CLOUD_PROVIDER_NAMES, type ProviderKind } from '@agentbox/config';
 import type { BoxRecord } from '@agentbox/core';
 import {
   clearRelayNotice,
@@ -32,24 +32,16 @@ import {
 import type { CloudCheckpointInfo } from '@agentbox/sandbox-cloud';
 import { resolveBoxOrExit } from '../box-ref.js';
 import { providerForBox } from '../provider/registry.js';
+import { loadProviderModule } from '../provider/loaders.js';
 import { handleLifecycleError } from './_errors.js';
 
 /** Cloud backends that store snapshots under ~/.agentbox/cloud-checkpoints/<backend>/. */
-const CLOUD_BACKENDS = ['daytona', 'hetzner', 'vercel', 'e2b'] as const;
-type CloudBackend = (typeof CLOUD_BACKENDS)[number];
+const CLOUD_BACKENDS = CLOUD_PROVIDER_NAMES;
+type CloudBackend = ProviderKind;
 
 /** Lazily resolve a cloud provider's checkpoint capability (dynamic import keeps SDKs out of the hot path). */
 async function cloudProviderFor(backend: CloudBackend): Promise<import('@agentbox/core').Provider> {
-  switch (backend) {
-    case 'daytona':
-      return (await import('@agentbox/sandbox-daytona')).daytonaProvider;
-    case 'hetzner':
-      return (await import('@agentbox/sandbox-hetzner')).hetznerProvider;
-    case 'vercel':
-      return (await import('@agentbox/sandbox-vercel')).vercelProvider;
-    case 'e2b':
-      return (await import('@agentbox/sandbox-e2b')).e2bProvider;
-  }
+  return (await loadProviderModule(backend)).provider;
 }
 
 /** Footer warning shown in attached sessions while a checkpoint runs. */

--- a/apps/cli/src/commands/create.ts
+++ b/apps/cli/src/commands/create.ts
@@ -234,7 +234,7 @@ export const createCommand = new Command('create')
       opts,
       resolveDefaultCheckpoint(
         cfg.effective,
-        providerName as 'docker' | 'daytona' | 'hetzner' | 'vercel',
+        providerName,
       ),
     );
     // VM size: `--size` flag wins; otherwise the cascaded box.size /
@@ -242,7 +242,7 @@ export const createCommand = new Command('create')
     // override beats a project-level per-provider key.
     const sizeDefault = resolveBoxSize(
       cfg.effective,
-      providerName as 'docker' | 'daytona' | 'hetzner' | 'vercel',
+      providerName,
     );
     const effectiveSize = opts.size && opts.size.length > 0 ? opts.size : sizeDefault;
     // Box image: same precedence pattern as --size. `--image` wins; otherwise
@@ -250,7 +250,7 @@ export const createCommand = new Command('create')
     // prepare --provider X`).
     const imageDefault = resolveBoxImage(
       cfg.effective,
-      providerName as 'docker' | 'daytona' | 'hetzner' | 'vercel',
+      providerName,
     );
     const effectiveImage = opts.image && opts.image.length > 0 ? opts.image : imageDefault;
 

--- a/apps/cli/src/commands/fork.ts
+++ b/apps/cli/src/commands/fork.ts
@@ -1,5 +1,6 @@
 import { log } from '@clack/prompts';
 import { Command } from 'commander';
+import { PROVIDER_NAMES } from '@agentbox/config';
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
@@ -13,8 +14,8 @@ type ForkAgent = 'claude' | 'codex' | 'opencode';
 const FORK_AGENTS = ['claude', 'codex', 'opencode'] as const;
 
 /** Providers fork accepts positionally (`agentbox fork hetzner`) or via
- *  --provider. Kept in sync with the per-agent create commands' provider set. */
-const FORK_PROVIDERS = ['docker', 'daytona', 'hetzner', 'vercel', 'e2b'] as const;
+ *  --provider. Sourced from the central `PROVIDERS` table (single source of truth). */
+const FORK_PROVIDERS = PROVIDER_NAMES;
 
 /** Resolve the provider from the positional arg (`agentbox fork <provider>`,
  *  the skill's `$ARGUMENTS` shape) and/or --provider. A blank value (an LLM

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -40,6 +40,8 @@ import {
   type CheckResult,
   type ProviderName,
 } from '../lib/doctor-checks.js';
+import { PROVIDER_NAMES, isProviderKind, providerMeta } from '@agentbox/config';
+import { loadProviderModule } from '../provider/loaders.js';
 import { markSetupComplete } from '../lib/first-run.js';
 import { maybePromptStar } from '../lib/star-prompt.js';
 import { installCmuxCommand } from './install-cmux.js';
@@ -392,22 +394,6 @@ export async function installForkSkill(
   }
 }
 
-const PROVIDER_HINTS: Record<ProviderName, string> = {
-  docker: 'builds a ~1GB local image; no login needed',
-  hetzner: 'paste an API token from the Hetzner Console',
-  daytona: 'approve a browser sign-in link',
-  vercel: 'installs the Vercel sandbox CLI, then a browser sign-in',
-  e2b: 'paste an API key from the E2B dashboard',
-};
-
-const PROVIDER_LABEL: Record<ProviderName, string> = {
-  docker: 'Docker (local)',
-  hetzner: 'Hetzner (cloud VPS)',
-  daytona: 'Daytona (cloud sandbox)',
-  vercel: 'Vercel (cloud microVM)',
-  e2b: 'E2B (cloud microVM)',
-};
-
 function ensureTty(): boolean {
   if (process.stdin.isTTY && process.stdout.isTTY) return true;
   process.stderr.write(
@@ -430,53 +416,17 @@ interface RunInstallWizardOptions {
 }
 
 async function runProviderLogin(name: ProviderName): Promise<boolean> {
-  if (name === 'docker') return true;
-  if (name === 'daytona') {
-    const mod = await import('@agentbox/sandbox-daytona');
-    const status = await mod.getDaytonaStatus();
-    if (status.configured) {
-      log.info('daytona: already configured');
-      const rotate = await confirm({ message: 'Re-authenticate Daytona?', initialValue: false });
-      if (rotate) await mod.ensureDaytonaCredentials({ force: true });
-      return true;
-    }
-    await mod.ensureDaytonaCredentials();
+  const mod = await loadProviderModule(name);
+  // No credential surface (docker) → nothing to log in.
+  if (!mod.ensureCredentials) return true;
+  const status = mod.readCredStatus ? await mod.readCredStatus() : { configured: false };
+  if (status.configured) {
+    log.info(`${name}: already configured${status.label ? ` (${status.label})` : ''}`);
+    const rotate = await confirm({ message: `Re-authenticate ${name}?`, initialValue: false });
+    if (rotate) await mod.ensureCredentials({ force: true });
     return true;
   }
-  if (name === 'hetzner') {
-    const mod = await import('@agentbox/sandbox-hetzner');
-    const status = mod.readHetznerCredStatus();
-    if (status.source !== 'none') {
-      log.info('hetzner: already configured');
-      const rotate = await confirm({ message: 'Re-authenticate Hetzner?', initialValue: false });
-      if (rotate) await mod.ensureHetznerCredentials({ force: true });
-      return true;
-    }
-    await mod.ensureHetznerCredentials();
-    return true;
-  }
-  if (name === 'vercel') {
-    const mod = await import('@agentbox/sandbox-vercel');
-    const status = mod.readVercelCredStatus();
-    if (status.auth !== 'none') {
-      log.info(`vercel: already configured (${status.auth})`);
-      const rotate = await confirm({ message: 'Re-authenticate Vercel?', initialValue: false });
-      if (rotate) await mod.ensureVercelCredentials({ force: true });
-      return true;
-    }
-    await mod.ensureVercelCredentials();
-    return true;
-  }
-  // e2b
-  const mod = await import('@agentbox/sandbox-e2b');
-  const status = mod.readE2bCredStatus();
-  if (status.auth !== 'none') {
-    log.info(`e2b: already configured (${status.auth})`);
-    const rotate = await confirm({ message: 'Re-authenticate E2B?', initialValue: false });
-    if (rotate) await mod.ensureE2bCredentials({ force: true });
-    return true;
-  }
-  await mod.ensureE2bCredentials();
+  await mod.ensureCredentials();
   return true;
 }
 
@@ -494,10 +444,10 @@ function tutorialBody(provider: ProviderName): string {
   );
 }
 
-const KNOWN_PROVIDERS: ProviderName[] = ['docker', 'hetzner', 'daytona', 'vercel', 'e2b'];
+const KNOWN_PROVIDERS: readonly ProviderName[] = PROVIDER_NAMES;
 
 function isProviderName(s: string): s is ProviderName {
-  return (KNOWN_PROVIDERS as readonly string[]).includes(s);
+  return isProviderKind(s);
 }
 
 /**
@@ -543,8 +493,8 @@ export async function runInstallWizard(opts: RunInstallWizardOptions = {}): Prom
       initialValue: 'docker',
       options: KNOWN_PROVIDERS.map((p) => ({
         value: p,
-        label: PROVIDER_LABEL[p],
-        hint: PROVIDER_HINTS[p],
+        label: providerMeta(p).label,
+        hint: providerMeta(p).loginHint,
       })),
     });
     providerName = picked;

--- a/apps/cli/src/commands/prepare.ts
+++ b/apps/cli/src/commands/prepare.ts
@@ -25,6 +25,7 @@ import { intro, log, spinner } from '@clack/prompts';
 import {
   boxImageConfigKey,
   loadEffectiveConfig,
+  PROVIDER_NAMES,
   setConfigValue,
   unsetConfigValue,
 } from '@agentbox/config';
@@ -313,7 +314,7 @@ export async function runPrepare(
   opts: RunPrepareOptions = {},
 ): Promise<void> {
   if (!isKnownProvider(providerName)) {
-    process.stderr.write('error: --provider must be one of: docker, daytona, hetzner, vercel, e2b\n');
+    process.stderr.write(`error: --provider must be one of: ${PROVIDER_NAMES.join(', ')}\n`);
     process.exit(1);
   }
 

--- a/apps/cli/src/lib/doctor-checks.ts
+++ b/apps/cli/src/lib/doctor-checks.ts
@@ -10,33 +10,27 @@ import { accessSync, constants as fsConstants, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { execa } from 'execa';
-import { loadEffectiveConfig } from '@agentbox/config';
+import { loadEffectiveConfig, PROVIDER_NAMES, type ProviderKind } from '@agentbox/config';
+import { errSummary, firstLine, type CheckResult, type CheckStatus } from '@agentbox/sandbox-core';
 import { ALL_CONNECTORS, type IntegrationConnector } from '@agentbox/integrations';
+import { loadProviderModule } from '../provider/loaders.js';
 
-/**
- * `info` is for rows that are intentionally inert (e.g. an integration the
- * user hasn't enabled). It surfaces as a distinct glyph but rolls up like
- * `ok` so it never pushes the overall doctor status to "warn" — disabling
- * Notion is a setting, not a problem.
- */
-export type CheckStatus = 'ok' | 'info' | 'warn' | 'fail';
-
-export interface CheckResult {
-  label: string;
-  status: CheckStatus;
-  detail: string;
-  hint?: string;
-}
+// The per-provider health probes live in each `@agentbox/sandbox-<name>`
+// package (`providerModule.doctorChecks`); this module just aggregates them
+// with the system + integration checks. `CheckResult`/`CheckStatus` are the
+// shared shape from sandbox-core.
+export type { CheckResult, CheckStatus };
 
 export interface CheckGroup {
-  /** Group title: 'system' | 'docker' | 'daytona' | 'hetzner' | 'vercel' | 'e2b'. */
+  /** Group title: 'system' | a provider name | 'integrations'. */
   title: string;
   results: CheckResult[];
 }
 
-export type ProviderName = 'docker' | 'daytona' | 'hetzner' | 'vercel' | 'e2b';
+/** Provider group name — the config `ProviderKind` (single source of truth). */
+export type ProviderName = ProviderKind;
 
-const ALL_PROVIDERS: ProviderName[] = ['docker', 'daytona', 'hetzner', 'vercel', 'e2b'];
+const ALL_PROVIDERS: readonly ProviderName[] = PROVIDER_NAMES;
 const NODE_MIN_MAJOR = 20;
 const NODE_MIN_MINOR = 10;
 
@@ -55,15 +49,6 @@ function parseNodeMajorMinor(v: string): [number, number] {
   const m = /^v?(\d+)\.(\d+)/.exec(v);
   if (!m) return [0, 0];
   return [Number(m[1]), Number(m[2])];
-}
-
-function firstLine(s: string): string {
-  const i = s.indexOf('\n');
-  return i === -1 ? s : s.slice(0, i);
-}
-
-function errSummary(err: unknown): string {
-  return err instanceof Error ? firstLine(err.message) : String(err);
 }
 
 function checkNode(): CheckResult {
@@ -132,253 +117,6 @@ async function checkSsh(): Promise<CheckResult> {
 export async function runSystemChecks(): Promise<CheckResult[]> {
   const [git, ssh] = await Promise.all([checkGit(), checkSsh()]);
   return [checkNode(), checkPlatform(), checkAgentboxHome(), git, ssh];
-}
-
-async function dockerChecks(): Promise<CheckResult[]> {
-  const linux = process.platform === 'linux';
-  const cli = await probeVersion('docker');
-  if (!cli) {
-    return [
-      {
-        label: 'docker cli',
-        status: 'warn',
-        detail: 'not found',
-        hint: linux
-          ? 'install docker engine: https://docs.docker.com/engine/install/'
-          : 'install Docker Desktop, OrbStack, or docker engine',
-      },
-    ];
-  }
-  const cliRes: CheckResult = { label: 'docker cli', status: 'ok', detail: cli };
-
-  // Daemon reachability via `docker info` (same probe pattern as
-  // packages/sandbox-docker/src/docker.ts:dockerInfo). On Linux the most common
-  // failure is not a stopped daemon but the user missing from the `docker`
-  // group — `docker info` then exits non-zero with "permission denied" on the
-  // socket. Distinguish the two so the hint points at the right fix.
-  const info = await execa('docker', ['info'], { reject: false });
-  if (info.exitCode !== 0) {
-    const permDenied = `${info.stderr ?? ''}`.toLowerCase().includes('permission denied');
-    let hint: string;
-    if (permDenied && linux) {
-      hint =
-        'add your user to the docker group: `sudo usermod -aG docker $USER`, then log out/in (or run `newgrp docker`)';
-    } else if (linux) {
-      hint = 'start Docker: `sudo systemctl start docker` (install docker engine if missing)';
-    } else {
-      hint = 'start Docker (Desktop / OrbStack)';
-    }
-    return [
-      cliRes,
-      {
-        label: 'docker daemon',
-        status: 'warn',
-        detail: permDenied ? 'permission denied' : 'unreachable',
-        hint,
-      },
-    ];
-  }
-  const daemonRes: CheckResult = { label: 'docker daemon', status: 'ok', detail: 'reachable' };
-
-  // Probe the base image + shared volumes. Lazy-import to keep the docker
-  // package off the hot path for non-docker users.
-  const mod = await import('@agentbox/sandbox-docker');
-  let imgRes: CheckResult;
-  try {
-    const img = await mod.imageInfo(mod.DEFAULT_BOX_IMAGE);
-    imgRes = img.exists
-      ? { label: 'box image', status: 'ok', detail: `${mod.DEFAULT_BOX_IMAGE} built` }
-      : {
-          label: 'box image',
-          status: 'warn',
-          detail: `${mod.DEFAULT_BOX_IMAGE} not built`,
-          hint: 'run `agentbox prepare --provider docker` (or let the wizard do it)',
-        };
-  } catch (err) {
-    imgRes = {
-      label: 'box image',
-      status: 'warn',
-      detail: errSummary(err),
-    };
-  }
-
-  const volNames = [mod.SHARED_CLAUDE_VOLUME, mod.SHARED_CODEX_VOLUME, mod.SHARED_OPENCODE_VOLUME];
-  const vols = await Promise.all(
-    volNames.map(async (n) => ({ name: n, exists: await mod.volumeExists(n).catch(() => false) })),
-  );
-  const present = vols.filter((v) => v.exists).length;
-  const volRes: CheckResult = {
-    label: 'shared volumes',
-    status: 'ok',
-    detail: `${String(present)}/${String(vols.length)} present (seeded lazily)`,
-  };
-
-  return [cliRes, daemonRes, imgRes, volRes];
-}
-
-async function daytonaChecks(): Promise<CheckResult[]> {
-  try {
-    const mod = await import('@agentbox/sandbox-daytona');
-    const status = await mod.getDaytonaStatus();
-    if (!status.configured) {
-      return [
-        {
-          label: 'credentials',
-          status: 'warn',
-          detail: status.reason ?? 'not configured',
-          hint: '`agentbox daytona login`',
-        },
-      ];
-    }
-    const credRes: CheckResult = { label: 'credentials', status: 'ok', detail: 'configured' };
-    const snapRes: CheckResult =
-      status.snapshots.length > 0
-        ? {
-            label: 'base snapshot',
-            status: 'ok',
-            detail: `${String(status.snapshots.length)} agentbox snapshot(s)`,
-          }
-        : {
-            label: 'base snapshot',
-            status: 'warn',
-            detail: 'none',
-            hint: '`agentbox prepare --provider daytona`',
-          };
-    return [credRes, snapRes];
-  } catch (err) {
-    return [
-      {
-        label: 'credentials',
-        status: 'warn',
-        detail: errSummary(err),
-      },
-    ];
-  }
-}
-
-async function hetznerChecks(): Promise<CheckResult[]> {
-  try {
-    const mod = await import('@agentbox/sandbox-hetzner');
-    const cred = mod.readHetznerCredStatus();
-    const credRes: CheckResult =
-      cred.source === 'none'
-        ? {
-            label: 'credentials',
-            status: 'warn',
-            detail: 'HCLOUD_TOKEN not set',
-            hint: '`agentbox hetzner login`',
-          }
-        : { label: 'credentials', status: 'ok', detail: `token from ${cred.source}` };
-
-    const prepared = mod.readPreparedState();
-    const snapRes: CheckResult = prepared.base?.imageId
-      ? {
-          label: 'base snapshot',
-          status: 'ok',
-          detail: `image ${String(prepared.base.imageId)} (${prepared.base.cliVersion ?? '—'})`,
-        }
-      : {
-          label: 'base snapshot',
-          status: 'warn',
-          detail: 'not baked',
-          hint: '`agentbox prepare --provider hetzner`',
-        };
-    return [credRes, snapRes];
-  } catch (err) {
-    return [
-      {
-        label: 'credentials',
-        status: 'warn',
-        detail: errSummary(err),
-      },
-    ];
-  }
-}
-
-async function vercelChecks(): Promise<CheckResult[]> {
-  try {
-    const mod = await import('@agentbox/sandbox-vercel');
-    const cred = mod.readVercelCredStatus();
-    const credRes: CheckResult =
-      cred.auth === 'none'
-        ? {
-            label: 'credentials',
-            status: 'warn',
-            detail: 'not configured',
-            hint: '`agentbox vercel login`',
-          }
-        : {
-            label: 'credentials',
-            status: 'ok',
-            detail: `${cred.auth} (${cred.source})`,
-          };
-
-    const prepared = mod.readPreparedState();
-    const snapRes: CheckResult = prepared.base?.snapshotId
-      ? {
-          label: 'base snapshot',
-          status: 'ok',
-          detail: `${prepared.base.snapshotId.slice(0, 16)}… (${prepared.base.cliVersion ?? '—'})`,
-        }
-      : {
-          label: 'base snapshot',
-          status: 'warn',
-          detail: 'not baked',
-          hint: '`agentbox prepare --provider vercel`',
-        };
-    return [credRes, snapRes];
-  } catch (err) {
-    return [
-      {
-        label: 'credentials',
-        status: 'warn',
-        detail: errSummary(err),
-      },
-    ];
-  }
-}
-
-async function e2bChecks(): Promise<CheckResult[]> {
-  try {
-    const mod = await import('@agentbox/sandbox-e2b');
-    const cred = mod.readE2bCredStatus();
-    const credRes: CheckResult =
-      cred.auth === 'none'
-        ? {
-            label: 'credentials',
-            status: 'warn',
-            detail: 'not configured',
-            hint: '`agentbox e2b login`',
-          }
-        : {
-            label: 'credentials',
-            status: 'ok',
-            detail: `${cred.auth} (${cred.source})`,
-          };
-
-    const prepared = mod.readPreparedState();
-    const tmplRes: CheckResult = prepared.base?.templateId
-      ? {
-          label: 'base template',
-          status: 'ok',
-          detail: `${prepared.base.templateName ?? prepared.base.templateId} (${prepared.base.cliVersion ?? '—'})`,
-        }
-      : {
-          label: 'base template',
-          status: 'warn',
-          detail: 'not baked',
-          hint: '`agentbox prepare --provider e2b`',
-        };
-    return [credRes, tmplRes];
-  } catch (err) {
-    return [
-      {
-        label: 'credentials',
-        status: 'warn',
-        detail: errSummary(err),
-      },
-    ];
-  }
 }
 
 /**
@@ -537,25 +275,8 @@ async function checkOneIntegration(
 }
 
 export async function runProviderChecks(name: ProviderName): Promise<CheckGroup> {
-  let results: CheckResult[];
-  switch (name) {
-    case 'docker':
-      results = await dockerChecks();
-      break;
-    case 'daytona':
-      results = await daytonaChecks();
-      break;
-    case 'hetzner':
-      results = await hetznerChecks();
-      break;
-    case 'vercel':
-      results = await vercelChecks();
-      break;
-    case 'e2b':
-      results = await e2bChecks();
-      break;
-  }
-  return { title: name, results };
+  const mod = await loadProviderModule(name);
+  return { title: name, results: await mod.doctorChecks() };
 }
 
 export async function runAllChecks(): Promise<CheckGroup[]> {

--- a/apps/cli/src/provider/cloud-backend.ts
+++ b/apps/cli/src/provider/cloud-backend.ts
@@ -1,32 +1,22 @@
 /**
- * Lazily resolve a cloud `CloudBackend` by provider name. Dynamic imports keep
- * the heavy provider SDKs (Daytona/Hetzner/Vercel) off the docker hot path.
- * Returns `null` for `docker` (no cloud backend) and any unknown name.
+ * Lazily resolve a cloud `CloudBackend` by provider name via the provider
+ * loader (`loaders.ts`), which keeps the heavy provider SDKs off the docker hot
+ * path. Returns `null` for `docker` (no cloud backend) and any unknown name.
  */
 import type { CloudBackend, ProviderName } from '@agentbox/core';
+import { isProviderKind } from '@agentbox/config';
+import { loadProviderModule } from './loaders.js';
 
 export async function cloudBackendForProvider(
   provider: ProviderName,
 ): Promise<CloudBackend | null> {
-  switch (provider) {
-    case 'daytona':
-      return (await import('@agentbox/sandbox-daytona')).daytonaBackend;
-    case 'hetzner':
-      return (await import('@agentbox/sandbox-hetzner')).hetznerBackend;
-    case 'vercel':
-      return (await import('@agentbox/sandbox-vercel')).vercelBackend;
-    case 'e2b':
-      return (await import('@agentbox/sandbox-e2b')).e2bBackend;
-    default:
-      return null;
-  }
+  if (!isProviderKind(provider)) return null;
+  return (await loadProviderModule(provider)).backend ?? null;
 }
 
 /**
  * Compute the CURRENT build-context fingerprint for a cloud provider's base
- * image / snapshot — same shape as `cloudBackendForProvider` but resolves the
- * provider package's `*BaseFingerprintLive()` helper instead of the backend.
- * Dynamic imports keep the cloud SDKs off the docker hot path.
+ * image / snapshot via the provider's `providerModule.currentBaseFingerprintLive`.
  *
  * Returns `undefined` for docker (its base self-heals via `ensureImage`) and
  * any provider whose live computation fails (typically a dev tree without
@@ -36,16 +26,7 @@ export async function currentCloudBaseFingerprintLive(
   provider: ProviderName,
   claudeInstall?: 'native' | 'npm',
 ): Promise<string | undefined> {
-  switch (provider) {
-    case 'daytona':
-      return (await import('@agentbox/sandbox-daytona')).currentDaytonaBaseFingerprintLive(claudeInstall);
-    case 'hetzner':
-      return (await import('@agentbox/sandbox-hetzner')).currentHetznerBaseFingerprintLive(claudeInstall);
-    case 'vercel':
-      return (await import('@agentbox/sandbox-vercel')).currentVercelBaseFingerprintLive(claudeInstall);
-    case 'e2b':
-      return (await import('@agentbox/sandbox-e2b')).currentE2bBaseFingerprintLive(claudeInstall);
-    default:
-      return undefined;
-  }
+  if (!isProviderKind(provider)) return undefined;
+  const mod = await loadProviderModule(provider);
+  return mod.currentBaseFingerprintLive?.(claudeInstall);
 }

--- a/apps/cli/src/provider/loaders.ts
+++ b/apps/cli/src/provider/loaders.ts
@@ -1,0 +1,33 @@
+/**
+ * Per-provider lazy module loaders — the ONE place the CLI enumerates the
+ * `@agentbox/sandbox-<name>` packages.
+ *
+ * Each package exposes a uniform `providerModule` (see `ProviderModule` in
+ * `@agentbox/sandbox-core`); the create / doctor / install / checkpoint code
+ * all resolve a provider through `loadProviderModule` and drive it generically,
+ * so those call sites carry no per-provider `switch`.
+ *
+ * The `import()` specifiers are LITERAL — one arm per provider — on purpose.
+ * The CLI's tsup build inlines every `@agentbox/sandbox-*` package
+ * (`noExternal: [/^@agentbox\//]`), which requires esbuild to statically
+ * resolve each specifier; a runtime-variable `import('@agentbox/sandbox-' +
+ * name)` would not inline and would `MODULE_NOT_FOUND` in the published CLI.
+ * `Record<ProviderKind, …>` makes this map exhaustive: adding a provider to the
+ * config `PROVIDERS` table forces a matching entry here (a TS error otherwise).
+ */
+
+import type { ProviderKind } from '@agentbox/config';
+import type { ProviderModule } from '@agentbox/sandbox-core';
+
+const IMPORTERS: Record<ProviderKind, () => Promise<{ providerModule: ProviderModule }>> = {
+  docker: () => import('@agentbox/sandbox-docker'),
+  daytona: () => import('@agentbox/sandbox-daytona'),
+  hetzner: () => import('@agentbox/sandbox-hetzner'),
+  vercel: () => import('@agentbox/sandbox-vercel'),
+  e2b: () => import('@agentbox/sandbox-e2b'),
+};
+
+/** Lazily import a provider package and return its uniform `providerModule`. */
+export async function loadProviderModule(name: ProviderKind): Promise<ProviderModule> {
+  return (await IMPORTERS[name]()).providerModule;
+}

--- a/apps/cli/src/provider/registry.ts
+++ b/apps/cli/src/provider/registry.ts
@@ -6,66 +6,32 @@
  */
 
 import type { EffectiveConfig } from '@agentbox/config';
+import { isProviderKind, PROVIDER_NAMES, type ProviderKind } from '@agentbox/config';
 import type { BoxRecord, Provider, ProviderName } from '@agentbox/core';
+import { loadProviderModule } from './loaders.js';
 
-export type KnownProviderName = 'docker' | 'daytona' | 'hetzner' | 'vercel' | 'e2b';
-
-const KNOWN: readonly KnownProviderName[] = ['docker', 'daytona', 'hetzner', 'vercel', 'e2b'];
+export type KnownProviderName = ProviderKind;
 
 export function isKnownProvider(name: string): name is KnownProviderName {
-  return (KNOWN as readonly string[]).includes(name);
+  return isProviderKind(name);
 }
 
+/**
+ * Resolve a `Provider` by name, running its first-run credential gate first.
+ * Each provider package's `providerModule.ensureCredentials` walks the user
+ * through `agentbox <provider> login` on first use (a no-op for docker, and
+ * for scripted/non-TTY callers). The base-snapshot gate lives inside
+ * `backend.provision`, not here, so `agentbox prepare` can build the snapshot
+ * without tripping it. The single lazy `import()` (see `loaders.ts`) keeps each
+ * provider SDK off the hot path.
+ */
 export async function getProvider(name: ProviderName): Promise<Provider> {
-  switch (name) {
-    case 'docker': {
-      const mod = await import('@agentbox/sandbox-docker');
-      return mod.dockerProvider;
-    }
-    case 'daytona': {
-      // Single lazy import covers both the first-run prompt gate and the
-      // provider itself — keeps the Daytona SDK off the Docker hot path.
-      // The prompt is a no-op when env is already configured or stdin isn't
-      // a TTY (scripted callers get the SDK's "not configured" error instead
-      // of a hung prompt).
-      const mod = await import('@agentbox/sandbox-daytona');
-      await mod.ensureDaytonaCredentials();
-      return mod.daytonaProvider;
-    }
-    case 'hetzner': {
-      // Same lazy-import pattern as daytona. `ensureHetznerCredentials` walks
-      // the user through `agentbox hetzner login` on first use. The base-
-      // snapshot gate (`ensureHetznerBaseSnapshot`) is deliberately *not*
-      // called here: it would chicken-and-egg `agentbox prepare --provider
-      // hetzner` (which exists precisely to BUILD the snapshot). The gate
-      // lives inside `backend.provision` instead — `prepare` calls the REST
-      // client directly, never `provision`, so it slips past the gate while
-      // `create`/`claude`/etc. still trip it.
-      const mod = await import('@agentbox/sandbox-hetzner');
-      await mod.ensureHetznerCredentials();
-      return mod.hetznerProvider;
-    }
-    case 'vercel': {
-      // Same lazy-import pattern. `ensureVercelCredentials` walks the user
-      // through `agentbox vercel login` (OIDC or token trio) on first use. The
-      // base-snapshot gate lives inside `backend.provision` (so `prepare` can
-      // build it without tripping the gate), matching the hetzner shape.
-      const mod = await import('@agentbox/sandbox-vercel');
-      await mod.ensureVercelCredentials();
-      return mod.vercelProvider;
-    }
-    case 'e2b': {
-      // Same lazy-import pattern. `ensureE2bCredentials` walks the user
-      // through `agentbox e2b login` (single API key) on first use. Task 1
-      // boots from E2B's default `base` template at create-time — no
-      // base-snapshot gate yet; Task 2 will add `prepare` + the gate.
-      const mod = await import('@agentbox/sandbox-e2b');
-      await mod.ensureE2bCredentials();
-      return mod.e2bProvider;
-    }
-    default:
-      throw new Error(`unknown sandbox provider: ${String(name)}`);
+  if (!isProviderKind(name)) {
+    throw new Error(`unknown sandbox provider: ${String(name)}`);
   }
+  const mod = await loadProviderModule(name);
+  if (mod.ensureCredentials) await mod.ensureCredentials();
+  return mod.provider;
 }
 
 /** Provider for an existing box record. Defaults to 'docker' for legacy records. */
@@ -89,7 +55,7 @@ export async function providerForCreate(choice: CreateProviderChoice): Promise<P
   const name = (flag && flag.length > 0 ? flag : choice.config.box.provider) as ProviderName;
   if (typeof name !== 'string' || name.length === 0 || !isKnownProvider(name)) {
     throw new Error(
-      `unknown sandbox provider "${String(name)}" (known: ${KNOWN.join(', ')})`,
+      `unknown sandbox provider "${String(name)}" (known: ${PROVIDER_NAMES.join(', ')})`,
     );
   }
   return getProvider(name);

--- a/apps/cli/src/wizard.ts
+++ b/apps/cli/src/wizard.ts
@@ -1,5 +1,5 @@
 import { confirm, log, multiselect } from './lib/prompt.js';
-import { findProjectRoot } from '@agentbox/config';
+import { findProjectRoot, isProviderKind, providerMeta } from '@agentbox/config';
 import type { ProviderName } from '@agentbox/core';
 import { DEFAULT_ENV_PATTERNS, scanHostEnvFiles } from '@agentbox/sandbox-docker';
 import { basename } from 'node:path';
@@ -369,18 +369,7 @@ export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutco
  * daytona: docker Image.build).
  */
 function rebuildMinutesFor(provider: ProviderName): string {
-  switch (provider) {
-    case 'e2b':
-      return '2';
-    case 'daytona':
-      return '7';
-    case 'vercel':
-      return '5-10';
-    case 'hetzner':
-      return '7-10';
-    default:
-      return '1';
-  }
+  return isProviderKind(provider) ? providerMeta(provider).rebuildMinutes : '1';
 }
 
 /**

--- a/packages/config/src/checkpoint.ts
+++ b/packages/config/src/checkpoint.ts
@@ -14,24 +14,17 @@
  * test `.length > 0` keep working unchanged.
  */
 import type { EffectiveConfig, ProviderKind } from './types.js';
+import { isProviderKind, perProviderConfigKey } from './providers.js';
+import { perProviderValue } from './image.js';
 
 export function resolveDefaultCheckpoint(
   cfg: EffectiveConfig,
   provider: ProviderKind | string,
 ): string {
-  // Treat unknown provider names like 'docker' for back-compat — a stray
-  // value in config or argv shouldn't crash before the validation layer.
-  const perProvider =
-    provider === 'daytona'
-      ? cfg.box.defaultCheckpointDaytona
-      : provider === 'hetzner'
-        ? cfg.box.defaultCheckpointHetzner
-        : provider === 'vercel'
-          ? cfg.box.defaultCheckpointVercel
-          : provider === 'e2b'
-            ? cfg.box.defaultCheckpointE2b
-            : cfg.box.defaultCheckpointDocker;
-  if (perProvider && perProvider.length > 0) return perProvider;
+  // Unknown provider names fall back to the global default — a stray value in
+  // config or argv shouldn't crash before the validation layer.
+  const perProvider = perProviderValue(cfg, 'defaultCheckpoint', provider);
+  if (perProvider.length > 0) return perProvider;
   return cfg.box.defaultCheckpoint;
 }
 
@@ -40,19 +33,9 @@ export function resolveDefaultCheckpoint(
  * checkpoint set-default [--provider X]` to write the right field. Passing
  * an unknown provider falls back to the global key (legacy callers).
  */
-export function defaultCheckpointConfigKey(
-  provider: ProviderKind | string | undefined,
-):
-  | 'box.defaultCheckpoint'
-  | 'box.defaultCheckpointDocker'
-  | 'box.defaultCheckpointDaytona'
-  | 'box.defaultCheckpointHetzner'
-  | 'box.defaultCheckpointVercel'
-  | 'box.defaultCheckpointE2b' {
-  if (provider === 'docker') return 'box.defaultCheckpointDocker';
-  if (provider === 'daytona') return 'box.defaultCheckpointDaytona';
-  if (provider === 'hetzner') return 'box.defaultCheckpointHetzner';
-  if (provider === 'vercel') return 'box.defaultCheckpointVercel';
-  if (provider === 'e2b') return 'box.defaultCheckpointE2b';
+export function defaultCheckpointConfigKey(provider: ProviderKind | string | undefined): string {
+  if (provider && isProviderKind(provider)) {
+    return perProviderConfigKey('defaultCheckpoint', provider);
+  }
   return 'box.defaultCheckpoint';
 }

--- a/packages/config/src/image.ts
+++ b/packages/config/src/image.ts
@@ -13,43 +13,41 @@
  * creates on other providers.
  */
 import type { EffectiveConfig, ProviderKind } from './types.js';
+import { isProviderKind, perProviderConfigKey } from './providers.js';
+
+/**
+ * Read a per-provider `box.<base><P>` string field off the effective config.
+ * Unknown provider names fall into the `docker` bucket (back-compat: a stray
+ * value in argv/config shouldn't crash before the validation layer).
+ */
+function perProviderValue(
+  cfg: EffectiveConfig,
+  base: 'image' | 'size' | 'defaultCheckpoint',
+  provider: ProviderKind | string,
+): string {
+  const name = isProviderKind(provider) ? provider : 'docker';
+  const field = perProviderConfigKey(base, name).slice('box.'.length);
+  const val = (cfg.box as Record<string, unknown>)[field];
+  return typeof val === 'string' ? val : '';
+}
 
 export function resolveBoxImage(cfg: EffectiveConfig, provider: ProviderKind | string): string {
-  // Unknown provider names fall into the docker bucket — a stray value in
-  // argv or config shouldn't crash before the validation layer.
-  const perProvider =
-    provider === 'daytona'
-      ? cfg.box.imageDaytona
-      : provider === 'hetzner'
-        ? cfg.box.imageHetzner
-        : provider === 'vercel'
-          ? cfg.box.imageVercel
-          : provider === 'e2b'
-            ? cfg.box.imageE2b
-            : cfg.box.imageDocker;
-  if (perProvider && perProvider.length > 0) return perProvider;
+  // Unknown provider names fall back to the generic `box.image` — a stray
+  // value in argv or config shouldn't crash before the validation layer.
+  const perProvider = perProviderValue(cfg, 'image', provider);
+  if (perProvider.length > 0) return perProvider;
   return cfg.box.image;
 }
+
+export { perProviderValue };
 
 /**
  * Flat KEY_REGISTRY key for `agentbox prepare --provider X` to pin the
  * resulting image into the right per-provider slot; mirrors
- * `defaultCheckpointConfigKey` / `boxSizeConfigKey`. Unknown provider →
- * generic `box.image` (legacy callers).
+ * `defaultCheckpointConfigKey`. Unknown provider → generic `box.image`
+ * (legacy callers).
  */
-export function boxImageConfigKey(
-  provider: ProviderKind | string | undefined,
-):
-  | 'box.image'
-  | 'box.imageDocker'
-  | 'box.imageDaytona'
-  | 'box.imageHetzner'
-  | 'box.imageVercel'
-  | 'box.imageE2b' {
-  if (provider === 'docker') return 'box.imageDocker';
-  if (provider === 'daytona') return 'box.imageDaytona';
-  if (provider === 'hetzner') return 'box.imageHetzner';
-  if (provider === 'vercel') return 'box.imageVercel';
-  if (provider === 'e2b') return 'box.imageE2b';
+export function boxImageConfigKey(provider: ProviderKind | string | undefined): string {
+  if (provider && isProviderKind(provider)) return perProviderConfigKey('image', provider);
   return 'box.image';
 }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -20,6 +20,17 @@ export {
 } from './types.js';
 
 export {
+  PROVIDERS,
+  PROVIDER_NAMES,
+  CLOUD_PROVIDER_NAMES,
+  isProviderKind,
+  providerMeta,
+  providerKeyCap,
+  perProviderConfigKey,
+  type ProviderMeta,
+} from './providers.js';
+
+export {
   coerceFromString,
   parseUserConfig,
   parseUserConfigObject,

--- a/packages/config/src/providers.ts
+++ b/packages/config/src/providers.ts
@@ -1,0 +1,137 @@
+/**
+ * Single source of truth for the set of sandbox providers.
+ *
+ * Adding one row to `PROVIDERS` is the *only* place a new provider's identity
+ * has to be registered. This table drives, by derivation:
+ *   - the `ProviderKind` union (below),
+ *   - the `box.provider` enum + its description (see `types.ts`),
+ *   - the per-provider `box.image<P>` / `box.size<P>` / `box.defaultCheckpoint<P>`
+ *     entries in `KEY_REGISTRY` (generated in `types.ts`),
+ *   - the CLI's known/cloud provider lists, the install-wizard picker
+ *     labels/hints, the wizard's rebuild-time estimate, and the doctor groups.
+ *
+ * The interface fields on `UserConfig`/`EffectiveConfig` and the JSON schema
+ * still list the per-provider keys explicitly (static types can't be generated
+ * from a runtime array); a test (`test/providers.test.ts`) fails if either
+ * drifts from this table.
+ */
+
+export interface ProviderMeta {
+  /** Canonical name — MUST equal the `@agentbox/sandbox-<name>` package suffix. */
+  readonly name: string;
+  /** 'local' = docker; 'cloud' = has a CloudBackend + a prepared base snapshot. */
+  readonly kind: 'local' | 'cloud';
+  /** Human label for the install-wizard picker. */
+  readonly label: string;
+  /** One-line hint for the install-wizard picker. */
+  readonly loginHint: string;
+  /** Rough base-image/snapshot bake time (minutes) shown by the install wizard. */
+  readonly rebuildMinutes: string;
+  /** Fragment describing this backend, joined into the `box.provider` enum description. */
+  readonly blurb: string;
+  /** Description of the per-provider `box.size<P>` KEY_REGISTRY entry. */
+  readonly sizeDesc: string;
+  /** Description of the per-provider `box.image<P>` KEY_REGISTRY entry. */
+  readonly imageDesc: string;
+}
+
+export const PROVIDERS = [
+  {
+    name: 'docker',
+    kind: 'local',
+    label: 'Docker (local)',
+    loginHint: 'builds a ~1GB local image; no login needed',
+    rebuildMinutes: '1',
+    blurb: 'local Docker containers',
+    sizeDesc:
+      'Per-provider override of `box.size` for docker. Reserved — docker sizing is controlled via `box.memory` / `box.cpus` / `box.disk`.',
+    imageDesc:
+      'Per-provider override of `box.image` for docker (local docker image ref, e.g. `agentbox/box:dev`). Wins over the generic when set.',
+  },
+  {
+    name: 'daytona',
+    kind: 'cloud',
+    label: 'Daytona (cloud sandbox)',
+    loginHint: 'approve a browser sign-in link',
+    rebuildMinutes: '7',
+    blurb: 'Daytona Cloud sandboxes',
+    sizeDesc:
+      'Per-provider override of `box.size` for daytona. `cpu-memory-disk` GB spec (e.g. `4-8-20`). Only honored on the image/Dockerfile create path; Daytona rejects custom resources on snapshot-resume.',
+    imageDesc:
+      'Per-provider override of `box.image` for daytona (named snapshot, e.g. `agentbox-base-<fingerprint>`). Written by `agentbox prepare --provider daytona`.',
+  },
+  {
+    name: 'hetzner',
+    kind: 'cloud',
+    label: 'Hetzner (cloud VPS)',
+    loginHint: 'paste an API token from the Hetzner Console',
+    rebuildMinutes: '7-10',
+    blurb: 'Hetzner Cloud VPSes',
+    sizeDesc:
+      'Per-provider override of `box.size` for hetzner. Server type string (e.g. `cx23`, `cx33`, `cx43`).',
+    imageDesc:
+      'Per-provider override of `box.image` for hetzner (image description, e.g. `agentbox-base-<fingerprint>`). Written by `agentbox prepare --provider hetzner`.',
+  },
+  {
+    name: 'vercel',
+    kind: 'cloud',
+    label: 'Vercel (cloud microVM)',
+    loginHint: 'installs the Vercel sandbox CLI, then a browser sign-in',
+    rebuildMinutes: '5-10',
+    blurb: 'Vercel Sandboxes',
+    sizeDesc:
+      'Per-provider override of `box.size` for vercel. Reserved — vercel sizing is controlled via `box.vercelVcpus`.',
+    imageDesc:
+      'Per-provider override of `box.image` for vercel (snapshot id, e.g. `snap_…`). Written by `agentbox prepare --provider vercel`.',
+  },
+  {
+    name: 'e2b',
+    kind: 'cloud',
+    label: 'E2B (cloud microVM)',
+    loginHint: 'paste an API key from the E2B dashboard',
+    rebuildMinutes: '2',
+    blurb: 'E2B microVMs',
+    sizeDesc:
+      'Per-provider override of `box.size` for e2b. Reserved — e2b sizing is template-level (set at `agentbox prepare --provider e2b` time via --vcpus / --memory).',
+    imageDesc:
+      'Per-provider override of `box.image` for e2b (template id or `name:tag`, e.g. `agentbox-base:latest`). Written by `agentbox prepare --provider e2b`.',
+  },
+] as const satisfies readonly ProviderMeta[];
+
+/** Sandbox backend new boxes are created on. Derived from the `PROVIDERS` table. */
+export type ProviderKind = (typeof PROVIDERS)[number]['name'];
+
+/** All provider names, in canonical order. */
+export const PROVIDER_NAMES: readonly ProviderKind[] = PROVIDERS.map((p) => p.name);
+
+/** Cloud provider names only (everything except docker). */
+export const CLOUD_PROVIDER_NAMES: readonly ProviderKind[] = PROVIDERS.filter(
+  (p) => p.kind === 'cloud',
+).map((p) => p.name);
+
+export function isProviderKind(name: string): name is ProviderKind {
+  return (PROVIDER_NAMES as readonly string[]).includes(name);
+}
+
+export function providerMeta(name: ProviderKind): ProviderMeta {
+  const m = PROVIDERS.find((p) => p.name === name);
+  if (!m) throw new Error(`unknown provider: ${String(name)}`);
+  return m;
+}
+
+/**
+ * Capitalize a provider name for its config-key suffix: `e2b` -> `E2b`,
+ * `docker` -> `Docker`, `digitalocean` -> `Digitalocean`. First char upper,
+ * the rest verbatim — matches the hand-written keys this table replaced.
+ */
+export function providerKeyCap(name: string): string {
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+/** Per-provider config key, e.g. `('image','hetzner')` -> `'box.imageHetzner'`. */
+export function perProviderConfigKey(
+  base: 'image' | 'size' | 'defaultCheckpoint',
+  provider: string,
+): string {
+  return `box.${base}${providerKeyCap(provider)}`;
+}

--- a/packages/config/src/size.ts
+++ b/packages/config/src/size.ts
@@ -17,20 +17,12 @@
  * shapes its result, so call sites can `.length > 0` test uniformly.
  */
 import type { EffectiveConfig, ProviderKind } from './types.js';
+import { perProviderValue } from './image.js';
 
 export function resolveBoxSize(cfg: EffectiveConfig, provider: ProviderKind | string): string {
-  // Unknown provider names fall into the docker bucket — a stray value in
-  // argv or config shouldn't crash before the validation layer.
-  const perProvider =
-    provider === 'daytona'
-      ? cfg.box.sizeDaytona
-      : provider === 'hetzner'
-        ? cfg.box.sizeHetzner
-        : provider === 'vercel'
-          ? cfg.box.sizeVercel
-          : provider === 'e2b'
-            ? cfg.box.sizeE2b
-            : cfg.box.sizeDocker;
-  if (perProvider && perProvider.length > 0) return perProvider;
+  // Unknown provider names fall back to the generic `box.size` — a stray value
+  // in argv or config shouldn't crash before the validation layer.
+  const perProvider = perProviderValue(cfg, 'size', provider);
+  if (perProvider.length > 0) return perProvider;
   return cfg.box.size;
 }

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -8,11 +8,18 @@
  *   cli > workspace > project > global > built-in defaults.
  */
 
+import {
+  PROVIDERS,
+  PROVIDER_NAMES,
+  perProviderConfigKey,
+  type ProviderKind,
+} from './providers.js';
+
 export type IdeFlavor = 'vscode' | 'cursor' | 'auto';
 export type EngineKind = 'orbstack' | 'docker-desktop' | 'other' | 'auto';
 export type BrowserKind = 'agent-browser' | 'playwright' | 'both';
-/** Sandbox backend new boxes are created on. */
-export type ProviderKind = 'docker' | 'daytona' | 'hetzner' | 'vercel' | 'e2b';
+/** Sandbox backend new boxes are created on. Defined in `providers.ts` (the single source of truth) and re-exported here for back-compat. */
+export type { ProviderKind };
 /**
  * How the base image/snapshot installs Claude Code at bake time. `native`
  * (Anthropic's installer, the default) or `npm` (`@anthropic-ai/claude-code`) —
@@ -467,19 +474,57 @@ export interface KeyDescriptor {
   advanced?: boolean;
 }
 
+/** Join blurbs into "a, b, c, or d" for the enum description. */
+function joinOr(items: readonly string[]): string {
+  if (items.length <= 1) return items.join('');
+  return `${items.slice(0, -1).join(', ')}, or ${items[items.length - 1]}`;
+}
+
+/**
+ * Per-provider config-key descriptors generated from the `PROVIDERS` table so a
+ * new provider gets its `box.defaultCheckpoint<P>` / `box.size<P>` /
+ * `box.image<P>` entries automatically. The `size`/`image` descriptions come
+ * from the table (they carry provider-specific detail); the checkpoint one is
+ * uniform.
+ */
+function perProviderCheckpointKeys(): KeyDescriptor[] {
+  return PROVIDERS.map((p) => ({
+    key: perProviderConfigKey('defaultCheckpoint', p.name),
+    type: 'string',
+    description: `Per-provider override of \`box.defaultCheckpoint\` for ${p.name}. Wins over the global when set; set via \`agentbox checkpoint set-default --provider ${p.name}\`.`,
+    advanced: true,
+  }));
+}
+function perProviderSizeKeys(): KeyDescriptor[] {
+  return PROVIDERS.map((p) => ({
+    key: perProviderConfigKey('size', p.name),
+    type: 'string',
+    description: p.sizeDesc,
+    advanced: true,
+  }));
+}
+function perProviderImageKeys(): KeyDescriptor[] {
+  return PROVIDERS.map((p) => ({
+    key: perProviderConfigKey('image', p.name),
+    type: 'string',
+    description: p.imageDesc,
+    advanced: true,
+  }));
+}
+
 /**
  * Single source of truth for which keys are addressable from the CLI. The
  * parser, `set`/`unset`, and `list` all walk this. Adding a key here is the
  * one place a new field has to be registered (plus the type interface above
- * and the JSON schema).
+ * and the JSON schema). Per-provider `box.{image,size,defaultCheckpoint}<P>`
+ * keys are generated from the `PROVIDERS` table (see `providers.ts`).
  */
 export const KEY_REGISTRY: readonly KeyDescriptor[] = [
   {
     key: 'box.provider',
     type: 'enum',
-    enumValues: ['docker', 'daytona', 'hetzner', 'vercel', 'e2b'] as const,
-    description:
-      'Sandbox backend new boxes are created on: local Docker containers, Daytona Cloud sandboxes, Hetzner Cloud VPSes, Vercel Sandboxes, or E2B microVMs.',
+    enumValues: PROVIDER_NAMES,
+    description: `Sandbox backend new boxes are created on: ${joinOr(PROVIDERS.map((p) => p.blurb))}.`,
   },
   {
     key: 'box.hostSnapshot',
@@ -493,82 +538,14 @@ export const KEY_REGISTRY: readonly KeyDescriptor[] = [
     description:
       'Checkpoint ref new boxes in this project start from when --snapshot is not given (set via `agentbox checkpoint set-default`). Used as fallback when no per-provider override is set.',
   },
-  {
-    key: 'box.defaultCheckpointDocker',
-    type: 'string',
-    description:
-      'Per-provider override of `box.defaultCheckpoint` for docker. Wins over the global when set; set via `agentbox checkpoint set-default --provider docker`.',
-    advanced: true,
-  },
-  {
-    key: 'box.defaultCheckpointDaytona',
-    type: 'string',
-    description:
-      'Per-provider override of `box.defaultCheckpoint` for daytona. Wins over the global when set; set via `agentbox checkpoint set-default --provider daytona`.',
-    advanced: true,
-  },
-  {
-    key: 'box.defaultCheckpointHetzner',
-    type: 'string',
-    description:
-      'Per-provider override of `box.defaultCheckpoint` for hetzner. Wins over the global when set; set via `agentbox checkpoint set-default --provider hetzner`.',
-    advanced: true,
-  },
-  {
-    key: 'box.defaultCheckpointVercel',
-    type: 'string',
-    description:
-      'Per-provider override of `box.defaultCheckpoint` for vercel. Wins over the global when set; set via `agentbox checkpoint set-default --provider vercel`.',
-    advanced: true,
-  },
-  {
-    key: 'box.defaultCheckpointE2b',
-    type: 'string',
-    description:
-      'Per-provider override of `box.defaultCheckpoint` for e2b. Wins over the global when set; set via `agentbox checkpoint set-default --provider e2b`.',
-    advanced: true,
-  },
+  ...perProviderCheckpointKeys(),
   {
     key: 'box.size',
     type: 'string',
     description:
       'Default VM size for cloud providers. Provider-interpreted: hetzner = server type (e.g. `cx33`); daytona = `cpu-memory-disk` GB (e.g. `4-8-20`). Used as fallback when no per-provider override is set. Docker/Vercel ignore it.',
   },
-  {
-    key: 'box.sizeDocker',
-    type: 'string',
-    description:
-      'Per-provider override of `box.size` for docker. Reserved — docker sizing is controlled via `box.memory` / `box.cpus` / `box.disk`.',
-    advanced: true,
-  },
-  {
-    key: 'box.sizeDaytona',
-    type: 'string',
-    description:
-      'Per-provider override of `box.size` for daytona. `cpu-memory-disk` GB spec (e.g. `4-8-20`). Only honored on the image/Dockerfile create path; Daytona rejects custom resources on snapshot-resume.',
-    advanced: true,
-  },
-  {
-    key: 'box.sizeHetzner',
-    type: 'string',
-    description:
-      'Per-provider override of `box.size` for hetzner. Server type string (e.g. `cx23`, `cx33`, `cx43`).',
-    advanced: true,
-  },
-  {
-    key: 'box.sizeVercel',
-    type: 'string',
-    description:
-      'Per-provider override of `box.size` for vercel. Reserved — vercel sizing is controlled via `box.vercelVcpus`.',
-    advanced: true,
-  },
-  {
-    key: 'box.sizeE2b',
-    type: 'string',
-    description:
-      'Per-provider override of `box.size` for e2b. Reserved — e2b sizing is template-level (set at `agentbox prepare --provider e2b` time via --vcpus / --memory).',
-    advanced: true,
-  },
+  ...perProviderSizeKeys(),
   {
     key: 'checkpoint.maxLayers',
     type: 'int',
@@ -632,36 +609,7 @@ export const KEY_REGISTRY: readonly KeyDescriptor[] = [
     description: 'Generic box image ref (fallback). Used as fallback when no per-provider override is set; the default `agentbox/box:dev` is treated as a sentinel by cloud backends (boot from their prepared base snapshot instead).',
     advanced: true,
   },
-  {
-    key: 'box.imageDocker',
-    type: 'string',
-    description: 'Per-provider override of `box.image` for docker (local docker image ref, e.g. `agentbox/box:dev`). Wins over the generic when set.',
-    advanced: true,
-  },
-  {
-    key: 'box.imageDaytona',
-    type: 'string',
-    description: 'Per-provider override of `box.image` for daytona (named snapshot, e.g. `agentbox-base-<fingerprint>`). Written by `agentbox prepare --provider daytona`.',
-    advanced: true,
-  },
-  {
-    key: 'box.imageHetzner',
-    type: 'string',
-    description: 'Per-provider override of `box.image` for hetzner (image description, e.g. `agentbox-base-<fingerprint>`). Written by `agentbox prepare --provider hetzner`.',
-    advanced: true,
-  },
-  {
-    key: 'box.imageVercel',
-    type: 'string',
-    description: 'Per-provider override of `box.image` for vercel (snapshot id, e.g. `snap_…`). Written by `agentbox prepare --provider vercel`.',
-    advanced: true,
-  },
-  {
-    key: 'box.imageE2b',
-    type: 'string',
-    description: 'Per-provider override of `box.image` for e2b (template id or `name:tag`, e.g. `agentbox-base:latest`). Written by `agentbox prepare --provider e2b`.',
-    advanced: true,
-  },
+  ...perProviderImageKeys(),
   {
     key: 'box.imageRegistry',
     type: 'string',

--- a/packages/config/test/providers.test.ts
+++ b/packages/config/test/providers.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { PROVIDERS, PROVIDER_NAMES, CLOUD_PROVIDER_NAMES, perProviderConfigKey } from '../src/providers.js';
+import { BUILT_IN_DEFAULTS, lookupKey } from '../src/types.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const schema = JSON.parse(
+  readFileSync(resolve(here, '..', 'schema', 'user-config.schema.json'), 'utf8'),
+) as { properties: { box: { properties: Record<string, unknown> } } };
+const boxSchemaKeys = schema.properties.box.properties;
+
+const BASES = ['image', 'size', 'defaultCheckpoint'] as const;
+
+describe('provider table is the single source of truth', () => {
+  it('every provider has all three per-provider keys registered in KEY_REGISTRY', () => {
+    for (const p of PROVIDERS) {
+      for (const base of BASES) {
+        const key = perProviderConfigKey(base, p.name);
+        expect(lookupKey(key), `${key} missing from KEY_REGISTRY`).toBeDefined();
+      }
+    }
+  });
+
+  it('every per-provider key exists in the JSON schema (parser ↔ schema agreement)', () => {
+    // The schema uses additionalProperties:false, so a KEY_REGISTRY entry
+    // without a matching schema key would make config files fail validation.
+    for (const p of PROVIDERS) {
+      for (const base of BASES) {
+        const leaf = perProviderConfigKey(base, p.name).slice('box.'.length);
+        expect(boxSchemaKeys[leaf], `box.${leaf} missing from user-config.schema.json`).toBeDefined();
+      }
+    }
+  });
+
+  it('every per-provider key has a built-in default (EffectiveConfig is total)', () => {
+    const box = BUILT_IN_DEFAULTS.box as unknown as Record<string, unknown>;
+    for (const p of PROVIDERS) {
+      for (const base of BASES) {
+        const leaf = perProviderConfigKey(base, p.name).slice('box.'.length);
+        expect(typeof box[leaf], `${leaf} missing from BUILT_IN_DEFAULTS.box`).toBe('string');
+      }
+    }
+  });
+
+  it('box.provider enum matches PROVIDER_NAMES exactly', () => {
+    const desc = lookupKey('box.provider');
+    expect(desc?.enumValues).toEqual([...PROVIDER_NAMES]);
+  });
+
+  it('docker is the only local provider; the rest are cloud', () => {
+    expect(PROVIDERS.find((p) => p.name === 'docker')?.kind).toBe('local');
+    expect(CLOUD_PROVIDER_NAMES).not.toContain('docker');
+    expect([...CLOUD_PROVIDER_NAMES].sort()).toEqual(
+      PROVIDERS.filter((p) => p.name !== 'docker')
+        .map((p) => p.name)
+        .sort(),
+    );
+  });
+});

--- a/packages/sandbox-core/package.json
+++ b/packages/sandbox-core/package.json
@@ -25,6 +25,7 @@
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
+    "@agentbox/config": "workspace:*",
     "@agentbox/core": "workspace:*",
     "execa": "^9.5.2",
     "smol-toml": "^1.7.0"

--- a/packages/sandbox-core/src/doctor.ts
+++ b/packages/sandbox-core/src/doctor.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared shape for a provider health-check row, produced by each provider's
+ * `doctorChecks()` and consumed by `agentbox doctor` / the install wizard, plus
+ * the `ProviderModule` contract the CLI loads each `@agentbox/sandbox-<name>`
+ * through.
+ *
+ * Lives in sandbox-core (not apps/cli) so each provider package can own its own
+ * probes and login/credential surface without depending on the CLI — a new
+ * provider ships all of this in its own package and the CLI dispatches to it
+ * generically via a lazy `import()`.
+ */
+
+import type { CloudBackend, Provider } from '@agentbox/core';
+
+/**
+ * `info` is for rows that are intentionally inert (e.g. an integration the
+ * user hasn't enabled). It surfaces as a distinct glyph but rolls up like
+ * `ok` so it never pushes the overall doctor status to "warn".
+ */
+export type CheckStatus = 'ok' | 'info' | 'warn' | 'fail';
+
+export interface CheckResult {
+  label: string;
+  status: CheckStatus;
+  detail: string;
+  hint?: string;
+}
+
+/** Normalized credential state used by the install wizard's re-auth prompt. */
+export interface CredStatusSummary {
+  configured: boolean;
+  /** Optional detail shown in the "already configured (…)" line (e.g. auth kind). */
+  label?: string;
+}
+
+/**
+ * The uniform surface every `@agentbox/sandbox-<name>` package exposes as
+ * `export const providerModule`. The CLI's provider loader resolves this via a
+ * lazy `import()` and drives create / doctor / install / checkpoint through it,
+ * so adding a provider needs no per-provider `switch` arm in the CLI.
+ */
+export interface ProviderModule {
+  /** The `Provider` implementation (lifecycle, exec, attach, checkpoint…). */
+  provider: Provider;
+  /** Cloud backend (host-side executor). Absent for the local docker provider. */
+  backend?: CloudBackend;
+  /**
+   * First-run credential gate. Called before `create`/`claude`/etc. hand out
+   * the provider. Absent for docker (no login). `force` re-runs the flow.
+   */
+  ensureCredentials?: (opts?: { force?: boolean }) => Promise<void>;
+  /** Normalized credential state for the install wizard. Absent for docker. */
+  readCredStatus?: () => Promise<CredStatusSummary> | CredStatusSummary;
+  /**
+   * CURRENT build-context fingerprint of the provider's base image/snapshot,
+   * for staleness nagging. Absent for docker (its base self-heals).
+   */
+  currentBaseFingerprintLive?: (
+    claudeInstall?: 'native' | 'npm',
+  ) => Promise<string | undefined>;
+  /** Local, offline-safe health probes for `agentbox doctor`. */
+  doctorChecks: () => Promise<CheckResult[]>;
+}
+
+/** First line of a multi-line string (for compact error summaries). */
+export function firstLine(s: string): string {
+  const i = s.indexOf('\n');
+  return i === -1 ? s : s.slice(0, i);
+}
+
+/** Compact one-line summary of an unknown thrown value. */
+export function errSummary(err: unknown): string {
+  return err instanceof Error ? firstLine(err.message) : String(err);
+}

--- a/packages/sandbox-core/src/index.ts
+++ b/packages/sandbox-core/src/index.ts
@@ -21,6 +21,14 @@ export {
 } from './git-detect.js';
 export { hostOpenCommand } from './host-open.js';
 export {
+  errSummary,
+  firstLine,
+  type CheckResult,
+  type CheckStatus,
+  type CredStatusSummary,
+  type ProviderModule,
+} from './doctor.js';
+export {
   carryPlaceholderContext,
   renderCarryEntries,
   type CarryBoxContext,

--- a/packages/sandbox-core/src/prepared-state.ts
+++ b/packages/sandbox-core/src/prepared-state.ts
@@ -23,7 +23,10 @@ import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, resolve as pathResolve } from 'node:path';
 
-export type PreparedProviderKind = 'docker' | 'daytona' | 'hetzner' | 'vercel' | 'e2b';
+import type { ProviderKind } from '@agentbox/config';
+
+/** Providers that bake a `~/.agentbox/<provider>-prepared.json` artifact. Same set as the config `ProviderKind` (the single source of truth). */
+export type PreparedProviderKind = ProviderKind;
 
 /**
  * The cross-provider record. `TImage` is the provider's opaque image

--- a/packages/sandbox-daytona/src/index.ts
+++ b/packages/sandbox-daytona/src/index.ts
@@ -5,10 +5,13 @@
  */
 
 import type { Provider } from '@agentbox/core';
+import type { ProviderModule } from '@agentbox/sandbox-core';
 import { createCloudProvider } from '@agentbox/sandbox-cloud';
 import { daytonaBackend, DEFAULT_BOX_IMAGE_REF } from './backend.js';
 import { prepareDaytona } from './prepare.js';
 import { currentDaytonaBaseFingerprintLive } from './prepared-state.js';
+import { ensureDaytonaCredentials } from './credentials.js';
+import { doctorChecks, readCredStatusSummary } from './provider-module.js';
 
 const cloudProvider = createCloudProvider(daytonaBackend, {
   defaultResources: { cpu: 2, memory: 4, disk: 8 },
@@ -18,6 +21,16 @@ export const daytonaProvider: Provider = {
   ...cloudProvider,
   prepare: prepareDaytona,
   baseFingerprint: () => currentDaytonaBaseFingerprintLive(),
+};
+
+/** Uniform surface the CLI provider loader resolves this package through. */
+export const providerModule: ProviderModule = {
+  provider: daytonaProvider,
+  backend: daytonaBackend,
+  ensureCredentials: ensureDaytonaCredentials,
+  readCredStatus: readCredStatusSummary,
+  currentBaseFingerprintLive: (claudeInstall) => currentDaytonaBaseFingerprintLive(claudeInstall),
+  doctorChecks,
 };
 
 export { daytonaBackend, DEFAULT_BOX_IMAGE_REF };

--- a/packages/sandbox-daytona/src/provider-module.ts
+++ b/packages/sandbox-daytona/src/provider-module.ts
@@ -1,0 +1,46 @@
+/**
+ * Doctor probes + normalized credential status for the daytona provider,
+ * assembled into `providerModule` in `index.ts`. Moved out of apps/cli so the
+ * CLI dispatches to it generically (see `@agentbox/sandbox-core`'s `ProviderModule`).
+ */
+
+import { errSummary, type CheckResult, type CredStatusSummary } from '@agentbox/sandbox-core';
+import { getDaytonaStatus } from './status.js';
+
+export async function readCredStatusSummary(): Promise<CredStatusSummary> {
+  const status = await getDaytonaStatus();
+  return { configured: status.configured };
+}
+
+export async function doctorChecks(): Promise<CheckResult[]> {
+  try {
+    const status = await getDaytonaStatus();
+    if (!status.configured) {
+      return [
+        {
+          label: 'credentials',
+          status: 'warn',
+          detail: status.reason ?? 'not configured',
+          hint: '`agentbox daytona login`',
+        },
+      ];
+    }
+    const credRes: CheckResult = { label: 'credentials', status: 'ok', detail: 'configured' };
+    const snapRes: CheckResult =
+      status.snapshots.length > 0
+        ? {
+            label: 'base snapshot',
+            status: 'ok',
+            detail: `${String(status.snapshots.length)} agentbox snapshot(s)`,
+          }
+        : {
+            label: 'base snapshot',
+            status: 'warn',
+            detail: 'none',
+            hint: '`agentbox prepare --provider daytona`',
+          };
+    return [credRes, snapRes];
+  } catch (err) {
+    return [{ label: 'credentials', status: 'warn', detail: errSummary(err) }];
+  }
+}

--- a/packages/sandbox-docker/src/index.ts
+++ b/packages/sandbox-docker/src/index.ts
@@ -1,4 +1,5 @@
 export { dockerProvider, type DockerCreateOptions } from './docker-provider.js';
+export { providerModule, dockerChecks } from './provider-module.js';
 export { downloadFromBox, uploadToBox, type BoxCpResult } from './box-cp.js';
 export { createDockerSyncTransport, type DockerSyncTransportInit } from './sync/sync-transport.js';
 export { makeDockerSync, type DockerSyncHandle } from './sync/docker-sync.js';

--- a/packages/sandbox-docker/src/provider-module.ts
+++ b/packages/sandbox-docker/src/provider-module.ts
@@ -1,0 +1,106 @@
+/**
+ * The docker provider's uniform `ProviderModule` surface (see
+ * `@agentbox/sandbox-core`'s `ProviderModule`). Docker is the local provider:
+ * no cloud backend, no credentials/login, no base-snapshot fingerprint — just
+ * the provider plus its doctor probes (moved here from apps/cli so the CLI
+ * dispatches to it generically).
+ */
+
+import { execa } from 'execa';
+import { errSummary, type CheckResult, type ProviderModule } from '@agentbox/sandbox-core';
+import { dockerProvider } from './docker-provider.js';
+import { DEFAULT_BOX_IMAGE, imageInfo } from './image.js';
+import { volumeExists } from './docker.js';
+import { SHARED_CLAUDE_VOLUME } from './sync/agents/claude.js';
+import { SHARED_CODEX_VOLUME } from './sync/agents/codex.js';
+import { SHARED_OPENCODE_VOLUME } from './sync/agents/opencode.js';
+
+async function probeVersion(bin: string, args: string[] = ['--version']): Promise<string | null> {
+  try {
+    const r = await execa(bin, args, { reject: false });
+    if (r.exitCode !== 0) return null;
+    const out = `${r.stdout ?? ''}${r.stderr ?? ''}`.trim().split('\n')[0] ?? '';
+    return out.length > 0 ? out : bin;
+  } catch {
+    return null;
+  }
+}
+
+/** Local, offline-safe docker health probes for `agentbox doctor`. */
+export async function dockerChecks(): Promise<CheckResult[]> {
+  const linux = process.platform === 'linux';
+  const cli = await probeVersion('docker');
+  if (!cli) {
+    return [
+      {
+        label: 'docker cli',
+        status: 'warn',
+        detail: 'not found',
+        hint: linux
+          ? 'install docker engine: https://docs.docker.com/engine/install/'
+          : 'install Docker Desktop, OrbStack, or docker engine',
+      },
+    ];
+  }
+  const cliRes: CheckResult = { label: 'docker cli', status: 'ok', detail: cli };
+
+  // Daemon reachability via `docker info`. On Linux the most common failure is
+  // not a stopped daemon but the user missing from the `docker` group — `docker
+  // info` then exits non-zero with "permission denied" on the socket.
+  const info = await execa('docker', ['info'], { reject: false });
+  if (info.exitCode !== 0) {
+    const permDenied = `${info.stderr ?? ''}`.toLowerCase().includes('permission denied');
+    let hint: string;
+    if (permDenied && linux) {
+      hint =
+        'add your user to the docker group: `sudo usermod -aG docker $USER`, then log out/in (or run `newgrp docker`)';
+    } else if (linux) {
+      hint = 'start Docker: `sudo systemctl start docker` (install docker engine if missing)';
+    } else {
+      hint = 'start Docker (Desktop / OrbStack)';
+    }
+    return [
+      cliRes,
+      {
+        label: 'docker daemon',
+        status: 'warn',
+        detail: permDenied ? 'permission denied' : 'unreachable',
+        hint,
+      },
+    ];
+  }
+  const daemonRes: CheckResult = { label: 'docker daemon', status: 'ok', detail: 'reachable' };
+
+  let imgRes: CheckResult;
+  try {
+    const img = await imageInfo(DEFAULT_BOX_IMAGE);
+    imgRes = img.exists
+      ? { label: 'box image', status: 'ok', detail: `${DEFAULT_BOX_IMAGE} built` }
+      : {
+          label: 'box image',
+          status: 'warn',
+          detail: `${DEFAULT_BOX_IMAGE} not built`,
+          hint: 'run `agentbox prepare --provider docker` (or let the wizard do it)',
+        };
+  } catch (err) {
+    imgRes = { label: 'box image', status: 'warn', detail: errSummary(err) };
+  }
+
+  const volNames = [SHARED_CLAUDE_VOLUME, SHARED_CODEX_VOLUME, SHARED_OPENCODE_VOLUME];
+  const vols = await Promise.all(
+    volNames.map(async (n) => ({ name: n, exists: await volumeExists(n).catch(() => false) })),
+  );
+  const present = vols.filter((v) => v.exists).length;
+  const volRes: CheckResult = {
+    label: 'shared volumes',
+    status: 'ok',
+    detail: `${String(present)}/${String(vols.length)} present (seeded lazily)`,
+  };
+
+  return [cliRes, daemonRes, imgRes, volRes];
+}
+
+export const providerModule: ProviderModule = {
+  provider: dockerProvider,
+  doctorChecks: dockerChecks,
+};

--- a/packages/sandbox-e2b/src/index.ts
+++ b/packages/sandbox-e2b/src/index.ts
@@ -27,13 +27,15 @@ import {
   resolveCloudCheckpoint,
   writeCloudCheckpointManifest,
 } from '@agentbox/sandbox-cloud';
-import { readCliStamp, recordBox } from '@agentbox/sandbox-core';
+import { readCliStamp, recordBox, type ProviderModule } from '@agentbox/sandbox-core';
 import { e2bBackend, DEFAULT_BOX_IMAGE_REF } from './backend.js';
 import { Sandbox, resolveApiKey } from './sdk.js';
 import { withE2bRetry } from './retry.js';
 import { prepareE2bProvider } from './prepare.js';
 import { buildE2bAttach } from './build-attach.js';
 import { currentE2bBaseFingerprintLive } from './prepared-state.js';
+import { ensureE2bCredentials } from './credentials.js';
+import { doctorChecks, readCredStatusSummary } from './provider-module.js';
 
 const BACKEND_NAME = 'e2b';
 
@@ -153,6 +155,16 @@ export const e2bProvider: Provider = {
   buildAttach: buildE2bAttach,
   checkpoint: e2bCheckpoint,
   baseFingerprint: () => currentE2bBaseFingerprintLive(),
+};
+
+/** Uniform surface the CLI provider loader resolves this package through. */
+export const providerModule: ProviderModule = {
+  provider: e2bProvider,
+  backend: e2bBackend,
+  ensureCredentials: ensureE2bCredentials,
+  readCredStatus: readCredStatusSummary,
+  currentBaseFingerprintLive: (claudeInstall) => currentE2bBaseFingerprintLive(claudeInstall),
+  doctorChecks,
 };
 
 export { e2bBackend, DEFAULT_BOX_IMAGE_REF };

--- a/packages/sandbox-e2b/src/provider-module.ts
+++ b/packages/sandbox-e2b/src/provider-module.ts
@@ -1,0 +1,46 @@
+/**
+ * Doctor probes + normalized credential status for the e2b provider,
+ * assembled into `providerModule` in `index.ts`. Moved out of apps/cli so the
+ * CLI dispatches to it generically (see `@agentbox/sandbox-core`'s `ProviderModule`).
+ */
+
+import { errSummary, type CheckResult, type CredStatusSummary } from '@agentbox/sandbox-core';
+import { readE2bCredStatus } from './credentials.js';
+import { readPreparedState } from './prepared-state.js';
+
+export function readCredStatusSummary(): CredStatusSummary {
+  const cred = readE2bCredStatus();
+  return { configured: cred.auth !== 'none', label: cred.auth };
+}
+
+export async function doctorChecks(): Promise<CheckResult[]> {
+  try {
+    const cred = readE2bCredStatus();
+    const credRes: CheckResult =
+      cred.auth === 'none'
+        ? {
+            label: 'credentials',
+            status: 'warn',
+            detail: 'not configured',
+            hint: '`agentbox e2b login`',
+          }
+        : { label: 'credentials', status: 'ok', detail: `${cred.auth} (${cred.source})` };
+
+    const prepared = readPreparedState();
+    const tmplRes: CheckResult = prepared.base?.templateId
+      ? {
+          label: 'base template',
+          status: 'ok',
+          detail: `${prepared.base.templateName ?? prepared.base.templateId} (${prepared.base.cliVersion ?? '—'})`,
+        }
+      : {
+          label: 'base template',
+          status: 'warn',
+          detail: 'not baked',
+          hint: '`agentbox prepare --provider e2b`',
+        };
+    return [credRes, tmplRes];
+  } catch (err) {
+    return [{ label: 'credentials', status: 'warn', detail: errSummary(err) }];
+  }
+}

--- a/packages/sandbox-hetzner/src/index.ts
+++ b/packages/sandbox-hetzner/src/index.ts
@@ -12,10 +12,13 @@
  */
 
 import type { Provider } from '@agentbox/core';
+import type { ProviderModule } from '@agentbox/sandbox-core';
 import { createCloudProvider } from '@agentbox/sandbox-cloud';
 import { hetznerBackend, HETZNER_DEFAULT_BOX_IMAGE_REF } from './backend.js';
 import { prepareHetznerProvider } from './prepare.js';
 import { currentHetznerBaseFingerprintLive } from './prepared-state.js';
+import { ensureHetznerCredentials } from './credentials.js';
+import { doctorChecks, readCredStatusSummary } from './provider-module.js';
 
 const cloudProvider = createCloudProvider(hetznerBackend, {
   defaultResources: { cpu: 2, memory: 4, disk: 40 },
@@ -25,6 +28,16 @@ export const hetznerProvider: Provider = {
   ...cloudProvider,
   prepare: prepareHetznerProvider,
   baseFingerprint: () => currentHetznerBaseFingerprintLive(),
+};
+
+/** Uniform surface the CLI provider loader resolves this package through. */
+export const providerModule: ProviderModule = {
+  provider: hetznerProvider,
+  backend: hetznerBackend,
+  ensureCredentials: ensureHetznerCredentials,
+  readCredStatus: readCredStatusSummary,
+  currentBaseFingerprintLive: (claudeInstall) => currentHetznerBaseFingerprintLive(claudeInstall),
+  doctorChecks,
 };
 
 export { hetznerBackend, HETZNER_DEFAULT_BOX_IMAGE_REF };

--- a/packages/sandbox-hetzner/src/provider-module.ts
+++ b/packages/sandbox-hetzner/src/provider-module.ts
@@ -1,0 +1,45 @@
+/**
+ * Doctor probes + normalized credential status for the hetzner provider,
+ * assembled into `providerModule` in `index.ts`. Moved out of apps/cli so the
+ * CLI dispatches to it generically (see `@agentbox/sandbox-core`'s `ProviderModule`).
+ */
+
+import { errSummary, type CheckResult, type CredStatusSummary } from '@agentbox/sandbox-core';
+import { readHetznerCredStatus } from './credentials.js';
+import { readPreparedState } from './prepared-state.js';
+
+export function readCredStatusSummary(): CredStatusSummary {
+  return { configured: readHetznerCredStatus().source !== 'none' };
+}
+
+export async function doctorChecks(): Promise<CheckResult[]> {
+  try {
+    const cred = readHetznerCredStatus();
+    const credRes: CheckResult =
+      cred.source === 'none'
+        ? {
+            label: 'credentials',
+            status: 'warn',
+            detail: 'HCLOUD_TOKEN not set',
+            hint: '`agentbox hetzner login`',
+          }
+        : { label: 'credentials', status: 'ok', detail: `token from ${cred.source}` };
+
+    const prepared = readPreparedState();
+    const snapRes: CheckResult = prepared.base?.imageId
+      ? {
+          label: 'base snapshot',
+          status: 'ok',
+          detail: `image ${String(prepared.base.imageId)} (${prepared.base.cliVersion ?? '—'})`,
+        }
+      : {
+          label: 'base snapshot',
+          status: 'warn',
+          detail: 'not baked',
+          hint: '`agentbox prepare --provider hetzner`',
+        };
+    return [credRes, snapRes];
+  } catch (err) {
+    return [{ label: 'credentials', status: 'warn', detail: errSummary(err) }];
+  }
+}

--- a/packages/sandbox-vercel/src/index.ts
+++ b/packages/sandbox-vercel/src/index.ts
@@ -29,10 +29,12 @@ import {
   deleteVercelSnapshot,
   DEFAULT_BOX_IMAGE_REF,
 } from './backend.js';
-import { readCliStamp, recordBox } from '@agentbox/sandbox-core';
+import { readCliStamp, recordBox, type ProviderModule } from '@agentbox/sandbox-core';
 import { prepareVercelProvider } from './prepare.js';
 import { buildVercelAttach } from './build-attach.js';
 import { currentVercelBaseFingerprintLive } from './prepared-state.js';
+import { ensureVercelCredentials } from './credentials.js';
+import { doctorChecks, readCredStatusSummary } from './provider-module.js';
 
 const BACKEND_NAME = 'vercel';
 
@@ -104,6 +106,16 @@ export const vercelProvider: Provider = {
   buildAttach: buildVercelAttach,
   checkpoint: vercelCheckpoint,
   baseFingerprint: () => currentVercelBaseFingerprintLive(),
+};
+
+/** Uniform surface the CLI provider loader resolves this package through. */
+export const providerModule: ProviderModule = {
+  provider: vercelProvider,
+  backend: vercelBackend,
+  ensureCredentials: ensureVercelCredentials,
+  readCredStatus: readCredStatusSummary,
+  currentBaseFingerprintLive: (claudeInstall) => currentVercelBaseFingerprintLive(claudeInstall),
+  doctorChecks,
 };
 
 export { vercelBackend, DEFAULT_BOX_IMAGE_REF };

--- a/packages/sandbox-vercel/src/provider-module.ts
+++ b/packages/sandbox-vercel/src/provider-module.ts
@@ -1,0 +1,46 @@
+/**
+ * Doctor probes + normalized credential status for the vercel provider,
+ * assembled into `providerModule` in `index.ts`. Moved out of apps/cli so the
+ * CLI dispatches to it generically (see `@agentbox/sandbox-core`'s `ProviderModule`).
+ */
+
+import { errSummary, type CheckResult, type CredStatusSummary } from '@agentbox/sandbox-core';
+import { readVercelCredStatus } from './credentials.js';
+import { readPreparedState } from './prepared-state.js';
+
+export function readCredStatusSummary(): CredStatusSummary {
+  const cred = readVercelCredStatus();
+  return { configured: cred.auth !== 'none', label: cred.auth };
+}
+
+export async function doctorChecks(): Promise<CheckResult[]> {
+  try {
+    const cred = readVercelCredStatus();
+    const credRes: CheckResult =
+      cred.auth === 'none'
+        ? {
+            label: 'credentials',
+            status: 'warn',
+            detail: 'not configured',
+            hint: '`agentbox vercel login`',
+          }
+        : { label: 'credentials', status: 'ok', detail: `${cred.auth} (${cred.source})` };
+
+    const prepared = readPreparedState();
+    const snapRes: CheckResult = prepared.base?.snapshotId
+      ? {
+          label: 'base snapshot',
+          status: 'ok',
+          detail: `${prepared.base.snapshotId.slice(0, 16)}… (${prepared.base.cliVersion ?? '—'})`,
+        }
+      : {
+          label: 'base snapshot',
+          status: 'warn',
+          detail: 'not baked',
+          hint: '`agentbox prepare --provider vercel`',
+        };
+    return [credRes, snapRes];
+  } catch (err) {
+    return [{ label: 'credentials', status: 'warn', detail: errSummary(err) }];
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,6 +373,9 @@ importers:
 
   packages/sandbox-core:
     dependencies:
+      '@agentbox/config':
+        specifier: workspace:*
+        version: link:../config
       '@agentbox/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## Why

Adding a cloud provider (e.g. the recent DigitalOcean droplet backend) touched **~18 cross-cutting sites** outside the new package — config types/schema/image/size/checkpoint, sandbox-core prepared-state, cli registry/cloud-backend/checkpoint/install/doctor/wizard/prepare/fork, relay, stage-runtime. Almost all were the same provider name repeated as a union arm, a `KNOWN`/`ALL` list, or a `switch` case.

This refactor collapses that surface so a new provider is **its `@agentbox/sandbox-<name>` package plus a handful of single-line insertions** (one `PROVIDERS` row, one `loaders.ts` entry, the workspace dep, and — only for a VPS-shaped provider — the relay block + stage-runtime list). The real code lives in the package.

## What

- **config `providers.ts`** — the single `PROVIDERS` table. Derives the `ProviderKind` union, the `box.provider` enum, the `PROVIDER_NAMES` / `CLOUD_PROVIDER_NAMES` lists, and the per-provider `box.{image,size,defaultCheckpoint}<P>` `KEY_REGISTRY` entries. The `image/size/checkpoint.ts` resolvers are now a single table lookup (`perProviderConfigKey`); behaviour preserved (unknown provider → docker bucket). New `providers.test.ts` fails if the table drifts from `KEY_REGISTRY`, the JSON schema, or `BUILT_IN_DEFAULTS`.
- **sandbox-core** — shared `ProviderModule` contract + `CheckResult`/`CheckStatus` types + `errSummary`/`firstLine`. `PreparedProviderKind` now aliases the config `ProviderKind`.
- **each `sandbox-<name>`** exports a uniform `providerModule` (provider, backend, ensureCredentials, readCredStatus, currentBaseFingerprintLive, doctorChecks). The **per-provider doctor probes moved out of apps/cli into each package** (`provider-module.ts`).
- **cli `provider/loaders.ts`** — the ONE place enumerating the sandbox packages, with **literal `import()` specifiers** (the tsup bundle inlines `@agentbox/sandbox-*` under `noExternal`, which requires static specifiers). `registry`/`cloud-backend`/`checkpoint`/`doctor`/`install`/`wizard`/`prepare`/`fork` now dispatch through the table + loader — the per-provider switches are gone. `create.ts` drops the stale 4-arm provider casts.
- **relay `resolveCloudBackend`** and **stage-runtime** are intentionally unchanged: the relay's literal-import block is the one documented, irreducible per-provider touch point (bundler constant-fold + it can't depend on the cli loader); stage-runtime only matters when a VPS-shaped provider is added.

## Verification

- `pnpm -w build` / `typecheck` / `lint` green; unit tests green (one pre-existing `@agentbox/ctl` git-commit flake that passes in isolation).
- CLI bundle still **inlines every `@agentbox/sandbox-*`** — no bare specifiers in `dist/*.js`.
- `agentbox doctor` output is **byte-identical** across docker/daytona/hetzner/vercel/e2b (the moved `doctorChecks` are behaviour-preserving).
- **Live smoke: `agentbox create` on docker, hetzner, vercel, e2b** — all four boxes provisioned, registered with the correct provider + preview URL, exec-reachable as `vscode`, then destroyed cleanly (create + destroy both route through the loader).

https://claude.ai/code/session_01A2GrRPZSUcaME4ZEEJG4D8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad refactor across CLI provider resolution, install/doctor, and config key generation; behavior is intended to be preserved but touches every provider path and lazy-import wiring.
> 
> **Overview**
> Introduces a **single `PROVIDERS` table** in `@agentbox/config` so provider names, labels, cloud vs local, and per-provider config keys (`box.image<P>`, `box.size<P>`, `box.defaultCheckpoint<P>`) are derived in one place instead of repeated unions and switches across the CLI and config.
> 
> The CLI gains **`loadProviderModule`** in `provider/loaders.ts` as the only enumeration of `@agentbox/sandbox-*` packages (literal dynamic imports for bundling). **Registry, install login, doctor, checkpoint, cloud-backend, and fork** now dispatch through that loader and shared config helpers; large per-provider `switch` blocks and duplicated doctor/login logic are removed from `apps/cli`.
> 
> **`ProviderModule`** in `sandbox-core` defines the uniform surface each sandbox package exports (`provider`, optional `backend` / credentials / fingerprint / `doctorChecks`). Per-provider **doctor probes and credential summaries move into each `sandbox-<name>` package**; `doctor-checks.ts` only aggregates them.
> 
> Config resolvers for image, size, and default checkpoint use **`perProviderConfigKey` / `perProviderValue`** instead of hand-written provider branches. **`providers.test.ts`** guards drift between the table, `KEY_REGISTRY`, schema, and defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95e1bd41d8176ed92f97268be767298983639ff3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->