### PR TITLE
feat(hub): public REST API (/api/v1) for launching + managing boxes

### DIFF
--- a/apps/hub/README.md
+++ b/apps/hub/README.md
@@ -27,6 +27,33 @@ Admin (the `AGENTBOX_RELAY_ADMIN_TOKEN` bearer, never loopback):
 `GET /admin/events`, `GET /admin/registry`, `GET /admin/prompts`,
 `POST /admin/prompts/answer`. `GET /healthz` is open.
 
+Those are the **internal** relay wire (per-box / loopback / admin-bearer). The
+**public** REST API is a separate, versioned surface — see below.
+
+## Public REST API (`/api/v1`)
+
+A stable, documented HTTP API for external callers (IDEs, scripts, the future
+macOS app) — a thin facade over the in-process backend, served on the relay port
+via the `uiHandler` seam (Next routes under `app/(dashboard)/api/v1/`). It does
+**not** reuse the internal `/admin`+`/rpc` wire (loopback-only, exit-code-coupled
+statuses, no schema).
+
+- **Auth:** `Authorization: Bearer <AGENTBOX_HUB_TOKEN>` in token mode (or the
+  better-auth session in password mode); always a JSON `401`, never a `/signin`
+  redirect. `/health`, `/openapi.json`, `/docs` are public.
+- **Envelope:** success returns the resource directly; errors are
+  `{ error: { code, message, details? } }` with a matching HTTP status.
+- **Routes:** `GET /boxes`, `GET /boxes/:id`,
+  `POST /boxes/:id/{pause,resume,stop,destroy}`, `POST /boxes` (create →
+  `202 {jobId}`), `GET|POST /projects`, `GET /approvals`,
+  `POST /approvals/:id/answer`, `GET /jobs/:id`, `GET /jobs/:id/logs` (SSE),
+  `GET /health`, `GET /openapi.json` (OpenAPI 3.1), `GET /docs` (Scalar).
+- **Reads** are topology-agnostic (in-process → Postgres via `getDashboardData()`);
+  **writes** use the in-process backend (hosted-plane writes are a follow-up).
+
+Full reference: `apps/web/content/docs/hub-api.mdx` (published at
+https://agent-box.sh/docs/hub-api).
+
 ## Configuration
 
 See [`.env.example`](./.env.example). Required: `POSTGRES_URL`,

--- a/apps/hub/app/(dashboard)/api/jobs/[id]/logs/route.ts
+++ b/apps/hub/app/(dashboard)/api/jobs/[id]/logs/route.ts
@@ -6,17 +6,15 @@
 // Same-origin Next route gated by proxy.ts (the token/session cookie rides
 // along), like /api/events. The log path + status come from the in-process hub
 // backend (globalThis) so this route never imports the relay/sandbox toolchain —
-// it only does plain fs reads.
-import { open, stat } from 'node:fs/promises';
+// it only does plain fs reads. The streaming itself lives in lib/job-log-stream.ts,
+// shared with the public /api/v1/jobs/[id]/logs route.
+import { streamJobLog } from '@/lib/job-log-stream';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-const POLL_MS = 500;
-const TERMINAL = new Set(['done', 'failed', 'cancelled']);
-
 export async function GET(
-  _req: Request,
+  req: Request,
   ctx: { params: Promise<{ id: string }> },
 ): Promise<Response> {
   const { id } = await ctx.params;
@@ -28,88 +26,5 @@ export async function GET(
   if (!job) {
     return new Response('job not found', { status: 404 });
   }
-
-  const enc = new TextEncoder();
-  const logPath = job.logPath;
-  let offset = 0;
-  let residual = '';
-  let closed = false;
-
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      const emit = (event: string, data: unknown): void => {
-        try {
-          controller.enqueue(enc.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
-        } catch {
-          /* stream already closed */
-        }
-      };
-
-      // Read any bytes appended since the last offset and emit whole lines.
-      const drain = async (): Promise<void> => {
-        let size: number;
-        try {
-          size = (await stat(logPath)).size;
-        } catch {
-          return; // file not created yet (ENOENT) — try again next tick
-        }
-        if (size <= offset) return;
-        const fh = await open(logPath, 'r');
-        try {
-          const len = size - offset;
-          const buf = Buffer.alloc(len);
-          await fh.read(buf, 0, len, offset);
-          offset = size;
-          residual += buf.toString('utf8');
-          const lines = residual.split('\n');
-          residual = lines.pop() ?? '';
-          for (const line of lines) emit('log', line);
-        } finally {
-          await fh.close();
-        }
-      };
-
-      const finish = async (status: string): Promise<void> => {
-        if (closed) return;
-        closed = true;
-        await drain().catch(() => {});
-        if (residual.length > 0) emit('log', residual);
-        emit('end', { status });
-        clearInterval(timer);
-        try {
-          controller.close();
-        } catch {
-          /* already closed */
-        }
-      };
-
-      emit('open', { id });
-      const timer = setInterval(() => {
-        void (async () => {
-          await drain().catch(() => {});
-          const cur = await backend.getJob(id).catch(() => null);
-          if (!cur || TERMINAL.has(cur.status)) await finish(cur?.status ?? 'gone');
-        })();
-      }, POLL_MS);
-
-      _req.signal.addEventListener('abort', () => {
-        clearInterval(timer);
-        closed = true;
-        try {
-          controller.close();
-        } catch {
-          /* already closed */
-        }
-      });
-    },
-  });
-
-  return new Response(stream, {
-    headers: {
-      'content-type': 'text/event-stream',
-      'cache-control': 'no-cache, no-transform',
-      connection: 'keep-alive',
-      'x-accel-buffering': 'no',
-    },
-  });
+  return streamJobLog(req, id, backend, job.logPath);
 }

--- a/apps/hub/app/(dashboard)/api/v1/approvals/[id]/answer/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/approvals/[id]/answer/route.ts
@@ -1,0 +1,23 @@
+// POST /api/v1/approvals/:id/answer — resolve a pending approval ({ answer: 'y'|'n' }).
+// Unblocks the parked in-box RPC. In-process backend only (block-mode mailbox).
+import { backendOrNull } from '../../../lib/backend';
+import { fail, failFromAction, ok } from '../../../lib/envelope';
+import { parseAnswer, readJson } from '../../../lib/validate';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: Request, ctx: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await ctx.params;
+  const backend = backendOrNull();
+  if (!backend) return fail('backend_unavailable', 'hub backend unavailable (run the hub server)');
+
+  const parsedBody = await readJson(req);
+  if (!parsedBody.ok) return fail('invalid_request', parsedBody.message);
+  const parsed = parseAnswer(parsedBody.value);
+  if (!parsed.ok) return fail('invalid_request', parsed.message);
+
+  const res = await backend.answerApproval(id, parsed.value);
+  if (!res.ok) return failFromAction(res.error);
+  return ok({ ok: true });
+}

--- a/apps/hub/app/(dashboard)/api/v1/approvals/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/approvals/route.ts
@@ -1,0 +1,11 @@
+// GET /api/v1/approvals — pending host-action approvals (the relay prompt mailbox).
+import { readState } from '../lib/backend';
+import { ok } from '../lib/envelope';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(): Promise<Response> {
+  const { approvals } = await readState();
+  return ok({ approvals });
+}

