### PR TITLE
feat(ssh): default-on ~/.agentbox/ssh/config via Include for SSH-capable boxes

### DIFF
--- a/apps/cli/src/cloud-ssh.ts
+++ b/apps/cli/src/cloud-ssh.ts
@@ -1,7 +1,8 @@
 import { log } from '@clack/prompts';
 import type { BoxRecord } from '@agentbox/core';
+import { recordBoxSsh } from '@agentbox/sandbox-core';
 import { providerForBox } from './provider/registry.js';
-import { agentboxAliasFor, parseSshTarget, writeAgentboxSshAlias } from './ssh-config.js';
+import { agentboxAliasFor, parseSshTarget, syncAgentboxSshConfig } from './ssh-config.js';
 
 export interface CloudSshAlias {
   /** Host alias written to `~/.ssh/config` (the box name). */
@@ -71,21 +72,52 @@ export async function resolveCloudSshTarget(
 }
 
 /**
- * Bring a cloud box online and (re)write its `~/.ssh/config` alias, returning
- * the connection target. Shared by `agentbox code` (VS Code Remote-SSH),
- * `agentbox open` (sshfs mount), and `agentbox shell --ssh-config` (external
- * app handoff) — all three need the same alias mapped to a live SSH target.
+ * Bring a cloud box online, persist its resolved SSH target to `box.cloud.ssh`,
+ * and regenerate `~/.agentbox/ssh/config` (+ the `~/.ssh/config` Include),
+ * returning the connection target. Shared by `agentbox code` (VS Code
+ * Remote-SSH), `agentbox open` (sshfs mount), and `agentbox shell --ssh-config`
+ * (external app handoff) — all three need the same alias mapped to a live SSH
+ * target. These are explicit user actions, so they write regardless of the
+ * `ssh.autoConfig` toggle (which only governs the proactive create/start path).
  */
 export async function ensureCloudSshAlias(
   box: BoxRecord,
   opts: CloudSshOptions = {},
 ): Promise<CloudSshAlias> {
   const conn = await resolveCloudSshTarget(box, opts);
-  await writeAgentboxSshAlias({
-    alias: conn.alias,
-    hostname: conn.host,
+  await recordBoxSsh(box.id, {
+    host: conn.host,
     user: conn.user,
     identityFile: conn.identityFile,
   });
+  await syncAgentboxSshConfig();
   return conn;
+}
+
+/**
+ * Proactive, default-on SSH-config write on create/start/resume — gated by the
+ * `ssh.autoConfig` config key so a user who manages `~/.ssh/config` themselves
+ * can opt out. Only persistent-identity providers qualify (Hetzner/DigitalOcean:
+ * a per-box identity file that survives across sessions); Daytona's ephemeral
+ * token and Docker/Vercel/E2B (no SSH) are skipped. Best-effort: a failure here
+ * must never break the lifecycle command that triggered it.
+ *
+ * The box is assumed already online (create just finished, or start/resume
+ * brought it up), so `bringOnline: false` avoids a redundant lifecycle pass.
+ * Re-resolving on start is what refreshes a Hetzner box's changed public IP.
+ */
+export async function autoWriteSshConfig(box: BoxRecord, enabled: boolean): Promise<void> {
+  if (!enabled) return;
+  try {
+    const conn = await resolveCloudSshTarget(box, { bringOnline: false });
+    if (!conn.identityFile) return;
+    await recordBoxSsh(box.id, {
+      host: conn.host,
+      user: conn.user,
+      identityFile: conn.identityFile,
+    });
+    await syncAgentboxSshConfig();
+  } catch {
+    /* best-effort: SSH-config auto-write must never break create/start */
+  }
 }

--- a/apps/cli/src/commands/create.ts
+++ b/apps/cli/src/commands/create.ts
@@ -23,6 +23,7 @@ import { cloudSizingProviderOptions } from '../lib/cloud-sizing.js';
 import { FromBranchError, UseBranchError, resolveBranchSelection } from '../lib/from-branch.js';
 import { openCommandLog } from '../lib/log-file.js';
 import { makeProgressReporter } from '../lib/progress.js';
+import { autoWriteSshConfig } from '../cloud-ssh.js';
 import { maybePromptPortless, setupPortlessHost } from '../portless-prompt.js';
 import { providerForCreate } from '../provider/registry.js';
 import { buildResyncWarning } from '../lib/resync-warning.js';
@@ -462,6 +463,13 @@ export const createCommand = new Command('create')
       s.stop(`box ${result.record.container} ready`);
       const createResyncWarning = result.resync ? buildResyncWarning(result.resync) : null;
       if (createResyncWarning) log.warn(createResyncWarning);
+
+      // Default-on: write the `~/.agentbox/ssh/config` entry for SSH-capable
+      // cloud boxes (Hetzner/DigitalOcean) so `ssh <box>` just works. Best-effort
+      // and gated by `ssh.autoConfig`; skips docker and token-auth providers.
+      if (!isDocker) {
+        await autoWriteSshConfig(result.record, cfg.effective.ssh.autoConfig);
+      }
 
       log.info(`id:        ${result.record.id}`);
       if (typeof result.record.projectIndex === 'number') {

--- a/apps/cli/src/commands/destroy.ts
+++ b/apps/cli/src/commands/destroy.ts
@@ -6,7 +6,7 @@ import { destroyBox, portlessUnalias } from '@agentbox/sandbox-docker';
 import { Command } from 'commander';
 import { resolveBoxOrExit } from '../box-ref.js';
 import { providerForBox } from '../provider/registry.js';
-import { agentboxAliasFor, removeAgentboxSshAlias } from '../ssh-config.js';
+import { syncAgentboxSshConfig } from '../ssh-config.js';
 import { handleLifecycleError } from './_errors.js';
 
 interface DestroyOptions {
@@ -113,11 +113,11 @@ export const destroyCommand = new Command('destroy')
       } else {
         const provider = await providerForBox(box);
         await provider.destroy(box);
-        // Best-effort: remove the `~/.ssh/config` block `agentbox code` may
-        // have written for this cloud box. A missing block isn't an error
-        // and a file failure shouldn't block destroy.
+        // Best-effort: regenerate `~/.agentbox/ssh/config` now the box is gone
+        // from state, dropping its `Host` block. A file failure shouldn't block
+        // destroy.
         try {
-          await removeAgentboxSshAlias(agentboxAliasFor(box.name));
+          await syncAgentboxSshConfig();
         } catch {
           /* best-effort */
         }

--- a/apps/cli/src/commands/shell.ts
+++ b/apps/cli/src/commands/shell.ts
@@ -24,8 +24,9 @@ import {
 import { resolveBoxOrExit, resolveBoxOrShift } from '../box-ref.js';
 import { providerForBox } from '../provider/registry.js';
 import { resolveCloudSshTarget } from '../cloud-ssh.js';
+import { recordBoxSsh } from '@agentbox/sandbox-core';
 import { hyperlink } from '../hyperlink.js';
-import { hasUnmanagedHostConflict, writeAgentboxSshAlias } from '../ssh-config.js';
+import { agentboxSshConfigPath, hasUnmanagedHostConflict, syncAgentboxSshConfig } from '../ssh-config.js';
 import { runWrappedAttach } from '../wrapped-pty/index.js';
 import { handleLifecycleError } from './_errors.js';
 import { requireDockerProvider } from './_provider-guard.js';
@@ -241,12 +242,12 @@ async function runSshConfig(box: BoxRecord, opts: ShellOptions): Promise<void> {
     );
   }
 
-  await writeAgentboxSshAlias({
-    alias: conn.alias,
-    hostname: conn.host,
+  await recordBoxSsh(box.id, {
+    host: conn.host,
     user: conn.user,
     identityFile: conn.identityFile,
   });
+  await syncAgentboxSshConfig();
 
   const codexUrl = `codex://settings/connections/ssh/add?name=${encodeURIComponent(conn.alias)}`;
   if (opts.json) {
@@ -269,7 +270,7 @@ async function runSshConfig(box: BoxRecord, opts: ShellOptions): Promise<void> {
 
   const codexLink = hyperlink(`Add ${conn.alias} to Codex SSH`, codexUrl, process.stdout);
   const lines = [
-    `wrote ~/.ssh/config alias "${conn.alias}"`,
+    `wrote ${agentboxSshConfigPath()} entry "${conn.alias}" (Include'd from ~/.ssh/config)`,
     ``,
     `ssh alias:      ${conn.alias}`,
     `host:           ${conn.host}`,

--- a/apps/cli/src/commands/shell.ts
+++ b/apps/cli/src/commands/shell.ts
@@ -233,12 +233,14 @@ async function runSshConfig(box: BoxRecord, opts: ShellOptions): Promise<void> {
     );
   }
   // The alias is the bare box name; warn (don't fail) if the user already has
-  // their own `Host <name>` — OpenSSH would let the earlier entry shadow ours.
+  // their own `Host <name>`. Our managed `Include` is prepended, so OpenSSH
+  // (first value per keyword) now applies agentbox's entry — silently shadowing
+  // the user's, which may not be what they expect.
   if (await hasUnmanagedHostConflict(conn.alias)) {
     log.warn(
-      `~/.ssh/config already has a non-agentbox \`Host ${conn.alias}\` entry. SSH uses the ` +
-        `first value per keyword, so it may override agentbox's HostName/IdentityFile — ` +
-        `remove it (or rename the box) if \`ssh ${conn.alias}\` doesn't reach the box.`,
+      `~/.ssh/config already has a non-agentbox \`Host ${conn.alias}\` entry. agentbox's ` +
+        `Include is prepended, so SSH applies agentbox's HostName/IdentityFile first and your ` +
+        `entry is ignored — rename the box (or remove your entry) if you meant yours to win.`,
     );
   }
 

--- a/apps/cli/src/commands/start.ts
+++ b/apps/cli/src/commands/start.ts
@@ -1,7 +1,9 @@
+import { loadEffectiveConfig } from '@agentbox/config';
 import { startBox } from '@agentbox/sandbox-docker';
 import { Command } from 'commander';
 import { restoreAgentSessions } from '../agent-sessions.js';
 import { resolveBoxOrExit } from '../box-ref.js';
+import { autoWriteSshConfig } from '../cloud-ssh.js';
 import { providerForBox } from '../provider/registry.js';
 import { handleLifecycleError } from './_errors.js';
 
@@ -28,6 +30,10 @@ export const startCommand = new Command('start')
         const provider = await providerForBox(box);
         const record = await provider.start(box);
         process.stdout.write(`started ${box.name}\n`);
+        // Refresh the box's `~/.agentbox/ssh/config` entry — a cloud box's public
+        // IP can change across stop/start, so re-resolve now it's back online.
+        const cfg = await loadEffectiveConfig(record.workspacePath);
+        await autoWriteSshConfig(record, cfg.effective.ssh.autoConfig);
         await restoreAgentSessions(record, provider, {
           onLog: (line) => process.stdout.write(`${line}\n`),
         });

--- a/apps/cli/src/commands/unpause.ts
+++ b/apps/cli/src/commands/unpause.ts
@@ -1,7 +1,9 @@
+import { loadEffectiveConfig } from '@agentbox/config';
 import { unpauseBox } from '@agentbox/sandbox-docker';
 import { Command } from 'commander';
 import { restoreAgentSessions } from '../agent-sessions.js';
 import { resolveBoxOrExit } from '../box-ref.js';
+import { autoWriteSshConfig } from '../cloud-ssh.js';
 import { providerForBox } from '../provider/registry.js';
 import { handleLifecycleError } from './_errors.js';
 
@@ -28,6 +30,10 @@ export const unpauseCommand = new Command('unpause')
         const provider = await providerForBox(box);
         await provider.resume(box);
         process.stdout.write(`unpaused ${box.name}\n`);
+        // Refresh the box's `~/.agentbox/ssh/config` entry — a cloud box's public
+        // IP can change across pause/resume, so re-resolve now it's back online.
+        const cfg = await loadEffectiveConfig(box.workspacePath);
+        await autoWriteSshConfig(box, cfg.effective.ssh.autoConfig);
         await restoreAgentSessions(box, provider, {
           onLog: (line) => process.stdout.write(`${line}\n`),
         });

--- a/apps/cli/src/ssh-config.ts
+++ b/apps/cli/src/ssh-config.ts
@@ -1,14 +1,21 @@
 import { promises as fs } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { readState } from '@agentbox/sandbox-core';
 
 /**
- * Host-side helper for maintaining one `Host <alias>` block per cloud box in
- * `~/.ssh/config`. Daytona's SSH gateway authenticates per-token (the User
- * field carries an ephemeral 60-min token from `sb.createSshAccess(60)`), so
- * we rewrite the block every `agentbox code` invocation to keep the alias
- * mapped to a live token. BEGIN/END markers around each managed block let us
- * coexist with user-authored entries.
+ * Host-side SSH-config manager for cloud boxes. AgentBox owns a dedicated file
+ * `~/.agentbox/ssh/config` holding one `Host <alias>` block per SSH-capable box,
+ * and injects a single managed `Include ~/.agentbox/ssh/config` line into the
+ * user's `~/.ssh/config` — so our churn stays out of their hand-maintained
+ * config. The owned file is regenerated wholesale from `state.json`
+ * (`syncAgentboxSshConfig`), which self-heals stale/destroyed boxes and reads
+ * only persisted state (no provider calls, never wakes a paused box).
+ *
+ * Daytona's SSH gateway authenticates per-token (the User field carries an
+ * ephemeral 60-min token from `sb.createSshAccess(60)`), so `agentbox code`
+ * re-resolves + re-syncs on every invocation to keep the alias mapped to a live
+ * token.
  */
 
 export interface SshAliasOptions {
@@ -32,6 +39,18 @@ function sshConfigPath(): string {
   return join(homedir(), '.ssh', 'config');
 }
 
+/** AgentBox-owned SSH config file `Include`d from `~/.ssh/config`. */
+export function agentboxSshConfigPath(): string {
+  return join(homedir(), '.agentbox', 'ssh', 'config');
+}
+
+function stateFilePath(): string {
+  return join(homedir(), '.agentbox', 'state.json');
+}
+
+const INCLUDE_BEGIN = '# BEGIN agentbox ssh include';
+const INCLUDE_END = '# END agentbox ssh include';
+
 function beginMarker(alias: string): string {
   return `# BEGIN agentbox cloud box ${alias}`;
 }
@@ -51,32 +70,13 @@ export function agentboxAliasFor(boxName: string): string {
   return boxName;
 }
 
-async function readConfig(): Promise<string> {
+async function readFileOrEmpty(path: string): Promise<string> {
   try {
-    return await fs.readFile(sshConfigPath(), 'utf8');
+    return await fs.readFile(path, 'utf8');
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return '';
     throw err;
   }
-}
-
-/**
- * Strip an existing managed block for `alias`. Returns the file contents with
- * any block bracketed by our BEGIN/END markers for this alias removed.
- *
- * Anchored at the start of a line (`m` flag) so the preceding newline stays
- * attached to whatever came before — removing a block between two pieces of
- * content must not collapse the separating newline.
- */
-function stripBlock(contents: string, alias: string): string {
-  const begin = beginMarker(alias);
-  const end = endMarker(alias);
-  const escape = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const pattern = new RegExp(
-    `^${escape(begin)}\\n[\\s\\S]*?${escape(end)}\\n?`,
-    'gm',
-  );
-  return contents.replace(pattern, '');
 }
 
 function buildBlock(opts: SshAliasOptions): string {
@@ -107,38 +107,86 @@ function buildBlock(opts: SshAliasOptions): string {
 }
 
 /**
- * Pre-`agentbox-cloud-<box>` → `<box>` rename, managed blocks were keyed by
- * `agentbox-cloud-<box>`. We strip that block whenever we rewrite/remove the
- * box's alias so upgrades don't leave a stale duplicate Host entry behind.
+ * Old versions wrote per-box `# BEGIN agentbox cloud box <alias>` … `# END …`
+ * blocks directly into `~/.ssh/config`. We now own `~/.agentbox/ssh/config`, so
+ * strip any such inline leftovers whenever we touch `~/.ssh/config`. AgentBox is
+ * unreleased → clean removal, no deprecation shim.
  */
-function legacyAliasFor(alias: string): string {
-  return `agentbox-cloud-${alias}`;
+function stripLegacyInlineBlocks(contents: string): string {
+  const pattern =
+    /^# BEGIN agentbox cloud box .*\n[\s\S]*?^# END agentbox cloud box .*\n?/gm;
+  return contents.replace(pattern, '');
 }
 
-export async function writeAgentboxSshAlias(opts: SshAliasOptions): Promise<void> {
+function hasIncludeBlock(contents: string): boolean {
+  return (
+    contents.includes(INCLUDE_BEGIN) || contents.includes(`Include ${agentboxSshConfigPath()}`)
+  );
+}
+
+/**
+ * Ensure `~/.ssh/config` contains exactly one managed `Include
+ * ~/.agentbox/ssh/config` block, prepended to the top. Prepend (not append)
+ * because OpenSSH applies the first value it sees per keyword — putting the
+ * Include first lets AgentBox's box entries win over any later user `Host *`
+ * defaults. Also strips any legacy inline per-box blocks. Idempotent.
+ */
+export async function ensureSshInclude(): Promise<void> {
   const path = sshConfigPath();
   await fs.mkdir(join(homedir(), '.ssh'), { recursive: true, mode: 0o700 });
-  const existing = await readConfig();
-  const stripped = stripBlock(stripBlock(existing, opts.alias), legacyAliasFor(opts.alias));
-  const separator = stripped.length === 0 || stripped.endsWith('\n') ? '' : '\n';
-  const next = `${stripped}${separator}${buildBlock(opts)}`;
+  const existing = stripLegacyInlineBlocks(await readFileOrEmpty(path));
+  let next = existing;
+  if (!hasIncludeBlock(existing)) {
+    const block = `${INCLUDE_BEGIN}\nInclude ${agentboxSshConfigPath()}\n${INCLUDE_END}\n`;
+    next = existing.length === 0 ? block : `${block}\n${existing}`;
+  }
   await fs.writeFile(path, next, { mode: 0o600 });
   // Re-assert mode in case the file existed with broader perms.
   await fs.chmod(path, 0o600);
 }
 
 /**
- * True when `~/.ssh/config` already has a user-authored `Host <alias>` stanza
- * OUTSIDE our managed block. Because the alias is now the bare box name, such a
- * collision matters: OpenSSH applies the first value it sees per keyword, so an
- * earlier user entry can shadow the HostName/IdentityFile/User we append.
+ * Regenerate the AgentBox-owned `~/.agentbox/ssh/config` from `state.json`: one
+ * `Host <name>` block per box that carries a resolved `cloud.ssh` target. Reads
+ * only persisted state — no provider calls, never wakes a paused box — so a
+ * destroyed box's block simply disappears on the next sync. Also ensures the
+ * `Include` line in `~/.ssh/config`.
+ */
+export async function syncAgentboxSshConfig(statePath: string = stateFilePath()): Promise<void> {
+  const state = await readState(statePath);
+  const blocks: string[] = [];
+  for (const box of state.boxes) {
+    const ssh = box.cloud?.ssh;
+    if (!ssh) continue;
+    blocks.push(
+      buildBlock({
+        alias: agentboxAliasFor(box.name),
+        hostname: ssh.host,
+        user: ssh.user,
+        identityFile: ssh.identityFile,
+      }),
+    );
+  }
+  const header =
+    '# Managed by agentbox — regenerated on box create/start/destroy.\n' +
+    '# Do not edit; changes are overwritten. Disable with `agentbox config set ssh.autoConfig false`.\n\n';
+  const path = agentboxSshConfigPath();
+  await fs.mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  await fs.writeFile(path, header + blocks.join('\n'), { mode: 0o600 });
+  await fs.chmod(path, 0o600);
+  await ensureSshInclude();
+}
+
+/**
+ * True when `~/.ssh/config` has a user-authored `Host <alias>` stanza. With the
+ * Include prepended, AgentBox's entry is read first so it wins — but a foreign
+ * `Host <alias>` is still worth flagging to the user in case they expected their
+ * own entry to take effect.
  */
 export async function hasUnmanagedHostConflict(alias: string): Promise<boolean> {
-  const contents = await readConfig();
+  const contents = stripLegacyInlineBlocks(await readFileOrEmpty(sshConfigPath()));
   if (contents === '') return false;
-  // Drop our managed block first so we only see foreign `Host` lines.
-  const foreign = stripBlock(contents, alias);
-  return foreign.split('\n').some((line) => {
+  return contents.split('\n').some((line) => {
     const m = /^\s*Host\s+(.+?)\s*$/.exec(line);
     if (!m) return false;
     return m[1]!.split(/\s+/).includes(alias);
@@ -182,15 +230,15 @@ export function parseSshTarget(argv: readonly string[]): SshTarget | undefined {
 
 /**
  * Read back the `HostName` / `IdentityFile` from the managed block for `alias`
- * in `~/.ssh/config`, if one exists. Used by `inspect` to surface the SSH
- * connection details without re-deriving them from a provider (which would
+ * in `~/.agentbox/ssh/config`, if one exists. Used by `inspect` to surface the
+ * SSH connection details without re-deriving them from a provider (which would
  * require bringing the box online). Returns undefined when no managed block is
  * present for the alias.
  */
 export async function readAgentboxSshAlias(
   alias: string,
 ): Promise<{ hostName?: string; identityFile?: string } | undefined> {
-  const contents = await readConfig();
+  const contents = await readFileOrEmpty(agentboxSshConfigPath());
   if (contents === '') return undefined;
   const begin = beginMarker(alias);
   const end = endMarker(alias);
@@ -201,13 +249,4 @@ export async function readAgentboxSshAlias(
   const field = (name: string): string | undefined =>
     new RegExp(`^\\s*${name}\\s+(.+)$`, 'm').exec(body)?.[1]?.trim();
   return { hostName: field('HostName'), identityFile: field('IdentityFile') };
-}
-
-export async function removeAgentboxSshAlias(alias: string): Promise<void> {
-  const path = sshConfigPath();
-  const existing = await readConfig();
-  if (existing === '') return;
-  const next = stripBlock(stripBlock(existing, alias), legacyAliasFor(alias));
-  if (next === existing) return; // no managed block matched
-  await fs.writeFile(path, next, { mode: 0o600 });
 }

--- a/apps/cli/test/ssh-config.test.ts
+++ b/apps/cli/test/ssh-config.test.ts
@@ -5,11 +5,12 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   agentboxAliasFor,
+  agentboxSshConfigPath,
+  ensureSshInclude,
   hasUnmanagedHostConflict,
   parseSshTarget,
   readAgentboxSshAlias,
-  removeAgentboxSshAlias,
-  writeAgentboxSshAlias,
+  syncAgentboxSshConfig,
 } from '../src/ssh-config.js';
 
 describe('agentboxAliasFor', () => {
@@ -47,14 +48,16 @@ describe('parseSshTarget', () => {
   });
 });
 
-describe('writeAgentboxSshAlias', () => {
+describe('syncAgentboxSshConfig + Include model', () => {
   let tmp: string;
   let prevHome: string | undefined;
 
   beforeEach(() => {
     tmp = mkdtempSync(join(tmpdir(), 'ab-ssh-cfg-'));
-    // On POSIX, `os.homedir()` falls back to `$HOME` when set, which is the
-    // hook we use to point the writer at a sandboxed dir.
+    // On POSIX, `os.homedir()` falls back to `$HOME` when set — the hook that
+    // points the writer (and `state.json` reader) at a sandboxed home. Critical:
+    // apps/cli tests share the real HOME by default, so a stray write here would
+    // clobber the user's ~/.ssh and ~/.agentbox.
     prevHome = process.env.HOME;
     process.env.HOME = tmp;
   });
@@ -65,118 +68,140 @@ describe('writeAgentboxSshAlias', () => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  async function readCfg(): Promise<string> {
-    return fs.readFile(join(tmp, '.ssh', 'config'), 'utf8');
+  async function writeState(boxes: unknown[]): Promise<void> {
+    await fs.mkdir(join(tmp, '.agentbox'), { recursive: true });
+    await fs.writeFile(
+      join(tmp, '.agentbox', 'state.json'),
+      JSON.stringify({ version: 1, boxes }, null, 2),
+    );
   }
+  const readOwned = (): Promise<string> => fs.readFile(agentboxSshConfigPath(), 'utf8');
+  const readSsh = (): Promise<string> => fs.readFile(join(tmp, '.ssh', 'config'), 'utf8');
 
-  it('emits IdentityFile + IdentitiesOnly when identityFile is set (Hetzner)', async () => {
-    await writeAgentboxSshAlias({
-      alias: agentboxAliasFor('hz-box'),
-      hostname: '1.2.3.4',
-      user: 'vscode',
-      identityFile: '/box/key',
-    });
-    const cfg = await readCfg();
-    expect(cfg).toContain('Host hz-box');
-    expect(cfg).toContain('  IdentityFile /box/key');
+  const hzBox = (name: string, host: string): Record<string, unknown> => ({
+    id: `id-${name}`,
+    name,
+    provider: 'hetzner',
+    container: `cloud:${name}`,
+    image: 'snap',
+    workspacePath: '/x',
+    createdAt: 'now',
+    cloud: {
+      backend: 'hetzner',
+      sandboxId: name,
+      ssh: { host, user: 'vscode', identityFile: `/box/${name}/key` },
+    },
+  });
+
+  it('writes one Host block per box with a resolved cloud.ssh target', async () => {
+    await writeState([hzBox('hz1', '1.2.3.4'), hzBox('hz2', '5.6.7.8')]);
+    await syncAgentboxSshConfig();
+    const cfg = await readOwned();
+    expect(cfg).toContain('Host hz1');
+    expect(cfg).toContain('  HostName 1.2.3.4');
+    expect(cfg).toContain('  IdentityFile /box/hz1/key');
     expect(cfg).toContain('  IdentitiesOnly yes');
+    expect(cfg).toContain('Host hz2');
+    expect(cfg).toContain('  HostName 5.6.7.8');
   });
 
-  it('omits IdentityFile lines when identityFile is undefined (Daytona)', async () => {
-    await writeAgentboxSshAlias({
-      alias: agentboxAliasFor('dt-box'),
-      hostname: 'ssh.app.daytona.io',
-      user: 'tok_abc',
-    });
-    const cfg = await readCfg();
-    expect(cfg).toContain('Host dt-box');
-    expect(cfg).not.toContain('IdentityFile');
-    expect(cfg).not.toContain('IdentitiesOnly');
+  it('skips docker boxes and cloud boxes without a resolved cloud.ssh', async () => {
+    await writeState([
+      hzBox('hz1', '1.2.3.4'),
+      {
+        id: 'id-dk',
+        name: 'dk',
+        provider: 'docker',
+        container: 'agentbox-dk',
+        image: 'i',
+        workspacePath: '/x',
+        createdAt: 'now',
+        docker: { image: 'i' },
+      },
+      {
+        id: 'id-nossh',
+        name: 'nossh',
+        provider: 'hetzner',
+        container: 'cloud:nossh',
+        image: 'i',
+        workspacePath: '/x',
+        createdAt: 'now',
+        cloud: { backend: 'hetzner', sandboxId: 'nossh' },
+      },
+    ]);
+    await syncAgentboxSshConfig();
+    const cfg = await readOwned();
+    expect(cfg).toContain('Host hz1');
+    expect(cfg).not.toContain('Host dk');
+    expect(cfg).not.toContain('Host nossh');
   });
 
-  it('rewrites in place (no duplicate blocks across calls)', async () => {
-    const opts = {
-      alias: agentboxAliasFor('hz-box'),
-      hostname: '1.2.3.4',
-      user: 'vscode',
-      identityFile: '/box/key-v1',
-    };
-    await writeAgentboxSshAlias(opts);
-    await writeAgentboxSshAlias({ ...opts, identityFile: '/box/key-v2' });
-    const cfg = await readCfg();
-    const beginCount = cfg.split('# BEGIN agentbox cloud box hz-box').length - 1;
-    expect(beginCount).toBe(1);
-    expect(cfg).toContain('/box/key-v2');
-    expect(cfg).not.toContain('/box/key-v1');
+  it('adds a single managed Include block to ~/.ssh/config, idempotently', async () => {
+    await writeState([hzBox('hz1', '1.2.3.4')]);
+    await syncAgentboxSshConfig();
+    await syncAgentboxSshConfig();
+    const ssh = await readSsh();
+    expect(ssh.split(`Include ${agentboxSshConfigPath()}`).length - 1).toBe(1);
+    expect(ssh.split('# BEGIN agentbox ssh include').length - 1).toBe(1);
   });
 
-  it('removeAgentboxSshAlias strips the managed block and leaves others alone', async () => {
-    await writeAgentboxSshAlias({
-      alias: agentboxAliasFor('hz-box'),
-      hostname: '1.2.3.4',
-      user: 'vscode',
-      identityFile: '/box/key',
-    });
-    await writeAgentboxSshAlias({
-      alias: agentboxAliasFor('dt-box'),
-      hostname: 'ssh.app.daytona.io',
-      user: 'tok_abc',
-    });
-    await removeAgentboxSshAlias(agentboxAliasFor('hz-box'));
-    const cfg = await readCfg();
-    expect(cfg).not.toContain('Host hz-box');
-    expect(cfg).toContain('Host dt-box');
+  it('prepends the Include above existing user content, preserving it', async () => {
+    await fs.mkdir(join(tmp, '.ssh'), { recursive: true });
+    await fs.writeFile(join(tmp, '.ssh', 'config'), 'Host myserver\n  HostName 9.9.9.9\n');
+    await writeState([hzBox('hz1', '1.2.3.4')]);
+    await syncAgentboxSshConfig();
+    const ssh = await readSsh();
+    expect(ssh.indexOf('# BEGIN agentbox ssh include')).toBeLessThan(ssh.indexOf('Host myserver'));
+    expect(ssh).toContain('Host myserver');
   });
 
-  it('readAgentboxSshAlias returns HostName + IdentityFile from a written block', async () => {
-    await writeAgentboxSshAlias({
-      alias: agentboxAliasFor('hz-box'),
-      hostname: '1.2.3.4',
-      user: 'vscode',
-      identityFile: '/box/key',
-    });
-    expect(await readAgentboxSshAlias(agentboxAliasFor('hz-box'))).toEqual({
+  it('strips legacy inline `agentbox cloud box` blocks, keeping user blocks', async () => {
+    await fs.mkdir(join(tmp, '.ssh'), { recursive: true });
+    const legacy =
+      '# BEGIN agentbox cloud box old\nHost old\n  HostName 7.7.7.7\n# END agentbox cloud box old\n';
+    await fs.writeFile(
+      join(tmp, '.ssh', 'config'),
+      legacy + 'Host keepme\n  HostName 8.8.8.8\n',
+    );
+    await writeState([hzBox('hz1', '1.2.3.4')]);
+    await syncAgentboxSshConfig();
+    const ssh = await readSsh();
+    expect(ssh).not.toContain('# BEGIN agentbox cloud box old');
+    expect(ssh).not.toContain('Host old');
+    expect(ssh).toContain('Host keepme');
+  });
+
+  it('regenerate drops a box no longer in state', async () => {
+    await writeState([hzBox('hz1', '1.2.3.4'), hzBox('hz2', '5.6.7.8')]);
+    await syncAgentboxSshConfig();
+    await writeState([hzBox('hz1', '1.2.3.4')]);
+    await syncAgentboxSshConfig();
+    const cfg = await readOwned();
+    expect(cfg).toContain('Host hz1');
+    expect(cfg).not.toContain('Host hz2');
+  });
+
+  it('readAgentboxSshAlias returns HostName + IdentityFile from the owned file', async () => {
+    await writeState([hzBox('hz1', '1.2.3.4')]);
+    await syncAgentboxSshConfig();
+    expect(await readAgentboxSshAlias('hz1')).toEqual({
       hostName: '1.2.3.4',
-      identityFile: '/box/key',
+      identityFile: '/box/hz1/key',
     });
-    expect(await readAgentboxSshAlias('no-such-box')).toBeUndefined();
+    expect(await readAgentboxSshAlias('nope')).toBeUndefined();
   });
 
-  it('migrates away a legacy `agentbox-cloud-<box>` block on rewrite', async () => {
-    // Simulate a block written by an older release keyed on the legacy alias.
-    await writeAgentboxSshAlias({
-      alias: 'agentbox-cloud-hz-box',
-      hostname: '9.9.9.9',
-      user: 'vscode',
-      identityFile: '/box/old-key',
-    });
-    // Now write under the new box-name alias.
-    await writeAgentboxSshAlias({
-      alias: agentboxAliasFor('hz-box'),
-      hostname: '1.2.3.4',
-      user: 'vscode',
-      identityFile: '/box/key',
-    });
-    const cfg = await readCfg();
-    expect(cfg).not.toContain('agentbox-cloud-hz-box');
-    expect(cfg).not.toContain('9.9.9.9');
-    expect(cfg).toContain('Host hz-box');
-    expect(cfg).toContain('1.2.3.4');
-  });
-
-  it('hasUnmanagedHostConflict detects a user-authored Host but ignores our block', async () => {
-    // Our own managed block is not a conflict.
-    await writeAgentboxSshAlias({
-      alias: agentboxAliasFor('hz-box'),
-      hostname: '1.2.3.4',
-      user: 'vscode',
-      identityFile: '/box/key',
-    });
-    expect(await hasUnmanagedHostConflict('hz-box')).toBe(false);
-    expect(await hasUnmanagedHostConflict('mybox')).toBe(false);
-
-    // A user-authored stanza for the same alias IS a conflict.
+  it('hasUnmanagedHostConflict flags a user-authored Host but not our Include', async () => {
+    await writeState([hzBox('hz1', '1.2.3.4')]);
+    await syncAgentboxSshConfig();
+    expect(await hasUnmanagedHostConflict('hz1')).toBe(false);
     await fs.appendFile(join(tmp, '.ssh', 'config'), '\nHost mybox other\n  HostName 5.6.7.8\n');
     expect(await hasUnmanagedHostConflict('mybox')).toBe(true);
+  });
+
+  it('ensureSshInclude adds the Include even with no boxes yet', async () => {
+    await ensureSshInclude();
+    const ssh = await readSsh();
+    expect(ssh).toContain(`Include ${agentboxSshConfigPath()}`);
   });
 });

--- a/apps/web/content/docs/configuration.mdx
+++ b/apps/web/content/docs/configuration.mdx
@@ -228,6 +228,25 @@ The permission-skip defaults are on precisely because each box is a throwaway sa
 
 See [access your box](/docs/access-your-box).
 
+## ssh
+
+| Key | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `ssh.autoConfig` | bool | `true` | auto-maintain `~/.agentbox/ssh/config` (Include'd from `~/.ssh/config`) for SSH-capable cloud boxes |
+
+For providers that reach a box over plain SSH with a persistent per-box key
+(**Hetzner**, and DigitalOcean once wired), AgentBox writes one `Host <box-name>`
+entry per box into its own `~/.agentbox/ssh/config` file and adds a single
+`Include ~/.agentbox/ssh/config` line to the top of your `~/.ssh/config` — so
+`ssh <box-name>` (and VS Code Remote-SSH, Codex, Claude desktop) just works
+without touching the rest of your config. The file is regenerated from box state
+on **create** and on **start/resume** (a cloud box's public IP can change across
+stop/start), and a box's entry is dropped on `destroy`. Set `ssh.autoConfig` to
+`false` if you manage `~/.ssh/config` yourself; the explicit
+`agentbox shell <box> --ssh-config`, `agentbox code`, and `agentbox open`
+commands still write the entry on demand. Docker boxes (no SSH) and Daytona
+(60-minute token auth, no persistent key) are never auto-added.
+
 ## browser
 
 | Key | Type | Default | Meaning |

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -149,6 +149,9 @@ export interface UserConfig {
     login?: boolean;
     tmux?: boolean;
   };
+  ssh?: {
+    autoConfig?: boolean;
+  };
   engine?: {
     kind?: EngineKind;
   };
@@ -288,6 +291,9 @@ export interface EffectiveConfig {
     user: string;
     login: boolean;
     tmux: boolean;
+  };
+  ssh: {
+    autoConfig: boolean;
   };
   engine: {
     kind: EngineKind;
@@ -441,6 +447,9 @@ export const BUILT_IN_DEFAULTS: EffectiveConfig = {
     user: 'vscode',
     login: true,
     tmux: true,
+  },
+  ssh: {
+    autoConfig: true,
   },
   engine: {
     kind: 'auto',
@@ -796,6 +805,12 @@ export const KEY_REGISTRY: readonly KeyDescriptor[] = [
     key: 'shell.tmux',
     type: 'bool',
     description: 'Run `agentbox shell` inside a detachable tmux session (Ctrl+a d to detach).',
+  },
+  {
+    key: 'ssh.autoConfig',
+    type: 'bool',
+    description:
+      'Automatically write a `~/.agentbox/ssh/config` entry (Include\'d from `~/.ssh/config`) for SSH-capable cloud boxes on create and start/resume, so `ssh <box>` just works. On by default; set false if you manage `~/.ssh/config` yourself. Explicit `agentbox shell --ssh-config`/`code`/`open` still write on demand regardless.',
   },
   {
     key: 'engine.kind',

--- a/packages/core/src/box-record.ts
+++ b/packages/core/src/box-record.ts
@@ -164,6 +164,16 @@ export interface CloudBoxFields {
    * correctly even if the host config changed. Mirrors config's `GitPushMode`.
    */
   gitPushMode?: 'auto' | 'relay' | 'lease';
+  /**
+   * Last resolved SSH connection target for this box (host/user, plus the
+   * per-box identity file for identity-authed providers like Hetzner). Persisted
+   * whenever we're already online (create/start/code/open/shell) so the
+   * `~/.agentbox/ssh/config` file can be regenerated purely from state — the
+   * regenerate never hits a provider API or wakes a paused box. The host IP can
+   * change across stop/start, so this is refreshed on start/resume. Absent for
+   * providers with no SSH.
+   */
+  ssh?: { host: string; user: string; identityFile?: string };
 }
 
 export interface GitWorktreeRecord {

--- a/packages/sandbox-core/src/index.ts
+++ b/packages/sandbox-core/src/index.ts
@@ -7,6 +7,7 @@ export {
   mutateState,
   readState,
   recordBox,
+  recordBoxSsh,
   recordLastAgent,
   removeBoxRecord,
   reserveProjectIndex,

--- a/packages/sandbox-core/src/state.ts
+++ b/packages/sandbox-core/src/state.ts
@@ -157,6 +157,29 @@ export async function recordLastAgent(
 }
 
 /**
+ * Persist a cloud box's last resolved SSH target (`box.cloud.ssh`). A locked
+ * read-modify-write so it can't clobber a concurrent state change. No-op when
+ * the box isn't in state (a race with `destroy`) or isn't a cloud record.
+ * `syncAgentboxSshConfig` reads this back to regenerate `~/.agentbox/ssh/config`
+ * offline, without re-resolving the target from the provider.
+ */
+export async function recordBoxSsh(
+  boxId: string,
+  ssh: { host: string; user: string; identityFile?: string },
+  path: string = STATE_FILE,
+): Promise<void> {
+  await mutateState(
+    (state) => ({
+      version: 1,
+      boxes: state.boxes.map((b) =>
+        b.id === boxId && b.cloud ? { ...b, cloud: { ...b.cloud, ssh } } : b,
+      ),
+    }),
+    path,
+  );
+}
+
+/**
  * Atomically allocate the next per-project index AND persist `record` claiming
  * it, under the state lock. Returns the reserved index (also stamped onto the
  * persisted record).


### PR DESCRIPTION
## What

Redirect per-box SSH \`Host\` blocks out of \`~/.ssh/config\` into an AgentBox-owned \`~/.agentbox/ssh/config\`, referenced by a single managed \`Include\` line prepended to the top of \`~/.ssh/config\`. Make it **default-on** (gated by a new \`ssh.autoConfig\` config key) so \`ssh <box>\` just works after create, without touching the user's hand-maintained config.

Applies to providers that reach a box over plain SSH with a persistent per-box key: **Hetzner** today, DigitalOcean once wired.

## How

- **Owned file, regenerated wholesale** from \`state.json\` (\`syncAgentboxSshConfig\`): one \`Host <box>\` block per box that has a resolved \`cloud.ssh\` target. Self-heals stale/destroyed boxes; reads only persisted state (no provider calls, never wakes a paused box).
- **Persisted target** — new \`box.cloud.ssh = { host, user, identityFile? }\` field + \`recordBoxSsh\` state helper, written whenever we're already online.
- **Include model** — \`~/.ssh/config\` only ever gets one managed \`# BEGIN/END agentbox ssh include\` block (\`Include ~/.agentbox/ssh/config\`), prepended so AgentBox entries win first-match. Legacy inline per-box blocks are stripped on next touch (AgentBox is unreleased — clean removal, no deprecation shim).
- **Default-on** via \`ssh.autoConfig\` (bool, default \`true\`): auto-writes on **create** and **start/resume** (refreshes a changed public IP). Explicit \`shell --ssh-config\` / \`code\` / \`open\` still write on demand regardless of the toggle. Docker (no SSH) and Daytona (60-min token) are skipped.

## Files

\`apps/cli/src/ssh-config.ts\` (rewritten), \`cloud-ssh.ts\`, \`commands/{create,start,unpause,shell,destroy}.ts\`, \`packages/core/src/box-record.ts\`, \`packages/sandbox-core/src/state.ts\` (+ index), \`packages/config/src/types.ts\` (4-spot key), \`apps/web/content/docs/configuration.mdx\`, reworked HOME-isolated \`test/ssh-config.test.ts\`.

## Verification

- 13 real-filesystem unit tests; full CLI suite (670); config schema-drift; typecheck + lint — all green.
- **Live Hetzner cycle:** create → correct owned-file block + single top-of-file Include + persisted \`cloud.ssh\` → real \`ssh <box>\` connected as \`vscode\` → \`ssh -G\` confirms existing user config still parses → stop/start refreshed + reconnected → destroy dropped the block (Include retained) → no orphan server/SSH-dir left behind.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The PR modifies the user’s `~/.ssh/config` (managed Include) and regenerates SSH host entries from state; mistakes could break `ssh <box>` or shadow user stanzas, though scope is limited and `ssh.autoConfig` allows opt-out.
> 
> **Overview**
> Moves cloud box SSH entries out of inline edits to `~/.ssh/config` into a dedicated **`~/.agentbox/ssh/config`**, wired in via a single managed **`Include`** block prepended to the user’s `~/.ssh/config`. **`syncAgentboxSshConfig`** rebuilds that file from **`state.json`** (one `Host <box-name>` per box with persisted **`box.cloud.ssh`**), so destroy and stale boxes drop off without per-alias removal; legacy inline `agentbox cloud box` blocks are stripped on touch.
> 
> **`recordBoxSsh`** persists `{ host, user, identityFile? }` whenever SSH is resolved online; **`ensureCloudSshAlias`** / **`shell --ssh-config`** now record + sync instead of **`writeAgentboxSshAlias`**. New **`ssh.autoConfig`** (default **`true`**) drives **`autoWriteSshConfig`** on cloud **create**, **start**, and **unpause** (skips Docker and providers without a persistent identity file, e.g. Daytona); explicit **`code`** / **`open`** / **`shell --ssh-config`** still write regardless. Cloud **destroy** calls **`syncAgentboxSshConfig`** instead of **`removeAgentboxSshAlias`**. Config types, **`KEY_REGISTRY`**, docs, and HOME-isolated tests updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75432cbe40b202271a07ec5f108bf3c60e3f6fd4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->