### PR TITLE
feat(cli): add `agentbox app log` for tray diagnostics

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -11,6 +11,16 @@ CLI, not the raw commits.
 
 ## [Unreleased]
 
+### Added
+
+- **`agentbox app log`** — collect the macOS tray app's diagnostics for a bug
+  report. Reads the tray's macOS unified-log entries (`--last <window>`, `-f` to
+  stream live, `--crashes` for crash reports only) and lists its crash reports from
+  `~/Library/Logs/DiagnosticReports`; `--open` reveals that folder in Finder and
+  `--out <file>` writes one self-contained bundle (versions + log + newest crash
+  report) to attach. The tray keeps no log file of its own — these are
+  macOS-native surfaces (unified logging + OS `.ips` crash reports).
+
 ### Fixed
 
 - **`agentbox hub` now starts after a fresh `npm install`.** The published

--- a/apps/cli/src/commands/app.ts
+++ b/apps/cli/src/commands/app.ts
@@ -7,12 +7,21 @@
  * in `install-tray.ts`, which owns `APP_NAME` / `APP_PATH`.
  */
 
-import { intro, log, outro } from '@clack/prompts';
+import { intro, log, outro, spinner } from '@clack/prompts';
 import { Command } from 'commander';
 import { execa } from 'execa';
-import { existsSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
-import { APP_NAME, APP_PATH } from './install-tray.js';
+import { AGENTBOX_VERSION } from '../version.js';
+import { APP_BUNDLE_ID, APP_NAME, APP_PATH } from './install-tray.js';
+
+/** macOS writes app crash reports here as `AgentBoxTray-<timestamp>.ips`. */
+const DIAGNOSTIC_REPORTS_DIR = join(homedir(), 'Library/Logs/DiagnosticReports');
+/** Unified-logging predicate scoping to the tray's subsystem. */
+const LOG_PREDICATE = `subsystem == "${APP_BUNDLE_ID}"`;
 
 /** True on macOS; otherwise print the standard no-op notice and let the caller return. */
 function ensureMac(): boolean {
@@ -46,6 +55,64 @@ function ensureInstalled(): boolean {
   log.error(`${APP_PATH} is not installed. Run \`agentbox install tray\` first.`);
   process.exitCode = 1;
   return false;
+}
+
+interface CrashReport {
+  name: string;
+  path: string;
+  mtimeMs: number;
+}
+
+/** Recent tray crash reports (`AgentBoxTray-*.ips`), newest first. [] if none / no dir. */
+function listCrashReports(): CrashReport[] {
+  let names: string[];
+  try {
+    names = readdirSync(DIAGNOSTIC_REPORTS_DIR);
+  } catch {
+    return []; // dir absent (no crash ever recorded) — not an error
+  }
+  return names
+    .filter((n) => n.startsWith(`${APP_NAME}-`) && n.endsWith('.ips'))
+    .map((n) => {
+      const path = join(DIAGNOSTIC_REPORTS_DIR, n);
+      return { name: n, path, mtimeMs: statSync(path).mtimeMs };
+    })
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+}
+
+/** Read the tray's unified-log entries for the given window via `log show`. */
+async function trayUnifiedLog(last: string): Promise<string> {
+  // `--info` surfaces info-level lines too (notice/error/fault always show). `reject:false`
+  // so a slow/edge-case `log` exit doesn't throw — we still want whatever it printed.
+  const res = await execa(
+    'log',
+    ['show', '--predicate', LOG_PREDICATE, '--last', last, '--style', 'compact', '--info'],
+    { reject: false, timeout: 60_000 },
+  );
+  return res.stdout ?? '';
+}
+
+/** Print the crash-report list (newest few) to stdout. */
+function printCrashReports(reports: CrashReport[], limit = 5): void {
+  if (reports.length === 0) {
+    log.info('No crash reports found.');
+    return;
+  }
+  log.info(`Crash reports (${reports.length}) in ${DIAGNOSTIC_REPORTS_DIR}:`);
+  for (const r of reports.slice(0, limit)) {
+    process.stdout.write(`  ${r.name}\t${new Date(r.mtimeMs).toISOString()}\n`);
+  }
+  if (reports.length > limit) {
+    process.stdout.write(`  … and ${reports.length - limit} older. Use --open to reveal them.\n`);
+  }
+}
+
+interface LogOpts {
+  last: string;
+  follow?: boolean;
+  crashes?: boolean;
+  open?: boolean;
+  out?: string;
 }
 
 interface StatusOpts {
@@ -120,9 +187,117 @@ const restartSub = new Command('restart')
     outro('Restarted');
   });
 
+const logSub = new Command('log')
+  .description("Show the tray app's diagnostics (unified log + crash reports) for bug reports")
+  .option('-n, --last <window>', 'time window for the unified log (e.g. 30m, 2h, 1d)', '1h')
+  .option('-f, --follow', 'stream live tray log entries instead of a snapshot')
+  .option('--crashes', 'show only recent crash reports (skip the unified log)')
+  .option('--open', 'reveal the crash-reports folder in Finder and exit')
+  .option('--out <file>', 'write a self-contained bug-report bundle to <file>')
+  .action(async (opts: LogOpts) => {
+    if (!ensureMac()) return;
+
+    if (opts.open) {
+      await execa('open', [DIAGNOSTIC_REPORTS_DIR]).catch(() => undefined);
+      log.info(`Opened ${DIAGNOSTIC_REPORTS_DIR}`);
+      return;
+    }
+
+    if (opts.out) {
+      await writeBugReportBundle(opts.out, opts.last);
+      return;
+    }
+
+    if (opts.follow) {
+      // Live stream; inherit stdio so Ctrl-C tears it down cleanly (mirrors `logs.ts`).
+      const child = spawn(
+        'log',
+        ['stream', '--predicate', LOG_PREDICATE, '--style', 'compact', '--level', 'info'],
+        { stdio: ['ignore', 'inherit', 'inherit'] },
+      );
+      const term = (): void => {
+        child.kill('SIGTERM');
+      };
+      process.on('SIGINT', term);
+      process.on('SIGTERM', term);
+      await new Promise<void>((resolve) => child.on('exit', () => resolve()));
+      return;
+    }
+
+    const reports = listCrashReports();
+
+    if (opts.crashes) {
+      printCrashReports(reports);
+      return;
+    }
+
+    const s = spinner();
+    s.start('Reading tray unified log…');
+    const logText = await trayUnifiedLog(opts.last);
+    s.stop('Tray unified log');
+    process.stdout.write(logText.endsWith('\n') || logText === '' ? logText : logText + '\n');
+    if (logText.trim() === '') {
+      log.info(
+        `No log entries in the last ${opts.last}. The tray may not be running, or try a longer --last window.`,
+      );
+    }
+    process.stdout.write('\n');
+    printCrashReports(reports);
+  });
+
+/** Assemble a single attachable bug-report file: env header + unified log + newest crash. */
+async function writeBugReportBundle(outPath: string, last: string): Promise<void> {
+  const s = spinner();
+  s.start('Collecting diagnostics…');
+
+  const cliVersion = AGENTBOX_VERSION;
+  const macVersion =
+    (await execa('sw_vers', ['-productVersion'], { reject: false }).catch(() => null))?.stdout ??
+    'unknown';
+  const pids = await trayPids();
+  const installed = existsSync(APP_PATH);
+  const logText = await trayUnifiedLog(last);
+  const reports = listCrashReports();
+  const newest = reports[0];
+  let newestBody = 'none';
+  if (newest) {
+    try {
+      newestBody = readFileSync(newest.path, 'utf8');
+    } catch (err) {
+      newestBody = `(failed to read ${newest.path}: ${err instanceof Error ? err.message : String(err)})`;
+    }
+  }
+
+  const bundle = [
+    '# AgentBox Tray bug report',
+    `generated (UTC): ${new Date().toISOString()}`,
+    `agentbox CLI: ${cliVersion}`,
+    `macOS: ${macVersion}`,
+    `tray installed: ${installed} (${APP_PATH})`,
+    `tray running: ${pids.length > 0}${pids.length ? ` (pid ${pids.join(', ')})` : ''}`,
+    `crash reports: ${reports.length}${newest ? ` (newest ${newest.name})` : ''}`,
+    '',
+    `## Unified log (subsystem ${APP_BUNDLE_ID}, last ${last})`,
+    '',
+    logText.trim() === '' ? '(no entries)' : logText.trimEnd(),
+    '',
+    '## Newest crash report',
+    '',
+    newest ? `file: ${newest.path}` : '(no crash reports)',
+    '',
+    newestBody.trimEnd(),
+    '',
+  ].join('\n');
+
+  writeFileSync(outPath, bundle);
+  s.stop('Diagnostics collected');
+  log.info(`Wrote bug-report bundle to ${outPath}`);
+}
+
 export const appCommand = new Command('app')
-  .description('Control the AgentBox Tray menu-bar app (status / start / stop / restart)')
+  .description('Control the AgentBox Tray menu-bar app (status / start / stop / restart / log)')
   .addCommand(statusSub, { isDefault: true })
   .addCommand(startSub)
   .addCommand(stopSub)
-  .addCommand(restartSub);
+  .addCommand(restartSub)
+  .addCommand(logSub);

--- a/apps/cli/src/commands/app.ts
+++ b/apps/cli/src/commands/app.ts
@@ -75,21 +75,40 @@ function listCrashReports(): CrashReport[] {
     .filter((n) => n.startsWith(`${APP_NAME}-`) && n.endsWith('.ips'))
     .map((n) => {
       const path = join(DIAGNOSTIC_REPORTS_DIR, n);
-      return { name: n, path, mtimeMs: statSync(path).mtimeMs };
+      try {
+        return { name: n, path, mtimeMs: statSync(path).mtimeMs };
+      } catch {
+        return null; // vanished between readdir and stat — skip it, don't fail the whole command
+      }
     })
+    .filter((r): r is CrashReport => r !== null)
     .sort((a, b) => b.mtimeMs - a.mtimeMs);
 }
 
+interface UnifiedLogResult {
+  text: string;
+  /** Set when `log show` failed/timed out, so callers don't misread empty output as "no entries". */
+  failureNote?: string;
+}
+
 /** Read the tray's unified-log entries for the given window via `log show`. */
-async function trayUnifiedLog(last: string): Promise<string> {
+async function trayUnifiedLog(last: string): Promise<UnifiedLogResult> {
   // `--info` surfaces info-level lines too (notice/error/fault always show). `reject:false`
-  // so a slow/edge-case `log` exit doesn't throw — we still want whatever it printed.
+  // so a slow/edge-case `log` exit resolves (with `failed`/`timedOut` set) rather than throwing —
+  // we still want whatever it printed, plus a note explaining the shortfall.
   const res = await execa(
     'log',
     ['show', '--predicate', LOG_PREDICATE, '--last', last, '--style', 'compact', '--info'],
     { reject: false, timeout: 60_000 },
   );
-  return res.stdout ?? '';
+  const text = res.stdout ?? '';
+  if (res.failed) {
+    const failureNote = res.timedOut
+      ? '`log show` timed out after 60s — output above may be partial. Narrow --last for a faster query.'
+      : `\`log show\` failed: ${(res.stderr || '').trim() || `exit code ${res.exitCode ?? 'unknown'}`}`;
+    return { text, failureNote };
+  }
+  return { text };
 }
 
 /** Print the crash-report list (newest few) to stdout. */
@@ -220,7 +239,14 @@ const logSub = new Command('log')
       };
       process.on('SIGINT', term);
       process.on('SIGTERM', term);
-      await new Promise<void>((resolve) => child.on('exit', () => resolve()));
+      await new Promise<void>((resolve) => {
+        // `error` (not `exit`) fires if `log stream` fails to spawn — resolve so we don't hang.
+        child.on('error', (err) => {
+          log.error(`failed to start \`log stream\`: ${err.message}`);
+          resolve();
+        });
+        child.on('exit', () => resolve());
+      });
       return;
     }
 