--- a/apps/hub/app/(dashboard)/api/v1/boxes/[id]/[action]/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/boxes/[id]/[action]/route.ts
@@ -16,6 +16,14 @@ export async function POST(
   if (!isLifecycleAction(action)) {
     return fail('invalid_request', `unknown action: ${action}`, { allowed: ['pause', 'resume', 'stop', 'destroy'] });
   }
+  // In-flight create jobs surface in GET /boxes as synthetic `creating`/`error`
+  // boxes with a `job:` id — they have no real container yet, so lifecycle would
+  // 404 in the backend and contradict the GET. Reject with a clear 409 instead.
+  if (id.startsWith('job:')) {
+    return fail('conflict', `box ${id} is still being created; ${action} is not available yet`, {
+      jobId: id.slice('job:'.length),
+    });
+  }
   const backend = backendOrNull();
   if (!backend) return fail('backend_unavailable', 'hub backend unavailable (run the hub server)');
 

--- a/apps/hub/app/(dashboard)/api/v1/boxes/[id]/[action]/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/boxes/[id]/[action]/route.ts
@@ -1,0 +1,25 @@
+// POST /api/v1/boxes/:id/:action — lifecycle: pause | resume | stop | destroy.
+// Mutations need the in-process host backend; the Postgres/plane path 503s (hosted
+// writes are a documented follow-up).
+import { backendOrNull } from '../../../lib/backend';
+import { fail, failFromAction, ok } from '../../../lib/envelope';
+import { isLifecycleAction } from '../../../lib/validate';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  _req: Request,
+  ctx: { params: Promise<{ id: string; action: string }> },
+): Promise<Response> {
+  const { id, action } = await ctx.params;
+  if (!isLifecycleAction(action)) {
+    return fail('invalid_request', `unknown action: ${action}`, { allowed: ['pause', 'resume', 'stop', 'destroy'] });
+  }
+  const backend = backendOrNull();
+  if (!backend) return fail('backend_unavailable', 'hub backend unavailable (run the hub server)');
+
+  const res = await backend[action](id);
+  if (!res.ok) return failFromAction(res.error);
+  return ok({ ok: true });
+}

--- a/apps/hub/app/(dashboard)/api/v1/boxes/[id]/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/boxes/[id]/route.ts
@@ -1,0 +1,14 @@
+// GET /api/v1/boxes/:id — one box from the normalized view (404 if absent).
+import { readState } from '../../lib/backend';
+import { fail, ok } from '../../lib/envelope';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await ctx.params;
+  const { boxes } = await readState();
+  const box = boxes.find((b) => b.id === id);
+  if (!box) return fail('not_found', `box not found: ${id}`);
+  return ok(box);
+}

--- a/apps/hub/app/(dashboard)/api/v1/boxes/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/boxes/route.ts
@@ -1,0 +1,27 @@
+// GET  /api/v1/boxes  — list boxes (topology-agnostic read).
+// POST /api/v1/boxes  — create a box (async; enqueues a build job, returns jobId).
+import { backendOrNull, readState } from '../lib/backend';
+import { fail, failFromAction, ok } from '../lib/envelope';
+import { parseCreateBox, readJson } from '../lib/validate';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(): Promise<Response> {
+  const { boxes } = await readState();
+  return ok({ boxes });
+}
+
+export async function POST(req: Request): Promise<Response> {
+  const backend = backendOrNull();
+  if (!backend) return fail('backend_unavailable', 'hub backend unavailable (run the hub server)');
+
+  const parsedBody = await readJson(req);
+  if (!parsedBody.ok) return fail('invalid_request', parsedBody.message);
+  const parsed = parseCreateBox(parsedBody.value);
+  if (!parsed.ok) return fail('invalid_request', parsed.message, parsed.details);
+
+  const res = await backend.create(parsed.value);
+  if (!res.ok) return failFromAction(res.error);
+  return ok({ jobId: res.jobId }, 202);
+}

--- a/apps/hub/app/(dashboard)/api/v1/docs/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/docs/route.ts
@@ -1,0 +1,10 @@
+// GET /api/v1/docs — a Scalar-rendered reference for the spec (public convenience
+// page; proxy.ts allowlists it). The API is fully usable without it.
+import { docsHtml } from '../lib/openapi';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export function GET(): Response {
+  return new Response(docsHtml(), { headers: { 'content-type': 'text/html; charset=utf-8' } });
+}

--- a/apps/hub/app/(dashboard)/api/v1/health/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/health/route.ts
@@ -1,0 +1,11 @@
+// Public liveness probe for the API. Unauthenticated (proxy.ts allowlists it) and
+// leaks no box state — just confirms the API is mounted and reports its version.
+import { hubProfile } from '@/lib/auth-config';
+import { ok } from '../lib/envelope';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export function GET(): Response {
+  return ok({ ok: true, apiVersion: 'v1', profile: hubProfile() });
+}

--- a/apps/hub/app/(dashboard)/api/v1/jobs/[id]/logs/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/jobs/[id]/logs/route.ts
@@ -1,0 +1,18 @@
+// GET /api/v1/jobs/:id/logs — stream a create-job log (SSE: open, log*, end).
+// Delegates to the shared tail in lib/job-log-stream.ts (same impl as the internal
+// /api/jobs/:id/logs route the create-box modal uses).
+import { streamJobLog } from '@/lib/job-log-stream';
+import { backendOrNull } from '../../../lib/backend';
+import { fail } from '../../../lib/envelope';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await ctx.params;
+  const backend = backendOrNull();
+  if (!backend) return fail('backend_unavailable', 'hub backend unavailable (run the hub server)');
+  const job = await backend.getJob(id);
+  if (!job) return fail('not_found', `job not found: ${id}`);
+  return streamJobLog(req, id, backend, job.logPath);
+}

--- a/apps/hub/app/(dashboard)/api/v1/jobs/[id]/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/jobs/[id]/route.ts
@@ -1,0 +1,16 @@
+// GET /api/v1/jobs/:id — create-job status. In-process backend only (the queue is
+// a laptop/hetzner concern; hosted jobs are a follow-up).
+import { backendOrNull } from '../../lib/backend';
+import { fail, ok } from '../../lib/envelope';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await ctx.params;
+  const backend = backendOrNull();
+  if (!backend) return fail('backend_unavailable', 'hub backend unavailable (run the hub server)');
+  const job = await backend.getJob(id);
+  if (!job) return fail('not_found', `job not found: ${id}`);
+  return ok({ id, status: job.status, ...(job.boxId ? { boxId: job.boxId } : {}) });
+}

--- a/apps/hub/app/(dashboard)/api/v1/lib/backend.ts
+++ b/apps/hub/app/(dashboard)/api/v1/lib/backend.ts
@@ -1,0 +1,21 @@
+// Accessors the v1 routes use to reach box state, mirroring lib/boxes/source.ts's
+// resolution order so the same route handlers work across topologies:
+//   - mutations (create/lifecycle/approvals) need the in-process host backend
+//     (globalThis, set by the embedded server); the Postgres/plane path has no
+//     in-process writer, so writes 503 there for now (hosted writes are a
+//     documented follow-up).
+//   - reads (boxes/projects/approvals) go through getDashboardData(), which
+//     already falls back in-process -> Postgres -> empty, so the read contract is
+//     topology-agnostic for free.
+import { getDashboardData } from '@/lib/boxes/source';
+import type { HubBackend } from '@/lib/boxes/backend-types';
+import type { HubState } from '@/lib/boxes/types';
+
+export function backendOrNull(): HubBackend | null {
+  return globalThis.__AGENTBOX_HUB_BACKEND ?? null;
+}
+
+// Topology-agnostic read of the full hub state (boxes/projects/approvals).
+export async function readState(): Promise<HubState> {
+  return getDashboardData();
+}

