### PR TITLE
rename(cli): tray app AgentBoxTray → AgentBox

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -13,13 +13,20 @@ CLI, not the raw commits.
 
 ### Added
 
-- **`agentbox app log`** — collect the macOS tray app's diagnostics for a bug
-  report. Reads the tray's macOS unified-log entries (`--last <window>`, `-f` to
+- **`agentbox app log`** — collect the macOS menu-bar app's diagnostics for a bug
+  report. Reads the app's macOS unified-log entries (`--last <window>`, `-f` to
   stream live, `--crashes` for crash reports only) and lists its crash reports from
   `~/Library/Logs/DiagnosticReports`; `--open` reveals that folder in Finder and
   `--out <file>` writes one self-contained bundle (versions + log + newest crash
-  report) to attach. The tray keeps no log file of its own — these are
+  report) to attach. The app keeps no log file of its own — these are
   macOS-native surfaces (unified logging + OS `.ips` crash reports).
+
+### Changed
+
+- **The macOS menu-bar app is now named "AgentBox"** (was "AgentBoxTray"). It
+  installs to `/Applications/AgentBox.app`; `agentbox install tray` removes any
+  old `AgentBoxTray.app` on install so the two never coexist. The bundle
+  identifier is unchanged, so launch-at-login and notifications carry over.
 
 ### Fixed
 

--- a/apps/cli/src/commands/app.ts
+++ b/apps/cli/src/commands/app.ts
@@ -16,7 +16,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import { AGENTBOX_VERSION } from '../version.js';
-import { APP_BUNDLE_ID, APP_NAME, APP_PATH } from './install-tray.js';
+import { APP_BUNDLE_ID, APP_NAME, APP_PATH, LEGACY_APP_NAME } from './install-tray.js';
 
 /** macOS writes app crash reports here as `AgentBox-<timestamp>.ips`. */
 const DIAGNOSTIC_REPORTS_DIR = join(homedir(), 'Library/Logs/DiagnosticReports');
@@ -30,9 +30,9 @@ function ensureMac(): boolean {
   return false;
 }
 