@@ -233,10 +259,12 @@ const logSub = new Command('log')
 
     const s = spinner();
     s.start('Reading tray unified log…');
-    const logText = await trayUnifiedLog(opts.last);
+    const { text: logText, failureNote } = await trayUnifiedLog(opts.last);
     s.stop('Tray unified log');
     process.stdout.write(logText.endsWith('\n') || logText === '' ? logText : logText + '\n');
-    if (logText.trim() === '') {
+    if (failureNote) {
+      log.warn(failureNote);
+    } else if (logText.trim() === '') {
       log.info(
         `No log entries in the last ${opts.last}. The tray may not be running, or try a longer --last window.`,
       );
@@ -256,7 +284,7 @@ async function writeBugReportBundle(outPath: string, last: string): Promise<void
     'unknown';
   const pids = await trayPids();
   const installed = existsSync(APP_PATH);
-  const logText = await trayUnifiedLog(last);
+  const { text: logText, failureNote } = await trayUnifiedLog(last);
   const reports = listCrashReports();
   const newest = reports[0];
   let newestBody = 'none';
@@ -279,6 +307,7 @@ async function writeBugReportBundle(outPath: string, last: string): Promise<void
     '',
     `## Unified log (subsystem ${APP_BUNDLE_ID}, last ${last})`,
     '',
+    ...(failureNote ? [`NOTE: ${failureNote}`, ''] : []),
     logText.trim() === '' ? '(no entries)' : logText.trimEnd(),
     '',
     '## Newest crash report',

--- a/apps/cli/src/commands/app.ts
+++ b/apps/cli/src/commands/app.ts
@@ -63,26 +63,36 @@ interface CrashReport {
   mtimeMs: number;
 }
 
-/** Recent tray crash reports (`AgentBoxTray-*.ips`), newest first. [] if none / no dir. */
+// macOS names tray reports `AgentBoxTray-<ts>.ips` (hyphen) today; allow an underscore too since
+// some report types use it. Built from APP_NAME so it stays in sync (no regex-special chars in it).
+const IPS_NAME = new RegExp(`^${APP_NAME}[-_].*\\.ips$`, 'i');
+
+/**
+ * Recent tray crash reports, newest first. [] if none. Scans the top level of DiagnosticReports
+ * **and** its `Retired/` subdir — macOS moves older `.ips` reports there, so a top-level-only scan
+ * would miss them.
+ */
 function listCrashReports(): CrashReport[] {
-  let names: string[];
-  try {
-    names = readdirSync(DIAGNOSTIC_REPORTS_DIR);
-  } catch {
-    return []; // dir absent (no crash ever recorded) — not an error
-  }
-  return names
-    .filter((n) => n.startsWith(`${APP_NAME}-`) && n.endsWith('.ips'))
-    .map((n) => {
-      const path = join(DIAGNOSTIC_REPORTS_DIR, n);
+  const dirs = [DIAGNOSTIC_REPORTS_DIR, join(DIAGNOSTIC_REPORTS_DIR, 'Retired')];
+  const reports: CrashReport[] = [];
+  for (const dir of dirs) {
+    let names: string[];
+    try {
+      names = readdirSync(dir);
+    } catch {
+      continue; // dir absent (no crash / no Retired yet) — not an error
+    }
+    for (const n of names) {
+      if (!IPS_NAME.test(n)) continue;
+      const path = join(dir, n);
       try {
-        return { name: n, path, mtimeMs: statSync(path).mtimeMs };
+        reports.push({ name: n, path, mtimeMs: statSync(path).mtimeMs });
       } catch {
-        return null; // vanished between readdir and stat — skip it, don't fail the whole command
+        // vanished between readdir and stat — skip it, don't fail the whole command
       }
-    })
-    .filter((r): r is CrashReport => r !== null)
-    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+    }
+  }
+  return reports.sort((a, b) => b.mtimeMs - a.mtimeMs);
 }
 
 interface UnifiedLogResult {

--- a/apps/cli/src/commands/app.ts
+++ b/apps/cli/src/commands/app.ts
@@ -243,9 +243,15 @@ const logSub = new Command('log')
         // `error` (not `exit`) fires if `log stream` fails to spawn — resolve so we don't hang.
         child.on('error', (err) => {
           log.error(`failed to start \`log stream\`: ${err.message}`);
+          process.exitCode = 1;
           resolve();
         });
-        child.on('exit', () => resolve());
+        // Propagate a genuine non-zero exit so scripts see the failure. A user Ctrl-C kills the
+        // child by signal (code null) — that's a normal stop, not a failure.
+        child.on('exit', (code) => {
+          if (code && code !== 0) process.exitCode = code;
+          resolve();
+        });
       });
       return;
     }
