### PR TITLE
feat(hub): `agentbox hub` command + published packaging + hosted fixes (Phase 5)

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -47,7 +47,8 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist runtime .turbo",
-    "prepublishOnly": "cd ../.. && pnpm -w build",
+    "stage": "node scripts/stage-runtime.mjs",
+    "prepublishOnly": "cd ../.. && pnpm -w build && pnpm --filter @agentbox/hub build:standalone && pnpm --filter @madarco/agentbox stage",
     "version": "git add CHANGELOG.md",
     "publish:patch": "npm version patch && git push --follow-tags",
     "publish:minor": "npm version minor && git push --follow-tags"

--- a/apps/cli/scripts/stage-runtime.mjs
+++ b/apps/cli/scripts/stage-runtime.mjs
@@ -76,7 +76,9 @@ function copy(srcRel, destAbs, exec = false) {
     return;
   }
   mkdirSync(dirname(destAbs), { recursive: true });
-  cpSync(src, destAbs, { recursive: true });
+  // verbatimSymlinks keeps relative symlink targets intact (the hub standalone
+  // tree relies on them); the default rewrites them to absolute source paths.
+  cpSync(src, destAbs, { recursive: true, verbatimSymlinks: true });
   if (exec) chmodSync(destAbs, 0o755);
 }
 
@@ -86,6 +88,14 @@ mkdirSync(runtime, { recursive: true });
 for (const [srcRel, destRel] of direct) {
   copy(srcRel, join(runtime, destRel));
 }