-/** PIDs of the running tray process, or [] if none. `pgrep` exits 1 (throws) when nothing matches. */
-async function trayPids(): Promise<number[]> {
-  const res = await execa('pgrep', ['-x', APP_NAME]).catch(() => null);
+/** PIDs of a process by exact executable name, or [] if none. `pgrep` exits 1 when nothing matches. */
+async function pidsForName(name: string): Promise<number[]> {
+  const res = await execa('pgrep', ['-x', name]).catch(() => null);
   if (!res) return [];
   return res.stdout
     .split('\n')
@@ -40,13 +40,28 @@ async function trayPids(): Promise<number[]> {
     .filter((n) => Number.isInteger(n) && n > 0);
 }
 
+/**
+ * PIDs of the running app, or [] if none. Covers both the current (`AgentBox`) and the legacy
+ * pre-rename (`AgentBoxTray`) executable names, so status/stop/restart still see a stray old process
+ * during migration.
+ */
+async function trayPids(): Promise<number[]> {
+  const [current, legacy] = await Promise.all([
+    pidsForName(APP_NAME),
+    pidsForName(LEGACY_APP_NAME),
+  ]);
+  return [...current, ...legacy];
+}
+
 async function startTray(): Promise<void> {
   await execa('open', [APP_PATH]);
 }
 
 async function stopTray(): Promise<void> {
-  // `pkill` exits 1 when there was nothing to kill — not an error for us.
+  // `pkill` exits 1 when there was nothing to kill — not an error for us. Cover the legacy
+  // pre-rename name too so `stop`/`restart` don't leave a stray old process alive.
   await execa('pkill', ['-x', APP_NAME]).catch(() => undefined);
+  await execa('pkill', ['-x', LEGACY_APP_NAME]).catch(() => undefined);
 }
 
 /** True only when the bundle is present; guard `start`/`restart` and point at the installer. */

--- a/apps/cli/src/commands/app.ts
+++ b/apps/cli/src/commands/app.ts
@@ -1,5 +1,5 @@
 /**
- * `agentbox app` — start / stop / restart / status for the AgentBox Tray macOS menu-bar app.
+ * `agentbox app` — start / stop / restart / status for the AgentBox macOS menu-bar app.
  *
  * Drives the running process directly (`open` / `pkill` / `pgrep`) without touching the installed
  * bundle — the lightweight lifecycle control the tray otherwise lacks (only `agentbox install tray`
@@ -18,7 +18,7 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { AGENTBOX_VERSION } from '../version.js';
 import { APP_BUNDLE_ID, APP_NAME, APP_PATH } from './install-tray.js';
 
-/** macOS writes app crash reports here as `AgentBoxTray-<timestamp>.ips`. */
+/** macOS writes app crash reports here as `AgentBox-<timestamp>.ips`. */
 const DIAGNOSTIC_REPORTS_DIR = join(homedir(), 'Library/Logs/DiagnosticReports');
 /** Unified-logging predicate scoping to the tray's subsystem. */
 const LOG_PREDICATE = `subsystem == "${APP_BUNDLE_ID}"`;
@@ -63,8 +63,8 @@ interface CrashReport {
   mtimeMs: number;
 }
 
-// macOS names tray reports `AgentBoxTray-<ts>.ips` (hyphen) today; allow an underscore too since
-// some report types use it. Built from APP_NAME so it stays in sync (no regex-special chars in it).
+// macOS names reports `AgentBox-<ts>.ips` (hyphen) today; allow an underscore too since some report
+// types use it. Built from APP_NAME so it stays in sync (no regex-special chars in it).
 const IPS_NAME = new RegExp(`^${APP_NAME}[-_].*\\.ips$`, 'i');
 
 /**
@@ -149,7 +149,7 @@ interface StatusOpts {
 }
 
 const statusSub = new Command('status')
-  .description('Show whether the AgentBox Tray app is running, with pid(s)')
+  .description('Show whether the AgentBox app is running, with pid(s)')
   .option('--json', 'emit { running, pids, installed, appPath } as JSON')
   .action(async (opts: StatusOpts) => {
     const mac = process.platform === 'darwin';
@@ -164,19 +164,19 @@ const statusSub = new Command('status')
     }
     if (!ensureMac()) return;
     if (pids.length) {
-      log.info(`AgentBox Tray is running (pid ${pids.join(', ')}).`);
+      log.info(`AgentBox is running (pid ${pids.join(', ')}).`);
     } else if (installed) {
-      log.info('AgentBox Tray is installed but not running.');
+      log.info('AgentBox is installed but not running.');
     } else {
-      log.warn('AgentBox Tray is not installed. Run `agentbox install tray`.');
+      log.warn('AgentBox is not installed. Run `agentbox install tray`.');
     }
   });
 
 const startSub = new Command('start')
-  .description('Launch the AgentBox Tray app if it is not already running')
+  .description('Launch the AgentBox app if it is not already running')
   .action(async () => {
     if (!ensureMac()) return;
-    intro('Starting AgentBox Tray…');
+    intro('Starting AgentBox…');
     if ((await trayPids()).length) {
       outro('Already running');
       return;
@@ -190,10 +190,10 @@ const startSub = new Command('start')
   });
 
 const stopSub = new Command('stop')
-  .description('Quit the running AgentBox Tray app (idempotent)')
+  .description('Quit the running AgentBox app (idempotent)')
   .action(async () => {
     if (!ensureMac()) return;
-    intro('Stopping AgentBox Tray…');
+    intro('Stopping AgentBox…');
     if (!(await trayPids()).length) {
       outro('Not running');
       return;
@@ -203,11 +203,11 @@ const stopSub = new Command('stop')
   });
 
 const restartSub = new Command('restart')
-  .description('Quit and relaunch the AgentBox Tray app')
+  .description('Quit and relaunch the AgentBox app')
   .action(async () => {
     if (!ensureMac()) return;
     if (!ensureInstalled()) return;
-    intro('Restarting AgentBox Tray…');
+    intro('Restarting AgentBox…');
     await stopTray();
     // Wait for the old process to actually exit before relaunching, else `open`
     // may just foreground the still-quitting instance.
@@ -313,7 +313,7 @@ async function writeBugReportBundle(outPath: string, last: string): Promise<void
   }
 
   const bundle = [
-    '# AgentBox Tray bug report',
+    '# AgentBox bug report',
     `generated (UTC): ${new Date().toISOString()}`,
     `agentbox CLI: ${cliVersion}`,
     `macOS: ${macVersion}`,
@@ -340,7 +340,7 @@ async function writeBugReportBundle(outPath: string, last: string): Promise<void
 }
 
 export const appCommand = new Command('app')
-  .description('Control the AgentBox Tray menu-bar app (status / start / stop / restart / log)')
+  .description('Control the AgentBox menu-bar app (status / start / stop / restart / log)')
   .addCommand(statusSub, { isDefault: true })
   .addCommand(startSub)
   .addCommand(stopSub)

--- a/apps/cli/src/commands/install-tray.ts
+++ b/apps/cli/src/commands/install-tray.ts
@@ -26,8 +26,9 @@ export const APP_PATH = `/Applications/${APP_NAME}.app`;
 export const APP_BUNDLE_ID = 'com.madarco.agentbox-tray';
 
 // The app was renamed AgentBoxTray.app → AgentBox.app but kept its bundle id. A leftover old bundle
-// would collide (two bundles, one id), so remove it on install/uninstall.
-const LEGACY_APP_NAME = 'AgentBoxTray';
+// would collide (two bundles, one id), so remove it on install/uninstall. `agentbox app` also uses
+// LEGACY_APP_NAME so status/stop/restart still see a stray pre-rename process during migration.
+export const LEGACY_APP_NAME = 'AgentBoxTray';
 const LEGACY_APP_PATH = `/Applications/${LEGACY_APP_NAME}.app`;
 
 // Overridable for forks/testing; default is the public agentbox repo's moving tray release.

--- a/apps/cli/src/commands/install-tray.ts
+++ b/apps/cli/src/commands/install-tray.ts
@@ -64,11 +64,11 @@ export async function installTray(opts: InstallTrayOptions = {}): Promise<Instal
   // Quit any running instance (new + legacy name) so we can replace the bundle cleanly.
   await execa('pkill', ['-x', APP_NAME]).catch(() => undefined);
   await execa('pkill', ['-x', LEGACY_APP_NAME]).catch(() => undefined);
-  // Remove a leftover pre-rename bundle so we never have two bundles sharing the same id.
-  if (existsSync(LEGACY_APP_PATH)) rmSync(LEGACY_APP_PATH, { recursive: true, force: true });
 
   if (opts.uninstall) {
     if (existsSync(APP_PATH)) rmSync(APP_PATH, { recursive: true, force: true });
+    // Also remove a leftover pre-rename bundle.
+    if (existsSync(LEGACY_APP_PATH)) rmSync(LEGACY_APP_PATH, { recursive: true, force: true });
     say(`Removed ${APP_PATH}. (Launch-at-login is unregistered by the app itself.)`);
     return { ran: true };
   }
@@ -97,6 +97,10 @@ export async function installTray(opts: InstallTrayOptions = {}): Promise<Instal
     // Replace any existing copy, extract with ditto (preserves signature + notarization ticket).
     if (existsSync(APP_PATH)) rmSync(APP_PATH, { recursive: true, force: true });
     await execa('ditto', ['-x', '-k', zip, '/Applications']);
+    // Only now that AgentBox.app is in place, remove a leftover pre-rename bundle so the two never
+    // coexist (same id). Doing it here — not earlier — means a failed download/extract can't strand
+    // a user who only had the old bundle.
+    if (existsSync(LEGACY_APP_PATH)) rmSync(LEGACY_APP_PATH, { recursive: true, force: true });
     // Belt-and-suspenders: clear any quarantine bit so Gatekeeper never blocks the download.
     await execa('xattr', ['-dr', 'com.apple.quarantine', APP_PATH]).catch(() => undefined);
     await launchTray(say);

--- a/apps/cli/src/commands/install-tray.ts
+++ b/apps/cli/src/commands/install-tray.ts
@@ -1,13 +1,13 @@
 /**
- * `agentbox install tray` — install the AgentBox Tray macOS menu-bar app.
+ * `agentbox install tray` — install the AgentBox macOS menu-bar app.
  *
- * The tray is distributed separately (it's macOS-only, and keeps this cross-platform CLI small):
- * a signed+notarized `AgentBoxTray.zip` is published to the public `madarco/agentbox` repo under the
+ * The app is distributed separately (it's macOS-only, and keeps this cross-platform CLI small):
+ * a signed+notarized `AgentBox.zip` is published to the public `madarco/agentbox` repo under the
  * moving `tray-latest` release. This command downloads it, verifies its SHA-256, unpacks it into
  * `/Applications` with `ditto` (which preserves the signature + stapled notarization ticket), and
  * launches it. macOS-only; a clean no-op elsewhere.
  *
- * Humans who prefer no CLI can instead download `AgentBoxTray.dmg` from the same release and drag it
+ * Humans who prefer no CLI can instead download `AgentBox.dmg` from the same release and drag it
  * to Applications.
  */
 
@@ -20,10 +20,15 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 
-export const APP_NAME = 'AgentBoxTray';
+export const APP_NAME = 'AgentBox';
 export const APP_PATH = `/Applications/${APP_NAME}.app`;
-/** Unified-logging subsystem the tray logs under (see the tray app's `Diagnostics/Log.swift`). */
+/** Unified-logging subsystem the app logs under (see the app's `Diagnostics/Log.swift`). */
 export const APP_BUNDLE_ID = 'com.madarco.agentbox-tray';
+
+// The app was renamed AgentBoxTray.app → AgentBox.app but kept its bundle id. A leftover old bundle
+// would collide (two bundles, one id), so remove it on install/uninstall.
+const LEGACY_APP_NAME = 'AgentBoxTray';
+const LEGACY_APP_PATH = `/Applications/${LEGACY_APP_NAME}.app`;
 
 // Overridable for forks/testing; default is the public agentbox repo's moving tray release.
 const RELEASE_BASE =
@@ -55,8 +60,11 @@ export async function installTray(opts: InstallTrayOptions = {}): Promise<Instal
     return { ran: false, reason: 'not-macos' };
   }
 
-  // Quit any running instance so we can replace the bundle cleanly.
+  // Quit any running instance (new + legacy name) so we can replace the bundle cleanly.
   await execa('pkill', ['-x', APP_NAME]).catch(() => undefined);
+  await execa('pkill', ['-x', LEGACY_APP_NAME]).catch(() => undefined);
+  // Remove a leftover pre-rename bundle so we never have two bundles sharing the same id.
+  if (existsSync(LEGACY_APP_PATH)) rmSync(LEGACY_APP_PATH, { recursive: true, force: true });
 
   if (opts.uninstall) {
     if (existsSync(APP_PATH)) rmSync(APP_PATH, { recursive: true, force: true });
@@ -122,7 +130,7 @@ async function launchTray(say: (m: string) => void): Promise<void> {
   }
 }
 
-/** Download `<tag>/AgentBoxTray.zip` + its `.sha256`, verify, and return the local zip path. */
+/** Download `<tag>/AgentBox.zip` + its `.sha256`, verify, and return the local zip path. */
 async function downloadAndVerify(
   tag: string,
   dir: string,
@@ -136,7 +144,7 @@ async function downloadAndVerify(
   await execa('curl', ['-fSL', '-o', zipPath, `${base}/${APP_NAME}.zip`]);
   await execa('curl', ['-fSL', '-o', shaPath, `${base}/${APP_NAME}.zip.sha256`]);
 
-  // The .sha256 sidecar is `shasum` format: "<hex>  AgentBoxTray.zip".
+  // The .sha256 sidecar is `shasum` format: "<hex>  AgentBox.zip".
   const expected = readFileSync(shaPath, 'utf8').trim().split(/\s+/)[0]?.toLowerCase();
   const actual = createHash('sha256').update(readFileSync(zipPath)).digest('hex');
   if (!expected || expected !== actual) {
@@ -149,7 +157,7 @@ export const installTrayCommand = new Command('tray')
   .description('Download and install the AgentBox Tray macOS menu-bar app into /Applications')
   .option('--uninstall', 'quit and remove the menu-bar app')
   .option('--tag <tag>', 'release tag to install from (default: tray-latest)')
-  .option('--zip <path>', 'install a local AgentBoxTray.zip instead of downloading')
+  .option('--zip <path>', 'install a local AgentBox.zip instead of downloading')
   .action(async (opts: { uninstall?: boolean; tag?: string; zip?: string }) => {
     intro(opts.uninstall ? 'Removing AgentBox Tray…' : 'Installing AgentBox Tray…');
     const res = await installTray(opts);

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -277,7 +277,7 @@ agentbox install --skills-only   # just (re)install the host /agentbox skill
 agentbox install cmux            # add a box-list panel to the cmux sidebar dock
 agentbox install herdr           # install the Herdr plugin (boxes overlay, shortcuts, Ctrl+click)
 agentbox install codex           # install + enable the AgentBox Codex plugin (drive AgentBox from Codex)
-agentbox install tray            # install the AgentBox Tray menu-bar app (macOS)
+agentbox install tray            # install the AgentBox menu-bar app (macOS)
 
 # Diagnose system + provider readiness
 agentbox doctor
@@ -290,7 +290,7 @@ agentbox prepare -p docker --build
 agentbox prepare -p hetzner --claude-install npm   # install Claude via npm (native-CDN 403 fallback)
 ```
 
-`install` is the first-run setup wizard (system check, pick a provider, log in, prepare its base image, install the host skill). `install cmux` pins a live `agentbox list` panel (all your boxes) to the [cmux](https://cmux.com) sidebar dock — see [cmux integration](/docs/integrations-cmux#the-agentbox-dock-right-sidebar). `install herdr` installs a [Herdr](https://herdr.dev) plugin with a boxes overlay, shortcuts, and Ctrl+click — see [Herdr integration](/docs/integrations-herdr#the-herdr-plugin). `install codex` registers the AgentBox [Codex](https://openai.com/index/introducing-codex/) plugin (marketplace + `codex plugin add`) and enables it by default in `~/.codex/config.toml`, so the `/agentbox` skill works in Codex with no manual toggle — it also runs automatically during `install` when Codex is detected. `install tray` installs the **AgentBox Tray** macOS menu-bar app into `/Applications` and launches it (a live view of every box with one-click actions); once installed, `agentbox app start|stop|restart|status` controls the running process (see [Maintenance](#maintenance)). `doctor` diagnoses system and provider readiness — including a per-provider **base freshness** check that warns when an already-baked snapshot is out of date (a CLI upgrade changed a baked file) and should be re-run through `agentbox prepare --provider <name>` — and reports each service integration ([Notion](/docs/integrations-notion), [Linear](/docs/integrations-linear)): host CLI installed? authed? enabled per project? `prepare` builds base images or snapshots — omit `--provider` for status only; `--claude-install <native|npm>` (or the `box.claudeInstall` config key) switches how Claude Code is installed into the base, with `npm` as a fallback for cloud egress IPs the native installer's CDN 403s.
+`install` is the first-run setup wizard (system check, pick a provider, log in, prepare its base image, install the host skill). `install cmux` pins a live `agentbox list` panel (all your boxes) to the [cmux](https://cmux.com) sidebar dock — see [cmux integration](/docs/integrations-cmux#the-agentbox-dock-right-sidebar). `install herdr` installs a [Herdr](https://herdr.dev) plugin with a boxes overlay, shortcuts, and Ctrl+click — see [Herdr integration](/docs/integrations-herdr#the-herdr-plugin). `install codex` registers the AgentBox [Codex](https://openai.com/index/introducing-codex/) plugin (marketplace + `codex plugin add`) and enables it by default in `~/.codex/config.toml`, so the `/agentbox` skill works in Codex with no manual toggle — it also runs automatically during `install` when Codex is detected. `install tray` installs the **AgentBox** macOS menu-bar app into `/Applications` and launches it (a live view of every box with one-click actions); once installed, `agentbox app start|stop|restart|status` controls the running process (see [Maintenance](#maintenance)). `doctor` diagnoses system and provider readiness — including a per-provider **base freshness** check that warns when an already-baked snapshot is out of date (a CLI upgrade changed a baked file) and should be re-run through `agentbox prepare --provider <name>` — and reports each service integration ([Notion](/docs/integrations-notion), [Linear](/docs/integrations-linear)): host CLI installed? authed? enabled per project? `prepare` builds base images or snapshots — omit `--provider` for status only; `--claude-install <native|npm>` (or the `box.claudeInstall` config key) switches how Claude Code is installed into the base, with `npm` as a fallback for cloud egress IPs the native installer's CDN 403s.
 
 <Callout title="TIP">`agentbox config get <key> --all` shows which layer each value comes from. See the full key reference in [Configuration](/docs/configuration).</Callout>
 
@@ -347,12 +347,12 @@ agentbox hub                 # start + open it in the browser
 agentbox hub status
 agentbox hub stop
 
-# Menu-bar app (macOS) — control the running AgentBox Tray process
+# Menu-bar app (macOS) — control the running AgentBox process
 agentbox app status
 agentbox app start
 agentbox app stop
 agentbox app restart
-agentbox app log                 # tray diagnostics (unified log + crash reports)
+agentbox app log                 # app diagnostics (unified log + crash reports)
 agentbox app log --out report.txt  # bundle everything into one file for a bug report
 
 # Update agentbox (wipes the box image so it rebuilds, reloads the relay)
@@ -360,7 +360,7 @@ agentbox self-update
 agentbox self-update --dry-run
 ```
 
-`prune` cleans up orphan state records; `--all` also removes orphan docker resources, and `--provider <cloud>` lists untracked cloud sandboxes and offers to delete them. `queue` manages background `-i` jobs. `relay` manages the host relay (`status`, `stop`, `start`, `restart`). `app` controls the macOS menu-bar app (`status`, `start`, `stop`, `restart`) — install it first with `agentbox install tray`. `app log` collects the tray's diagnostics for a bug report: it reads the tray's macOS unified-log entries (`--last <window>`, `-f` to stream live, `--crashes` for just the crash reports) and lists its crash reports from `~/Library/Logs/DiagnosticReports`; `--open` reveals that folder in Finder, and `--out <file>` writes a single self-contained bundle (versions, log, newest crash report) to attach. The tray keeps no log file of its own — these are macOS-native surfaces. `self-update` updates the CLI.
+`prune` cleans up orphan state records; `--all` also removes orphan docker resources, and `--provider <cloud>` lists untracked cloud sandboxes and offers to delete them. `queue` manages background `-i` jobs. `relay` manages the host relay (`status`, `stop`, `start`, `restart`). `app` controls the macOS menu-bar app (`status`, `start`, `stop`, `restart`) — install it first with `agentbox install tray`. `app log` collects the app's diagnostics for a bug report: it reads the app's macOS unified-log entries (`--last <window>`, `-f` to stream live, `--crashes` for just the crash reports) and lists its crash reports from `~/Library/Logs/DiagnosticReports`; `--open` reveals that folder in Finder, and `--out <file>` writes a single self-contained bundle (versions, log, newest crash report) to attach. The app keeps no log file of its own — these are macOS-native surfaces. `self-update` updates the CLI.
 
 `hub` runs the **AgentBox hub** — the host relay plus a local Web UI (dashboard, box detail, live approvals) on `http://127.0.0.1:8787`, gated by a per-machine token. When [Portless](https://portless.sh) is installed it also serves at a friendly `https://agentbox.localhost`. It's a superset of the relay on the same port: `agentbox hub` takes over from a bare relay, and normal box commands reuse it. Needs Node ≥ 22.5.
 

--- a/examples/agentbox-provider-example/package.json
+++ b/examples/agentbox-provider-example/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "agentbox-provider-example",
+  "version": "0.1.0",
+  "description": "A real, working AgentBox provider plugin (Vercel-backed) built only on @agentbox/provider-sdk — the reference example. Internal test, not published.",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js"
+    }
+  },
+  "agentbox": {
+    "providerApiVersion": 1
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --target node20 --no-splitting",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "files": [
+    "dist",
+    "scripts",
+    "README.md"
+  ],
+  "dependencies": {
+    "@agentbox/provider-sdk": "file:../../packages/provider-sdk",
+    "@clack/prompts": "^0.9.0",
+    "@vercel/sandbox": "^2.0.1",
+    "execa": "^9.5.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.1",
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.2"
+  }
+}

--- a/examples/agentbox-provider-example/scripts/custom-system-CLAUDE.md
+++ b/examples/agentbox-provider-example/scripts/custom-system-CLAUDE.md
@@ -1,0 +1,57 @@
+# AgentBox sandbox (vercel provider)
+
+You are running inside an AgentBox sandbox: a Vercel Sandbox (a Firecracker
+microVM on Amazon Linux 2023) provisioned just for this box. Your user is
+`vscode` and you can use passwordless **sudo** to run commands as root. The
+whole microVM is yours — the user's host filesystem is not visible from here
+and nothing is bind-mounted.
+
+**Docker is available.** The box bakes the docker engine and `dockerd` is
+started automatically, so `docker` works out of the box — no sudo needed (the
+socket is opened to your user). Build images, run containers, and use
+`image:` services in `agentbox.yaml` directly. Because this box is persistent,
+pulled images and the docker install carry over across pause/resume.
+
+This box is **persistent**: stopping it captures a snapshot and resuming
+restarts from that snapshot, so the filesystem survives a pause. You can also
+save the current filesystem state for future boxes with
+`agentbox-ctl checkpoint --set-default`, but a checkpoint/snapshot STOPS the
+box, so use it only at the end of the setup wizard.
+
+`/workspace` is a normal git checkout seeded from the host repo at create time.
+Because there is no host bind-mount, plain `git` inside the box only affects
+this box-local repo — commits do **not** appear in the user's host `git log`
+until you hand them off. For any operation that must reach the host repo or its
+remotes (push, fetch, pull, picking up host-side changes), use
+`agentbox-ctl git push|fetch|pull -- <args>` — it RPCs to the host, which runs
+git with the real SSH agent and writes back into the host's worktree state. The
+wrapper already builds `git push <remote> <branch>` host-side from the
+registered worktree; the `-- <args>` slot is for extra flags only (e.g.
+`--force-with-lease`, `--tags`). Re-passing the remote or branch makes git treat
+them as refspecs and fails with `refs/remotes/origin/HEAD cannot be resolved to
+branch`. To make the branch available on the host **without** publishing it to
+the remote, add `--host-only` (e.g. `agentbox-ctl git push --host-only`); it
+lands the branch in the host's local repo only. Add `--as <branch>` to choose
+the host branch name (default: this box's branch), and `--force` to allow a
+non-fast-forward overwrite.
+
+For GitHub PR work, use `agentbox-ctl git pr <op> [args...]` — same model, relay
+shells to host `gh`. Ops: `create`, `view`, `list`, `comment`, `review`,
+`merge`, `close`, `reopen`, `checkout`. `view` / `list` are read-only and run
+silently; everything else asks the user to confirm in the host wrapper (deny →
+exit 10).
+
+For ad-hoc file transfers between this box and the host, use
+`agentbox-ctl cp toHost <boxPath...> <hostPath>` and
+`agentbox-ctl cp fromHost <hostPath...> <boxPath>` (both accept multiple paths; wildcards expand in your shell) or `agentbox-ctl download claude` /
+`download env` / `download config`. They RPC to the host and ask the user for
+confirmation on the wrapper that runs `agentbox claude`; deny returns exit 10
+(`denied by user`). Don't put any timeout on the command, it will run forever
+and the user will be notified through multiple channels.
+
+If an agentbox.yaml file is present, services and docker containers will be started automatically.
+Check the status with `agentbox-ctl status`.
+
+To view any web services, open the browser to https://<AGENTBOX_BOX_HOST>. The AGENTBOX_BOX_HOST env var is available in the box and the same url will work from the host as well because it is a cloud provided url.
+
+Box identity: /etc/agentbox/box.env and the AGENTBOX_* env vars.

--- a/examples/agentbox-provider-example/scripts/provision.sh
+++ b/examples/agentbox-provider-example/scripts/provision.sh
@@ -1,0 +1,433 @@
+#!/usr/bin/env bash
+# AgentBox Vercel base-snapshot installer.
+#
+# Idempotent installer run once on a fresh Vercel Sandbox (Amazon Linux 2023,
+# node24 runtime) during `agentbox prepare --provider vercel`. After it
+# completes we `sandbox.snapshot()` the microVM — that snapshot is what every
+# per-box create boots from.
+#
+# Differences from the hetzner installer (packages/sandbox-hetzner/scripts/
+# install-box.sh), which this mirrors:
+#   - dnf, not apt (Amazon Linux 2023).
+#   - docker is installed from the AL2023 repos (Vercel Sandbox now supports
+#     nested containers). dockerd is NOT auto-started by systemd; the cloud
+#     scaffold launches it via agentbox-dockerd-start on create/resume.
+#   - The `vscode` user is created without forcing uid 1000 (the Vercel default
+#     user may already hold it; there are no bind mounts so the exact uid is
+#     irrelevant — only ownership of /workspace + /home/vscode matters).
+#
+# Required inputs (uploaded to /tmp before this runs):
+#   /tmp/agentbox-ctl                  -- prebuilt @agentbox/ctl bundle (cjs)
+#   /tmp/agentbox-vnc-start            -- VNC startup helper
+#   /tmp/agentbox-dockerd-start        -- in-box dockerd startup helper
+#   /tmp/agentbox-checkpoint-cleanup   -- pre-snapshot cleanup helper
+#   /tmp/agentbox-open                 -- in-box xdg-open shim
+#   /tmp/agentbox-gh-shim              -- in-box `gh` shim (routes to host gh)
+#   /tmp/agentbox-git-shim             -- in-box `git` shim (routes via relay)
+#   /tmp/agentbox-ntn-shim             -- in-box `ntn`/`notion` shim (routes to host ntn)
+#   /tmp/agentbox-linear-shim          -- in-box `linear` shim (routes to host linear; rejects `auth token`)
+#   /tmp/agentbox-custom-CLAUDE.md     -- /etc/claude-code/CLAUDE.md content
+#   /tmp/agentbox-managed-settings.json -- /etc/claude-code/managed-settings.json
+#   /tmp/agentbox-codex-hooks.json     -- /usr/local/share/agentbox/codex-hooks.json
+#   /tmp/agentbox-setup-skill.md       -- /usr/local/share/agentbox/setup-guide.md
+#
+# Output: noisy progress to stdout (streamed into ~/.agentbox/logs/prepare.log).
+# Each major step prints `>>> BEGIN <step>` / `<<< END <step>`.
+
+set -euo pipefail
+
+step() { printf '\n>>> BEGIN %s\n' "$1"; }
+done_() { printf '<<< END %s\n' "$1"; }
+
+# Retry a command with exponential backoff. Usage: retry_backoff <max> cmd...
+# Waits 60s before attempt 2, 240s before attempt 3 (~5 min total budget). Used
+# for the Claude native installer, whose CDN (claude.ai / downloads.claude.ai,
+# behind Cloudflare) intermittently 403s cloud-datacenter egress IPs under load.
+retry_backoff() {
+  local max=$1; shift
+  local attempt=1
+  local -a waits=(60 240)
+  while true; do
+    if "$@"; then return 0; fi
+    if [ "$attempt" -ge "$max" ]; then return 1; fi
+    local w=${waits[$((attempt-1))]:-240}
+    echo "retry_backoff: attempt ${attempt}/${max} failed — backing off ${w}s" >&2
+    sleep "$w"
+    attempt=$((attempt+1))
+  done
+}
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "provision.sh: must run as root (got uid $(id -u))" >&2
+  exit 64
+fi
+
+step "dnf base packages"
+# NOTE: do NOT request `curl` — AL2023 ships `curl-minimal` which provides the
+# `curl` binary, and asking for full `curl` conflicts with it and aborts the
+# whole (atomic) dnf transaction. `--allowerasing` lets dnf resolve any other
+# such conflict by swapping rather than failing. No `| tail || true` here: that
+# masks dnf's real exit code and lets the script march on with nothing
+# installed (the bug that broke the first bake).
+dnf install -y -q --allowerasing \
+  ca-certificates \
+  git \
+  tar \
+  gzip \
+  which \
+  shadow-utils \
+  sudo \
+  python3 \
+  python3-pip \
+  tmux \
+  vim \
+  libcap \
+  rsync
+done_ "dnf base packages"
+
+step "node 24 sanity"
+# Vercel's node24 runtime already ships node; just confirm it's on PATH.
+if ! command -v node >/dev/null 2>&1; then
+  echo "provision.sh: node not found on the node24 runtime — unexpected" >&2
+  exit 65
+fi
+node --version
+done_ "node 24 sanity"
+
+step "vscode user + sudoers"
+# No forced uid: the Vercel default user (`vercel-sandbox`) may already hold
+# 1000, and there are no bind mounts so uid-parity with the docker provider
+# doesn't matter. Ownership + passwordless sudo is what counts.
+if ! id vscode >/dev/null 2>&1; then
+  useradd -m -s /bin/bash vscode
+fi
+install -d -m 0755 -o vscode -g vscode /home/vscode
+echo 'vscode ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/90-agentbox-vscode
+chmod 0440 /etc/sudoers.d/90-agentbox-vscode
+# Vercel's AL2023 base ships /etc/sudoers WITHOUT an includedir for
+# /etc/sudoers.d (and with non-0440 perms), so the drop-in above is silently
+# ignored and `sudo -n` as vscode fails with "a password is required" — which
+# breaks the workspace seed, ctl-launch, and carry (all run as vscode and lean
+# on passwordless sudo). Wire the include in and normalise perms so the rule
+# actually loads, then fail loud if the result doesn't parse.
+if ! grep -qE '^[[:space:]]*[@#]includedir[[:space:]]+/etc/sudoers\.d' /etc/sudoers; then
+  printf '\n@includedir /etc/sudoers.d\n' >> /etc/sudoers
+fi
+chmod 0440 /etc/sudoers
+visudo -cf /etc/sudoers >/dev/null
+done_ "vscode user + sudoers"
+
+step "agentbox base dirs + /workspace ownership"
+mkdir -p /workspace /run/agentbox /var/log/agentbox /var/lib/agentbox /etc/agentbox /etc/claude-code \
+         /usr/local/share/agentbox
+chmod 755 /workspace
+chown vscode:vscode /workspace /run/agentbox /var/log/agentbox /var/lib/agentbox
+done_ "agentbox base dirs + /workspace ownership"
+
+step "docker engine (in-box DinD)"
+# Vercel Sandbox now supports nested containers. Install the engine + iptables
+# from the AL2023 repos; dockerd itself is launched by the cloud scaffold via
+# agentbox-dockerd-start (NOT systemd), so the agentbox path owns its lifecycle.
+# No /etc/docker/daemon.json here — agentbox-dockerd-start rewrites it with the
+# resolved storage-driver on every start.
+dnf install -y -q --allowerasing docker iptables
+groupadd -f docker
+usermod -aG docker vscode
+systemctl disable --now docker.service docker.socket 2>/dev/null || true
+done_ "docker engine (in-box DinD)"
+
+step "node setcap (bind <1024 without root)"
+# The cloud WebProxy binds port 80; grant node the capability so it needn't run
+# as root. Best-effort — if setcap is unavailable the WebProxy can still be
+# launched via sudo.
+NODE_BIN="$(readlink -f "$(command -v node)")"
+setcap cap_net_bind_service=+ep "$NODE_BIN" || echo "provision.sh: setcap failed (continuing)"
+done_ "node setcap (bind <1024 without root)"
+
+step "corepack (pnpm + yarn shims)"
+npm install -g corepack@latest 2>&1 | tail -2 || true
+corepack enable pnpm yarn 2>/dev/null || true
+sudo -u vscode -H mkdir -p /home/vscode/.cache/node/corepack
+done_ "corepack (pnpm + yarn shims)"
+
+step "git system-wide safe.directory"
+# The Vercel node24 runtime's git is built with prefix /opt/git, so its system
+# config is /opt/git/etc/gitconfig and the parent dir may not exist — without
+# it `git config --system` fails with "could not lock config file" (exit 255).
+# Create the dir, then set it system-wide AND for the vscode user so workspace
+# git ops never trip "dubious ownership". All best-effort — a git-config quirk
+# must never abort the bake.
+mkdir -p /opt/git/etc 2>/dev/null || true
+git config --system --add safe.directory '*' 2>/dev/null || true
+sudo -u vscode -H git config --global --add safe.directory '*' 2>/dev/null || true
+done_ "git system-wide safe.directory"
+
+step "git-lfs (binary + system filter)"
+# Not in the atomic base dnf transaction on purpose: AL2023 may not carry
+# git-lfs in its default repos, and a missing package would abort the whole
+# (atomic) base install. Best-effort here — try dnf, then git-lfs's official
+# packagecloud rpm repo as a fallback. If both miss, LFS repos degrade to
+# pointer files rather than breaking the bake.
+if ! command -v git-lfs >/dev/null 2>&1; then
+  dnf install -y -q git-lfs 2>/dev/null || {
+    curl -fsSL https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | bash 2>&1 | tail -3 || true
+    dnf install -y -q git-lfs 2>&1 | tail -3 || true
+  }
+fi
+# Register filter.lfs.* in the (Vercel-relocated /opt/git/etc) system gitconfig
+# AND for vscode, so an in-box checkout of an LFS repo smudges instead of writing
+# pointers. Cloud boxes have no bind-mounted ~/.gitconfig, so this is the only
+# place the filter lives. --skip-repo never touches a checkout at bake time.
+git lfs install --system --skip-repo 2>/dev/null || true
+sudo -u vscode -H git lfs install --skip-repo 2>/dev/null || true
+done_ "git-lfs (binary + system filter)"
+
+step "agentbox-ctl install"
+install -m 0755 /tmp/agentbox-ctl /usr/local/bin/agentbox-ctl
+done_ "agentbox-ctl install"
+
+step "baked helper scripts (vnc / dockerd / cleanup / xdg-open)"
+install -m 0755 /tmp/agentbox-vnc-start          /usr/local/bin/agentbox-vnc-start
+install -m 0755 /tmp/agentbox-dockerd-start      /usr/local/bin/agentbox-dockerd-start
+install -m 0755 /tmp/agentbox-checkpoint-cleanup /usr/local/bin/agentbox-checkpoint-cleanup
+install -m 0755 /tmp/agentbox-open               /usr/local/bin/agentbox-open
+ln -sf /usr/local/bin/agentbox-open /usr/local/bin/xdg-open
+# NOTE: the gh + git shims are installed LAST (see "relay shims" near the end).
+# Installing them here would put the relay-routing `git` on PATH ahead of
+# /usr/bin/git and route provision.sh's own noVNC `git clone` through a relay
+# that doesn't exist during the bake.
+done_ "baked helper scripts (vnc / dockerd / cleanup / xdg-open)"
+
+step "baked config files (claude / codex / setup guide / tmux.conf)"
+install -m 0644 /tmp/agentbox-custom-CLAUDE.md      /etc/claude-code/CLAUDE.md
+install -m 0644 /tmp/agentbox-managed-settings.json /etc/claude-code/managed-settings.json
+install -m 0644 /tmp/agentbox-codex-hooks.json      /usr/local/share/agentbox/codex-hooks.json
+install -m 0644 /tmp/agentbox-setup-skill.md        /usr/local/share/agentbox/setup-guide.md
+
+cat > /etc/tmux.conf <<'TMUX'
+set -g default-terminal "tmux-256color"
+set -as terminal-overrides ",*:Tc"
+set -as terminal-overrides ",*:RGB"
+set -as terminal-features ",*:hyperlinks"
+set -as terminal-features ",*:RGB"
+set -g allow-passthrough on
+set -g set-clipboard on
+set -g extended-keys on
+set -as terminal-features ",*:extkeys"
+set -g mouse on
+bind -T copy-mode    WheelUpPane   send -N2 -X scroll-up
+bind -T copy-mode    WheelDownPane send -N2 -X scroll-down
+bind -T copy-mode-vi WheelUpPane   send -N2 -X scroll-up
+bind -T copy-mode-vi WheelDownPane send -N2 -X scroll-down
+set -g history-limit 50000
+set -g escape-time 0
+TMUX
+done_ "baked config files (claude / codex / setup guide / tmux.conf)"
+
+step "credential pivot symlinks (vscode home)"
+sudo -u vscode -H mkdir -p \
+  /home/vscode/.claude \
+  /home/vscode/.claude/skills/agentbox-setup \
+  /home/vscode/.codex \
+  /home/vscode/.local/share/opencode \
+  /home/vscode/.agentbox-creds/claude \
+  /home/vscode/.agentbox-creds/codex \
+  /home/vscode/.agentbox-creds/opencode
+sudo -u vscode -H ln -sf /home/vscode/.agentbox-creds/claude/.credentials.json \
+  /home/vscode/.claude/.credentials.json
+sudo -u vscode -H ln -sf /home/vscode/.agentbox-creds/codex/auth.json \
+  /home/vscode/.codex/auth.json
+sudo -u vscode -H ln -sf /home/vscode/.agentbox-creds/opencode/auth.json \
+  /home/vscode/.local/share/opencode/auth.json
+sudo -u vscode -H ln -sf /home/vscode/.claude/_claude.json /home/vscode/.claude.json
+sudo -u vscode -H cp /usr/local/share/agentbox/setup-guide.md \
+  /home/vscode/.claude/skills/agentbox-setup/SKILL.md
+done_ "credential pivot symlinks (vscode home)"
+
+step "login-shell shim (/etc/profile.d/agentbox.sh)"
+cat > /etc/profile.d/agentbox.sh <<'PROFILE'
+# Auto-loaded by login shells; box.env is written at create time.
+if [ -r /etc/agentbox/box.env ]; then
+  set -a
+  . /etc/agentbox/box.env
+  set +a
+fi
+case ":$PATH:" in
+  *:/home/vscode/.local/bin:*) : ;;
+  *) PATH=/home/vscode/.local/bin:$PATH ;;
+esac
+# Force /usr/local/bin to win PATH. Vercel's AL2023 base prepends /opt/git/bin
+# AHEAD of /usr/local/bin, so the relay-routing shims at /usr/local/bin/{git,gh}
+# are otherwise shadowed by the real binaries and agent-typed `git push` /
+# `gh ...` bypass the host relay (backlog #19). A plain `case` prepend doesn't
+# help — /usr/local/bin is already on PATH, just not first — so strip any
+# existing occurrence and re-prepend.
+PATH=/usr/local/bin:$(printf '%s' "$PATH" | sed -e 's#:/usr/local/bin:#:#g' -e 's#^/usr/local/bin:##' -e 's#:/usr/local/bin$##' -e 's#^/usr/local/bin$##')
+export PATH
+export COLORTERM=${COLORTERM:-truecolor}
+export DISABLE_AUTOUPDATER=${DISABLE_AUTOUPDATER:-1}
+export DISPLAY=${DISPLAY:-:1}
+export AGENT_BROWSER_EXECUTABLE_PATH=${AGENT_BROWSER_EXECUTABLE_PATH:-/usr/local/bin/chromium}
+export BROWSER=${BROWSER:-/usr/local/bin/agentbox-open}
+# Land interactive login shells in the workspace, so remote-host integrations
+# (Codex app, VS Code Remote-SSH, plain `ssh <box>`) open in the project instead
+# of $HOME. Interactive-only so scp/sftp and `ssh box <cmd>` are untouched; only
+# when still at $HOME so a caller-chosen dir (e.g. agentbox's tmux `-c /workspace`)
+# is never overridden.
+case $- in
+  *i*)
+    if [ "$PWD" = "$HOME" ] && [ -d /workspace ]; then
+      cd /workspace
+    fi
+    ;;
+esac
+PROFILE
+chmod 0644 /etc/profile.d/agentbox.sh
+done_ "login-shell shim (/etc/profile.d/agentbox.sh)"
+
+step "VNC stack (TigerVNC + websockify + noVNC)"
+# Best-effort: VNC is a convenience (agentbox screen). A package that isn't in
+# the AL2023 repos shouldn't fail the whole bake — the VNC daemon launch is
+# already best-effort on the create path.
+dnf install -y -q --allowerasing tigervnc-server xterm 2>&1 | tail -3 || \
+  echo "provision.sh: tigervnc-server install failed (VNC may be unavailable)"
+pip3 install --quiet websockify 2>&1 | tail -2 || \
+  echo "provision.sh: websockify install failed (VNC may be unavailable)"
+# noVNC static assets — clone shallow into a stable path the vnc-start script
+# can serve.
+if [ ! -d /usr/local/share/novnc ]; then
+  git clone --depth 1 https://github.com/novnc/noVNC /usr/local/share/novnc 2>&1 | tail -2 || \
+    echo "provision.sh: noVNC clone failed (VNC may be unavailable)"
+fi
+sudo -u vscode -H mkdir -p /home/vscode/.vnc
+done_ "VNC stack (TigerVNC + websockify + noVNC)"
+
+step "X11 clipboard tools (xclip + autocutsel, built from source)"
+# xclip and autocutsel are NOT in the AL2023 repos (unlike Debian/Ubuntu where
+# docker + hetzner apt-install them). They are load-bearing: xclip backs the
+# host->box Ctrl+V image paste (apps/cli/src/lib/paste-image.ts), and autocutsel
+# keeps the VNC CLIPBOARD/PRIMARY selections in sync (agentbox-vnc-start). Build
+# both from source — all deps are in the AL2023 default repos. Fail loud: a
+# missing binary is a silently broken feature, not a skippable convenience.
+dnf install -y -q --allowerasing \
+  gcc make automake autoconf git \
+  libX11-devel libXmu-devel libXt-devel libXaw-devel
+git clone --depth 1 https://github.com/astrand/xclip /tmp/xclip
+( cd /tmp/xclip && autoreconf -i && ./configure --prefix=/usr/local && make && make install )
+rm -rf /tmp/xclip
+command -v xclip >/dev/null || { echo "provision.sh: xclip build failed"; exit 1; }
+git clone --depth 1 https://github.com/sigmike/autocutsel /tmp/autocutsel
+( cd /tmp/autocutsel && autoreconf -i && ./configure --prefix=/usr/local && make && make install )
+rm -rf /tmp/autocutsel
+command -v autocutsel >/dev/null || { echo "provision.sh: autocutsel build failed"; exit 1; }
+done_ "X11 clipboard tools (xclip + autocutsel, built from source)"
+
+step "agent CLIs (codex + opencode + agent-browser, global npm)"
+npm install -g @openai/codex opencode-ai agent-browser 2>&1 | tail -3 || \
+  echo "provision.sh: one or more agent npm installs failed (continuing)"
+done_ "agent CLIs (codex + opencode + agent-browser, global npm)"
+
+# AGENTBOX_CLAUDE_INSTALL selects how Claude Code is installed (default
+# `native`). `npm` is an opt-in fallback for hosts whose egress IP the native
+# installer's CDN 403s — see `box.claudeInstall`.
+if [ "${AGENTBOX_CLAUDE_INSTALL:-native}" = "npm" ]; then
+  step "Claude Code (npm: @anthropic-ai/claude-code)"
+  # npm-global drops `claude` at Node's prefix bin, not the
+  # /home/vscode/.local/bin/claude the rest of AgentBox hardcodes. Symlink it
+  # into that path so the box stays indistinguishable from a native install.
+  npm install -g @anthropic-ai/claude-code
+  install -d -o vscode -g vscode /home/vscode/.local/bin
+  ln -sf "$(command -v claude)" /home/vscode/.local/bin/claude
+  chown -h vscode:vscode /home/vscode/.local/bin/claude
+  command -v claude >/dev/null || { echo "provision.sh: npm claude install produced no claude on PATH" >&2; exit 71; }
+  done_ "Claude Code (npm: @anthropic-ai/claude-code)"
+else
+  step "Claude Code (native installer, run as vscode)"
+  # Anthropic's native installer drops `claude` at /home/vscode/.local/bin/claude
+  # with installMethod=native (matching the host-seeded .claude.json, so the
+  # startup integrity check stays quiet) and ships native-only features the npm
+  # package lacks. Its CDN (claude.ai / downloads.claude.ai) sits behind
+  # Cloudflare, which intermittently 403s cloud-datacenter egress IPs under load —
+  # so retry with backoff rather than falling back to npm. A bare `curl | bash`
+  # would hide a 403 (curl -f exits non-zero but the pipe's status is bash's 0),
+  # so keep pipefail and fold the PATH check in so a "succeeded but absent" result
+  # also retries. A failed provision is better than a claude-less snapshot.
+  if ! retry_backoff 3 sudo -u vscode -H bash -lc \
+       'set -o pipefail; curl -fsSL https://claude.ai/install.sh | bash -s stable && command -v claude >/dev/null'; then
+    echo "provision.sh: Claude native installer failed after 3 attempts (Cloudflare 403?) — aborting provision" >&2
+    exit 71
+  fi
+  done_ "Claude Code (native installer, run as vscode)"
+fi
+
+step "Chrome runtime libs (dnf)"
+# agent-browser launches Chromium at AGENT_BROWSER_EXECUTABLE_PATH
+# (/usr/local/bin/chromium, set in the login-shell shim above). Docker + hetzner
+# bake that binary in; do the same here. These are the AL2023 (dnf) equivalents
+# of the Ubuntu `t64` Chrome deps the other two providers apt-install — the
+# Ubuntu package names don't exist on Amazon Linux 2023. Fail loud: a missing lib
+# means a silently broken browser, not a convenience we can skip.
+dnf install -y -q --allowerasing \
+  nss nspr atk at-spi2-atk at-spi2-core cups-libs \
+  libdrm libxkbcommon libXcomposite libXdamage libXfixes libXrandr \
+  libXext libX11 libxcb mesa-libgbm pango cairo alsa-lib \
+  liberation-fonts
+done_ "Chrome runtime libs (dnf)"
+
+step "playwright + Chromium download (as vscode)"
+# Run the download as vscode so the cache lands under
+# /home/vscode/.cache/ms-playwright. Resolve a stable symlink at
+# /usr/local/bin/chromium so AGENT_BROWSER_EXECUTABLE_PATH stays predictable
+# across Chromium revision bumps (mirrors hetzner install-box.sh).
+npm install -g playwright 2>&1 | tail -3
+sudo -u vscode -H bash -lc 'playwright install chromium'
+CHROME_BIN="$(sudo -u vscode -H bash -lc 'ls /home/vscode/.cache/ms-playwright/chromium-*/chrome-linux*/chrome 2>/dev/null | sort | tail -1')"
+if [ -z "$CHROME_BIN" ] || [ ! -x "$CHROME_BIN" ]; then
+  echo "provision.sh: could not resolve Playwright Chromium binary" >&2
+  exit 70
+fi
+# Fail loud if a shared lib is missing — this is where an incomplete AL2023 dep
+# set surfaces at bake time instead of at first agent-browser launch. Capture
+# ldd's output first (|| true): under `set -euo pipefail` a non-zero ldd exit
+# would otherwise dominate the `ldd | grep` pipeline and make the missing-libs
+# check a silent no-op even when 'not found' lines are present.
+LDD_OUT="$(ldd "$CHROME_BIN" 2>&1 || true)"
+if printf '%s\n' "$LDD_OUT" | grep -q 'not found'; then
+  echo "provision.sh: Chromium has unresolved shared libs:" >&2
+  printf '%s\n' "$LDD_OUT" | grep 'not found' >&2
+  exit 71
+fi
+ln -sf "$CHROME_BIN" /usr/local/bin/chromium
+done_ "playwright + Chromium download (as vscode)"
+
+step "dnf cleanup"
+dnf clean all 2>/dev/null || true
+done_ "dnf cleanup"
+
+# Relay-routing shims, installed LAST — after every git/gh use in this script
+# (the noVNC `git clone` and any npm/installer step). At RUNTIME agent calls to
+# `gh ...` / `git push|pull|fetch|clone` must route through the host relay; the
+# login-shell shim above forces /usr/local/bin ahead of Vercel's /opt/git/bin so
+# these win (a plain install location is NOT enough on AL2023 — see #19). During
+# the bake there is no relay, so they must not shadow the real binaries until
+# provisioning is done. Installed from /tmp just before the trim step removes the
+# sources.
+step "relay shims (gh + git + ntn + linear)"
+install -m 0755 /tmp/agentbox-gh-shim     /usr/local/bin/gh
+install -m 0755 /tmp/agentbox-git-shim    /usr/local/bin/git
+install -m 0755 /tmp/agentbox-ntn-shim    /usr/local/bin/ntn
+ln -sf /usr/local/bin/ntn /usr/local/bin/notion
+install -m 0755 /tmp/agentbox-linear-shim /usr/local/bin/linear
+done_ "relay shims (gh + git + ntn + linear)"
+
+step "trim /tmp/agentbox-*"
+rm -f /tmp/agentbox-ctl /tmp/agentbox-vnc-start /tmp/agentbox-dockerd-start \
+      /tmp/agentbox-checkpoint-cleanup /tmp/agentbox-open \
+      /tmp/agentbox-gh-shim /tmp/agentbox-git-shim /tmp/agentbox-ntn-shim \
+      /tmp/agentbox-linear-shim \
+      /tmp/agentbox-custom-CLAUDE.md /tmp/agentbox-managed-settings.json \
+      /tmp/agentbox-codex-hooks.json /tmp/agentbox-setup-skill.md
+mv /tmp/agentbox-provision.sh /var/log/agentbox/provision.sh 2>/dev/null || true
+done_ "trim /tmp/agentbox-*"
+
+printf '\n*** provision.sh: complete — microVM ready for snapshot.\n'

--- a/examples/agentbox-provider-example/src/cli-store.ts
+++ b/examples/agentbox-provider-example/src/cli-store.ts
@@ -1,0 +1,105 @@
+/**
+ * Reader for the Vercel CLI's own credential store — written by `sandbox login`
+ * / `vercel login` (the `sandbox`/`sbx` CLI and `vercel` CLI share one store).
+ *
+ * AgentBox's "CLI-login" auth mode (see credentials.ts) drives that CLI for the
+ * browser OAuth, then reads the resulting OAuth access token live from here on
+ * every SDK call rather than copying it into `secrets.env`: the token is a
+ * short-lived, opaque `vca_…` access token that the CLI refreshes lazily from
+ * its stored refresh token, so the CLI store is the single self-refreshing
+ * source of truth. We only cache the stable bits (team/project id + a marker)
+ * in `secrets.env`.
+ *
+ * Pure FS + path logic — no clack, no execa — so it stays trivially testable.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/** The shape of the CLI's `auth.json` (only the fields we consume). */
+export interface VercelCliAuth {
+  /** Opaque OAuth access token (`vca_…`). NOT a JWT — expiry is `expiresAt`. */
+  token: string;
+  /** Unix seconds. Absent on some CLI versions → treated as near-expiry. */
+  expiresAt?: number;
+  /** Present but unused by us; the CLI uses it to self-refresh `token`. */
+  refreshToken?: string;
+}
+
+/**
+ * Resolve the `com.vercel.cli` data directory the way the CLI itself does
+ * (xdg-app-paths-style), per platform:
+ *   - macOS:   ~/Library/Application Support/com.vercel.cli
+ *   - Windows: %APPDATA%\com.vercel.cli
+ *   - else:    $XDG_DATA_HOME/com.vercel.cli  (default ~/.local/share/...)
+ *
+ * `AGENTBOX_VERCEL_CLI_DIR` overrides outright — for tests and the rare install
+ * that relocates the store.
+ */
+export function vercelCliDir(): string {
+  const override = process.env.AGENTBOX_VERCEL_CLI_DIR;
+  if (override && override.trim().length > 0) return override.trim();
+
+  const name = 'com.vercel.cli';
+  if (process.platform === 'darwin') {
+    return join(homedir(), 'Library', 'Application Support', name);
+  }
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA;
+    if (appData && appData.trim().length > 0) return join(appData, name);
+    return join(homedir(), 'AppData', 'Roaming', name);
+  }
+  const xdg = process.env.XDG_DATA_HOME;
+  const base = xdg && xdg.trim().length > 0 ? xdg.trim() : join(homedir(), '.local', 'share');
+  return join(base, name);
+}
+
+/** Absolute paths to the CLI store files, for status/diagnostics. */
+export function cliStorePaths(): { authPath: string; configPath: string } {
+  const dir = vercelCliDir();
+  return { authPath: join(dir, 'auth.json'), configPath: join(dir, 'config.json') };
+}
+
+function readJson(path: string): unknown {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the live access token from the CLI store. Returns null when the store is
+ * missing / unparseable / has no token (CLI never logged in, or logged out) so
+ * callers can surface a clear "run `agentbox vercel login`" error.
+ */
+export function readCliAuth(): VercelCliAuth | null {
+  const raw = readJson(cliStorePaths().authPath) as Record<string, unknown> | null;
+  if (!raw || typeof raw.token !== 'string' || raw.token.length === 0) return null;
+  return {
+    token: raw.token,
+    expiresAt: typeof raw.expiresAt === 'number' ? raw.expiresAt : undefined,
+    refreshToken: typeof raw.refreshToken === 'string' ? raw.refreshToken : undefined,
+  };
+}
+
+/** Read the CLI's currently-selected team (`config.json` `currentTeam`). */
+export function readCliCurrentTeam(): string | null {
+  const raw = readJson(cliStorePaths().configPath) as Record<string, unknown> | null;
+  return raw && typeof raw.currentTeam === 'string' && raw.currentTeam.length > 0
+    ? raw.currentTeam
+    : null;
+}
+
+/**
+ * Whether the access token is at/near expiry and should be refreshed before
+ * use. A missing `expiresAt` is treated as near-expiry so we always probe a
+ * refresh rather than ship a token of unknown age. `skewSec` is the safety
+ * window: refresh if the token expires within that many seconds.
+ */
+export function isNearExpiry(auth: VercelCliAuth, skewSec = 120): boolean {
+  if (auth.expiresAt === undefined) return true;
+  return auth.expiresAt * 1000 < Date.now() + skewSec * 1000;
+}

--- a/examples/agentbox-provider-example/src/env-loader.ts
+++ b/examples/agentbox-provider-example/src/env-loader.ts
@@ -1,0 +1,99 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+
+/**
+ * Vercel env auto-loader. The `@vercel/sandbox` SDK reads `VERCEL_OIDC_TOKEN`
+ * from `process.env`; for the access-token path we read `VERCEL_TOKEN` +
+ * `VERCEL_TEAM_ID` + `VERCEL_PROJECT_ID` and thread them into every SDK call as
+ * explicit `Credentials`. We pull all of these in from `~/.agentbox/secrets.env`
+ * (written by `agentbox vercel login`) so the SDK Just Works after a one-time
+ * login — exactly the daytona/hetzner model.
+ *
+ * Lookup order (first wins; process.env is never overwritten):
+ *   1. `process.env` (already set in the shell).
+ *   2. `~/.agentbox/secrets.env` — written by `agentbox vercel login`.
+ *
+ * Project-level `.env` / `.env.local` are intentionally NOT consulted: those
+ * files belong to the app code being developed, and a `VERCEL_*` value there
+ * (e.g. a `vercel env pull` OIDC token, or the app's own deploy token) is meant
+ * for in-box code, not for the host CLI to harvest and provision sandboxes with.
+ * Put host credentials in `~/.agentbox/secrets.env` (or the shell env).
+ *
+ * Only Vercel-prefixed keys are imported; the rest of the file is left alone.
+ * Idempotent and side-effect-free after the first call.
+ */
+const VERCEL_KEYS = [
+  'VERCEL_OIDC_TOKEN',
+  'VERCEL_TOKEN',
+  'VERCEL_TEAM_ID',
+  'VERCEL_PROJECT_ID',
+  // Marker for CLI-login mode (`agentbox vercel login` → `sandbox login`). The
+  // access token is NOT stored here — it's read live from the Vercel CLI store;
+  // only this marker + team/project ids are persisted.
+  'VERCEL_AUTH_SOURCE',
+] as const;
+
+let loaded = false;
+
+export function ensureVercelEnvLoaded(): void {
+  if (loaded) return;
+  loaded = true;
+  importVercelFromFile(resolve(homedir(), '.agentbox', 'secrets.env'), VERCEL_KEYS);
+}
+
+/**
+ * Force a re-read of `~/.agentbox/secrets.env`. Used by the interactive
+ * `agentbox vercel login` flow after it persists the credential trio, so the
+ * same process can pick it up without a restart.
+ */
+export function reloadVercelEnv(): void {
+  loaded = false;
+  ensureVercelEnvLoaded();
+}
+
+function importVercelFromFile(path: string, keys: readonly string[]): void {
+  if (!existsSync(path)) return;
+  let body: string;
+  try {
+    body = readFileSync(path, 'utf8');
+  } catch {
+    return;
+  }
+  const parsed = parseEnvFile(body);
+  for (const key of keys) {
+    if (process.env[key] !== undefined) continue;
+    const value = parsed[key];
+    if (typeof value === 'string') {
+      process.env[key] = value;
+    }
+  }
+}
+
+/**
+ * Minimal `.env` parser: handles `KEY=value`, `KEY="value"`, `KEY='value'`,
+ * `export KEY=value`, blank lines, and `#` comments. No variable
+ * interpolation — predictable over feature-complete (matches the daytona
+ * loader's behavior).
+ */
+export function parseEnvFile(body: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const rawLine of body.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith('#')) continue;
+    const stripped = line.startsWith('export ') ? line.slice('export '.length) : line;
+    const eq = stripped.indexOf('=');
+    if (eq <= 0) continue;
+    const key = stripped.slice(0, eq).trim();
+    let value = stripped.slice(eq + 1).trim();
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1);
+    }
+    out[key] = value;
+  }
+  return out;
+}

