### PR TITLE
feat(config): git.pushMode — choose relay vs lease for a box's git push

### DIFF
--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -588,6 +588,7 @@ export const claudeCommand = new Command('claude')
     // authorized on its GitHub App so the box can lease push tokens.
     await ensureProjectRepoOnControlPlane({
       controlPlaneUrl: cfg.effective.relay.controlPlaneUrl,
+      gitPushMode: cfg.effective.git.pushMode,
       projectRoot,
       yes: !!opts.yes,
     });

--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -838,6 +838,10 @@ export const claudeCommand = new Command('claude')
           useBranch,
           resyncOnStart: opts.resync,
           projectRoot,
+          // Control-plane topology + git push routing — mirror `agentbox create`
+          // so cloud boxes from the agent commands honor the same config.
+          controlPlaneUrl: cfg.effective.relay.controlPlaneUrl,
+          gitPushMode: cfg.effective.git.pushMode,
           // Per-provider session-lifetime (e2b/vercel timeout) so the keepalive
           // seeds correctly; mirrors `agentbox create`.
           providerOptions: cloudSizingProviderOptions(provider.name, cfg.effective),

--- a/apps/cli/src/commands/codex.ts
+++ b/apps/cli/src/commands/codex.ts
@@ -470,6 +470,7 @@ export const codexCommand = new Command('codex')
     // authorized on its GitHub App so the box can lease push tokens.
     await ensureProjectRepoOnControlPlane({
       controlPlaneUrl: cfg.effective.relay.controlPlaneUrl,
+      gitPushMode: cfg.effective.git.pushMode,
       projectRoot,
       yes: !!opts.yes,
     });

--- a/apps/cli/src/commands/codex.ts
+++ b/apps/cli/src/commands/codex.ts
@@ -594,6 +594,10 @@ export const codexCommand = new Command('codex')
           useBranch,
           resyncOnStart: opts.resync,
           projectRoot,
+          // Control-plane topology + git push routing — mirror `agentbox create`
+          // so cloud boxes from the agent commands honor the same config.
+          controlPlaneUrl: cfg.effective.relay.controlPlaneUrl,
+          gitPushMode: cfg.effective.git.pushMode,
           // Per-provider session-lifetime (e2b/vercel timeout); mirrors create.
           providerOptions: cloudSizingProviderOptions(provider.name, cfg.effective),
         },

--- a/apps/cli/src/commands/create.ts
+++ b/apps/cli/src/commands/create.ts
@@ -431,6 +431,7 @@ export const createCommand = new Command('create')
         // on the plane, and the box forwards /rpc + leases push tokens directly.
         // Cloud-only in effect; the docker provider ignores it.
         controlPlaneUrl: cfg.effective.relay.controlPlaneUrl,
+        gitPushMode: cfg.effective.git.pushMode,
         projectRoot,
         onLog: (line) => {
           s.message(line);

--- a/apps/cli/src/commands/opencode.ts
+++ b/apps/cli/src/commands/opencode.ts
@@ -433,6 +433,7 @@ export const opencodeCommand = new Command('opencode')
     // authorized on its GitHub App so the box can lease push tokens.
     await ensureProjectRepoOnControlPlane({
       controlPlaneUrl: cfg.effective.relay.controlPlaneUrl,
+      gitPushMode: cfg.effective.git.pushMode,
       projectRoot,
       yes: !!opts.yes,
     });

--- a/apps/cli/src/commands/opencode.ts
+++ b/apps/cli/src/commands/opencode.ts
@@ -557,6 +557,10 @@ export const opencodeCommand = new Command('opencode')
           useBranch,
           resyncOnStart: opts.resync,
           projectRoot,
+          // Control-plane topology + git push routing — mirror `agentbox create`
+          // so cloud boxes from the agent commands honor the same config.
+          controlPlaneUrl: cfg.effective.relay.controlPlaneUrl,
+          gitPushMode: cfg.effective.git.pushMode,
           // Per-provider session-lifetime (e2b/vercel timeout); mirrors create.
           providerOptions: cloudSizingProviderOptions(provider.name, cfg.effective),
         },