+
+// Hub standalone build — `agentbox hub` spawns this self-contained Next+relay
+// server (packages/sandbox-docker/src/hub.ts resolveHubServer() looks for
+// runtime/hub/apps/hub/server.js). Built by `apps/hub` `build:standalone`; the
+// traced tree uses relative symlinks so cpSync (dereference:false) keeps it
+// self-contained. Absent in a partial dev build (warn+skip) — a publish runs
+// build:standalone first (apps/cli prepublishOnly).
+copy('apps/hub/dist-standalone', join(runtime, 'hub'));
 copy(dockerfileSrc, join(dockerCtx, 'Dockerfile.box'));
 for (const srcRel of contextFiles) {
   copy(srcRel, join(dockerCtx, srcRel), execBitFiles.has(srcRel));

--- a/apps/cli/src/commands/control-plane.ts
+++ b/apps/cli/src/commands/control-plane.ts
@@ -133,9 +133,21 @@ const setupSub = new Command('setup')
       if (target !== 'none') {
         // Prompt for the hub login admin BEFORE the deploy spinner starts (a
         // spinner and @clack prompts can't share the terminal). Setting these
-        // turns login on in the deployed hub so it is never left loginless.
-        // hetzner (docker-compose) auth wiring is a Phase 5 follow-up.
-        const hubAuth = target === 'vercel' ? await resolveHubAuthEnv() : null;
+        // turns login on in the deployed hub so it is never left loginless — both
+        // vercel and hetzner (the Caddy-HTTPS docker-compose deploy).
+        const hubAuth = await resolveHubAuthEnv();
+        // hetzner reads ENV_PATH (written to the VPS .env); append the auth env +
+        // the Postgres auth profile so docker-compose enforces login there too.
+        if (target === 'hetzner' && hubAuth) {
+          const authBody =
+            `AGENTBOX_HUB_PROFILE=vercel\n` +
+            `AGENTBOX_HUB_AUTH=${hubAuth.AGENTBOX_HUB_AUTH}\n` +
+            `BETTER_AUTH_SECRET=${hubAuth.BETTER_AUTH_SECRET}\n` +
+            `AGENTBOX_HUB_ADMIN_EMAIL=${hubAuth.AGENTBOX_HUB_ADMIN_EMAIL}\n` +
+            `AGENTBOX_HUB_ADMIN_PASSWORD=${hubAuth.AGENTBOX_HUB_ADMIN_PASSWORD}\n`;
+          await writeFile(ENV_PATH, envBody + authBody, { mode: 0o600 });
+          await chmod(ENV_PATH, 0o600);
+        }
         try {
           const ds = spinner();
           ds.start(`deploying the control plane to ${target}`);

--- a/apps/cli/src/commands/hub.ts
+++ b/apps/cli/src/commands/hub.ts
@@ -1,0 +1,121 @@
+import { spawn } from 'node:child_process';
+import { log, spinner } from '@clack/prompts';
+import { ensureHub, getHubStatus, stopHub, type HubStatus } from '@agentbox/sandbox-docker';
+import { hostOpenCommand } from '@agentbox/sandbox-core';
+import { Command } from 'commander';
+import { handleLifecycleError } from './_errors.js';
+import { rehydrateFromState } from './relay.js';
+
+/** Best-effort: open the hub URL in the host browser (never throws). */
+function openInBrowser(url: string): void {
+  try {
+    const child = spawn(hostOpenCommand(), [url], { detached: true, stdio: 'ignore' });
+    child.unref();
+  } catch {
+    /* the caller has already printed the URL */
+  }
+}
+
+interface StatusOpts {
+  json?: boolean;
+}
+
+function renderStatus(s: HubStatus): string {
+  if (s.running) {
+    return [
+      `hub: running${s.ui ? '' : ' (bare relay on the port — no UI; run `agentbox hub start`)'}`,
+      `  pid:  ${s.pid === null ? '?' : String(s.pid)}`,
+      `  port: ${String(s.port)}`,
+      `  url:  ${s.openUrl}`,
+      `  log:  ${s.logFile}`,
+    ].join('\n');
+  }
+  if (s.pidAlive) {
+    return [`hub: not responding (pid ${String(s.pid)} alive but /healthz silent)`, `  log:  ${s.logFile}`].join('\n');
+  }
+  return ['hub: not running', `  log:  ${s.logFile}`].join('\n');
+}
+
+const statusSub = new Command('status')
+  .description('Show whether the hub (relay + Web UI) is running, with its URL')
+  .option('--json', 'emit HubStatus as JSON')
+  .action(async (opts: StatusOpts) => {
+    try {
+      const s = await getHubStatus();
+      if (opts.json) {
+        process.stdout.write(JSON.stringify(s, null, 2) + '\n');
+        return;
+      }
+      process.stdout.write(renderStatus(s) + '\n');
+    } catch (err) {
+      handleLifecycleError(err);
+    }
+  });
+
+interface StartOpts {
+  open?: boolean;
+}
+
+const startSub = new Command('start')
+  .description('Start the hub (relay + Web UI on port 8787) and open it')
+  .option('--no-open', "don't open the browser, just print the URL")
+  .action(async (opts: StartOpts) => {
+    try {
+      const s = spinner();
+      s.start('starting hub');
+      const ep = await ensureHub({ onLog: (line) => s.message(line) });
+      await rehydrateFromState();
+      s.stop(`hub running on ${ep.hostUrl}`);
+      process.stdout.write(`\n  Open: ${ep.openUrl}\n\n`);
+      if (opts.open !== false) openInBrowser(ep.openUrl);
+    } catch (err) {
+      handleLifecycleError(err);
+    }
+  });
+
+const stopSub = new Command('stop')
+  .description('Stop the hub process (idempotent)')
+  .action(async () => {
+    try {
+      const s = spinner();
+      s.start('stopping hub');
+      const result = await stopHub();
+      s.stop(result.stopped ? `stopped hub (pid ${String(result.pid)})` : 'hub was not running');
+    } catch (err) {
+      handleLifecycleError(err);
+    }
+  });
+
+const restartSub = new Command('restart')
+  .description('Stop then start the hub')
+  .option('--no-open', "don't open the browser, just print the URL")
+  .action(async (opts: StartOpts) => {
+    try {
+      const s = spinner();
+      s.start('stopping hub');
+      const stopped = await stopHub();
+      s.stop(stopped.stopped ? `stopped hub (pid ${String(stopped.pid)})` : 'hub was not running');
+      const s2 = spinner();
+      s2.start('starting hub');
+      try {
+        const ep = await ensureHub({ onLog: (line) => s2.message(line) });
+        await rehydrateFromState();
+        s2.stop(`hub running on ${ep.hostUrl}`);
+        process.stdout.write(`\n  Open: ${ep.openUrl}\n\n`);
+        if (opts.open !== false) openInBrowser(ep.openUrl);
+      } catch (err) {
+        s2.stop('hub start failed');
+        log.warn(err instanceof Error ? err.message : String(err));
+        throw err;
+      }
+    } catch (err) {
+      handleLifecycleError(err);
+    }
+  });
+
+export const hubCommand = new Command('hub')
+  .description('Run the AgentBox hub — the relay + Web UI on http://127.0.0.1:8787')
+  .addCommand(startSub, { isDefault: true })
+  .addCommand(statusSub)
+  .addCommand(stopSub)
+  .addCommand(restartSub);

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -70,6 +70,7 @@ import { prepareCommand } from './commands/prepare.js';
 import { pruneCommand } from './commands/prune.js';
 import { queueCommand } from './commands/queue.js';
 import { relayCommand } from './commands/relay.js';
+import { hubCommand } from './commands/hub.js';
 import { controlPlaneCommand } from './commands/control-plane.js';
 import { runQueuedJobCommand } from './commands/_run-queued-job.js';
 import { claudeLoginWorkerCommand } from './commands/_claude-login-worker.js';
@@ -133,6 +134,7 @@ program.addCommand(checkpointCommand);
 program.addCommand(configCommand);
 program.addCommand(queueCommand);
 program.addCommand(relayCommand);
+program.addCommand(hubCommand);
 program.addCommand(controlPlaneCommand);
 // Internal worker spawned by the relay's queue scheduler. Hidden from
 // `--help` (it shows nothing user-facing — see _run-queued-job.ts).
@@ -169,6 +171,7 @@ const FIRST_RUN_EXEMPT = new Set([
   'doctor',
   'help',
   'relay',
+  'hub',
   '_run-queued-job',
   '_claude-login-worker',
   'drive',

--- a/apps/hub/.gitignore
+++ b/apps/hub/.gitignore
@@ -1,4 +1,6 @@
 /.next/
+/dist-standalone/
+/.standalone-server/
 /node_modules/
 next-env.d.ts
 *.tsbuildinfo

--- a/apps/hub/Dockerfile
+++ b/apps/hub/Dockerfile
@@ -22,5 +22,7 @@ ENV PORT=3000
 COPY --from=build /repo .
 WORKDIR /repo/apps/hub
 EXPOSE 3000
-# next start serves the production build; the route handlers run on Node.
-CMD ["pnpm", "exec", "next", "start", "-p", "3000"]
+# Create/upgrade the auth tables + seed the admin (self-skips when auth is off,
+# i.e. no BETTER_AUTH_SECRET), then serve the production build. Runs at boot (not
+# build) so it sees the container's POSTGRES_URL + auth env.
+CMD ["sh", "-c", "pnpm run db:auth-migrate && pnpm exec next start -p 3000"]

--- a/apps/hub/README.md
+++ b/apps/hub/README.md
@@ -48,10 +48,17 @@ The hub runs in one of three profiles, selected by `AGENTBOX_HUB_PROFILE`:
 else hetzner); set `AGENTBOX_HUB_PROFILE=vercel` explicitly for the serverless
 path. `AGENTBOX_HUB_AUTH=off` disables all protection on any profile.
 
+**Run it locally.** `agentbox hub` (start/stop/status/restart) spawns the
+embedded hub on 8787 and opens `http://127.0.0.1:8787/?token=<secret>`. It ships a
+self-contained Next `output:'standalone'` build (a compiled `server.ts` + traced
+`node_modules` staged under the CLI's `runtime/hub/`), so it runs from a published
+install (Node ≥ 22.5). The hub is a superset of the lean relay: `agentbox hub`
+reclaims any lean relay on 8787, and once it's up the create path reuses it (both
+answer `/healthz`, distinguished by a `ui` flag).
+
 **localhost — token gate.** There is no login screen: `server.ts` auto-generates
 `~/.agentbox/hub/token` (0600) and logs the entry URL
-`http://127.0.0.1:8787/?token=<secret>` (the `agentbox hub` command, Phase 5,
-opens it for you). The hub validates the token, stores it in an httpOnly cookie,
+`http://127.0.0.1:8787/?token=<secret>`. The hub validates the token, stores it in an httpOnly cookie,
 and redirects to the clean URL; later requests are authorized by the cookie, and
 direct access without it is locked (401). This protects the loopback bind from
 other local processes and DNS-rebinding.

--- a/apps/hub/docker-compose.yml
+++ b/apps/hub/docker-compose.yml
@@ -29,6 +29,15 @@ services:
       AGENTBOX_RELAY_ADMIN_TOKEN: ${AGENTBOX_RELAY_ADMIN_TOKEN:?set AGENTBOX_RELAY_ADMIN_TOKEN}
       GITHUB_APP_ID: ${GITHUB_APP_ID:-}
       GITHUB_APP_PRIVATE_KEY: ${GITHUB_APP_PRIVATE_KEY:-}
+      # Web-UI auth (Postgres store — the same shape as the Vercel deploy). Login
+      # is secret-gated: with no BETTER_AUTH_SECRET the UI stays open (unchanged);
+      # the CLI deploy path (control-plane setup --deploy hetzner) sets these +
+      # BETTER_AUTH_SECRET so a network-reachable/Caddy-HTTPS hub is gated.
+      AGENTBOX_HUB_PROFILE: ${AGENTBOX_HUB_PROFILE:-vercel}
+      AGENTBOX_HUB_AUTH: ${AGENTBOX_HUB_AUTH:-}
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-}
+      AGENTBOX_HUB_ADMIN_EMAIL: ${AGENTBOX_HUB_ADMIN_EMAIL:-}
+      AGENTBOX_HUB_ADMIN_PASSWORD: ${AGENTBOX_HUB_ADMIN_PASSWORD:-}
     ports:
       - '8787:3000'
     depends_on:

--- a/apps/hub/lib/boxes/postgres-source.ts
+++ b/apps/hub/lib/boxes/postgres-source.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 
+import type { PostgresStore } from '@agentbox/relay/control-plane';
 import type { Approval, Box, BoxStatus, HubState, Project } from './types';
 
 /*
@@ -119,12 +120,29 @@ export function hasPostgresSource(): boolean {
   return Boolean(process.env.POSTGRES_URL ?? process.env.RELAY_STORE_URL);
 }
 
+// One Postgres pool (+ one migrate) per server instance, not per dashboard load —
+// PostgresStore creates its pool lazily on first query, so a new store per render
+// would leak pools until the connection limit is hit. Mirrors lib/plane.ts.
+let storePromise: Promise<PostgresStore> | null = null;
+function getStore(url: string): Promise<PostgresStore> {
+  if (!storePromise) {
+    storePromise = (async () => {
+      const { PostgresStore } = await import('@agentbox/relay/control-plane');
+      const store = new PostgresStore({ connectionString: url });
+      await store.migrate();
+      return store;
+    })().catch((err: unknown) => {
+      storePromise = null; // let the next request retry (e.g. transient DB outage)
+      throw err;
+    });
+  }
+  return storePromise;
+}
+
 export async function getPostgresDashboardData(): Promise<Omit<HubState, 'authMode'>> {
   const url = process.env.POSTGRES_URL ?? process.env.RELAY_STORE_URL;
   if (!url) throw new Error('hub: POSTGRES_URL required for the hosted source');
-  const { PostgresStore } = await import('@agentbox/relay/control-plane');
-  const store = new PostgresStore({ connectionString: url });
-  await store.migrate();
+  const store = await getStore(url);
 
   const regs = (await store.listBoxes()) as unknown as Registration[];
   const statuses = await store.listStatuses();

--- a/apps/hub/lib/boxes/postgres-source.ts
+++ b/apps/hub/lib/boxes/postgres-source.ts
@@ -1,0 +1,147 @@
+import 'server-only';
+
+import type { Approval, Box, BoxStatus, HubState, Project } from './types';
+
+/*
+ * Hosted (Postgres) box source. Used by the `next start` deploy path (vercel /
+ * hetzner-compose), where there is no in-process host backend — box state lives
+ * in Postgres, written by the relay routes. Dynamically imports the relay's
+ * PostgresStore so `pg` never enters the localhost bundle.
+ */
+
+// Loose views over the relay types (kept structural to avoid a runtime import of
+// @agentbox/relay just for types in the Next bundle).
+interface Registration {
+  boxId: string;
+  name: string;
+  registeredAt: string;
+  createdAt?: string;
+  kind?: string;
+  backend?: string;
+  projectIndex?: number;
+  worktrees?: { branch?: string }[];
+  originUrl?: string;
+}
+type Snapshot = Record<string, unknown>;
+interface AgentState {
+  state?: string;
+  sessionRunning?: boolean;
+  sessionTitle?: string;
+}
+interface PromptRow {
+  ev: { id: string; message: string; detail?: string; defaultAnswer?: 'y' | 'n'; context?: { command?: string; cwd?: string; argv?: string[] } };
+  createdAt: string;
+}
+
+function b64url(s: string): string {
+  return Buffer.from(s).toString('base64url');
+}
+
+function repoName(r: Registration): string {
+  if (r.originUrl) {
+    const tail = r.originUrl.replace(/\.git$/, '').split(/[/:]/).pop();
+    if (tail) return tail;
+  }
+  return r.name;
+}
+
+/** Project identity for grouping — the repo (origin) when known, else the box name. */
+function projectKey(r: Registration): string {
+  return b64url(r.originUrl ?? r.name);
+}
+
+function agents(s: Snapshot | undefined): { claude?: AgentState; codex?: AgentState; opencode?: AgentState } {
+  return {
+    claude: s?.claude as AgentState | undefined,
+    codex: s?.codex as AgentState | undefined,
+    opencode: s?.opencode as AgentState | undefined,
+  };
+}
+
+function deriveStatus(s: Snapshot | undefined): BoxStatus {
+  if (!s) return 'stopped';
+  const { claude, codex, opencode } = agents(s);
+  if ([claude?.state, codex?.state, opencode?.state].includes('error')) return 'error';
+  const running = Boolean(claude?.sessionRunning || codex?.sessionRunning || opencode?.sessionRunning);
+  return running ? 'running' : 'stopped';
+}
+
+function mapBox(r: Registration, s: Snapshot | undefined): Box {
+  const { claude, codex, opencode } = agents(s);
+  const createdAt = Date.parse(r.createdAt ?? r.registeredAt) || Date.now();
+  return {
+    id: r.boxId,
+    projectId: projectKey(r),
+    repo: repoName(r),
+    branch: r.worktrees?.[0]?.branch ?? '',
+    task: claude?.sessionTitle ?? codex?.sessionTitle ?? opencode?.sessionTitle ?? r.name,
+    agent: codex?.sessionRunning ? 'codex' : opencode?.sessionRunning ? 'opencode' : 'claude',
+    status: deriveStatus(s),
+    createdAt,
+    lastActivity: createdAt,
+    host: r.backend ? `${r.kind ?? 'cloud'} · ${r.backend}` : (r.kind ?? 'cloud'),
+    commits: null,
+    filesTouched: null,
+    error: deriveStatus(s) === 'error' ? (claude?.sessionTitle ?? 'Agent reported an error') : null,
+  };
+}
+
+function deriveProjects(regs: Registration[]): Project[] {
+  const byKey = new Map<string, { key: string; name: string; createdAt: number }>();
+  for (const r of regs) {
+    const key = projectKey(r);
+    const createdAt = Date.parse(r.createdAt ?? r.registeredAt) || Date.now();
+    const existing = byKey.get(key);
+    if (!existing) byKey.set(key, { key, name: repoName(r), createdAt });
+    else if (createdAt < existing.createdAt) existing.createdAt = createdAt;
+  }
+  return [...byKey.values()]
+    .map((p) => ({ id: p.key, name: p.name, repo: p.name, defaultBranch: 'main', provider: 'cloud', createdAt: p.createdAt }))
+    .sort((a, b) => b.createdAt - a.createdAt);
+}
+
+function mapApproval(boxId: string, row: PromptRow): Approval {
+  return {
+    id: row.ev.id,
+    boxId,
+    message: row.ev.message,
+    detail: row.ev.detail,
+    command: row.ev.context?.command,
+    cwd: row.ev.context?.cwd,
+    argv: row.ev.context?.argv,
+    defaultAnswer: row.ev.defaultAnswer ?? 'n',
+    createdAt: Date.parse(row.createdAt) || Date.now(),
+  };
+}
+
+/** True when a hosted Postgres source should back the dashboard. */
+export function hasPostgresSource(): boolean {
+  return Boolean(process.env.POSTGRES_URL ?? process.env.RELAY_STORE_URL);
+}
+
+export async function getPostgresDashboardData(): Promise<Omit<HubState, 'authMode'>> {
+  const url = process.env.POSTGRES_URL ?? process.env.RELAY_STORE_URL;
+  if (!url) throw new Error('hub: POSTGRES_URL required for the hosted source');
+  const { PostgresStore } = await import('@agentbox/relay/control-plane');
+  const store = new PostgresStore({ connectionString: url });
+  await store.migrate();
+
+  const regs = (await store.listBoxes()) as unknown as Registration[];
+  const statuses = await store.listStatuses();
+  const statusByBox = new Map(statuses.map((s) => [s.boxId, s.status as Snapshot]));
+
+  // Poll-mode approvals live in Postgres, one query per box (backlog is small).
+  const approvals: Approval[] = [];
+  for (const r of regs) {
+    const pending = (await store.listPendingPrompts(r.boxId)) as unknown as PromptRow[];
+    for (const row of pending) approvals.push(mapApproval(r.boxId, row));
+  }
+
+  return {
+    user: { login: 'hub', name: 'hub' },
+    github: { available: false, installed: false, appName: 'GitHub App', account: '', installedAt: 0, repos: [] },
+    projects: deriveProjects(regs),
+    boxes: regs.map((r) => mapBox(r, statusByBox.get(r.boxId))),
+    approvals,
+  };
+}

--- a/apps/hub/lib/boxes/source.ts
+++ b/apps/hub/lib/boxes/source.ts
@@ -1,16 +1,22 @@
 import 'server-only';
 
 import { authMode } from '../auth-config';
+import { getPostgresDashboardData, hasPostgresSource } from './postgres-source';
 import type { HubState } from './types';
 
-// Thin Next-side wrapper. The real work lives in the Node-only backend the
-// custom server sets on globalThis (lib/hub-backend.ts), so Next never imports
-// the sandbox/relay toolchain.
+// Thin Next-side wrapper. Box state comes from one of two sources:
+//  - the in-process host backend the custom server sets on globalThis (embedded
+//    localhost/hetzner `agentbox hub`) — Next never imports the sandbox toolchain;
+//  - a Postgres source (the `next start` deploy path, vercel/hetzner-compose),
+//    dynamically imported so `pg` stays out of the localhost bundle.
 export async function getDashboardData(): Promise<HubState> {
   const backend = globalThis.__AGENTBOX_HUB_BACKEND;
-  if (!backend) {
-    // No custom server (e.g. plain `next start`) — nothing to read.
-    return { user: { login: 'user', name: 'user' }, github: { available: false, installed: false, appName: 'GitHub App', account: '', installedAt: 0, repos: [] }, projects: [], boxes: [], approvals: [], authMode: authMode() };
+  if (backend) {
+    return { ...(await backend.getData()), authMode: authMode() };
   }
-  return { ...(await backend.getData()), authMode: authMode() };
+  if (hasPostgresSource()) {
+    return { ...(await getPostgresDashboardData()), authMode: authMode() };
+  }
+  // No source (e.g. plain `next start` with no Postgres) — nothing to read.
+  return { user: { login: 'user', name: 'user' }, github: { available: false, installed: false, appName: 'GitHub App', account: '', installedAt: 0, repos: [] }, projects: [], boxes: [], approvals: [], authMode: authMode() };
 }

--- a/apps/hub/next.config.mjs
+++ b/apps/hub/next.config.mjs
@@ -1,6 +1,14 @@
+import path from 'node:path';
+
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
+  // Self-contained build for `agentbox hub`: `.next/standalone` bundles a traced
+  // node_modules so the CLI can spawn the hub from a published install without a
+  // full dependency tree. The tracing root is the monorepo root so workspace
+  // packages (@agentbox/relay, imported by server.ts) get traced in.
+  output: 'standalone',
+  outputFileTracingRoot: path.join(import.meta.dirname, '..', '..'),
   // Server-only packages that must not be bundled into Next's server output:
   // pg (dynamic require), and the AgentBox box-runtime packages (they shell out
   // to docker/ssh via execa and are read from node_modules at runtime by the

--- a/apps/hub/next.config.mjs
+++ b/apps/hub/next.config.mjs
@@ -1,14 +1,17 @@
 import path from 'node:path';
 
+// `agentbox hub` ships a self-contained standalone build (traced node_modules) so
+// the CLI can spawn the hub from a published install. Gated behind an env flag set
+// only by `build:standalone` — the deploy builds (`next build` → `next start` /
+// Vercel's adapter) stay non-standalone (next start doesn't support standalone).
+const standalone = process.env.AGENTBOX_HUB_STANDALONE === '1';
+
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
-  // Self-contained build for `agentbox hub`: `.next/standalone` bundles a traced
-  // node_modules so the CLI can spawn the hub from a published install without a
-  // full dependency tree. The tracing root is the monorepo root so workspace
-  // packages (@agentbox/relay, imported by server.ts) get traced in.
-  output: 'standalone',
-  outputFileTracingRoot: path.join(import.meta.dirname, '..', '..'),
+  ...(standalone
+    ? { output: 'standalone', outputFileTracingRoot: path.join(import.meta.dirname, '..', '..') }
+    : {}),
   // Server-only packages that must not be bundled into Next's server output:
   // pg (dynamic require), and the AgentBox box-runtime packages (they shell out
   // to docker/ssh via execa and are read from node_modules at runtime by the

--- a/apps/hub/package.json
+++ b/apps/hub/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "build:standalone": "next build && node scripts/build-standalone.mjs",
     "start": "next start",
     "hub:dev": "tsx watch server.ts",
     "hub:start": "next build && NODE_ENV=production tsx server.ts",

--- a/apps/hub/package.json
+++ b/apps/hub/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "build:standalone": "next build && node scripts/build-standalone.mjs",
+    "build:standalone": "AGENTBOX_HUB_STANDALONE=1 next build && node scripts/build-standalone.mjs",
     "start": "next start",
     "hub:dev": "tsx watch server.ts",
     "hub:start": "next build && NODE_ENV=production tsx server.ts",

--- a/apps/hub/scripts/build-standalone.mjs
+++ b/apps/hub/scripts/build-standalone.mjs
@@ -1,0 +1,96 @@
+/**
+ * Assemble a self-contained, spawnable hub for `agentbox hub`.
+ *
+ * `next build` (output:'standalone') produces `.next/standalone` — a traced tree
+ * with a minimal `node_modules` — but its generated `server.js` is Next's own
+ * minimal server, not our custom relay+Next server. So we:
+ *   1. esbuild-bundle `server.ts` (our custom server) into `server.js` + lazy
+ *      chunks, bundling the @agentbox box toolchain in and keeping `next`, the
+ *      cloud providers/SDKs, and better-auth/pg external.
+ *   2. Copy the standalone tree (relative symlinks preserved) + `.next/static`.
+ *   3. Drop our `server.js` where Next's default one sat (sibling of `.next`).
+ *
+ * Output: `apps/hub/dist-standalone/` (mirrors the `.next/standalone` layout;
+ * the runnable entry is `dist-standalone/apps/hub/server.js`). The CLI stage step
+ * copies this into `apps/cli/runtime/hub/`.
+ *
+ * Run after `next build` (the `build:standalone` npm script chains them).
+ */
+import { createRequire } from 'node:module';
+import { cp, rm, readdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const hubDir = path.resolve(fileURLToPath(import.meta.url), '..', '..');
+const nextDir = path.join(hubDir, '.next');
+const standaloneSrc = path.join(nextDir, 'standalone');
+const outDir = path.join(hubDir, 'dist-standalone');
+// The runnable app root inside the standalone tree (where `.next` + package.json live).
+const appRel = path.relative(path.join(hubDir, '..', '..'), hubDir); // e.g. "apps/hub"
+const outApp = path.join(outDir, appRel);
+
+if (!existsSync(standaloneSrc)) {
+  console.error(`[build-standalone] ${standaloneSrc} missing — run \`next build\` first.`);
+  process.exit(1);
+}
+
+// esbuild is a transitive workspace dep; resolve it via tsup's tree.
+const require = createRequire(import.meta.url);
+const esbuild = require(
+  createRequire(require.resolve('tsup')).resolve('esbuild'),
+);
+
+console.log('[build-standalone] esbuild-bundling server.ts …');
+await esbuild.build({
+  entryPoints: [path.join(hubDir, 'server.ts')],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  target: 'node22',
+  outdir: path.join(hubDir, '.standalone-server'),
+  entryNames: 'server',
+  splitting: true, // keep lazy import('./lib/auth') + dynamic cloud-provider imports as separate chunks
+  external: [
+    'next',
+    'next/*',
+    'pg',
+    'pg-native',
+    // dynamic-only cloud providers + their heavy SDKs: resolved from node_modules
+    // at runtime, and only when a cloud box lifecycle action fires (never in the
+    // common docker/localhost path).
+    '@agentbox/sandbox-daytona',
+    '@agentbox/sandbox-vercel',
+    '@agentbox/sandbox-e2b',
+    '@agentbox/sandbox-hetzner',
+    '@daytonaio/sdk',
+    '@vercel/sandbox',
+    'e2b',
+    // password-mode auth: lazy chunk, never loaded in localhost token mode.
+    'better-auth',
+    'better-auth/*',
+    'kysely',
+  ],
+  banner: {
+    js: "import { createRequire as __cr } from 'node:module'; import { fileURLToPath as __f } from 'node:url'; import { dirname as __d } from 'node:path'; const require = __cr(import.meta.url); const __filename = __f(import.meta.url); const __dirname = __d(__filename);",
+  },
+  logLevel: 'warning',
+});
+
+console.log('[build-standalone] assembling dist-standalone …');
+await rm(outDir, { recursive: true, force: true });
+// Preserve the relative symlinks the traced pnpm tree uses (dereferencing bloats
+// it ~4x). verbatimSymlinks keeps the ORIGINAL relative targets — the default
+// (false) rewrites them to absolute source paths, which breaks a staged/published
+// copy that no longer sits next to the source tree.
+await cp(standaloneSrc, outDir, { recursive: true, verbatimSymlinks: true });
+// Static assets aren't part of the traced server output — copy them in.
+await cp(path.join(nextDir, 'static'), path.join(outApp, '.next', 'static'), { recursive: true });
+// Overlay our bundled custom server (server.js + chunks) where Next's default sat.
+const serverOut = path.join(hubDir, '.standalone-server');
+for (const f of await readdir(serverOut)) {
+  await cp(path.join(serverOut, f), path.join(outApp, f));
+}
+await rm(serverOut, { recursive: true, force: true });
+
+console.log(`[build-standalone] done → ${path.relative(process.cwd(), path.join(outApp, 'server.js'))}`);

--- a/apps/hub/server.ts
+++ b/apps/hub/server.ts
@@ -10,6 +10,8 @@
  * Run with tsx: `tsx server.ts` (dev) or `NODE_ENV=production tsx server.ts`
  * (after `next build`). The standalone/`agentbox hub` bin packaging is Phase 5.
  */
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
 import next from 'next';
 import { startRelayDaemon } from '@agentbox/relay/daemon';
 import { createHubBackend } from './lib/hub-backend';
@@ -36,7 +38,23 @@ async function main(): Promise<void> {
     process.env.AGENTBOX_HUB_TOKEN = await ensureHubToken();
   }
 
-  const app = next({ dev, dir: import.meta.dirname, hostname: host, port });
+  // Standalone build (`agentbox hub`): hand Next its precompiled config so the
+  // full next() API skips loadConfig() + the webpack hook — output:'standalone'
+  // prunes webpack, so without this next() dies on `next/dist/compiled/webpack`.
+  // Dev (`tsx server.ts`) has no required-server-files.json → unaffected.
+  const dir = import.meta.dirname;
+  if (!dev) {
+    const rsfPath = path.join(dir, '.next', 'required-server-files.json');
+    if (existsSync(rsfPath)) {
+      const rsf = JSON.parse(readFileSync(rsfPath, 'utf8')) as { config: unknown };
+      process.env.__NEXT_PRIVATE_STANDALONE_CONFIG ??= JSON.stringify(rsf.config);
+      // Next resolves distDir ('./.next') against cwd; the CLI spawns us with an
+      // arbitrary cwd, so anchor it here (the standalone `server.js` does the same).
+      process.chdir(dir);
+    }
+  }
+
+  const app = next({ dev, dir, hostname: host, port });
   await app.prepare();
   const handle = app.getRequestHandler();
 

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -331,12 +331,19 @@ agentbox queue clear --all
 agentbox relay status
 agentbox relay restart
 
+# Web UI — the relay + a dashboard on http://127.0.0.1:8787
+agentbox hub                 # start + open it in the browser
+agentbox hub status
+agentbox hub stop
+
 # Update agentbox (wipes the box image so it rebuilds, reloads the relay)
 agentbox self-update
 agentbox self-update --dry-run
 ```
 
 `prune` cleans up orphan state records; `--all` also removes orphan docker resources, and `--provider <cloud>` lists untracked cloud sandboxes and offers to delete them. `queue` manages background `-i` jobs. `relay` manages the host relay (`status`, `stop`, `start`, `restart`). `self-update` updates the CLI.
+
+`hub` runs the **AgentBox hub** — the host relay plus a local Web UI (dashboard, box detail, live approvals) on `http://127.0.0.1:8787`, gated by a per-machine token. It's a superset of the relay on the same port: `agentbox hub` takes over from a bare relay, and normal box commands reuse it. Needs Node ≥ 22.5.
 
 ## Control plane
 

--- a/apps/web/content/docs/hub.mdx
+++ b/apps/web/content/docs/hub.mdx
@@ -1,0 +1,75 @@
+---
+title: Hub (Web UI)
+description: A local dashboard for your boxes — served by the host relay on http://127.0.0.1:8787
+---
+
+The **hub** is a local Web UI for your boxes: a dashboard, box detail views, and a
+live **approvals** inbox, served by the host relay on `http://127.0.0.1:8787`. It's
+the same `@agentbox/relay` core you already run, with a Next.js UI delegated onto
+its port — one process, no extra port opened.
+
+```bash
+agentbox hub
+```
+
+That starts the hub (if it isn't already running) and opens it in your browser at
+`http://127.0.0.1:8787/?token=<secret>`.
+
+<Figure caption="The hub dashboard — boxes grouped by project, with live status and lifecycle controls." />
+
+## What's in it
+
+- **Dashboard** — every box on this machine, grouped by project, with live status
+  (running / paused / stopped / error) and per-box **pause / resume / stop /
+  destroy** controls.
+- **Box detail** — a box's task, agent, branch, host, and timestamps.
+- **Approvals** — the host-action requests a box is blocked on (a `git push` to a
+  protected branch, `cp`, `download`, gh/integration writes). **Approve** unblocks
+  the box; **Deny** returns an error to it. This is the same gate the relay prompts
+  for in an attached terminal — surfaced in the browser so you can answer from
+  anywhere on your machine.
+- **Live updates** — box states and approvals stream in over SSE; no manual
+  refresh. A pending approval appears the moment a box requests it.
+
+<Callout type="info" title="Creating boxes">Creating boxes from the hub isn't wired yet — use `agentbox create` (and the `-i` background flag) from the terminal. The hub reflects and controls the boxes you already have.</Callout>
+
+## Commands
+
+```bash
+agentbox hub              # start + open in the browser (default)
+agentbox hub --no-open    # start without opening a browser, just print the URL
+agentbox hub status       # is it running? (add --json)
+agentbox hub stop         # stop the hub process
+agentbox hub restart      # stop then start
+```
+
+## How it relates to the relay
+
+The hub is a **superset of the host relay** — it embeds the relay and adds the UI,
+on the same port (8787). The two are mutually exclusive there, so:
+
+- `agentbox hub` takes over from a bare `agentbox relay` if one is already running.
+- Once the hub is up, ordinary box commands (`agentbox create`, `claude`, …) reuse
+  it — they don't spawn a second relay.
+
+So you can run `agentbox hub` once and leave it; everything else keeps working
+through it. Stopping the hub (`agentbox hub stop`) frees the port, and the next box
+command brings a lean relay back automatically.
+
+## Auth
+
+On localhost the hub binds loopback (`127.0.0.1`) and gates access with a
+per-machine **token** — there's no login screen. `agentbox hub` generates a secret
+at `~/.agentbox/hub/token` (mode `0600`) and hands it to you in the URL; the hub
+stores it in an httpOnly cookie and redirects to the clean URL. Direct access
+without the token is refused (401). This protects the loopback bind from other
+local processes and DNS-rebinding. `AGENTBOX_HUB_AUTH=off` disables the gate.
+
+<Callout type="info" title="Requirements">The hub server needs **Node ≥ 22.5** (the lean relay and the rest of the CLI keep a lower floor). If you're below that, `agentbox hub` prints a clear error — use `agentbox relay` instead.</Callout>
+
+## Running it for a team
+
+`agentbox hub` is the single-user, on-your-machine UI. For a **shared, multi-user**
+deployment with password login and a cross-machine box registry — so cloud boxes
+keep working with your laptop off — deploy the same app as the hosted
+[control plane](/docs/control-plane) (Vercel or a VPS, backed by Postgres).

--- a/apps/web/content/docs/meta.json
+++ b/apps/web/content/docs/meta.json
@@ -32,6 +32,7 @@
     "e2b",
     "---Reference---",
     "cli",
+    "hub",
     "control-plane",
     "agentbox-yaml",
     "configuration",

--- a/docs/hub-webui-plan.md
+++ b/docs/hub-webui-plan.md
@@ -437,11 +437,48 @@ Live SSE push + a net-new **Approvals** view over the relay prompt mailbox.
   (The relay's existing integration tests already cover block-mode
   add→`/admin/prompts/answer`→exit-10 over real HTTP.)
 
-### Phase 5 — CLI wiring
-`agentbox hub` / `AGENTBOX_HUB=1` spawns the hub on 8787; default CLI keeps the
-lean relay bin.
-- **Verify:** audit the relay bin's module graph has no Next (bundle size
-  unchanged); hub mode serves UI + API on the single port 8787.
+### Phase 5 — CLI wiring + published packaging + hosted fixes — DONE
+`agentbox hub` (start/stop/status/restart) spawns the embedded relay + Next UI on
+8787; default CLI keeps the lean relay bin. Shipped in three parts.
+- **5a — command + lifecycle.** `/healthz` gained `ui:Boolean(uiHandler)` so the
+  hub (superset of the lean relay, both on 8787, mutually exclusive) is
+  distinguishable. `packages/sandbox-docker/src/hub.ts` (`ensureHub`/`stopHub`/
+  `getHubStatus`, separate `hub.pid`/`hub.log`) reuses relay.ts's probes + the
+  version-reclaim gate: reuses a running hub, reclaims a lean relay (or
+  version-mismatched hub) to take the port. The hub spawn sets `AGENTBOX_CLI_ENTRY`
+  + version so the create path's `ensureRelay()` reuses it and never reclaims it.
+  `apps/cli/src/commands/hub.ts` mirrors `relay.ts`; `start` is the default
+  subcommand and opens `http://127.0.0.1:8787/?token=…`.
+- **5b — published packaging (PoC-established recipe).** Next `output:'standalone'`
+  (gated behind `AGENTBOX_HUB_STANDALONE`, set only by `build:standalone`, so the
+  `next start`/Vercel deploy builds stay non-standalone). `apps/hub/scripts/build-standalone.mjs`
+  esbuild-bundles the custom `server.ts` with **code-splitting** (lazy `lib/auth` +
+  cloud-provider chunks stay unloaded in token mode), externalizing `next` + cloud
+  SDKs + better-auth/pg. `server.ts` sets `__NEXT_PRIVATE_STANDALONE_CONFIG` (from
+  `.next/required-server-files.json`) + `process.chdir(dir)` so the full `next()`
+  API skips `loadConfig()`/webpack; the spawn forces `NODE_ENV=production`.
+  `stage-runtime.mjs` stages `dist-standalone` → `runtime/hub` with
+  `verbatimSymlinks:true` (keeps the traced tree's relative symlinks
+  self-contained). `resolveHubServer()` locator + Node ≥ 22.5 gate +
+  `--experimental-sqlite` on 22.5–23; `prepublishOnly` builds the standalone
+  before staging.
+- **5c — hosted-path Bugbot fixes (#140).** #1 (High): compose/hetzner auth wiring
+  (docker-compose env passthrough + `AGENTBOX_HUB_PROFILE=vercel` Postgres auth,
+  Dockerfile boot-time `db:auth-migrate`, `control-plane.ts` collects
+  `resolveHubAuthEnv()` for hetzner + appends to the deploy `.env`). #2 (Medium):
+  `PostgresStore.listStatuses()` + `apps/hub/lib/boxes/postgres-source.ts` — the
+  `next start` deploy path now maps `listBoxes()`+`listStatuses()`+
+  `listPendingPrompts()` → `HubState` (dynamic pg import keeps pg out of the
+  localhost bundle); `source.ts` routes to it when there's no in-process backend
+  but `POSTGRES_URL` is set.
+- **Verified:** typecheck/lint clean across relay/sandbox-docker/cli/hub; relay 261
+  tests green. Live (dev tree, real `~/.agentbox`): `hub start` → `ui:true`/
+  `cliEntry:true`, token gate 401/200, `ensureRelay` reuses the hub (pid unchanged),
+  a lean relay is reclaimed + replaced, idempotent restart, `stop` frees the port.
+  Published shape: `runtime/hub` staged (relative symlinks) + runs out-of-tree.
+  Hosted: `next start` + seeded Postgres rendered the real box; auth env → `/signin`.
+- **Deferred:** shrinking the ~194M standalone (swc platform prune); the
+  `AGENTBOX_HUB=1` env alias (only the `agentbox hub` command ships).
 
 ---
 

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -351,6 +351,10 @@ export function createRelayServer(opts: RelayServerOptions): RelayServerHandle {
         boxes: await store.countBoxes(),
         events: await store.countEvents(),
         pid: process.pid,
+        // True when a Next UI is delegated here (the embedded hub) vs a bare relay.
+        // Lets `agentbox hub` distinguish "a hub already runs" from "a lean relay
+        // holds the port" (reclaim + respawn as the hub).
+        ui: Boolean(uiHandler),
         cliEntry: Boolean(process.env.AGENTBOX_CLI_ENTRY),
         // The spawning CLI's version/commit (inherited via env at spawn time).
         // `version` lets host-side ensureRelay reclaim a relay left over from a

--- a/packages/relay/src/store/postgres-store.ts
+++ b/packages/relay/src/store/postgres-store.ts
@@ -255,6 +255,18 @@ export class PostgresStore implements Store {
     await this.query(`DELETE FROM box_status WHERE box_id = $1`, [boxId]);
   }
 
+  /**
+   * All box status snapshots in one query (avoids N+1 over listBoxes +
+   * per-box getStatus). Used by the hosted hub UI to render every box's live
+   * status. Not on the Store interface — only the hosted Postgres path needs it.
+   */
+  async listStatuses(): Promise<Array<{ boxId: string; status: BoxStatusSnapshot }>> {
+    const rows = await this.query<{ box_id: string; status: BoxStatusSnapshot }>(
+      `SELECT box_id, status FROM box_status`,
+    );
+    return rows.map((r) => ({ boxId: r.box_id, status: r.status }));
+  }
+
   // --- prompt mailbox ---
 
   async createPrompt(row: PromptRow): Promise<void> {

--- a/packages/sandbox-docker/src/hub.ts
+++ b/packages/sandbox-docker/src/hub.ts
@@ -178,14 +178,20 @@ export async function ensureHub(opts: EnsureHubOptions = {}): Promise<HubEndpoin
   } else {
     const pid = await readPid(HUB_PID_FILE);
     if (pid !== null && (await processAlive(pid))) {
+      // A hub process exists but isn't answering /healthz yet — give startup a
+      // beat before deciding it's wedged.
       for (let i = 0; i < 10; i++) {
         if (await pingHealthz(300)) return endpointFor();
         await delay(200);
       }
-      log(`hub pid ${String(pid)} alive but /healthz unresponsive — proceeding`);
-      return endpointFor();
+      // Still unresponsive after ~2s: replace it rather than report a false
+      // "running" for a hub that never came up.
+      log(`hub pid ${String(pid)} alive but /healthz unresponsive — restarting it`);
+      await reclaimPort(pid, log);
+      // fall through to a fresh spawn
+    } else if (pid !== null) {
+      await unlink(HUB_PID_FILE).catch(() => {});
     }
-    if (pid !== null) await unlink(HUB_PID_FILE).catch(() => {});
   }
 
   const hubServer = resolveHubServer();

--- a/packages/sandbox-docker/src/hub.ts
+++ b/packages/sandbox-docker/src/hub.ts
@@ -1,0 +1,285 @@
+import { spawn } from 'node:child_process';
+import { existsSync, openSync } from 'node:fs';
+import { mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+import { DEFAULT_RELAY_PORT } from '@agentbox/relay';
+import {
+  fetchHealthz,
+  killPid,
+  pingHealthz,
+  processAlive,
+  resolveCliEntry,
+  shouldReclaimForVersion,
+} from './relay.js';
+
+/**
+ * `agentbox hub` lifecycle. The hub is the embedded relay + Next UI in ONE
+ * process on the relay port (8787) — a superset of the lean `agentbox-relay`.
+ * The two are mutually exclusive on the port, so:
+ *   - starting the hub reclaims any lean relay already holding 8787;
+ *   - a running hub answers /healthz with `ui:true`, so the create path's
+ *     `ensureRelay()` reuses it (it also sets AGENTBOX_CLI_ENTRY so the capability
+ *     gate is satisfied and it's never reclaimed for that reason).
+ *
+ * Shares the low-level probes (fetchHealthz/pingHealthz/killPid/processAlive) and
+ * the version-reclaim gate with relay.ts; keeps its own pid/log files so its
+ * status is independent of the lean relay's.
+ */
+
+const STATE_DIR = join(homedir(), '.agentbox');
+const HUB_PID_FILE = join(STATE_DIR, 'hub.pid');
+const HUB_LOG_FILE = join(STATE_DIR, 'hub.log');
+const HUB_TOKEN_FILE = join(STATE_DIR, 'hub', 'token');
+const PORT = DEFAULT_RELAY_PORT;
+const HOST = '127.0.0.1';
+
+/** Minimum Node for the hub server (node:sqlite in password mode + Next 16). */
+const NODE_MIN = { major: 22, minor: 5 };
+
+export interface HubEndpoint {
+  /** Base URL the browser opens (127.0.0.1:8787). */
+  hostUrl: string;
+  /** Full open URL including `?token=` when the token gate is on. */
+  openUrl: string;
+  port: number;
+  /** The token gate secret, when auth is on (localhost token mode). */
+  token: string | null;
+}
+
+export interface EnsureHubOptions {
+  onLog?: (line: string) => void;
+}
+
+function nodeVersion(): { major: number; minor: number } {
+  const [major, minor] = process.versions.node.split('.').map((n) => Number.parseInt(n, 10));
+  return { major: major ?? 0, minor: minor ?? 0 };
+}
+
+/** Throw a clear error below the hub's Node floor (the CLI floor is lower). */
+function assertNodeSupported(): void {
+  const v = nodeVersion();
+  if (v.major < NODE_MIN.major || (v.major === NODE_MIN.major && v.minor < NODE_MIN.minor)) {
+    throw new Error(
+      `agentbox hub needs Node >= ${NODE_MIN.major}.${NODE_MIN.minor} (running ${process.versions.node}). ` +
+        'Upgrade Node, or run the lean relay with `agentbox relay start`.',
+    );
+  }
+}
+
+/**
+ * Node flags for the hub spawn. `node:sqlite` (better-auth on the password
+ * profile) is behind `--experimental-sqlite` on Node 22.5–23; unflagged on 24+.
+ */
+function nodeFlags(): string[] {
+  const v = nodeVersion();
+  return v.major < 24 ? ['--experimental-sqlite'] : [];
+}
+
+async function readPid(file: string): Promise<number | null> {
+  try {
+    const pid = Number.parseInt((await readFile(file, 'utf8')).trim(), 10);
+    return Number.isFinite(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+async function readToken(): Promise<string | null> {
+  try {
+    const t = (await readFile(HUB_TOKEN_FILE, 'utf8')).trim();
+    return t.length > 0 ? t : null;
+  } catch {
+    return null;
+  }
+}
+
+async function endpointFor(): Promise<HubEndpoint> {
+  const token = await readToken();
+  const hostUrl = `http://${HOST}:${String(PORT)}`;
+  return {
+    hostUrl,
+    openUrl: token ? `${hostUrl}/?token=${token}` : hostUrl,
+    port: PORT,
+    token,
+  };
+}
+
+/**
+ * Locate the built hub server (`server.js`) the CLI spawns. Mirrors
+ * relay.ts:resolveRelayBin. Layouts:
+ *   0. env override: AGENTBOX_HUB_BIN
+ *   1. bundled CLI: <root>/runtime/hub/apps/hub/server.js (sibling of dist/)
+ *   2. workspace dev: <repo>/apps/hub/dist-standalone/apps/hub/server.js
+ */
+export function resolveHubServer(): string {
+  const override = process.env.AGENTBOX_HUB_BIN;
+  if (override && existsSync(override)) return override;
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    resolve(here, '..', 'runtime', 'hub', 'apps', 'hub', 'server.js'),
+    resolve(here, '..', '..', '..', 'apps', 'hub', 'dist-standalone', 'apps', 'hub', 'server.js'),
+    resolve(here, '..', '..', 'apps', 'hub', 'dist-standalone', 'apps', 'hub', 'server.js'),
+  ];
+  for (const c of candidates) {
+    if (existsSync(c)) return c;
+  }
+  throw new Error(
+    'could not locate the built hub server; run `pnpm --filter @agentbox/hub build:standalone` ' +
+      `(dev), or set AGENTBOX_HUB_BIN. Tried:\n  ${candidates.join('\n  ')}`,
+  );
+}
+
+/** Kill whatever holds the port (a lean relay or a stale hub) and confirm it freed. */
+async function reclaimPort(reportedPid: number | undefined, log: (line: string) => void): Promise<void> {
+  const pidFromFile = await readPid(HUB_PID_FILE);
+  const seen = new Set<number>();
+  for (const pid of [reportedPid, pidFromFile]) {
+    if (typeof pid !== 'number' || pid <= 0 || seen.has(pid)) continue;
+    seen.add(pid);
+    if (!(await processAlive(pid))) continue;
+    log(`stopping process on :${String(PORT)} (pid ${String(pid)})`);
+    await killPid(pid);
+  }
+  await unlink(HUB_PID_FILE).catch(() => {});
+  if (await pingHealthz(300)) {
+    throw new Error(
+      `something is still listening on :${String(PORT)} and could not be stopped ` +
+        `(reported pid ${String(reportedPid ?? 'unknown')}); kill it manually and retry`,
+    );
+  }
+}
+
+/**
+ * Idempotently bring up the embedded hub on 8787. Reuses an already-running hub
+ * (`ui:true`, version match); reclaims a lean relay or a version-mismatched hub
+ * first. Best-effort like ensureRelay: failures throw.
+ */
+export async function ensureHub(opts: EnsureHubOptions = {}): Promise<HubEndpoint> {
+  const log = opts.onLog ?? (() => {});
+  assertNodeSupported();
+  await mkdir(STATE_DIR, { recursive: true });
+
+  const currentVersion = process.env.AGENTBOX_CLI_VERSION;
+  const health = await fetchHealthz(500);
+  if (health !== null) {
+    if (health.ui === true && !shouldReclaimForVersion(health, currentVersion)) {
+      return endpointFor(); // a hub already runs here
+    }
+    log(
+      health.ui === true
+        ? 'a hub from a different agentbox version holds :8787 — reclaiming'
+        : 'a lean relay holds :8787 — reclaiming to start the hub',
+    );
+    await reclaimPort(health.pid, log);
+    // fall through to spawn
+  } else {
+    const pid = await readPid(HUB_PID_FILE);
+    if (pid !== null && (await processAlive(pid))) {
+      for (let i = 0; i < 10; i++) {
+        if (await pingHealthz(300)) return endpointFor();
+        await delay(200);
+      }
+      log(`hub pid ${String(pid)} alive but /healthz unresponsive — proceeding`);
+      return endpointFor();
+    }
+    if (pid !== null) await unlink(HUB_PID_FILE).catch(() => {});
+  }
+
+  const hubServer = resolveHubServer();
+  const cliEntry = resolveCliEntry();
+  if (cliEntry === null) {
+    throw new Error(
+      'cannot start the hub: agentbox CLI entry not found (is the build complete?). ' +
+        'Set AGENTBOX_CLI_ENTRY to override.',
+    );
+  }
+  return spawnHub(hubServer, cliEntry, log);
+}
+
+async function spawnHub(hubServer: string, cliEntry: string, log: (line: string) => void): Promise<HubEndpoint> {
+  const logFd = openSync(HUB_LOG_FILE, 'a');
+  const child = spawn(process.execPath, [...nodeFlags(), hubServer], {
+    detached: true,
+    stdio: ['ignore', logFd, logFd],
+    env: {
+      ...process.env,
+      // The staged hub is a production Next build; force production so server.ts
+      // takes the standalone path (dev mode would load webpack, which the
+      // standalone build prunes).
+      NODE_ENV: 'production',
+      AGENTBOX_CLI_ENTRY: cliEntry,
+      // The hub is the localhost profile (token gate); bind loopback.
+      AGENTBOX_HUB_HOST: HOST,
+    },
+  });
+  child.unref();
+  if (typeof child.pid === 'number') {
+    await writeFile(HUB_PID_FILE, String(child.pid), 'utf8');
+    log(`spawned hub process (pid ${String(child.pid)}, port ${String(PORT)})`);
+  }
+  // Next prepare takes a beat longer than the lean relay; give it ~25s.
+  for (let i = 0; i < 50; i++) {
+    if (await pingHealthz(300)) {
+      log(`hub reachable on http://${HOST}:${String(PORT)}`);
+      return endpointFor();
+    }
+    await delay(200);
+  }
+  throw new Error(`hub did not become reachable on http://${HOST}:${String(PORT)} within ~25s; see ${HUB_LOG_FILE}`);
+}
+
+export interface StopHubResult {
+  stopped: boolean;
+  pid: number | null;
+}
+
+/** Stop the hub process + clear its pidfile. SIGTERM then SIGKILL. Idempotent. */
+export async function stopHub(): Promise<StopHubResult> {
+  const pid = await readPid(HUB_PID_FILE);
+  if (pid === null) return { stopped: false, pid: null };
+  if (!(await processAlive(pid))) {
+    await unlink(HUB_PID_FILE).catch(() => {});
+    return { stopped: false, pid };
+  }
+  await killPid(pid);
+  await unlink(HUB_PID_FILE).catch(() => {});
+  return { stopped: true, pid };
+}
+
+export interface HubStatus {
+  /** /healthz responded. */
+  running: boolean;
+  /** /healthz reported a delegated Next UI (vs a bare relay on the port). */
+  ui: boolean;
+  pid: number | null;
+  pidAlive: boolean;
+  port: number;
+  hostUrl: string;
+  openUrl: string;
+  token: string | null;
+  pidFile: string;
+  logFile: string;
+}
+
+/** Read-only snapshot of the hub's liveness (mirrors getRelayStatus). */
+export async function getHubStatus(): Promise<HubStatus> {
+  const pid = await readPid(HUB_PID_FILE);
+  const pidAlive = pid !== null && (await processAlive(pid));
+  const health = await fetchHealthz(300);
+  const ep = await endpointFor();
+  return {
+    running: health !== null,
+    ui: health?.ui === true,
+    pid,
+    pidAlive,
+    port: PORT,
+    hostUrl: ep.hostUrl,
+    openUrl: ep.openUrl,
+    token: ep.token,
+    pidFile: HUB_PID_FILE,
+    logFile: HUB_LOG_FILE,
+  };
+}

--- a/packages/sandbox-docker/src/index.ts
+++ b/packages/sandbox-docker/src/index.ts
@@ -205,6 +205,16 @@ export {
   type RelayStatus,
   type StopRelayResult,
 } from './relay.js';
+export {
+  ensureHub,
+  getHubStatus,
+  resolveHubServer,
+  stopHub,
+  type EnsureHubOptions,
+  type HubEndpoint,
+  type HubStatus,
+  type StopHubResult,
+} from './hub.js';
 // The host-config stage producers now live in the provider-neutral sync layer
 // (`@agentbox/sandbox-core`); cloud consumers import them from there. The claude
 // per-project path helpers + Stage types stay re-exported here (from core) for

--- a/packages/sandbox-docker/src/relay.ts
+++ b/packages/sandbox-docker/src/relay.ts
@@ -194,7 +194,7 @@ async function reclaimRelay(reportedPid: number | undefined, log: (line: string)
 }
 
 /** SIGTERM, wait for exit, then SIGKILL — same escalation as {@link stopRelay}. */
-async function killPid(pid: number): Promise<void> {
+export async function killPid(pid: number): Promise<void> {
   try {
     process.kill(pid, 'SIGTERM');
   } catch {
@@ -282,7 +282,7 @@ export function resolveRelayBin(): string {
  *   2. installed: `<...>/agentbox/node_modules/@agentbox/sandbox-docker/dist` ↔ `<...>/agentbox/dist/index.js`
  * Best-effort: returns null when not found (relay reports a clear error).
  */
-function resolveCliEntry(): string | null {
+export function resolveCliEntry(): string | null {
   const override = process.env.AGENTBOX_CLI_ENTRY;
   if (override && existsSync(override)) return override;
   const here = dirname(fileURLToPath(import.meta.url));
@@ -524,7 +524,7 @@ export async function getRelayStatus(): Promise<RelayStatus> {
   };
 }
 
-function pingHealthz(timeoutMs: number): Promise<boolean> {
+export function pingHealthz(timeoutMs: number): Promise<boolean> {
   return new Promise<boolean>((resolveP) => {
     const req = httpRequest(
       { host: '127.0.0.1', port: PORT, method: 'GET', path: '/healthz', timeout: timeoutMs },
@@ -543,12 +543,14 @@ function pingHealthz(timeoutMs: number): Promise<boolean> {
   });
 }
 
-interface HealthzBody {
+export interface HealthzBody {
   ok: boolean;
   boxes: number;
   events: number;
   /** The relay's own pid (for reclaiming). Absent on relays predating this field. */
   pid?: number;
+  /** True when a Next UI is delegated (the embedded hub) vs a bare relay. Absent on old relays. */
+  ui?: boolean;
   /** Whether the relay has AGENTBOX_CLI_ENTRY (can run cp/download/checkpoint). Absent on old relays. */
   cliEntry?: boolean;
   /** The agentbox version that spawned the relay. Absent on relays predating this field. */
@@ -557,7 +559,7 @@ interface HealthzBody {
   commit?: string;
 }
 
-function fetchHealthz(timeoutMs: number): Promise<HealthzBody | null> {
+export function fetchHealthz(timeoutMs: number): Promise<HealthzBody | null> {
   return new Promise<HealthzBody | null>((resolveP) => {
     const req = httpRequest(
       { host: '127.0.0.1', port: PORT, method: 'GET', path: '/healthz', timeout: timeoutMs },
@@ -583,6 +585,7 @@ function fetchHealthz(timeoutMs: number): Promise<HealthzBody | null> {
                 boxes: parsed.boxes,
                 events: parsed.events,
                 pid: typeof parsed.pid === 'number' ? parsed.pid : undefined,
+                ui: typeof parsed.ui === 'boolean' ? parsed.ui : undefined,
                 cliEntry: typeof parsed.cliEntry === 'boolean' ? parsed.cliEntry : undefined,
                 version:
                   typeof parsed.version === 'string' && parsed.version.length > 0
@@ -622,7 +625,7 @@ async function readPidFile(): Promise<number | null> {
   }
 }
 
-async function processAlive(pid: number): Promise<boolean> {
+export async function processAlive(pid: number): Promise<boolean> {
   try {
     // Signal 0 is the existence probe: throws if no such process.
     process.kill(pid, 0);


### PR DESCRIPTION
Phase 5 of the hub Web UI plan (`docs/hub-webui-plan.md`): ship the `agentbox hub` command, make it runnable from a published npm install, and fix the two hosted-path Bugbot findings from #140. Three parts.

## 5a — the `agentbox hub` command + lifecycle
- `/healthz` gains a `ui` field so the hub (a **superset** of the lean relay — both on 8787, mutually exclusive) is distinguishable.
- `packages/sandbox-docker/src/hub.ts` (`ensureHub`/`stopHub`/`getHubStatus`, separate `hub.pid`/`hub.log`) reuses relay.ts's probes + version-reclaim gate: reuses a running hub, **reclaims a lean relay** (or version-mismatched hub) to take the port. The hub spawn sets `AGENTBOX_CLI_ENTRY` + version, so the create path's `ensureRelay()` **reuses** it and never reclaims it.
- `apps/cli/src/commands/hub.ts` mirrors `relay.ts`; `start` is the default subcommand and opens `http://127.0.0.1:8787/?token=…`.

## 5b — published-npm packaging (Next standalone + esbuild)
Established via a PoC first. `output:'standalone'` (gated behind `AGENTBOX_HUB_STANDALONE`, set only by `build:standalone`, so the `next start`/Vercel **deploy** builds stay non-standalone). `build-standalone.mjs` esbuild-bundles the custom `server.ts` with **code-splitting** (lazy `lib/auth` + cloud-provider chunks stay unloaded in token mode), externalizing `next`/cloud-SDKs/better-auth/pg. `server.ts` sets `__NEXT_PRIVATE_STANDALONE_CONFIG` + `chdir` so the full `next()` API skips `loadConfig()`/webpack; the spawn forces `NODE_ENV=production`. `stage-runtime.mjs` stages `dist-standalone` → `runtime/hub` with `verbatimSymlinks` (keeps the traced tree's relative symlinks self-contained); `resolveHubServer()` locator; Node ≥ 22.5 gate + `--experimental-sqlite` on 22.5–23; `prepublishOnly` builds it before staging.

## 5c — hosted-path Bugbot fixes (#140)
- **#1 (High)** compose/hetzner hub UI was ungated: docker-compose env passthrough + `AGENTBOX_HUB_PROFILE=vercel` (Postgres auth), Dockerfile boot-time `db:auth-migrate`, and `control-plane.ts` collects `resolveHubAuthEnv()` for hetzner + appends it to the deploy `.env`.
- **#2 (Medium)** hosted UI ignored Postgres boxes: `PostgresStore.listStatuses()` + `apps/hub/lib/boxes/postgres-source.ts` map `listBoxes()`+`listStatuses()`+`listPendingPrompts()` → `HubState` (dynamic pg import keeps pg out of the localhost bundle); `source.ts` routes to it when there's no in-process backend but `POSTGRES_URL` is set.

## Verification
- typecheck/lint clean across relay/sandbox-docker/cli/hub; relay **261** tests green.
- **Live (dev tree):** `hub start` → `ui:true`/`cliEntry:true`; token gate 401/307/200; `ensureRelay` **reuses** the hub (pid unchanged); a lean relay is **reclaimed + replaced**; idempotent restart; `stop` frees the port.
- **Published shape:** `runtime/hub` staged with relative symlinks; the standalone tree runs **out-of-tree** (proves it doesn't depend on the source).
- **Hosted:** `next start` still serves with output gated off (no warning); `next start` + a seeded Postgres rendered the **real box** (repo/branch/title/status); auth env → `/signin` redirect. `PostgresStore.listStatuses()` verified against a live Postgres.

Docs: `docs/hub-webui-plan.md` Phase 5 → DONE; `apps/hub/README.md` usage; `apps/web/.../cli.mdx` documents `agentbox hub`.

Deferred: shrinking the ~194M standalone (swc platform prune).

https://claude.ai/code/session_01TGoDQvktdXD5rqJuJm9Uyk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Port 8787 reclaim and a large staged runtime affect local relay/hub behavior; hosted changes touch auth secrets and Postgres-backed UI data on network-exposed deploys.
> 
> **Overview**
> **`agentbox hub`** is a new CLI command (start/stop/status/restart, default start opens the token URL) that runs the embedded relay + Next dashboard on port 8787. `/healthz` now exposes **`ui`** so lifecycle code can tell a hub from a lean relay; **`ensureHub`** reclaims the port from a bare relay or stale hub, while box create’s **`ensureRelay`** reuses a running hub when versions match.
> 
> **Published packaging:** `build:standalone` produces a traced Next standalone tree with an esbuild-bundled custom **`server.ts`**; **`prepublishOnly`** / **`stage-runtime`** copy it into **`runtime/hub`** with **`verbatimSymlinks`** so the npm package is self-contained. **`server.ts`** sets standalone Next config and **`chdir`** for spawned runs.
> 
> **Hosted path fixes:** Docker compose and **`control-plane setup --deploy hetzner`** wire password auth (env + boot **`db:auth-migrate`**). **`postgres-source.ts`** and **`PostgresStore.listStatuses()`** feed the dashboard when **`POSTGRES_URL`** is set and there is no in-process backend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef6f13d696a770abe5780deeef2105b8147518a5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->