@@ -287,7 +293,7 @@ async function writeBugReportBundle(outPath: string, last: string): Promise<void
   const { text: logText, failureNote } = await trayUnifiedLog(last);
   const reports = listCrashReports();
   const newest = reports[0];
-  let newestBody = 'none';
+  let newestBody = '';
   if (newest) {
     try {
       newestBody = readFileSync(newest.path, 'utf8');

--- a/apps/cli/src/commands/install-tray.ts
+++ b/apps/cli/src/commands/install-tray.ts
@@ -22,6 +22,8 @@ import { setTimeout as delay } from 'node:timers/promises';
 
 export const APP_NAME = 'AgentBoxTray';
 export const APP_PATH = `/Applications/${APP_NAME}.app`;
+/** Unified-logging subsystem the tray logs under (see the tray app's `Diagnostics/Log.swift`). */
+export const APP_BUNDLE_ID = 'com.madarco.agentbox-tray';
 
 // Overridable for forks/testing; default is the public agentbox repo's moving tray release.
 const RELEASE_BASE =

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -352,13 +352,15 @@ agentbox app status
 agentbox app start
 agentbox app stop
 agentbox app restart
+agentbox app log                 # tray diagnostics (unified log + crash reports)
+agentbox app log --out report.txt  # bundle everything into one file for a bug report
 
 # Update agentbox (wipes the box image so it rebuilds, reloads the relay)
 agentbox self-update
 agentbox self-update --dry-run
 ```
 
-`prune` cleans up orphan state records; `--all` also removes orphan docker resources, and `--provider <cloud>` lists untracked cloud sandboxes and offers to delete them. `queue` manages background `-i` jobs. `relay` manages the host relay (`status`, `stop`, `start`, `restart`). `app` controls the macOS menu-bar app (`status`, `start`, `stop`, `restart`) — install it first with `agentbox install tray`. `self-update` updates the CLI.
+`prune` cleans up orphan state records; `--all` also removes orphan docker resources, and `--provider <cloud>` lists untracked cloud sandboxes and offers to delete them. `queue` manages background `-i` jobs. `relay` manages the host relay (`status`, `stop`, `start`, `restart`). `app` controls the macOS menu-bar app (`status`, `start`, `stop`, `restart`) — install it first with `agentbox install tray`. `app log` collects the tray's diagnostics for a bug report: it reads the tray's macOS unified-log entries (`--last <window>`, `-f` to stream live, `--crashes` for just the crash reports) and lists its crash reports from `~/Library/Logs/DiagnosticReports`; `--open` reveals that folder in Finder, and `--out <file>` writes a single self-contained bundle (versions, log, newest crash report) to attach. The tray keeps no log file of its own — these are macOS-native surfaces. `self-update` updates the CLI.
 
 `hub` runs the **AgentBox hub** — the host relay plus a local Web UI (dashboard, box detail, live approvals) on `http://127.0.0.1:8787`, gated by a per-machine token. When [Portless](https://portless.sh) is installed it also serves at a friendly `https://agentbox.localhost`. It's a superset of the relay on the same port: `agentbox hub` takes over from a bare relay, and normal box commands reuse it. Needs Node ≥ 22.5.
 


### PR DESCRIPTION
## What

Adds `agentbox app log` — a one-command way to collect the macOS tray app's diagnostics for a bug report.

- Reads the tray's macOS **unified-log** entries (subsystem `com.madarco.agentbox-tray`): `--last <window>`, `-f/--follow` to stream live, `--crashes` for crash reports only.
- Lists **crash reports** from `~/Library/Logs/DiagnosticReports/AgentBoxTray-*.ips`; `--open` reveals that folder in Finder.
- `--out <file>` writes a **self-contained bundle** (agentbox + macOS versions, tray running/installed state, unified log, newest `.ips`) to attach to an issue.

Exports `APP_BUNDLE_ID` from `install-tray.ts` as the logging subsystem.

## Why

The tray had no diagnosable log. Paired with the tray-app change (madarco/agentbox-tray) that emits proper `os.Logger` breadcrumbs + a file-free crash breadcrumb, this makes "what happened?" one command. Per design, the tray writes **no log file of its own** — it uses macOS-native surfaces (unified logging + OS `.ips` reports), so nothing hits the SSD that the OS wasn't already writing.

## Verification

- `typecheck`, `lint`, `build` all green.
- Exercised live on macOS: default (log + crash list), `--crashes`, `--out` (bundle with real version `0.22.0` / macOS `14.4.1` + a real `.ips`), and `-f` (streams, Ctrl-C exits cleanly).

Docs: `apps/web/content/docs/cli.mdx` (Maintenance section) + `apps/cli/CHANGELOG.md`.

https://claude.ai/code/session_01WHtFJBjFg7n95j9jE9R4rb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only macOS diagnostics via system `log` and local crash report files; no changes to tray lifecycle, auth, or box operations.
> 
> **Overview**
> Adds **`agentbox app log`** under the existing `app` command (macOS only) so users can gather AgentBox Tray diagnostics in one place for bug reports.
> 
> The new subcommand reads unified logs via `log show` / `log stream` filtered by **`APP_BUNDLE_ID`** (`com.madarco.agentbox-tray`, newly exported from `install-tray.ts`), with `--last`, `-f` for live follow, and `--crashes` for `.ips` listings from `~/Library/Logs/DiagnosticReports` (including `Retired/`). **`--out <file>`** writes a single attachable bundle (CLI/macOS versions, tray state, log window, newest crash report); **`--open`** reveals the crash folder in Finder.
> 
> Docs and changelog are updated in `cli.mdx` and `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 241afb72b1e9af9f182894a978cca007f7a54d6f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->