--- a/apps/cli/src/control-plane/ensure-repo-installed.ts
+++ b/apps/cli/src/control-plane/ensure-repo-installed.ts
@@ -128,11 +128,15 @@ function writeReposState(state: ReposState): void {
  */
 export async function ensureProjectRepoOnControlPlane(args: {
   controlPlaneUrl: string | undefined;
+  gitPushMode?: 'auto' | 'relay' | 'lease';
   projectRoot: string;
   yes?: boolean;
 }): Promise<void> {
   const { controlPlaneUrl, projectRoot } = args;
   if (!controlPlaneUrl) return;
+  // `relay` push mode never leases, so the repo doesn't need to be authorized on
+  // the control plane's GitHub App — skip the check/nag.
+  if (args.gitPushMode === 'relay') return;
   const ownerRepo = await resolveOwnerRepo(projectRoot);
   if (!ownerRepo) return;
   const { owner, repo } = ownerRepo;

--- a/apps/web/content/docs/sync-and-git.mdx
+++ b/apps/web/content/docs/sync-and-git.mdx
@@ -109,6 +109,23 @@ Plain `git push` inside the box just works: a `git`/`gh` shim routes network ops
 {/* DIAGRAM /diagrams/sync-and-git.png — nano-banana-pro, home-diagram style ref. Recipe + prompt in apps/web/images.md → Phase D. */}
 <Figure src="/diagrams/sync-and-git.png" caption="On a cloud box, the workspace is a git-bundle copy: git commit lands instantly in the box's own .git. Pushing to your remote runs through the host relay, with your approval." />
 
+### How the push reaches GitHub — `git.pushMode`
+
+There are two ways a box's `git push` can reach your remote:
+
+- **Relay** (the default above) — the box asks the host relay to push, and the host runs `git push` with your own credentials. They never enter the box. Docker boxes always use this (they bind-mount your `.git`); cloud boxes run it through the relay's cloud poller (a git-bundle pull-back).
+- **Lease** — when a [control plane](/docs/control-plane) is configured for a cloud box, the relay/plane leases a short-lived, repo-scoped GitHub-App token and the box pushes **directly** with it, so the box keeps working with your laptop off.
+
+`auto` (the default) leases when a control plane is configured for the box, and uses the relay otherwise. Force one with the `git.pushMode` config key:
+
+```bash
+agentbox config set git.pushMode relay   # always push through the host relay (your creds)
+agentbox config set git.pushMode lease   # always lease a token; box pushes directly
+agentbox config set git.pushMode auto    # default (lease iff a control plane is set)
+```
+
+Only affects cloud boxes. Forcing `relay` needs a reachable host relay for the box; forcing `lease` needs a reachable relay/plane with a GitHub App configured.
+
 ## Pull requests
 
 The relay also proxies the host `gh` CLI: `agentbox git pr <op> <box>` from the host, or — inside the box — plain `gh pr <op>`, which the box's `gh` shim routes through the relay the same way (the explicit form is `agentbox-ctl git pr <op>`). `gh` runs in the host main repo and infers the repo from `git remote -v`. This needs `gh` installed and `gh auth login` on the host.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -10,6 +10,7 @@ export {
   type ConfigSource,
   type EffectiveConfig,
   type EngineKind,
+  type GitPushMode,
   type IdeFlavor,
   type KeyDescriptor,
   type KeyType,

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -26,6 +26,19 @@ export type { ProviderKind };
  * an opt-in fallback for cloud egress IPs whose CDN the native installer 403s.
  */
 export type ClaudeInstallMethod = 'native' | 'npm';
+/**
+ * How a box's `git push` reaches GitHub:
+ * - `relay` — the box asks the host relay to push with the HOST's credentials
+ *   (they never enter the box). Docker boxes always use this; for a cloud box it
+ *   runs through the host relay's cloud poller (git-bundle pull-back).
+ * - `lease` — the relay/plane leases a short-lived GitHub-App token and the box
+ *   pushes directly with it (keeps working with the laptop off). Needs a
+ *   reachable relay/plane with a GitHub App configured.
+ * - `auto` (default) — lease when a control plane is configured for the box
+ *   (`relay.controlPlaneUrl`), else relay. Today's behavior.
+ * Docker boxes ignore this (always `relay` — they bind-mount the host `.git`).
+ */
+export type GitPushMode = 'auto' | 'relay' | 'lease';
 /** Where `agentbox claude|codex|opencode` opens the attached session when the host
  *  shell is running inside tmux, cmux, Herdr, or iTerm2. `same` keeps today's inline behavior. */
 export type AttachOpenIn = 'split' | 'window' | 'tab' | 'same';
@@ -152,6 +165,9 @@ export interface UserConfig {
      * (the default). Set via `agentbox control-plane set-url`.
      */
     controlPlaneUrl?: string;
+  };
+  git?: {
+    pushMode?: GitPushMode;
   };
   vnc?: {
     containerPort?: number;
@@ -280,6 +296,9 @@ export interface EffectiveConfig {
   relay: {
     port: number;
     controlPlaneUrl: string | undefined;
+  };
+  git: {
+    pushMode: GitPushMode;
   };
   vnc: {
     containerPort: number;
@@ -429,6 +448,9 @@ export const BUILT_IN_DEFAULTS: EffectiveConfig = {
   relay: {
     port: 8787,
     controlPlaneUrl: undefined,
+  },
+  git: {
+    pushMode: 'auto',
   },
   vnc: {
     containerPort: 6080,
@@ -789,6 +811,13 @@ export const KEY_REGISTRY: readonly KeyDescriptor[] = [
     type: 'string',
     description:
       'Public HTTPS URL of a deployed control plane (hosted Next.js + Postgres app). When set, new cloud boxes point at it for git-token leasing, permission state, and the box registry/events, and push to GitHub directly with a leased token so they keep working with the laptop off. Set via `agentbox control-plane set-url`.',
+  },
+  {
+    key: 'git.pushMode',
+    type: 'enum',
+    enumValues: ['auto', 'relay', 'lease'] as const,
+    description:
+      "How a box's `git push` reaches GitHub: `relay` (the host relay pushes with your host credentials — they never enter the box), `lease` (the relay/plane leases a short-lived GitHub-App token and the box pushes directly, so it works with the laptop off), or `auto` (default — lease when `relay.controlPlaneUrl` is set for the box, else relay). Only affects cloud boxes; docker boxes always use `relay`. Forcing `relay` needs a reachable host relay for the box; forcing `lease` needs a reachable relay/plane with a GitHub App.",
   },
   {
     key: 'vnc.containerPort',

--- a/packages/core/src/box-record.ts
+++ b/packages/core/src/box-record.ts
@@ -150,6 +150,12 @@ export interface CloudBoxFields {
    * re-threads the box's forwarder upstream + `AGENTBOX_GIT_LEASE` correctly.
    */
   controlPlaneUrl?: string;
+  /**
+   * Git push routing (`git.pushMode`): `'auto' | 'relay' | 'lease'`. Persisted
+   * (not re-derived from config) so a resume re-kick re-threads `AGENTBOX_GIT_LEASE`
+   * correctly even if the host config changed. Mirrors config's `GitPushMode`.
+   */
+  gitPushMode?: 'auto' | 'relay' | 'lease';
 }
 
 export interface GitWorktreeRecord {

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -151,6 +151,12 @@ export interface CreateBoxRequest {
    * Absent → classic host-side sync (`'cloud'`/`'docker'`). Docker ignores it.
    */
   controlPlaneUrl?: string;
+  /**
+   * Git push routing (`git.pushMode`): `'auto' | 'relay' | 'lease'`. Mirrors
+   * config's `GitPushMode` (core doesn't depend on config). Threaded to the box
+   * bootstrap to gate `AGENTBOX_GIT_LEASE`. Docker ignores it (always relay).
+   */
+  gitPushMode?: 'auto' | 'relay' | 'lease';
   /** Provider-specific knobs (docker: sharedCache/portless; daytona: resources/region). */
   providerOptions?: Record<string, unknown>;
   onLog?: (line: string) => void;

--- a/packages/sandbox-cloud/src/bootstrap-launch.ts
+++ b/packages/sandbox-cloud/src/bootstrap-launch.ts
@@ -1,4 +1,5 @@
 import type { CloudBackend, CloudHandle } from '@agentbox/core';
+import type { GitPushMode } from '@agentbox/config';
 import { bashScript, quoteShellArgv } from './shell.js';
 
 /**
@@ -54,6 +55,13 @@ export interface KickCloudBootstrapArgs {
    * reEnsure/attach) from the persisted record so resume preserves the topology.
    */
   controlPlaneUrl?: string;
+  /**
+   * Git push routing for this box (`git.pushMode`): `relay` (host relay pushes
+   * with host creds), `lease` (box leases a token and pushes direct), or `auto`
+   * (default — lease iff a control plane is configured). Only `lease` (explicit
+   * or auto-with-control-plane) writes `AGENTBOX_GIT_LEASE=1`. Omitted = `auto`.
+   */
+  gitPushMode?: GitPushMode;
   onLog?: (line: string) => void;
 }
 
@@ -112,10 +120,19 @@ export function buildBootstrapEnv(args: KickCloudBootstrapArgs): {
     boxEnvFile.push(`AGENTBOX_WEB_PROXY_PORT=${quoteShellArgv([String(args.webProxyPort)])}`);
   if (args.boxHost) boxEnvFile.push(`AGENTBOX_BOX_HOST=${quoteShellArgv([args.boxHost])}`);
 
-  // Control-plane topology: the daemon needs the upstream URL (process env), and
-  // the login-shell `git push` needs the lease flag (box.env, world-readable).
+  // Control-plane topology: the daemon needs the upstream URL (process env)
+  // regardless of push routing — it drives the registry/events/permissions, not
+  // just leasing.
   if (args.controlPlaneUrl) {
     env.push(`AGENTBOX_CONTROL_PLANE_URL=${quoteShellArgv([args.controlPlaneUrl])}`);
+  }
+
+  // Git push routing (git.pushMode). The login-shell `git push` leases + pushes
+  // direct only when this flag is set; otherwise it routes through the host relay.
+  // `auto` (default) leases iff a control plane is configured for the box.
+  const pushMode = args.gitPushMode ?? 'auto';
+  const lease = pushMode === 'lease' || (pushMode === 'auto' && Boolean(args.controlPlaneUrl));
+  if (lease) {
     boxEnvFile.push(`AGENTBOX_GIT_LEASE=1`);
   }
 

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -447,6 +447,7 @@ export function createCloudProvider(
       launchDockerd: opts.launchDockerd !== false,
       vncPassword: box.vncEnabled ? box.vncPassword : undefined,
       controlPlaneUrl: box.cloud?.controlPlaneUrl,
+      gitPushMode: box.cloud?.gitPushMode,
       boxHost: deriveCloudBoxHost(box.name, webPreview?.url),
     });
     // Re-register on resume. A control-plane box registers on the plane (with
@@ -807,6 +808,7 @@ export function createCloudProvider(
           vncPassword,
           clone: inBoxClone,
           controlPlaneUrl: req.controlPlaneUrl,
+          gitPushMode: req.gitPushMode,
           boxHost: deriveCloudBoxHost(name, webPreview?.url),
           onLog: log,
         });
@@ -1028,6 +1030,7 @@ export function createCloudProvider(
             workspaceBranch: branch,
             topology: resolveSyncTopology(backend.name, req.controlPlaneUrl),
             controlPlaneUrl: req.controlPlaneUrl,
+            gitPushMode: req.gitPushMode,
           },
           createdAt: new Date().toISOString(),
         };


### PR DESCRIPTION
Adds a `git.pushMode` config key so the two git-push mechanisms are **selectable** instead of purely implicit.

## Why
Today the choice is automatic and invisible: a cloud box with `relay.controlPlaneUrl` set → **lease** (GitHub-App token, box pushes direct); everything else → **relay** (host relay pushes with your credentials). There was no way to say "use the host relay even though a control plane is configured" — e.g. to avoid the GitHub App / per-repo authorization, when the relay is reachable anyway.

## What
`git.pushMode` = `auto` | `relay` | `lease` (default `auto` = today's behavior):
- **relay** — host relay pushes with your creds (never enter the box). Docker always; cloud via the relay's poller (git-bundle pull-back).
- **lease** — relay/plane leases a short-lived GitHub-App token; box pushes directly (laptop-off).
- **auto** — lease iff a control plane is configured for the box, else relay.

```bash
agentbox config set git.pushMode relay
agentbox config set git.pushMode lease
```

The switch is the single `AGENTBOX_GIT_LEASE` marker the in-box CLI reads; it's now gated on `pushMode` in `buildBootstrapEnv` instead of solely on `controlPlaneUrl`. Crucially, the control-plane URL is **still exported regardless of mode** — it drives the registry/events/permissions topology, not just leasing — so `relay` mode keeps the plane's other features while routing pushes host-side.

Threaded exactly like `controlPlaneUrl`: `CreateBoxRequest` + `BoxCloud` (persisted so a resume re-kick re-threads it), the four create/agent commands, and cloud-provider's kick callsites. `ensureProjectRepoOnControlPlane` skips the GitHub-App authorization nag when `pushMode=relay` (no lease → no App needed). Docker ignores it (always relay).

## Scope note
This is the routing **flag** only. Making an always-on server (hetzner) act as the host relay for cloud boxes — so `relay` works through a deployed control plane with no laptop and no GitHub App — is the larger **full-host / "control-box"** profile (repo materialization at `workspacePath` + server git creds + registry/poller on the server; it existed, was removed, and is a roadmap item). Deferred by decision; lease stays a supported option.

## Verification
- `buildBootstrapEnv` lease-decision matrix verified (auto/relay/lease × plane/no-plane), incl. control-plane URL preserved under `relay`.
- config 110 tests green; typecheck + lint clean across config/core/sandbox-cloud/cli.
- Docs: `sync-and-git.mdx` gains a "How the push reaches GitHub — `git.pushMode`" section.

https://claude.ai/code/session_01TGoDQvktdXD5rqJuJm9Uyk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches git push routing and control-plane bootstrap for cloud boxes; misconfiguration could break pushes, but defaults preserve existing auto behavior and docker is unaffected.
> 
> **Overview**
> Adds **`git.pushMode`** (`auto` | `relay` | `lease`, default `auto`) so cloud boxes can explicitly choose how `git push` reaches GitHub instead of inferring it only from whether a control plane URL is set.
> 
> **Relay** routes pushes through the host relay with your credentials; **lease** mints a short-lived GitHub App token so the box pushes directly (laptop-off). **`auto`** keeps prior behavior: lease when `relay.controlPlaneUrl` is set, else relay. Docker boxes are unchanged (always relay).
> 
> The routing switch is implemented by gating **`AGENTBOX_GIT_LEASE`** in `buildBootstrapEnv`: it is written only when mode is `lease`, or `auto` with a control plane. **`AGENTBOX_CONTROL_PLANE_URL`** is still set whenever a plane is configured, so registry/events/permissions work even in **`relay`** push mode.
> 
> `gitPushMode` is threaded like `controlPlaneUrl` through create/agent commands, `CreateBoxRequest`, persisted `BoxCloud`, and cloud bootstrap kicks so resumes re-apply the same routing. **`ensureProjectRepoOnControlPlane`** skips the GitHub App repo-authorization nag when **`git.pushMode=relay`**. Docs add a sync-and-git section; config registry exposes `git.pushMode`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3893e1dbf9a525fa9dcc68d4c85f31245ca0428. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->