--- a/apps/hub/app/(dashboard)/api/v1/lib/envelope.ts
+++ b/apps/hub/app/(dashboard)/api/v1/lib/envelope.ts
@@ -29,10 +29,17 @@ export function fail(code: ApiErrorCode, message: string, details?: unknown): Re
   return Response.json({ error: { code, message, ...(details === undefined ? {} : { details }) } }, { status });
 }
 
-// Map a backend ActionResult error into an envelope. "not found" style errors
-// become 404; everything else is a 409 conflict (the op was rejected by the
-// provider/state, not a client-input problem).
+// Map a backend ActionResult error into an envelope. Genuine missing-resource
+// errors become 404; everything else is a 409 conflict (the op was rejected by
+// the provider/state, not a client-input problem). The match is intentionally
+// narrow — the backend's real not-found strings are "box not found: …",
+// "unknown project …", and "no pending approval". A bare "unknown" (e.g. a Docker
+// "unknown flag" / "unknown: not found" daemon message) must NOT be mistaken for
+// a 404, or an operational failure would masquerade as a missing resource.
 export function failFromAction(error: string): Response {
-  const notFound = /not found|unknown|no such|does not exist/i.test(error);
+  const notFound =
+    /\b(not found|no such|does not exist)\b/i.test(error) ||
+    /\bunknown (project|box)\b/i.test(error) ||
+    /no pending approval/i.test(error);
   return fail(notFound ? 'not_found' : 'conflict', error);
 }

--- a/apps/hub/app/(dashboard)/api/v1/lib/envelope.ts
+++ b/apps/hub/app/(dashboard)/api/v1/lib/envelope.ts
@@ -1,0 +1,38 @@
+// One consistent JSON envelope for the whole public API. Success returns the
+// resource/collection directly (stable, documented shapes); errors always return
+// `{ error: { code, message, details? } }` with a correct HTTP status — never the
+// exit-code-coupled statuses the internal relay surface uses.
+
+export type ApiErrorCode =
+  | 'invalid_request'
+  | 'not_found'
+  | 'unauthorized'
+  | 'backend_unavailable'
+  | 'conflict'
+  | 'internal';
+
+const STATUS_HINT: Record<ApiErrorCode, number> = {
+  invalid_request: 400,
+  unauthorized: 401,
+  not_found: 404,
+  conflict: 409,
+  backend_unavailable: 503,
+  internal: 500,
+};
+
+export function ok(data: unknown, status = 200): Response {
+  return Response.json(data, { status });
+}
+
+export function fail(code: ApiErrorCode, message: string, details?: unknown): Response {
+  const status = STATUS_HINT[code];
+  return Response.json({ error: { code, message, ...(details === undefined ? {} : { details }) } }, { status });
+}
+
+// Map a backend ActionResult error into an envelope. "not found" style errors
+// become 404; everything else is a 409 conflict (the op was rejected by the
+// provider/state, not a client-input problem).
+export function failFromAction(error: string): Response {
+  const notFound = /not found|unknown|no such|does not exist/i.test(error);
+  return fail(notFound ? 'not_found' : 'conflict', error);
+}

