### PR TITLE
feat(control-plane): `control-plane unset-url` to stop using a control plane

### DIFF
--- a/apps/cli/src/commands/control-plane.ts
+++ b/apps/cli/src/commands/control-plane.ts
@@ -239,11 +239,11 @@ const unsetUrlSub = new Command('unset-url')
   .action(async (opts: { purge?: boolean }) => {
     try {
       // set-url writes the global scope; also clear a per-project override if one
-      // exists (best-effort — a non-project cwd has no project file to touch).
+      // exists. A cwd with no project config just yields `existed:false` (the
+      // project unset never throws for that) — real I/O/write errors from either
+      // scope propagate to handleLifecycleError rather than being masked.
       const g = await unsetConfigValue('global', 'relay.controlPlaneUrl', process.cwd());
-      const p = await unsetConfigValue('project', 'relay.controlPlaneUrl', process.cwd()).catch(
-        () => ({ existed: false }),
-      );
+      const p = await unsetConfigValue('project', 'relay.controlPlaneUrl', process.cwd());
       if (!g.existed && !p.existed) {
         log.info('No control plane was configured (relay.controlPlaneUrl not set).');
       } else {

--- a/apps/cli/src/commands/control-plane.ts
+++ b/apps/cli/src/commands/control-plane.ts
@@ -6,7 +6,7 @@ import { chmod, mkdir, rm, writeFile } from 'node:fs/promises';
 import { hostname, homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
-import { loadEffectiveConfig, setConfigValue } from '@agentbox/config';
+import { loadEffectiveConfig, setConfigValue, unsetConfigValue } from '@agentbox/config';
 import {
   drainCreateJobs,
   GitHubAppLeaser,
@@ -233,6 +233,39 @@ const setUrlSub = new Command('set-url')
     }
   });
 
+const unsetUrlSub = new Command('unset-url')
+  .description('Stop using a control plane on this machine (removes relay.controlPlaneUrl)')
+  .option('--purge', "also delete this machine's local App metadata + admin token (~/.agentbox/control-plane)")
+  .action(async (opts: { purge?: boolean }) => {
+    try {
+      // set-url writes the global scope; also clear a per-project override if one
+      // exists (best-effort — a non-project cwd has no project file to touch).
+      const g = await unsetConfigValue('global', 'relay.controlPlaneUrl', process.cwd());
+      const p = await unsetConfigValue('project', 'relay.controlPlaneUrl', process.cwd()).catch(
+        () => ({ existed: false }),
+      );
+      if (!g.existed && !p.existed) {
+        log.info('No control plane was configured (relay.controlPlaneUrl not set).');
+      } else {
+        const where = [g.existed ? 'global' : null, p.existed ? 'project' : null].filter(Boolean).join(' + ');
+        log.success(
+          `Removed relay.controlPlaneUrl (${where}). New cloud boxes now push through the host relay ` +
+            '(your laptop must be on), and the GitHub-App repo-authorization prompt no longer fires.',
+        );
+      }
+      if (existsSync(CP_DIR)) {
+        if (opts.purge) {
+          await rm(CP_DIR, { recursive: true, force: true });
+          log.success(`Purged this machine's control-plane credentials (${CP_DIR}).`);
+        } else {
+          log.info(`This machine's App metadata + admin token remain in ${CP_DIR} (use --purge to delete).`);
+        }
+      }
+    } catch (err) {
+      handleLifecycleError(err);
+    }
+  });
+
 interface StatusOpts {
   url?: string;
   json?: boolean;
@@ -413,5 +446,6 @@ export const controlPlaneCommand = new Command('control-plane')
   .addCommand(statusSub, { isDefault: true })
   .addCommand(setupSub)
   .addCommand(setUrlSub)
+  .addCommand(unsetUrlSub)
   .addCommand(addSub)
   .addCommand(workerSub);


### PR DESCRIPTION
Adds the inverse of `control-plane set-url`: removes `relay.controlPlaneUrl` (global + a per-project override if present), so new cloud boxes fall back to host-relay pushes and the GitHub-App repo-authorization prompt stops firing. `--purge` also deletes this machine's local App metadata + admin token (`~/.agentbox/control-plane`).

Verified end-to-end (e2b boxes, git-lease flag in the box):
| Case | AGENTBOX_GIT_LEASE |
|---|---|
| `create` + control plane + `auto` | 1 (lease) |
| `codex` (agent cmd) + control plane + `auto` | 1 (lease — confirms #143 threading) |
| `create` + control plane + `git.pushMode=relay` | empty (host-relay) |
| `create` after `control-plane unset-url` | empty (host-relay) |

https://claude.ai/code/session_01TGoDQvktdXD5rqJuJm9Uyk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only config and optional local credential directory cleanup; no changes to control-plane server auth or box provisioning logic.
> 
> **Overview**
> Adds **`agentbox control-plane unset-url`**, the inverse of `set-url`, so machines can stop routing new cloud boxes through a hosted control plane.
> 
> The command removes **`relay.controlPlaneUrl`** from **global** config and, best-effort, any **per-project** override via `unsetConfigValue`. Success messaging explains that new boxes fall back to **host-relay** pushes and the **GitHub App repo-authorization** prompt should stop. An optional **`--purge`** deletes local setup artifacts under **`~/.agentbox/control-plane`** (App metadata + admin token); without it, those files are left in place with a hint to use `--purge`.
> 
> The new subcommand is registered on the existing **`control-plane`** command group.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9647fb4c14350dcd0cc5af2551ab41c646ba8fb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->