--- a/examples/agentbox-provider-example/src/retry.ts
+++ b/examples/agentbox-provider-example/src/retry.ts
@@ -1,0 +1,147 @@
+/**
+ * Bounded retry wrapper for Vercel Sandbox SDK calls — mirrors
+ * `withDaytonaRetry` / `withHetznerRetry` in shape and intent. The Vercel
+ * control plane rate-limits (429) and can return transient 5xx during
+ * incidents; without bounded retries those propagate as wedges in the calling
+ * lifecycle code.
+ *
+ * Non-idempotent ops (`provision`/`Sandbox.create`, `createSnapshot`) pass
+ * `retryOnAmbiguous: false` so a timeout after the request reached the origin
+ * doesn't create a duplicate billable sandbox/snapshot.
+ */
+
+export interface WithRetryOptions {
+  method: string;
+  /** Per-attempt timeout (ms). Default 30_000. */
+  attemptTimeoutMs?: number;
+  /** Backoff before attempts 2, 3, … (ms). Default [1000, 2000, 4000]. */
+  backoffMs?: readonly number[];
+  /**
+   * Retry on errors where we can't be sure the server applied the request
+   * (connection failures, per-attempt timeouts, 5xx). Set false for
+   * non-idempotent operations where a retry could create a duplicate resource.
+   */
+  retryOnAmbiguous: boolean;
+  /** Override the default stderr retry sink (used by tests). */
+  onRetry?: (line: string) => void;
+}
+
+const DEFAULT_BACKOFF: readonly number[] = [1000, 2000, 4000];
+const DEFAULT_ATTEMPT_TIMEOUT_MS = 30_000;
+
+class AttemptTimeoutError extends Error {
+  constructor(method: string, ms: number) {
+    super(`vercel ${method}: per-attempt timeout after ${String(ms)}ms`);
+    this.name = 'AttemptTimeoutError';
+  }
+}
+
+export function isAttemptTimeout(err: unknown): err is AttemptTimeoutError {
+  return err instanceof AttemptTimeoutError;
+}
+
+/** HTTP status code dug out of whatever error shape the SDK throws. */
+function statusCodeOf(err: unknown): number | undefined {
+  if (!err || typeof err !== 'object') return undefined;
+  for (const key of ['statusCode', 'status', 'code'] as const) {
+    const v = (err as Record<string, unknown>)[key];
+    if (typeof v === 'number') return v;
+  }
+  const resp = (err as { response?: { status?: unknown } }).response;
+  if (resp && typeof resp.status === 'number') return resp.status;
+  return undefined;
+}
+
+export function isRetriable(err: unknown, allowAmbiguous: boolean): boolean {
+  if (err instanceof AttemptTimeoutError) return allowAmbiguous;
+
+  const status = statusCodeOf(err);
+  if (status !== undefined) {
+    if (status === 429) return true; // rate limited — the server told us to wait
+    if (status >= 500 && status <= 599) return allowAmbiguous;
+    return false; // 4xx (auth, validation, not_found) — permanent
+  }
+
+  // Raw fetch / undici errors. Node wraps low-level errors in `{ cause }`.
+  if (err && typeof err === 'object') {
+    const candidates: unknown[] = [err, (err as { cause?: unknown }).cause];
+    for (const c of candidates) {
+      if (!c || typeof c !== 'object') continue;
+      const code = (c as { code?: unknown }).code;
+      if (
+        code === 'ECONNRESET' ||
+        code === 'ETIMEDOUT' ||
+        code === 'ECONNABORTED' ||
+        code === 'EAI_AGAIN' ||
+        code === 'ECONNREFUSED' ||
+        code === 'ENOTFOUND' ||
+        code === 'UND_ERR_SOCKET' ||
+        code === 'UND_ERR_CONNECT_TIMEOUT'
+      ) {
+        return allowAmbiguous;
+      }
+    }
+  }
+  return false;
+}
+
+export async function withVercelRetry<T>(
+  opts: WithRetryOptions,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const backoff = opts.backoffMs ?? DEFAULT_BACKOFF;
+  const maxAttempts = backoff.length + 1;
+  const timeoutMs = opts.attemptTimeoutMs ?? DEFAULT_ATTEMPT_TIMEOUT_MS;
+  const log = opts.onRetry ?? defaultRetryLog;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await raceTimeout(fn(), timeoutMs, opts.method);
+    } catch (err) {
+      const last = attempt === maxAttempts;
+      if (last || !isRetriable(err, opts.retryOnAmbiguous)) throw err;
+      const delay = backoff[attempt - 1] ?? backoff[backoff.length - 1] ?? 4000;
+      log(
+        `vercel ${opts.method}: attempt ${String(attempt)} failed (${errorSummary(err)}); retrying in ${String(delay)}ms`,
+      );
+      await sleep(delay);
+    }
+  }
+  throw new Error(`withVercelRetry: exhausted attempts for ${opts.method}`);
+}
+
+function defaultRetryLog(line: string): void {
+  process.stderr.write(`\n[vercel-retry] ${line}\n`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function raceTimeout<T>(p: Promise<T>, ms: number, method: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      p,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new AttemptTimeoutError(method, ms)), ms);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+function errorSummary(err: unknown): string {
+  if (err instanceof Error) {
+    const status = statusCodeOf(err);
+    return status !== undefined
+      ? `${err.name}(${String(status)}): ${truncate(err.message)}`
+      : `${err.name}: ${truncate(err.message)}`;
+  }
+  return truncate(String(err));
+}
+
+function truncate(s: string, max = 160): string {
+  return s.length > max ? `${s.slice(0, max)}…` : s;
+}

--- a/examples/agentbox-provider-example/src/sbx-cli.ts
+++ b/examples/agentbox-provider-example/src/sbx-cli.ts
@@ -1,0 +1,77 @@
+/**
+ * Driver for the official Vercel Sandbox CLI (`sandbox` / `sbx`, installed via
+ * `npm i -g sandbox`). This example reuses the CLI for two things:
+ *   - `refreshSbxToken` — run a cheap read command (`sandbox list`) which makes
+ *     the CLI lazily refresh its access token from its stored refresh token when
+ *     the token is stale (non-interactive; no browser).
+ *   - `detectSbx`      — probe whether the CLI is present, for interactive attach
+ *     (`agentbox shell|claude|...` drives `sbx exec` for a real PTY).
+ *
+ * Trimmed from the built-in provider's version: the interactive install/login
+ * helpers live only in the built-in `agentbox vercel login` — this example
+ * reuses that login (shared `~/.agentbox/secrets.env` + Vercel CLI store).
+ */
+
+import { execa } from 'execa';
+
+/**
+ * Binaries the Sandbox CLI installs. `sbx` is the short alias; we prefer it but
+ * fall back to `sandbox`.
+ */
+const SBX_BINS = ['sbx', 'sandbox'] as const;
+
+export interface SbxState {
+  /** A Sandbox CLI binary resolved on PATH and answered `--version`. */
+  installed: boolean;
+  /** The binary name that answered (`sbx` or `sandbox`), when installed. */
+  bin?: string;
+  /** Version string, when installed. */
+  version?: string;
+}
+
+let cached: SbxState | null = null;
+
+/**
+ * Probe the host for the Sandbox CLI. Cached per-process (install state can't
+ * change mid-command); `resetSbxCache` clears it for tests.
+ */
+export async function detectSbx(): Promise<SbxState> {
+  if (cached !== null) return cached;
+  for (const bin of SBX_BINS) {
+    try {
+      const r = await execa(bin, ['--version'], { reject: false });
+      if (r.exitCode === 0) {
+        cached = { installed: true, bin, version: (r.stdout ?? '').trim() || undefined };
+        return cached;
+      }
+    } catch {
+      // try the next bin name
+    }
+  }
+  cached = { installed: false };
+  return cached;
+}
+
+/** Drop the per-process probe cache so the next `detectSbx()` re-probes. */
+export function resetSbxCache(): void {
+  cached = null;
+}
+
+/**
+ * Trigger the CLI's lazy token refresh by running a cheap read command. The CLI
+ * refreshes its access token from the stored refresh token when the token is
+ * stale and leaves a still-valid token untouched, so this is safe to call
+ * eagerly. Non-interactive (stdin from /dev/null); returns true on exit 0.
+ */
+export async function refreshSbxToken(bin: string): Promise<boolean> {
+  try {
+    const r = await execa(bin, ['list'], {
+      reject: false,
+      timeout: 30_000,
+      stdin: 'ignore',
+    });
+    return r.exitCode === 0;
+  } catch {
+    return false;
+  }
+}

--- a/examples/agentbox-provider-example/src/sdk.ts
+++ b/examples/agentbox-provider-example/src/sdk.ts
@@ -1,0 +1,189 @@
+/**
+ * Thin loader around `@vercel/sandbox`. Resolves the auth credentials once and
+ * threads them into every SDK call.
+ *
+ * Three auth modes (in precedence order):
+ *   - OIDC: `VERCEL_OIDC_TOKEN` in env → decode the JWT for owner/project and
+ *     pass `{ token, teamId, projectId }` explicitly.
+ *   - CLI-login: `VERCEL_AUTH_SOURCE=cli` → read the live OAuth access token
+ *     from the Vercel CLI's own store (`auth.json`) and the cached team/project
+ *     ids from `secrets.env`. The token is never copied to `secrets.env`; the
+ *     CLI store is the self-refreshing source of truth. `ensureFreshCredentials`
+ *     refreshes it (via the `sbx` CLI) before use when it's near expiry.
+ *   - Access token: `VERCEL_TOKEN` + `VERCEL_TEAM_ID` + `VERCEL_PROJECT_ID` →
+ *     passed explicitly as `{ token, teamId, projectId }` on each call, since
+ *     the SDK does NOT read those from env automatically.
+ */
+
+import { ensureVercelEnvLoaded } from './env-loader.js';
+import { isNearExpiry, readCliAuth, readCliCurrentTeam } from './cli-store.js';
+import { detectSbx, refreshSbxToken } from './sbx-cli.js';
+
+export interface VercelCredentials {
+  token: string;
+  teamId: string;
+  projectId: string;
+}
+
+/**
+ * Resolve the credentials to thread into SDK calls. Throws when nothing is
+ * configured (or an OIDC token has expired) so callers get a clear, actionable
+ * error instead of an opaque SDK auth failure.
+ *
+ * For OIDC we do NOT return `{}` and let the SDK read the env var: the SDK's
+ * env-OIDC path (`@vercel/oidc`) tries to *refresh* the token via the Vercel
+ * CLI's `.vercel/project.json` + cached auth, which an agentbox box doesn't
+ * have, so it fails with "Could not get credentials from OIDC context". Instead
+ * we decode the OIDC JWT — which embeds `owner_id` (teamId) and `project_id` —
+ * and pass `{ token, teamId, projectId }` explicitly, which uses the SDK's
+ * direct-credentials path (the OIDC token is itself a valid API bearer).
+ */
+export function resolveCredentials(): VercelCredentials {
+  ensureVercelEnvLoaded();
+  const oidc = process.env.VERCEL_OIDC_TOKEN;
+  if (oidc) {
+    const claims = decodeOidcClaims(oidc);
+    if (!claims) {
+      throw new Error(
+        'VERCEL_OIDC_TOKEN is set but could not be decoded (not a valid Vercel OIDC JWT). ' +
+          'Re-run `vercel env pull`, or use the VERCEL_TOKEN + VERCEL_TEAM_ID + VERCEL_PROJECT_ID trio.',
+      );
+    }
+    if (claims.exp !== undefined && claims.exp * 1000 < Date.now()) {
+      throw new Error(
+        'VERCEL_OIDC_TOKEN has expired (Vercel dev OIDC tokens last ~12h). ' +
+          'Re-run `vercel env pull` to refresh it, then retry.',
+      );
+    }
+    return { token: oidc, teamId: claims.teamId, projectId: claims.projectId };
+  }
+  if (process.env.VERCEL_AUTH_SOURCE === 'cli') {
+    const auth = readCliAuth();
+    if (!auth) {
+      throw new Error(
+        'Vercel CLI session not found — run `agentbox vercel login` (or `sbx login`) to sign in again.',
+      );
+    }
+    const teamId = process.env.VERCEL_TEAM_ID ?? readCliCurrentTeam() ?? undefined;
+    const projectId = process.env.VERCEL_PROJECT_ID;
+    if (!teamId || !projectId) {
+      throw new Error(
+        'Vercel CLI auth is missing the team/project id — re-run `agentbox vercel login`.',
+      );
+    }
+    // Live token straight from the CLI store; nothing cached on disk.
+    return { token: auth.token, teamId, projectId };
+  }
+  const token = process.env.VERCEL_TOKEN;
+  const teamId = process.env.VERCEL_TEAM_ID;
+  const projectId = process.env.VERCEL_PROJECT_ID;
+  if (token && teamId && projectId) return { token, teamId, projectId };
+  throw new Error(
+    'Vercel credentials not configured.\n' +
+      'Either run `vercel link && vercel env pull` to get a VERCEL_OIDC_TOKEN, ' +
+      'or set VERCEL_TOKEN + VERCEL_TEAM_ID + VERCEL_PROJECT_ID ' +
+      '(see `agentbox vercel login`).',
+  );
+}
+
+interface OidcClaims {
+  teamId: string;
+  projectId: string;
+  exp?: number;
+}
+
+/** Decode the `owner_id`/`project_id`/`exp` claims from a Vercel OIDC JWT. */
+function decodeOidcClaims(token: string): OidcClaims | null {
+  const parts = token.split('.');
+  if (parts.length < 2 || !parts[1]) return null;
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8')) as {
+      owner_id?: unknown;
+      project_id?: unknown;
+      exp?: unknown;
+    };
+    if (typeof payload.owner_id !== 'string' || typeof payload.project_id !== 'string') return null;
+    return {
+      teamId: payload.owner_id,
+      projectId: payload.project_id,
+      exp: typeof payload.exp === 'number' ? payload.exp : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** True when any auth mode is configured. Used by the credential gate. */
+export function hasUsableCredentials(): boolean {
+  ensureVercelEnvLoaded();
+  if (process.env.VERCEL_OIDC_TOKEN) return true;
+  if (
+    process.env.VERCEL_AUTH_SOURCE === 'cli' &&
+    process.env.VERCEL_TEAM_ID &&
+    process.env.VERCEL_PROJECT_ID &&
+    readCliAuth()
+  ) {
+    return true;
+  }
+  return Boolean(
+    process.env.VERCEL_TOKEN && process.env.VERCEL_TEAM_ID && process.env.VERCEL_PROJECT_ID,
+  );
+}
+
+/**
+ * Refresh the CLI-login access token before use when it's near expiry. No-op
+ * for the OIDC and access-token modes (nothing to refresh). For CLI mode: if the
+ * live token in the CLI store is within the safety window, run a cheap `sbx`
+ * read command, which makes the CLI rotate its own token from the stored refresh
+ * token, then re-read `secrets.env`. Throws an actionable error when the CLI is
+ * gone or the refresh fails (e.g. the refresh token itself expired).
+ *
+ * Call this once at the top of each backend operation, BEFORE the (sync)
+ * `resolveCredentials()` reads the token. An in-process single-flight collapses
+ * concurrent ops onto one refresh; cross-process races are harmless (the CLI
+ * writes its store atomically and a fresh-token refresh is a no-op).
+ */
+let inflightRefresh: Promise<void> | null = null;
+
+export function ensureFreshCredentials(): Promise<void> {
+  ensureVercelEnvLoaded();
+  if (process.env.VERCEL_AUTH_SOURCE !== 'cli') return Promise.resolve();
+  if (inflightRefresh) return inflightRefresh;
+  inflightRefresh = refreshCliToken().finally(() => {
+    inflightRefresh = null;
+  });
+  return inflightRefresh;
+}
+
+async function refreshCliToken(): Promise<void> {
+  const auth = readCliAuth();
+  if (!auth) return; // resolveCredentials() will throw the clear "logged out" error
+  if (!isNearExpiry(auth)) return; // still valid — no work
+
+  const det = await detectSbx();
+  if (!det.installed || !det.bin) {
+    throw new Error(
+      'Vercel access token is near expiry and the `sandbox` CLI is no longer installed — ' +
+        'reinstall it (`npm install -g sandbox`) or run `agentbox vercel login`.',
+    );
+  }
+  const ok = await refreshSbxToken(det.bin);
+  if (!ok) {
+    throw new Error(
+      'Vercel token refresh failed — run `agentbox vercel login` (the refresh token may have expired).',
+    );
+  }
+  // The token lives in the CLI store, not secrets.env — refreshSbxToken rotated
+  // auth.json in place, so the next readCliAuth() returns the fresh token.
+  const fresh = readCliAuth();
+  if (!fresh || isNearExpiry(fresh, 0)) {
+    throw new Error(
+      'Vercel token is still stale after a refresh attempt — run `agentbox vercel login`.',
+    );
+  }
+}
+
+// Re-export the SDK surface we use so the rest of the package imports from one
+// place (and tests can mock `./sdk.js` instead of the package).
+export { Sandbox, Snapshot } from '@vercel/sandbox';
+export type { Sandbox as SandboxType } from '@vercel/sandbox';

--- a/examples/agentbox-provider-example/tsconfig.json
+++ b/examples/agentbox-provider-example/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "strict": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/packages/provider-sdk/src/index.ts
+++ b/packages/provider-sdk/src/index.ts
@@ -109,6 +109,40 @@ export {
   type EffectiveConfig,
 } from '@agentbox/config';
 
+// ---- interactive attach helpers (build a cloud box's `buildAttach` argv) ----
+// A provider with no SSH (like vercel/e2b) overrides `buildAttach` and drives
+// its own PTY transport; these render the shared inner tmux command + forward a
+// safe TERM, exactly as the built-in cloud providers do.
+export { hostTermForCloud, renderInnerCommand } from '@agentbox/sandbox-cloud';
+
+// ---- prepare-time agent-config staging (bake host ~/.claude etc into a base) ----
+// A provider that bakes its base image by booting a builder sandbox stages the
+// host's static agent config into the snapshot with these (same helpers the
+// built-in cloud `prepare` flows use).
+export {
+  stageClaudeStaticForUpload,
+  stageCodexStaticForUpload,
+  stageOpencodeStaticForUpload,
+  type StageResult,
+} from '@agentbox/sandbox-cloud';
+
+// ---- cloud checkpoint authoring (for id-addressed-snapshot providers) ----
+// A provider whose snapshots are id-addressed (like vercel/e2b, where the cloud
+// returns an opaque snapshot id you can't name) overrides the whole `checkpoint`
+// capability instead of using the scaffold default. These are the host-side
+// manifest helpers that override needs — the same ones the built-in vercel/e2b
+// providers use.
+export {
+  writeCloudCheckpointManifest,
+  listCloudCheckpoints,
+  resolveCloudCheckpoint,
+  removeCloudCheckpointDir,
+  currentCloudBaseFingerprint,
+  type CloudCheckpointInfo,
+  type CloudCheckpointManifest,
+  type WriteCloudManifestFields,
+} from '@agentbox/sandbox-cloud';
+
 // ---- shared box-side runtime assets (ctl.cjs + shims from the running CLI) ----
 export {
   resolveSharedRuntimeAsset,


### PR DESCRIPTION
## What

Renames the macOS menu-bar app from **AgentBoxTray** to **AgentBox** on the CLI side (pairs with madarco/agentbox-tray#3).

- `APP_NAME = 'AgentBox'` → installs to `/Applications/AgentBox.app`, downloads `AgentBox.zip` from the `tray-latest` release, and `pgrep`/`pkill` by the new executable name.
- Crash-report discovery keys on the new name (macOS writes `AgentBox-*.ips`).
- `agentbox app` user-facing strings + `cli.mdx` + CHANGELOG updated.

## One-time migration

`agentbox install tray` now quits and removes any leftover pre-rename `AgentBoxTray.app`. Since the rename **keeps the bundle id** (`com.madarco.agentbox-tray`), two bundles sharing one id would otherwise collide — this ensures they never coexist.

## Kept unchanged (deliberate)

- Bundle id `com.madarco.agentbox-tray` — the `agentbox app log` unified-logging subsystem, launch-at-login, and notifications carry over.
- Command names `agentbox install tray` and `agentbox app`.

## Coordination / caveats

- A new tray release (madarco/agentbox-tray `publish-release.sh`, which now emits `AgentBox.zip`) must be published to `tray-latest` before `agentbox install tray` from this CLI can find the renamed asset.
- Pre-rename `AgentBoxTray-*.ips` crash reports are no longer listed by `agentbox app log` (it now matches `AgentBox-*.ips`).

## Verification

- `typecheck`, `lint`, `build` green.
- `agentbox app status --json` → `appPath: /Applications/AgentBox.app`.
- Only remaining `AgentBoxTray` literal is the intentional `LEGACY_APP_NAME` cleanup constant.

https://claude.ai/code/session_01WHtFJBjFg7n95j9jE9R4rb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> macOS tray rename is migration-aware and mostly cosmetic; provider-sdk additions are additive re-exports. Coordinate publishing `AgentBox.zip` to `tray-latest` before users install from this CLI.
> 
> **Overview**
> Renames the macOS menu-bar app from **AgentBoxTray** to **AgentBox** across the CLI: install path `/Applications/AgentBox.app`, release asset `AgentBox.zip`, crash reports matching `AgentBox-*.ips`, and updated user-facing strings in `agentbox app`, docs, and CHANGELOG. **Bundle id** `com.madarco.agentbox-tray` and commands `agentbox install tray` / `agentbox app` are unchanged.
> 
> **Migration:** `LEGACY_APP_NAME` (`AgentBoxTray`) is used so `install tray` quits/removes the old bundle (only after a successful extract), and `app` status/stop/restart/`pkill` still see legacy processes. Pre-rename `AgentBoxTray-*.ips` reports are no longer listed by `app log`.
> 
> **Also in this diff:** `@agentbox/provider-sdk` re-exports cloud attach, prepare staging, and checkpoint manifest helpers from `@agentbox/sandbox-cloud`, plus a private **`examples/agentbox-provider-example`** Vercel-backed reference plugin (provision script, auth/retry SDK wrappers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19ad03a19188a6a9fb9c288f1ead501409d14e0c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->