--- a/apps/hub/app/(dashboard)/api/v1/lib/openapi.ts
+++ b/apps/hub/app/(dashboard)/api/v1/lib/openapi.ts
@@ -1,0 +1,273 @@
+// Hand-authored OpenAPI 3.1 document for the public API. Kept in lock-step with the
+// route handlers + validators by hand (the repo has no zod/codegen convention); the
+// verification checklist asserts every route appears here. Served verbatim at
+// GET /api/v1/openapi.json; GET /api/v1/docs renders it with Scalar.
+
+const errorResponse = {
+  description: 'Error',
+  content: {
+    'application/json': {
+      schema: { $ref: '#/components/schemas/Error' },
+    },
+  },
+};
+
+export function buildOpenApi(): Record<string, unknown> {
+  return {
+    openapi: '3.1.0',
+    info: {
+      title: 'AgentBox Hub API',
+      version: '1.0.0',
+      description:
+        'Launch and manage AgentBox sandboxes ("boxes") programmatically. Every endpoint except /health, /openapi.json and /docs requires an Authorization: Bearer <hub token> header (the token the hub prints on boot, also at ~/.agentbox/hub/token). Errors always return { error: { code, message, details? } }.',
+    },
+    servers: [{ url: '/api/v1' }],
+    security: [{ bearerAuth: [] }],
+    paths: {
+      '/health': {
+        get: {
+          summary: 'Liveness + API version',
+          security: [],
+          responses: {
+            '200': {
+              description: 'OK',
+              content: { 'application/json': { schema: { $ref: '#/components/schemas/Health' } } },
+            },
+          },
+        },
+      },
+      '/boxes': {
+        get: {
+          summary: 'List boxes',
+          responses: {
+            '200': {
+              description: 'Boxes',
+              content: {
+                'application/json': {
+                  schema: { type: 'object', properties: { boxes: { type: 'array', items: { $ref: '#/components/schemas/Box' } } }, required: ['boxes'] },
+                },
+              },
+            },
+            '401': errorResponse,
+          },
+        },
+        post: {
+          summary: 'Create a box (async — returns a job id)',
+          requestBody: {
+            required: true,
+            content: { 'application/json': { schema: { $ref: '#/components/schemas/CreateBox' } } },
+          },
+          responses: {
+            '202': {
+              description: 'Accepted — build job enqueued',
+              content: { 'application/json': { schema: { type: 'object', properties: { jobId: { type: 'string' } }, required: ['jobId'] } } },
+            },
+            '400': errorResponse,
+            '401': errorResponse,
+            '404': errorResponse,
+            '503': errorResponse,
+          },
+        },
+      },
+      '/boxes/{id}': {
+        get: {
+          summary: 'Get one box',
+          parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+          responses: {
+            '200': { description: 'Box', content: { 'application/json': { schema: { $ref: '#/components/schemas/Box' } } } },
+            '401': errorResponse,
+            '404': errorResponse,
+          },
+        },
+      },
+      '/boxes/{id}/{action}': {
+        post: {
+          summary: 'Lifecycle action (pause | resume | stop | destroy)',
+          parameters: [
+            { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+            { name: 'action', in: 'path', required: true, schema: { type: 'string', enum: ['pause', 'resume', 'stop', 'destroy'] } },
+          ],
+          responses: {
+            '200': { description: 'Done', content: { 'application/json': { schema: { type: 'object', properties: { ok: { const: true } }, required: ['ok'] } } } },
+            '400': errorResponse,
+            '401': errorResponse,
+            '404': errorResponse,
+            '409': errorResponse,
+            '503': errorResponse,
+          },
+        },
+      },
+      '/projects': {
+        get: {
+          summary: 'List registered projects',
+          responses: {
+            '200': { description: 'Projects', content: { 'application/json': { schema: { type: 'object', properties: { projects: { type: 'array', items: { $ref: '#/components/schemas/Project' } } }, required: ['projects'] } } } },
+            '401': errorResponse,
+          },
+        },
+        post: {
+          summary: 'Register a folder (absolute path) as a project',
+          requestBody: { required: true, content: { 'application/json': { schema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] } } } },
+          responses: {
+            '200': { description: 'Registered', content: { 'application/json': { schema: { type: 'object', properties: { ok: { const: true } }, required: ['ok'] } } } },
+            '400': errorResponse,
+            '401': errorResponse,
+            '503': errorResponse,
+          },
+        },
+      },
+      '/approvals': {
+        get: {
+          summary: 'List pending host-action approvals',
+          responses: {
+            '200': { description: 'Approvals', content: { 'application/json': { schema: { type: 'object', properties: { approvals: { type: 'array', items: { $ref: '#/components/schemas/Approval' } } }, required: ['approvals'] } } } },
+            '401': errorResponse,
+          },
+        },
+      },
+      '/approvals/{id}/answer': {
+        post: {
+          summary: 'Answer a pending approval',
+          parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+          requestBody: { required: true, content: { 'application/json': { schema: { type: 'object', properties: { answer: { type: 'string', enum: ['y', 'n'] } }, required: ['answer'] } } } },
+          responses: {
+            '200': { description: 'Resolved', content: { 'application/json': { schema: { type: 'object', properties: { ok: { const: true } }, required: ['ok'] } } } },
+            '400': errorResponse,
+            '401': errorResponse,
+            '404': errorResponse,
+            '503': errorResponse,
+          },
+        },
+      },
+      '/jobs/{id}': {
+        get: {
+          summary: 'Get a create job status',
+          parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+          responses: {
+            '200': { description: 'Job', content: { 'application/json': { schema: { $ref: '#/components/schemas/Job' } } } },
+            '401': errorResponse,
+            '404': errorResponse,
+          },
+        },
+      },
+      '/jobs/{id}/logs': {
+        get: {
+          summary: 'Stream a create job log (SSE)',
+          description: 'text/event-stream. Emits `open`, then `log` events per line, then a terminal `end` event with the final status.',
+          parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+          responses: {
+            '200': { description: 'SSE stream', content: { 'text/event-stream': {} } },
+            '401': errorResponse,
+            '404': errorResponse,
+            '503': errorResponse,
+          },
+        },
+      },
+    },
+    components: {
+      securitySchemes: {
+        bearerAuth: { type: 'http', scheme: 'bearer', description: 'The hub token (Authorization: Bearer <token>).' },
+      },
+      schemas: {
+        Health: {
+          type: 'object',
+          properties: { ok: { const: true }, apiVersion: { type: 'string' }, profile: { type: 'string' } },
+          required: ['ok', 'apiVersion'],
+        },
+        Error: {
+          type: 'object',
+          properties: {
+            error: {
+              type: 'object',
+              properties: { code: { type: 'string' }, message: { type: 'string' }, details: {} },
+              required: ['code', 'message'],
+            },
+          },
+          required: ['error'],
+        },
+        Box: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            projectId: { type: 'string' },
+            repo: { type: 'string' },
+            branch: { type: 'string' },
+            task: { type: 'string' },
+            agent: { type: 'string' },
+            status: { type: 'string', enum: ['running', 'paused', 'stopped', 'creating', 'error'] },
+            createdAt: { type: 'number' },
+            lastActivity: { type: 'number' },
+            host: { type: 'string' },
+            commits: { type: ['number', 'null'] },
+            filesTouched: { type: ['number', 'null'] },
+            error: { type: ['string', 'null'] },
+          },
+          required: ['id', 'projectId', 'status', 'agent'],
+        },
+        Project: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            repo: { type: 'string' },
+            defaultBranch: { type: 'string' },
+            provider: { type: 'string' },
+            createdAt: { type: 'number' },
+          },
+          required: ['id', 'name'],
+        },
+        Approval: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            boxId: { type: 'string' },
+            message: { type: 'string' },
+            detail: { type: 'string' },
+            command: { type: 'string' },
+            cwd: { type: 'string' },
+            argv: { type: 'array', items: { type: 'string' } },
+            defaultAnswer: { type: 'string', enum: ['y', 'n'] },
+            createdAt: { type: 'number' },
+          },
+          required: ['id', 'boxId', 'message', 'defaultAnswer'],
+        },
+        Job: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            status: { type: 'string', enum: ['queued', 'running', 'done', 'failed', 'cancelled'] },
+            boxId: { type: 'string' },
+          },
+          required: ['id', 'status'],
+        },
+        CreateBox: {
+          type: 'object',
+          properties: {
+            projectId: { type: 'string' },
+            agent: { type: 'string', enum: ['claude', 'codex', 'opencode'] },
+            name: { type: 'string' },
+            prompt: { type: 'string' },
+          },
+          required: ['projectId', 'agent'],
+        },
+      },
+    },
+  };
+}
+
+// Zero-build docs page: Scalar's standalone bundle renders the spec at /openapi.json.
+// Loaded from a CDN (a convenience page; the API itself is fully usable without it).
+export function docsHtml(): string {
+  return `<!doctype html>
+<html>
+  <head>
+    <title>AgentBox Hub API</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <script id="api-reference" data-url="/api/v1/openapi.json"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
+</html>`;
+}

--- a/apps/hub/app/(dashboard)/api/v1/lib/validate.ts
+++ b/apps/hub/app/(dashboard)/api/v1/lib/validate.ts
@@ -1,0 +1,59 @@
+// Hand-rolled request validation for the public API boundary. The repo has no zod
+// convention (validation is typeof-guards throughout); these mirror that style and
+// return a discriminated result so routes stay a flat parse-then-act.
+import type { CreateBoxInput } from '@/lib/boxes/backend-types';
+
+export type Parsed<T> = { ok: true; value: T } | { ok: false; message: string; details?: unknown };
+
+const AGENTS = ['claude', 'codex', 'opencode'] as const;
+export const LIFECYCLE_ACTIONS = ['pause', 'resume', 'stop', 'destroy'] as const;
+export type LifecycleAction = (typeof LIFECYCLE_ACTIONS)[number];
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+export function parseCreateBox(body: unknown): Parsed<CreateBoxInput> {
+  if (!isObject(body)) return { ok: false, message: 'body must be a JSON object' };
+  const { projectId, agent, name, prompt } = body;
+  if (typeof projectId !== 'string' || projectId.length === 0) {
+    return { ok: false, message: 'projectId is required (string)' };
+  }
+  if (typeof agent !== 'string' || !(AGENTS as readonly string[]).includes(agent)) {
+    return { ok: false, message: `agent must be one of ${AGENTS.join(', ')}`, details: { got: agent } };
+  }
+  if (name !== undefined && typeof name !== 'string') return { ok: false, message: 'name must be a string' };
+  if (prompt !== undefined && typeof prompt !== 'string') return { ok: false, message: 'prompt must be a string' };
+  return { ok: true, value: { projectId, agent: agent as CreateBoxInput['agent'], name, prompt } };
+}
+
+export function parseAnswer(body: unknown): Parsed<'y' | 'n'> {
+  if (!isObject(body)) return { ok: false, message: 'body must be a JSON object' };
+  const { answer } = body;
+  if (answer !== 'y' && answer !== 'n') return { ok: false, message: "answer must be 'y' or 'n'" };
+  return { ok: true, value: answer };
+}
+
+export function parseProject(body: unknown): Parsed<{ path: string }> {
+  if (!isObject(body)) return { ok: false, message: 'body must be a JSON object' };
+  const { path } = body;
+  if (typeof path !== 'string' || path.length === 0) {
+    return { ok: false, message: 'path is required (absolute directory path)' };
+  }
+  return { ok: true, value: { path } };
+}
+
+export function isLifecycleAction(v: string): v is LifecycleAction {
+  return (LIFECYCLE_ACTIONS as readonly string[]).includes(v);
+}
+
+// Read + JSON-parse a request body, tolerating an empty body as {}.
+export async function readJson(req: Request): Promise<Parsed<unknown>> {
+  const text = await req.text();
+  if (text.trim().length === 0) return { ok: true, value: {} };
+  try {
+    return { ok: true, value: JSON.parse(text) };
+  } catch {
+    return { ok: false, message: 'body is not valid JSON' };
+  }
+}

