### PR TITLE
fix(cli): verify tray launched after install, retry once

### DIFF
--- a/apps/cli/src/commands/install-tray.ts
+++ b/apps/cli/src/commands/install-tray.ts
@@ -18,6 +18,7 @@ import { createHash } from 'node:crypto';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
 
 export const APP_NAME = 'AgentBoxTray';
 export const APP_PATH = `/Applications/${APP_NAME}.app`;
@@ -87,13 +88,36 @@ export async function installTray(opts: InstallTrayOptions = {}): Promise<Instal
     await execa('ditto', ['-x', '-k', zip, '/Applications']);
     // Belt-and-suspenders: clear any quarantine bit so Gatekeeper never blocks the download.
     await execa('xattr', ['-dr', 'com.apple.quarantine', APP_PATH]).catch(() => undefined);
-    await execa('open', [APP_PATH]);
+    await launchTray(say);
   } finally {
     if (scratch) rmSync(scratch, { recursive: true, force: true });
   }
 
   say(`Installed ${APP_PATH} and launched it (look for the box icon in the menu bar).`);
   return { ran: true };
+}
+
+/** True while the tray process is running. `pgrep -x` exits 1 (rejects) when nothing matches. */
+async function trayRunning(): Promise<boolean> {
+  return (await execa('pgrep', ['-x', APP_NAME]).catch(() => null)) !== null;
+}
+
+/**
+ * Launch the freshly-installed app and confirm it actually came up. `open` returns before an
+ * `LSUIElement` menu-bar app finishes registering, and right after a `ditto` extract Launch Services
+ * can briefly not resolve the new bundle — so poll, then retry `open` once before giving up.
+ * (Launch-at-login stays opt-in via the app's Settings; this only covers the post-install start.)
+ */
+async function launchTray(say: (m: string) => void): Promise<void> {
+  await execa('open', [APP_PATH]).catch(() => undefined);
+  for (let i = 0; i < 6; i++) {
+    if (await trayRunning()) return;
+    await delay(500);
+  }
+  await execa('open', [APP_PATH]).catch(() => undefined);
+  if (!(await trayRunning())) {
+    say(`The menu-bar app did not start automatically — launch it from ${APP_PATH}.`);
+  }
 }
 
 /** Download `<tag>/AgentBoxTray.zip` + its `.sha256`, verify, and return the local zip path. */


### PR DESCRIPTION
## What

`agentbox install tray` (and the setup-wizard step) installed the menu-bar app but sometimes left it **not running** — the user had to launch it by hand from /Applications.

## Why

`installTray()` fired a single `open` and returned. But `open` resolves *before* an `LSUIElement` menu-bar app finishes registering, and right after a `ditto` extract Launch Services can briefly fail to resolve the freshly-written bundle. Net effect: the post-install launch silently didn't stick. (The build is properly Developer-ID signed + notarized — verified via `spctl` — so Gatekeeper was never the cause.)

## Change

- After `open`, poll `pgrep -x AgentBoxTray` for ~3s; if still not running, retry `open` once, then fall back to a clear "launch it from /Applications" message.
- Reuses the same `pgrep -x` liveness check that `agentbox app status` already uses.
- **Launch-at-login is unchanged** — it stays opt-in via the app's Settings toggle.

## Scope

CLI-only, macOS-only path. No behavior change on non-darwin (still a clean no-op). The separate AgentBox logo app-icon work lands in the `madarco/agentbox-tray` repo.

## Test

`pnpm --filter @madarco/agentbox build` green. Manual: `agentbox install tray --zip <local>` relaunches and confirms the process is up (note: it replaces a running tray, which comes back).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> macOS-only install UX change with no auth, data, or security surface; failure mode is a clearer manual-launch message.
> 
> **Overview**
> Post-install tray startup no longer relies on a single `open` call. **`installTray()`** now calls **`launchTray()`**, which opens the app, polls **`pgrep -x AgentBoxTray`** for up to ~3s (same liveness pattern as **`agentbox app status`**), retries **`open`** once if the process never appears, and tells the user to launch manually from `/Applications` if it still fails.
> 
> macOS CLI install path only; launch-at-login behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 790cd2280cac8dea217c8019eea2e5e345a79b00. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->