### PR TITLE
fix(portless): adopt a running proxy on non-interactive box creates

### DIFF
--- a/apps/cli/src/commands/_run-queued-job.ts
+++ b/apps/cli/src/commands/_run-queued-job.ts
@@ -24,6 +24,7 @@ import {
 import {
   createBox,
   DEFAULT_BOX_IMAGE,
+  detectEngine,
   ensureImage,
   hostBackupHasCredentials,
   rebuildPluginNativeDeps,
@@ -56,6 +57,7 @@ import { applyClaudeSkipPermissions, applyCodexSkipPermissions } from '../lib/sk
 import { providerForCreate } from '../provider/registry.js';
 import { cloudAgentStartDetached } from './_cloud-attach.js';
 import { spawnQueuedOpenTerminal } from '../terminal/queue-open.js';
+import { resolvePortlessNonInteractive } from '../portless-prompt.js';
 import { buildSetupInitialPrompt } from '../wizard.js';
 
 /**
@@ -296,6 +298,20 @@ async function runDockerJob(
     await ensureClaudeLoginFresh({ id: job.id, log, image: cfg.effective.box.image, isCloud: false });
   }
 
+  // Background jobs (incl. hub / tray-app created boxes) can't negotiate
+  // Portless interactively. An explicit --portless/--no-portless on the job
+  // wins; otherwise resolve non-interactively — honoring a persisted config
+  // opt-in, and, on Docker Desktop, adopting an already-running proxy so the
+  // very first box started from the tray app gets its <name>.localhost alias
+  // (previously it only worked after opting in once from a real terminal).
+  const portlessEnabled =
+    opts.portless ??
+    (await resolvePortlessNonInteractive({
+      engine: await detectEngine(),
+      enabled: cfg.effective.portless.enabled,
+      cwd: opts.workspace,
+    }));
+
   log.write(`creating box for agent=${job.noAgent ? 'none' : job.agent}`);
   const result = await createBox({
     workspacePath: opts.workspace,
@@ -320,12 +336,7 @@ async function runDockerJob(
     withEnv: cfg.effective.box.withEnv,
     vnc: { enabled: cfg.effective.box.vnc },
     docker: { sharedCache: cfg.effective.box.dockerCacheShared },
-    // Background jobs (incl. hub-created boxes) can't negotiate Portless
-    // interactively, but they must still honor a resolved `portless.enabled`.
-    // Explicit --portless / --no-portless on the job wins; otherwise fall back
-    // to the effective config so a host that opted in gets its <name>.localhost
-    // alias registered. Undefined (never opted in) still skips, as before.
-    portless: opts.portless ?? cfg.effective.portless.enabled,
+    portless: portlessEnabled,
     portlessStateDir: cfg.effective.portless.stateDir || undefined,
     resyncOnStart: opts.resync,
     limits: resolveLimits(cfg.effective.box, opts),

--- a/apps/cli/src/portless-prompt.ts
+++ b/apps/cli/src/portless-prompt.ts
@@ -108,7 +108,9 @@ export async function setupPortlessHost(
 export async function maybePromptPortless(args: PortlessPromptArgs): Promise<boolean> {
   if (args.enabled !== undefined) return args.enabled;
   if (args.engine === 'orbstack') return false;
-  if (!process.stdin.isTTY || args.yes) return false;
+  // Non-interactive (`--yes`, CI, no TTY): can't prompt — adopt a running proxy
+  // instead of forcing the user to opt in from a terminal first.
+  if (!process.stdin.isTTY || args.yes) return resolvePortlessNonInteractive(args);
 
   const answer = await confirm({
     message:
@@ -127,4 +129,33 @@ export async function maybePromptPortless(args: PortlessPromptArgs): Promise<boo
 
   if (answer) await setupPortlessHost();
   return answer;
+}
+
+/**
+ * Resolve `portless.enabled` when we can't prompt — background queue jobs, the
+ * tray app's hub-create path, `--yes`, CI. Honors an already-decided value
+ * (config or `--portless`/`--no-portless`). Otherwise, on Docker Desktop, it
+ * adopts an already-running Portless proxy — and persists the choice so later
+ * runs skip re-detection, mirroring an interactive "yes" for a user who already
+ * has Portless up. Without this, the first box started from the tray app never
+ * uses Portless even though the proxy is live on :443, until the user happens to
+ * run `agentbox` once from a real terminal. Never installs or starts a proxy
+ * unasked; OrbStack needs no Portless (it has `.orb.local`).
+ */
+export async function resolvePortlessNonInteractive(args: {
+  engine: DockerEngine;
+  enabled: boolean | undefined;
+  cwd: string;
+}): Promise<boolean> {
+  if (args.enabled !== undefined) return args.enabled;
+  if (args.engine === 'orbstack') return false;
+  const state = await detectPortless();
+  if (state.proxyRunning) {
+    try {
+      await setConfigValue('global', 'portless.enabled', true, args.cwd, { raw: false });
+    } catch {
+      // Best-effort persist; still use the running proxy for this run.
+    }
+  }
+  return state.proxyRunning;
 }

--- a/apps/cli/test/portless-prompt.test.ts
+++ b/apps/cli/test/portless-prompt.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { maybePromptPortless, resolvePortlessNonInteractive } from '../src/portless-prompt.js';
+
+// Mock the two side-effecting dependencies so the test stays pure (no docker,
+// no config write, no network) — we only assert the decision logic.
+vi.mock('@agentbox/config', () => ({
+  setConfigValue: vi.fn(async () => {}),
+}));
+
+const proxyRunning = { value: false };
+vi.mock('@agentbox/sandbox-docker', () => ({
+  detectPortless: vi.fn(async () => ({ installed: true, proxyRunning: proxyRunning.value })),
+  installPortless: vi.fn(),
+  portlessInstallHint: () => '',
+  portlessStartHint: () => '',
+  resetPortlessCache: vi.fn(),
+  startPortlessProxy: vi.fn(),
+  startPortlessProxyRoot: vi.fn(),
+}));
+
+const { setConfigValue } = (await import('@agentbox/config')) as unknown as {
+  setConfigValue: ReturnType<typeof vi.fn>;
+};
+const { detectPortless } = (await import('@agentbox/sandbox-docker')) as unknown as {
+  detectPortless: ReturnType<typeof vi.fn>;
+};
+
+const ORIG_TTY = process.stdin.isTTY;
+
+afterEach(() => {
+  Object.defineProperty(process.stdin, 'isTTY', { value: ORIG_TTY, configurable: true });
+  proxyRunning.value = false;
+  vi.clearAllMocks();
+});
+
+function setTTY(v: boolean) {
+  Object.defineProperty(process.stdin, 'isTTY', { value: v, configurable: true });
+}
+
+const base = { engine: 'docker-desktop' as const, enabled: undefined, yes: false, cwd: '/tmp' };
+
+describe('maybePromptPortless non-interactive path (tray app / --yes)', () => {
+  it('adopts an already-running proxy when there is no TTY (the tray-app bug)', async () => {
+    setTTY(false);
+    proxyRunning.value = true;
+
+    const enabled = await maybePromptPortless(base);
+
+    expect(enabled).toBe(true);
+    expect(detectPortless).toHaveBeenCalled();
+    // Persisted so later runs skip re-detection, mirroring an interactive "yes".
+    expect(setConfigValue).toHaveBeenCalledWith(
+      'global',
+      'portless.enabled',
+      true,
+      '/tmp',
+      expect.anything(),
+    );
+  });
+
+  it('returns false and does not persist when no proxy is running', async () => {
+    setTTY(false);
+    proxyRunning.value = false;
+
+    const enabled = await maybePromptPortless(base);
+
+    expect(enabled).toBe(false);
+    expect(setConfigValue).not.toHaveBeenCalled();
+  });
+
+  it('adopts a running proxy under --yes even with a TTY', async () => {
+    setTTY(true);
+    proxyRunning.value = true;
+
+    const enabled = await maybePromptPortless({ ...base, yes: true });
+
+    expect(enabled).toBe(true);
+  });
+
+  it('short-circuits to the already-decided value without detecting', async () => {
+    setTTY(false);
+    proxyRunning.value = true;
+
+    const enabled = await maybePromptPortless({ ...base, enabled: false });
+
+    expect(enabled).toBe(false);
+    expect(detectPortless).not.toHaveBeenCalled();
+  });
+
+  it('stays off for OrbStack (already has .orb.local)', async () => {
+    setTTY(false);
+    proxyRunning.value = true;
+
+    const enabled = await maybePromptPortless({ ...base, engine: 'orbstack' });
+
+    expect(enabled).toBe(false);
+    expect(detectPortless).not.toHaveBeenCalled();
+  });
+});
+
+// The tray app creates boxes via hub → queue worker, which never calls
+// maybePromptPortless; it resolves through resolvePortlessNonInteractive.
+describe('resolvePortlessNonInteractive (queue worker / hub-create path)', () => {
+  const wargs = { engine: 'docker-desktop' as const, enabled: undefined, cwd: '/tmp' };
+
+  it('adopts and persists an already-running proxy', async () => {
+    proxyRunning.value = true;
+
+    const enabled = await resolvePortlessNonInteractive(wargs);
+
+    expect(enabled).toBe(true);
+    expect(setConfigValue).toHaveBeenCalledWith(
+      'global',
+      'portless.enabled',
+      true,
+      '/tmp',
+      expect.anything(),
+    );
+  });
+
+  it('returns false without persisting when no proxy is running', async () => {
+    proxyRunning.value = false;
+
+    const enabled = await resolvePortlessNonInteractive(wargs);
+
+    expect(enabled).toBe(false);
+    expect(setConfigValue).not.toHaveBeenCalled();
+  });
+
+  it('honors an explicit config value without detecting', async () => {
+    proxyRunning.value = true;
+
+    expect(await resolvePortlessNonInteractive({ ...wargs, enabled: false })).toBe(false);
+    expect(detectPortless).not.toHaveBeenCalled();
+  });
+
+  it('stays off for OrbStack even with a live proxy', async () => {
+    proxyRunning.value = true;
+
+    expect(await resolvePortlessNonInteractive({ ...wargs, engine: 'orbstack' })).toBe(false);
+    expect(detectPortless).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

On a fresh Mac, starting the **first** box from the tray app does **not** get a Portless `https://<box>.localhost` URL — even though the Portless proxy is running on :443. Running `agentbox claude` once from a terminal (which shows the interactive "Use Portless?" prompt, answered Yes) fixes it: from then on every box, app-created included, gets Portless.

## Root cause

The tray app creates boxes via the Control Hub (`POST /api/v1/boxes`), which enqueues a **background queue job**. That path never runs the interactive Portless opt-in — the queue worker resolved Portless from config only:

```ts
// _run-queued-job.ts (before)
portless: opts.portless ?? cfg.effective.portless.enabled,   // undefined on a fresh machine → no Portless
```

`portless.enabled` is unset until the user opts in once from a real terminal (the only path that prompts + persists `portless.enabled: true`). So the first app-created box got no `.localhost` alias despite a live proxy. The foreground non-interactive CLI path (`maybePromptPortless`) had the same blind spot: `if (!process.stdin.isTTY || args.yes) return false`.

## Fix

Add a shared `resolvePortlessNonInteractive()` helper: when Portless is undecided and the engine is Docker Desktop, **adopt an already-running proxy** (persisting the choice so later runs skip re-detection) — but never install or start one unasked, and stay off for OrbStack (which has `.orb.local`). Wired into both non-interactive entry points:

- `maybePromptPortless` — the `--yes`/no-TTY branch now resolves through it instead of returning `false`.
- `_run-queued-job.ts` — the queue worker (the tray/hub create path) resolves through it before `createBox`.

## Verification

- **Live e2e** in the exact repro environment (Docker Desktop + Portless on :443, `portless.enabled` unset to simulate a fresh Mac): non-interactive `create -y` registered `https://portless-smoke.localhost` + `https://vnc-portless-smoke.localhost` and re-persisted `portless.enabled: true`. Before the fix this path returned `false` and registered no alias.
- **9 new unit tests** (`apps/cli/test/portless-prompt.test.ts`) covering both entry points: adopt-when-running, skip-when-down, honor explicit config/flag, OrbStack stays off.
- `typecheck` + `eslint` clean.

No behavior change for users who already opted in (config short-circuits), for `--no-portless`, or for OrbStack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-only change for undecided Portless on non-interactive paths; explicit config, flags, and OrbStack are unchanged, and no proxy is started without user consent.
> 
> **Overview**
> Fixes tray-app / hub **first box** missing `https://<box>.localhost` when Portless is already on `:443` but `portless.enabled` was never set (only the interactive CLI prompt persisted it).
> 
> Adds **`resolvePortlessNonInteractive`**: if Portless is undecided, honor explicit flags/config; skip OrbStack; on Docker Desktop **enable Portless when a proxy is already running** and best-effort persist `portless.enabled: true` — without installing or starting Portless. Wires it into **`maybePromptPortless`** (no TTY / `--yes`) and the **queue worker** (`_run-queued-job`) before `createBox`.
> 
> New unit tests cover adopt-when-running, no-proxy, explicit config, and OrbStack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80dee039fb9f482e376cc54f0d1a27761d1ba6cd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->