--- a/apps/hub/app/(dashboard)/api/v1/openapi.json/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/openapi.json/route.ts
@@ -1,0 +1,9 @@
+// GET /api/v1/openapi.json — the OpenAPI 3.1 spec (public; proxy.ts allowlists it).
+import { buildOpenApi } from '../lib/openapi';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export function GET(): Response {
+  return Response.json(buildOpenApi());
+}

--- a/apps/hub/app/(dashboard)/api/v1/projects/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/projects/route.ts
@@ -1,0 +1,27 @@
+// GET  /api/v1/projects — registered projects (create targets).
+// POST /api/v1/projects — register a folder (absolute path) as a project.
+import { backendOrNull, readState } from '../lib/backend';
+import { fail, ok } from '../lib/envelope';
+import { parseProject, readJson } from '../lib/validate';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(): Promise<Response> {
+  const { projects } = await readState();
+  return ok({ projects });
+}
+
+export async function POST(req: Request): Promise<Response> {
+  const backend = backendOrNull();
+  if (!backend) return fail('backend_unavailable', 'hub backend unavailable (run the hub server)');
+
+  const parsedBody = await readJson(req);
+  if (!parsedBody.ok) return fail('invalid_request', parsedBody.message);
+  const parsed = parseProject(parsedBody.value);
+  if (!parsed.ok) return fail('invalid_request', parsed.message);
+
+  const res = await backend.addProject(parsed.value.path);
+  if (!res.ok) return fail('invalid_request', res.error);
+  return ok({ ok: true });
+}

