### PR TITLE
docs: add islo.dev under Community Providers

### DIFF
--- a/apps/web/content/docs/islo.mdx
+++ b/apps/web/content/docs/islo.mdx
@@ -1,0 +1,77 @@
+---
+title: islo
+description: Run your agents on islo.dev microVMs — a community AgentBox provider plugin with pause/resume, public preview URLs, and fast async exec
+---
+
+Run your agents on [islo.dev](https://islo.dev) microVMs with the same `agentbox` commands as a
+local box. **islo is a community provider** — a [plugin](/docs/build-a-provider) published as its
+own package (`agentbox-provider-islo`), not bundled into the CLI. It gives you name-addressed
+sandboxes with first-class pause/resume, a public HTTPS preview URL per port, and a fast two-step
+exec API — no local Docker needed.
+
+Switch per box with `--provider islo`, or pin it project-wide with `box.provider: islo` in
+[`agentbox.yaml`](/docs/agentbox-yaml). Comparing options? See the built-ins
+[local-docker](/docs/local-docker), [hetzner](/docs/hetzner), [daytona](/docs/daytona),
+[vercel](/docs/vercel), and [e2b](/docs/e2b).
+
+<Callout type="info" title="Community provider">
+  Maintained outside the AgentBox core, at
+  [`zozo123/agentbox-provider-islo`](https://github.com/zozo123/agentbox-provider-islo)
+  ([npm](https://www.npmjs.com/package/agentbox-provider-islo)). Built only on
+  [`@madarco/agentbox-provider-sdk`](https://www.npmjs.com/package/@madarco/agentbox-provider-sdk)
+  and the official [`@islo-labs/sdk`](https://www.npmjs.com/package/@islo-labs/sdk). Report bugs
+  at the [issue tracker](https://github.com/zozo123/agentbox-provider-islo/issues) or
+  **support@incredibuild.com**.
+</Callout>
+
+## Install
+
+Install the plugin, then register it so `--provider islo` resolves:
+
+```bash
+npm i -g agentbox-provider-islo
+agentbox plugin add agentbox-provider-islo
+agentbox plugin list            # → islo … (SDK v1)
+```
+
+## Credentials
+
+Mint an islo API key with the [islo CLI](https://islo.dev) and expose it as `ISLO_API_KEY`:
+
+```bash
+islo api-key create agentbox --show
+export ISLO_API_KEY=isl_...      # or add ISLO_API_KEY=… to ~/.agentbox/secrets.env
+agentbox doctor                  # shows the `islo:` group
+```
+
+The key is auto-exchanged for a short-lived session JWT and refreshed transparently. Credentials
+persist to `~/.agentbox/secrets.env`; project `.env` files are never harvested. See
+[environment](/docs/environment). Optional overrides: `ISLO_BASE_URL`, `ISLO_COMPUTE_URL`,
+`ISLO_IMAGE`.
+
+## Use it
+
+```bash
+agentbox create --provider islo
+```
+
+From there, [run an agent](/docs/run-an-agent) and [access your box](/docs/access-your-box) as
+usual. Lifecycle maps onto islo natively:
+
+| AgentBox                | islo                                               |
+| ----------------------- | -------------------------------------------------- |
+| `create` / `list`       | `createSandbox` / `listSandboxes`                  |
+| `stop` / `pause`        | `stopSandbox` / `pauseSandbox`                     |
+| `start` / `resume`      | `resumeSandbox` (waits until the VM is running)    |
+| `destroy`               | `deleteSandbox`                                    |
+| exec, `cp`, preview URL | async exec, compute file endpoint, public `shares` |
+
+## Base image
+
+islo boxes boot from islo's default image or the `ISLO_IMAGE` you set. Like every AgentBox
+**cloud** provider, a full `create` needs the AgentBox runtime (`agentbox-ctl`, node, the agents)
+present in the box; the built-in providers bake this with a per-provider
+[`prepare`](/docs/build-a-provider) step. For islo, point `ISLO_IMAGE` at an islo-hosted image
+that already carries the runtime. Native base-image baking (`prepare`) and a no-SSH interactive
+`buildAttach` are planned follow-ups; the underlying sandbox lifecycle (provision, exec, file
+transfer, pause/resume, preview URLs, destroy) is complete today.

--- a/apps/web/content/docs/meta.json
+++ b/apps/web/content/docs/meta.json
@@ -30,6 +30,8 @@
     "daytona",
     "vercel",
     "e2b",
+    "---Community Providers---",
+    "islo",
     "---Reference---",
     "cli",
     "hub",


### PR DESCRIPTION
## Summary

Adds an **islo.dev** page under a new **Community Providers** section in the docs, per [`build-a-provider`](https://agent-box.sh/docs/build-a-provider#what-the-package-must-ship).

`agentbox-provider-islo` is a community provider plugin for [islo.dev](https://islo.dev) microVMs, hosted and published separately (not in this repo):

- **Repo:** https://github.com/zozo123/agentbox-provider-islo
- **npm:** `agentbox-provider-islo`

It's a thin `CloudBackend` over the official [`@islo-labs/sdk`](https://www.npmjs.com/package/@islo-labs/sdk), built only on `@madarco/agentbox-provider-sdk@^1`, exporting `providerModule` with `agentbox.providerApiVersion: 1` — following the package requirements in the docs.

## What's in this PR

Docs only — `apps/web/content/docs/islo.mdx` + a `Community Providers` entry in `content/docs/meta.json`. (The plugin previously lived in `examples/` in an earlier revision of this branch; per maintainer guidance it now lives in its own repo, so this PR is docs-only.)

## The plugin (in its own repo)

Verified **end-to-end against the live islo API**: provision→running, exec (clean stdout + exit codes), file upload/download round-trip, `listFiles`, `previewUrl`, `pause`→`resume`, `list`, `destroy`. `agentbox plugin add` registers `islo (SDK v1)` and `agentbox doctor` renders the `islo:` group. Backend mapping (name-addressed cloud; two-step async exec; multipart file transfer; public `shares` for preview) is documented in the repo README.

`prepare` (native base-image baking) and no-SSH `buildAttach` are noted as follow-ups, as the docs describe for cloud providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)