--- a/apps/hub/components/app-sidebar.tsx
+++ b/apps/hub/components/app-sidebar.tsx
@@ -86,6 +86,7 @@ export function AppSidebar() {
         />
         <SideItem active={pathname.startsWith('/settings')} to="/settings" icon={Icons.settings} label="Settings" />
         <SideItem href="https://agent-box.sh/docs" icon={Icons.book} label="Docs" ext />
+        <SideItem href="/api/v1/docs" icon={Icons.terminal} label="API" ext />
       </nav>
 
       <SideLabel>Projects</SideLabel>

--- a/apps/hub/components/topbar.tsx
+++ b/apps/hub/components/topbar.tsx
@@ -70,6 +70,10 @@ export function Topbar() {
         <Icons.book />
         Docs
       </Button>
+      <Button variant="ghost" size="sm" href="/api/v1/docs" target="_blank" rel="noopener">
+        <Icons.terminal />
+        API
+      </Button>
       {state.authMode === 'password' ? (
         <Button
           variant="ghost"

--- a/apps/hub/lib/job-log-stream.ts
+++ b/apps/hub/lib/job-log-stream.ts
@@ -1,0 +1,96 @@
+// Tail a queue worker's per-job log file (`~/.agentbox/logs/queue-<id>.log`) and
+// stream appended lines as SSE `log` events, then a terminal `end` event when the
+// job reaches done/failed/cancelled. Shared by /api/jobs/[id]/logs (the create-box
+// modal) and /api/v1/jobs/[id]/logs (the public API) so the streaming logic lives
+// in one place. Plain fs reads only — never imports the relay/sandbox toolchain;
+// the log path + status come from the in-process hub backend.
+import { open, stat } from 'node:fs/promises';
+import type { HubBackend } from './boxes/backend-types';
+
+const POLL_MS = 500;
+const TERMINAL = new Set(['done', 'failed', 'cancelled']);
+
+export function streamJobLog(req: Request, id: string, backend: HubBackend, logPath: string): Response {
+  const enc = new TextEncoder();
+  let offset = 0;
+  let residual = '';
+  let closed = false;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const emit = (event: string, data: unknown): void => {
+        try {
+          controller.enqueue(enc.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
+        } catch {
+          /* stream already closed */
+        }
+      };
+
+      // Read any bytes appended since the last offset and emit whole lines.
+      const drain = async (): Promise<void> => {
+        let size: number;
+        try {
+          size = (await stat(logPath)).size;
+        } catch {
+          return; // file not created yet (ENOENT) — try again next tick
+        }
+        if (size <= offset) return;
+        const fh = await open(logPath, 'r');
+        try {
+          const len = size - offset;
+          const buf = Buffer.alloc(len);
+          await fh.read(buf, 0, len, offset);
+          offset = size;
+          residual += buf.toString('utf8');
+          const lines = residual.split('\n');
+          residual = lines.pop() ?? '';
+          for (const line of lines) emit('log', line);
+        } finally {
+          await fh.close();
+        }
+      };
+
+      const finish = async (status: string): Promise<void> => {
+        if (closed) return;
+        closed = true;
+        await drain().catch(() => {});
+        if (residual.length > 0) emit('log', residual);
+        emit('end', { status });
+        clearInterval(timer);
+        try {
+          controller.close();
+        } catch {
+          /* already closed */
+        }
+      };
+
+      emit('open', { id });
+      const timer = setInterval(() => {
+        void (async () => {
+          await drain().catch(() => {});
+          const cur = await backend.getJob(id).catch(() => null);
+          if (!cur || TERMINAL.has(cur.status)) await finish(cur?.status ?? 'gone');
+        })();
+      }, POLL_MS);
+
+      req.signal.addEventListener('abort', () => {
+        clearInterval(timer);
+        closed = true;
+        try {
+          controller.close();
+        } catch {
+          /* already closed */
+        }
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache, no-transform',
+      connection: 'keep-alive',
+      'x-accel-buffering': 'no',
+    },
+  });
+}

--- a/apps/hub/proxy.ts
+++ b/apps/hub/proxy.ts
@@ -10,6 +10,45 @@ function tokenEq(a: string, b: string): boolean {
   return ab.length === bb.length && timingSafeEqual(ab, bb);
 }
 
+// Public REST API surface. It shares the hub's gate but answers JSON 401s (never a
+// /signin redirect, which a non-browser client can't follow) and accepts a Bearer
+// token, since an IDE/API client can't carry the browser cookie.
+const API_PREFIX = '/api/v1';
+// Endpoints that never require auth: liveness + the spec + its docs page (no state).
+const API_PUBLIC = new Set(['/api/v1/health', '/api/v1/openapi.json', '/api/v1/docs']);
+
+function bearerOf(request: NextRequest): string | null {
+  const h = request.headers.get('authorization');
+  const m = h ? /^Bearer\s+(.+)$/i.exec(h) : null;
+  return m ? m[1].trim() : null;
+}
+
+function apiUnauthorized(): NextResponse {
+  return NextResponse.json(
+    { error: { code: 'unauthorized', message: 'Missing or invalid credentials. Send Authorization: Bearer <hub token>.' } },
+    { status: 401 },
+  );
+}
+
+// Gate a /api/v1 request. `mode` is never 'off' here (handled by the caller).
+function gateApi(request: NextRequest, mode: 'token' | 'password'): NextResponse {
+  if (API_PUBLIC.has(request.nextUrl.pathname)) return NextResponse.next();
+  if (mode === 'token') {
+    const expected = process.env.AGENTBOX_HUB_TOKEN ?? '';
+    if (!expected) return apiUnauthorized();
+    const bearer = bearerOf(request);
+    if (bearer && tokenEq(bearer, expected)) return NextResponse.next();
+    // Same-origin browser fetches (the hub's own UI) carry the token cookie.
+    const cookie = request.cookies.get(HUB_TOKEN_COOKIE)?.value;
+    if (cookie && tokenEq(cookie, expected)) return NextResponse.next();
+    return apiUnauthorized();
+  }
+  // password (hetzner/vercel): accept the better-auth session cookie. A dedicated
+  // API-key scheme for headless clients lands with the hosted-remote phase.
+  if (getSessionCookie(request)) return NextResponse.next();
+  return apiUnauthorized();
+}
+
 // Next 16 middleware. Gates the hub UI by mode. The matcher excludes every
 // relay-owned prefix so that on vercel (where those paths are the app/[...path]
 // catch-all) box→host comms and the bearer-gated /admin/* are never redirected to
@@ -18,6 +57,10 @@ function tokenEq(a: string, b: string): boolean {
 export function proxy(request: NextRequest): NextResponse {
   const mode = authMode();
   if (mode === 'off') return NextResponse.next();
+
+  // The public API is gated but answers JSON (not a signin redirect) and accepts
+  // a Bearer token — handle it before the browser flows below.
+  if (request.nextUrl.pathname.startsWith(API_PREFIX)) return gateApi(request, mode);
 
   // localhost token gate: a shared-secret cookie, no login screen. `?token=`
   // sets the cookie once and redirects to the clean URL; thereafter the cookie

--- a/apps/web/content/docs/hub-api.mdx
+++ b/apps/web/content/docs/hub-api.mdx
@@ -1,0 +1,122 @@
+---
+title: Hub REST API
+description: A versioned HTTP API for launching and managing boxes — for IDEs, scripts, and remote hubs
+---
+
+The hub serves a small, versioned **REST API** under `/api/v1` on the same port as
+the [hub UI](/docs/hub) and relay (`http://127.0.0.1:8787` locally). It's for
+programmatic callers — IDE integrations, scripts, a future macOS app — and is the
+way to drive AgentBox when the hub runs on a **separate host** (a [control
+plane](/docs/control-plane)), where there's no local CLI to shell out to.
+
+<Callout type="info" title="Local vs. remote">On your own machine you can also just call the CLI with `--json` (`agentbox list --json`, `agentbox status <box> --json`). The API is what you reach for across a network, or when you want one stable HTTP contract instead of spawning a process per call.</Callout>
+
+## Base URL and versioning
+
+```
+http://127.0.0.1:8787/api/v1
+```
+
+Every path is prefixed with `/api/v1`. The version is in the path so future
+breaking changes can ship as `/api/v2` without disturbing existing clients.
+
+## Auth
+
+Every endpoint except `/health`, `/openapi.json`, and `/docs` requires the hub
+token as a **Bearer** credential:
+
+```bash
+TOKEN=$(cat ~/.agentbox/hub/token)
+curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8787/api/v1/boxes
+```
+
+The token is the same per-machine secret the hub prints on boot (and stores at
+`~/.agentbox/hub/token`, mode `0600`). Requests without a valid token get a JSON
+`401` — never a redirect, so non-browser clients work cleanly. On a shared
+(password-protected) hub, `/api/v1` accepts the logged-in session; dedicated API
+keys arrive with the hosted deployment.
+
+## Response shape
+
+Success responses return the resource or collection directly. Errors are always:
+
+```json
+{ "error": { "code": "not_found", "message": "box not found: abc123" } }
+```
+
+with an HTTP status that matches the `code` (`400 invalid_request`,
+`401 unauthorized`, `404 not_found`, `409 conflict`, `503 backend_unavailable`).
+
+## Endpoints
+
+| Method + path | Description |
+|---|---|
+| `GET /health` | Liveness + API version (no auth). |
+| `GET /boxes` | List every box (normalized view). |
+| `GET /boxes/{id}` | One box. |
+| `POST /boxes` | Create a box — returns `202 { jobId }`. Body: `{ projectId, agent, name?, prompt? }`. |
+| `POST /boxes/{id}/pause` | Pause a running box. |
+| `POST /boxes/{id}/resume` | Resume a paused box. |
+| `POST /boxes/{id}/stop` | Stop a box. |
+| `POST /boxes/{id}/destroy` | Destroy a box (container + volumes). |
+| `GET /projects` | Registered projects (create targets). |
+| `POST /projects` | Register a folder as a project. Body: `{ path }` (absolute). |
+| `GET /approvals` | Pending host-action approvals. |
+| `POST /approvals/{id}/answer` | Answer an approval. Body: `{ answer: "y" \| "n" }`. |
+| `GET /jobs/{id}` | Create-job status (`queued`/`running`/`done`/`failed`). |
+| `GET /jobs/{id}/logs` | Stream the build log (SSE). |
+| `GET /openapi.json` | The OpenAPI 3.1 spec (no auth). |
+| `GET /docs` | Interactive API reference (no auth). |
+
+The box view is provider-agnostic: `{ id, projectId, repo, branch, task, agent,
+status, createdAt, lastActivity, host, commits, filesTouched, error }`, where
+`status` is one of `running | paused | stopped | creating | error`.
+
+## Creating a box
+
+Creation is asynchronous — it enqueues a build job and returns immediately:
+
+```bash
+# Register the folder once (skip if it's already a project):
+curl -X POST -H "Authorization: Bearer $TOKEN" -H 'content-type: application/json' \
+  -d '{"path":"/abs/path/to/repo"}' \
+  http://127.0.0.1:8787/api/v1/projects
+
+# Create a box for it (grab the projectId from GET /projects):
+curl -X POST -H "Authorization: Bearer $TOKEN" -H 'content-type: application/json' \
+  -d '{"projectId":"<id>","agent":"claude","name":"feature-x"}' \
+  http://127.0.0.1:8787/api/v1/boxes
+# -> 202 { "jobId": "..." }
+```
+
+A box being built shows up in `GET /boxes` with `status: "creating"` right away,
+then flips to `running` once the container is up.
+
+## Streaming logs (SSE)
+
+`GET /jobs/{id}/logs` is a Server-Sent Events stream: an `open` event, then a `log`
+event per line, then a terminal `end` event with the final status.
+
+```bash
+curl -N -H "Authorization: Bearer $TOKEN" \
+  http://127.0.0.1:8787/api/v1/jobs/<jobId>/logs
+```
+
+```
+event: open
+data: {"id":"<jobId>"}
+
+event: log
+data: "... building image ..."
+
+event: end
+data: {"status":"done"}
+```
+
+## Exploring the API
+
+`GET /api/v1/docs` renders the full spec (an interactive reference), and
+`GET /api/v1/openapi.json` returns the raw OpenAPI 3.1 document you can feed to a
+client generator or an IDE's HTTP client.
+
+<Callout type="info" title="What's not here yet">Provider listing, bake/prepare and provider-install jobs, and the structured mid-run prompt/link interaction stream are on the roadmap. Today the API covers boxes, projects, approvals, and create jobs.</Callout>

--- a/apps/web/content/docs/hub.mdx
+++ b/apps/web/content/docs/hub.mdx
@@ -31,7 +31,11 @@ That starts the hub (if it isn't already running) and opens it in your browser a
 - **Live updates** — box states and approvals stream in over SSE; no manual
   refresh. A pending approval appears the moment a box requests it.
 
-<Callout type="info" title="Creating boxes">Creating boxes from the hub isn't wired yet — use `agentbox create` (and the `-i` background flag) from the terminal. The hub reflects and controls the boxes you already have.</Callout>
+- **Create boxes** — register a project folder and start a box (with an agent and
+  an optional task) straight from the dashboard; the live build log streams into a
+  panel and the box appears as `creating` → `running`.
+
+<Callout type="info" title="Driving it programmatically">Everything the UI does is also available over HTTP — see the [Hub REST API](/docs/hub-api) for launching and managing boxes from an IDE, a script, or a remote hub.</Callout>
 
 ## Commands
 

--- a/apps/web/content/docs/meta.json
+++ b/apps/web/content/docs/meta.json
@@ -33,6 +33,7 @@
     "---Reference---",
     "cli",
     "hub",
+    "hub-api",
     "control-plane",
     "agentbox-yaml",
     "configuration",

--- a/docs/hub-webui-plan.md
+++ b/docs/hub-webui-plan.md
@@ -500,6 +500,51 @@ effort — see `docs/web-create-boxes-backlog.md` and the approved architecture 
   secrets/env/checkpoint surfaces, and the full `--protocol json` interaction bus
   (prompts/links) + hosted-plane parity — tracked in the backlog.
 
+### Phase 7 — Public REST API (`/api/v1`) — DONE
+A versioned, documented HTTP API so external tools (IDEs above all, and a future
+macOS app) can launch + manage boxes — including when the hub runs on a **separate
+host**, where there's no local CLI to shell out to. Design decision: a **new
+`/api/v1/*` route group on the hub** (Next routes under
+`apps/hub/app/(dashboard)/api/v1/`, served on the relay port via the existing
+`uiHandler` seam), **not** an extension of the relay's internal `/admin`+`/rpc`
+if-ladder — that surface is loopback-internal by design, couples HTTP status to
+child-process exit codes, and has no schema. The API is a thin facade over the
+already-shipped backend seam (`__AGENTBOX_HUB_BACKEND` + `getDashboardData()` +
+`enqueueQueueJob`) — no new box logic.
+- **Contract:** one envelope everywhere — success returns the resource directly,
+  errors always `{ error: { code, message, details? } }` with a correct status.
+  Routes: `GET /boxes`, `GET /boxes/:id`,
+  `POST /boxes/:id/{pause,resume,stop,destroy}`, `POST /boxes` (create → `202
+  {jobId}`), `GET|POST /projects`, `GET /approvals`, `POST /approvals/:id/answer`,
+  `GET /jobs/:id`, `GET /jobs/:id/logs` (SSE), `GET /health`, `GET /openapi.json`,
+  `GET /docs`. The box view model is the normalized hub `Box` (provider-agnostic),
+  identical to what the UI and the future Postgres source produce.
+- **Auth:** `proxy.ts` gates `/api/v1/*` and answers **JSON 401** (never a `/signin`
+  redirect). Token mode accepts `Authorization: Bearer <AGENTBOX_HUB_TOKEN>` (or the
+  same-origin cookie); password mode accepts the better-auth session. `/health`,
+  `/openapi.json`, `/docs` are public. Dedicated API keys arrive with hosted-remote.
+- **Topology:** reads route through `getDashboardData()` (in-process → Postgres →
+  empty), so the read contract is topology-agnostic already; mutations use the
+  in-process backend (the Postgres/plane write path is the documented follow-up).
+- **OpenAPI + docs:** hand-authored OpenAPI 3.1 at `/api/v1/openapi.json` (no zod dep
+  added — validation is hand-rolled `typeof` guards, matching the repo's convention),
+  Scalar-rendered reference at `/api/v1/docs`. The per-job log SSE tail is shared with
+  the internal create-modal route via `lib/job-log-stream.ts`.
+- **New:** `apps/hub/app/(dashboard)/api/v1/**` (routes + `lib/{envelope,backend,
+  validate,openapi}.ts`), `apps/hub/lib/job-log-stream.ts`. **Modified:**
+  `apps/hub/proxy.ts` (Bearer gate), the internal `api/jobs/[id]/logs/route.ts`
+  (delegates to the shared tail).
+- **Verified (embedded `server.ts`, scratch port + isolated `$HOME`):** health
+  public; boxes/projects/approvals 401 without Bearer, 200 with it, 401 wrong token;
+  validation → 400 envelopes, unknown project → 404, unknown box/job → 404, bad
+  action → 400; `openapi.json` valid 3.1 with all paths, `/docs` renders; regression
+  `/healthz`, `/admin/registry`, `/api/events`, dashboard `/` all intact. Full create
+  E2E through the API: `POST /boxes` → `202 {jobId}` → job `running` →
+  `GET /jobs/:id/logs` streamed the real build log → box surfaced as `creating`.
+- **Deferred:** `/providers`, bake/provider-install jobs, the structured
+  `/jobs/:id/events` + `/jobs/:id/answer` interaction stream (Phases A–C), hosted
+  writes, and API-key management.
+
 ---
 
 ## Docs to update (in the phase that changes the behavior)

--- a/docs/web-create-boxes-backlog.md
+++ b/docs/web-create-boxes-backlog.md
@@ -99,11 +99,36 @@ streaming), before the full `--protocol json` interaction bus.
 - [ ] Dispatch on job `kind`: `create-box` (existing), `prepare`/`bake`
   (`runPrepare`), `provider-install`. Run core lib in-worker with `--protocol json`.
 
-## Phase D — Relay / hub HTTP API surface
-- [ ] Tier-1 in-process routes (`/boxes`, `/boxes/:id/{pause,resume,stop,destroy}`,
-  `/providers`).
-- [ ] Tier-2/3 job routes (`POST /boxes|/prepare|/providers/:name/install`,
-  `GET /jobs/:id/events`, `POST /jobs/:id/answer`). Document as the public API.
+## Phase D — Hub public REST API (`/api/v1`) — first cut DONE
+The public API lives as a **versioned `/api/v1/*` route group on the hub** (Next
+routes under `apps/hub/app/(dashboard)/api/v1/`), served on the relay port via the
+existing `uiHandler` seam — deliberately **not** an extension of the relay's internal
+`/admin`+`/rpc` if-ladder (that stays loopback-internal, with exit-code-coupled
+statuses and no schema). One consistent envelope: success returns the resource
+directly; errors always `{ error: { code, message, details? } }` with a correct HTTP
+status. Thin facade over the already-shipped backend seam — no new box logic.
+- [x] **Tier-1 in-process routes:** `GET /boxes`, `GET /boxes/:id`,
+  `POST /boxes/:id/{pause,resume,stop,destroy}`, `GET|POST /projects`,
+  `GET /approvals`, `POST /approvals/:id/answer`. Reads go through
+  `getDashboardData()` (in-process → Postgres → empty), so the read contract is
+  **topology-agnostic** already; mutations use `globalThis.__AGENTBOX_HUB_BACKEND`
+  (503 on the Postgres path — hosted writes are the follow-up below).
+- [x] **Tier-2 job routes:** `POST /boxes` (create → `202 {jobId}` via
+  `enqueueQueueJob`), `GET /jobs/:id`, `GET /jobs/:id/logs` (SSE, shared tail in
+  `lib/job-log-stream.ts` with the internal modal route).
+- [x] **Auth:** `proxy.ts` gates `/api/v1/*` — accepts `Authorization: Bearer
+  <AGENTBOX_HUB_TOKEN>` (or the same-origin cookie) in token mode, the better-auth
+  session in password mode, and always answers **JSON 401** (never a `/signin`
+  redirect a non-browser client can't follow). `/health`, `/openapi.json`, `/docs`
+  are public.
+- [x] **OpenAPI 3.1 + docs:** hand-authored spec at `GET /api/v1/openapi.json`
+  (no zod dep added — the repo has no zod convention; validation is hand-rolled
+  `typeof` guards in `api/v1/lib/validate.ts`, matching the codebase), Scalar docs at
+  `GET /api/v1/docs`.
+- **Deferred to Phase D-next:** `/providers` list, `POST /prepare` (bake) +
+  `POST /providers/:name/install`, and the structured `GET /jobs/:id/events` /
+  `POST /jobs/:id/answer` interaction stream (needs Phases A–C). Dedicated API-key
+  management + hosted-plane **writes** land with the hosted-remote phase below.
 
 ## Phase E — Web UI + docs
 - [ ] Generalized prompt/link surface (extend Approvals for job origin + links).


### PR DESCRIPTION
## What

Adds a versioned, OpenAPI-documented **REST API on the hub** (`/api/v1`) so external tools — IDEs above all, plus scripts and a future macOS app — can launch and manage boxes programmatically, including when the hub runs on a **separate host** (where there's no local CLI to shell out to).

This executes the first cut of **Phase D** from `docs/web-create-boxes-backlog.md` / the approved plan.

## Design decision

A **new `/api/v1/*` route group on the hub** (Next routes served on the relay port via the existing `uiHandler` seam) — deliberately **not** an extension of the relay's internal `/admin`+`/rpc` wire. That surface is loopback-internal by design, couples HTTP status to child-process exit codes (a failed `git push` returns 500), and has no schema — unfit as a public contract. The API is a thin facade over the backend seam the hub UI already drives (`__AGENTBOX_HUB_BACKEND` + `getDashboardData()` + `enqueueQueueJob`) — no duplicated box logic.

## Endpoints

`GET /boxes`, `GET /boxes/:id`, `POST /boxes` (create → `202 {jobId}`), `POST /boxes/:id/{pause,resume,stop,destroy}`, `GET|POST /projects`, `GET /approvals`, `POST /approvals/:id/answer`, `GET /jobs/:id`, `GET /jobs/:id/logs` (SSE), `GET /health`, `GET /openapi.json` (OpenAPI 3.1), `GET /docs` (Scalar).

- **Envelope:** success returns the resource directly; errors are `{ error: { code, message, details? } }` with a matching HTTP status.
- **Auth** (`proxy.ts`): `Authorization: Bearer <hub token>` in token mode (or the better-auth session in password mode); always a JSON `401`, never a `/signin` redirect. `/health`, `/openapi.json`, `/docs` are public. Dedicated API keys arrive with the hosted-remote phase.
- **Topology:** reads route through `getDashboardData()` (in-process → Postgres → empty) so the read contract is already topology-agnostic; mutations use the in-process backend (hosted writes are a documented follow-up).
- **Streaming:** the per-job log SSE tail lives in `lib/job-log-stream.ts`, shared with the internal create-modal route (`/api/jobs/:id/logs`) so there's one implementation.
- **UI:** an **API** nav link (sidebar + topbar) → `/api/v1/docs`.
- No `zod` dep added — validation is hand-rolled `typeof` guards (`api/v1/lib/validate.ts`), matching the repo's convention; the OpenAPI 3.1 doc is hand-authored.

## Verification

Embedded `server.ts`, scratch port + isolated `$HOME`, plus a live run on the real hub (`:8787`) after `build:standalone` + stage + `agentbox hub restart`:

- Auth: `/health` public; boxes/projects/approvals → 401 without Bearer, 200 with it, 401 wrong token.
- Envelopes: bad agent / missing projectId / malformed JSON / bad action → 400; unknown project → 404; unknown box/job → 404.
- OpenAPI 3.1 valid with all paths + schemas; `/docs` renders; API nav link present in the dashboard.
- **Full create + lifecycle E2E through the API with docker ground truth:** `POST /boxes` → `202 {jobId}` → job `running` → `/jobs/:id/logs` streamed the real build log → box `creating` → `running` → **pause** (`docker inspect` paused) → **resume** (running) → **destroy** (container removed, gone from list, 404).
- Regression: `/healthz`, `/admin/registry`, `/api/events`, dashboard `/` all intact. `typecheck` + `lint` + `next build` clean.

## Deferred

`/providers`, bake/provider-install jobs, the structured `/jobs/:id/events` + `/jobs/:id/answer` interaction stream (Phases A–C), hosted-plane writes, and API-key management.

https://claude.ai/code/session_01TGoDQvktdXD5rqJuJm9Uyk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated public API that can create boxes, change lifecycle, and resolve approvals; writes still depend on the in-process backend (hosted path 503s), but misconfiguration or token leakage would expose the same powers as the hub UI.
> 
> **Overview**
> Introduces a **versioned public REST API** at `/api/v1` on the hub relay port—a documented HTTP contract for IDEs, scripts, and remote hubs, separate from the internal relay `/admin`+`/rpc` wire.
> 
> **API surface:** CRUD-style reads and writes for boxes (list/get, async `POST /boxes` → `202 {jobId}`, lifecycle pause/resume/stop/destroy), projects, pending approvals (list + answer), and create jobs (status + SSE logs). Responses use a stable envelope: direct JSON on success; `{ error: { code, message, details? } }` on failure. Shared helpers (`envelope`, hand-rolled `validate`, `backend`/`readState`) wire reads through `getDashboardData()` and mutations through `__AGENTBOX_HUB_BACKEND` (503 when no in-process writer). Lifecycle on synthetic `job:` ids returns **409** instead of a misleading 404.
> 
> **Auth & discovery:** `proxy.ts` gates `/api/v1` with **Bearer hub token** (or session/cookie in password mode) and always returns **JSON 401**—no `/signin` redirect. Public: `/health`, `/openapi.json`, Scalar `/docs`. Hand-authored **OpenAPI 3.1** documents the contract.
> 
> **Refactor:** Per-job log SSE is extracted to `lib/job-log-stream.ts` and used by both the dashboard and `GET /api/v1/jobs/:id/logs`.
> 
> **Docs & UI:** Hub README, new `hub-api.mdx`, hub doc updates (create boxes + API link), plan/backlog marked Phase D done; sidebar/topbar link to `/api/v1/docs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ed68b772912a0d840c966998c38441ab436c711. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->