### PR TITLE
fix(open): detect VS Code/Cursor via .app bundle, not just PATH

### DIFF
--- a/apps/cli/src/commands/_open-in.ts
+++ b/apps/cli/src/commands/_open-in.ts
@@ -84,6 +84,60 @@ export function defaultHerdrSocketPath(seams: DetectSeams = realSeams()): string
 const CMUX_APP_CLI_SUFFIX = 'cmux.app/Contents/Resources/bin/cmux';
 
 /**
+ * VS Code-family desktop apps, in try order. Each maps its macOS `.app` bundle
+ * to the `--folder-uri`-capable CLI *inside* the bundle. A freshly-dragged
+ * install has the bundle but no `code`/`cursor` shim on PATH (that shim only
+ * appears after the user runs "Shell Command: Install 'code' command in PATH"),
+ * so detection and launch must fall back to the bundle — otherwise the tray's
+ * Open In… menu hides VS Code entirely on an otherwise-ready machine.
+ */
+interface VscodeApp {
+  /** IDE flavor (matches `IdeFlavor` in sandbox-docker). */
+  flavor: 'vscode' | 'cursor';
+  /** PATH binary name, tried before the bundle. */
+  cli: string;
+  /** macOS bundle name under /Applications or ~/Applications. */
+  appName: string;
+  /** Path to the bundled CLI, relative to the .app bundle. */
+  bundleCliSuffix: string;
+}
+
+const VSCODE_APPS: readonly VscodeApp[] = [
+  {
+    flavor: 'vscode',
+    cli: 'code',
+    appName: 'Visual Studio Code.app',
+    bundleCliSuffix: 'Contents/Resources/app/bin/code',
+  },
+  {
+    flavor: 'cursor',
+    cli: 'cursor',
+    appName: 'Cursor.app',
+    bundleCliSuffix: 'Contents/Resources/app/bin/cursor',
+  },
+];
+
+/**
+ * Resolve a VS Code-family `--folder-uri` CLI: PATH first, then the macOS
+ * bundle's bundled `code`/`cursor` binary (so a drag-installed app with no PATH
+ * shim still launches, and via the real CLI rather than the `open <scheme>://`
+ * protocol handler whose %2B URL-encoding can break the Remote attach). `cli`
+ * is a flavor CLI name (`code` / `cursor`); returns undefined when neither the
+ * CLI nor its bundle is present.
+ */
+export function resolveVscodeCli(cli: string, seams: DetectSeams = realSeams()): string | undefined {
+  if (pathHasBinary(cli, seams)) return cli;
+  if (seams.platform !== 'darwin') return undefined;
+  const app = VSCODE_APPS.find((a) => a.cli === cli);
+  if (!app) return undefined;
+  for (const root of ['/Applications', join(seams.homedir(), 'Applications')]) {
+    const p = join(root, app.appName, app.bundleCliSuffix);
+    if (seams.existsSync(p)) return p;
+  }
+  return undefined;
+}
+
+/**
  * Locate a cmux control CLI usable from *outside* cmux: explicit env override,
  * then PATH, then the macOS app bundle (cmux does not install itself on PATH;
  * `/Applications` and `~/Applications` both count, matching detectOpenTargets).
@@ -117,7 +171,12 @@ export function detectOpenTargets(seams: DetectSeams = realSeams()): OpenTargets
       available: pathHasBinary('cmux', seams) || macAppInstalled('cmux.app', seams),
     },
     vscode: {
-      available: pathHasBinary('code', seams) || pathHasBinary('cursor', seams),
+      // PATH shim OR the .app bundle — a freshly-dragged VS Code/Cursor has no
+      // `code`/`cursor` on PATH until the user runs the "Install 'code' command"
+      // step, but `agentbox open --in vscode` can launch it from the bundle.
+      available: VSCODE_APPS.some(
+        (a) => pathHasBinary(a.cli, seams) || macAppInstalled(a.appName, seams),
+      ),
       providers: [...IDE_PROVIDERS],
     },
     iterm2: {

--- a/apps/cli/src/commands/code.ts
+++ b/apps/cli/src/commands/code.ts
@@ -19,6 +19,7 @@ import {
 import { resolveBoxOrExit } from '../box-ref.js';
 import { providerForBox } from '../provider/registry.js';
 import { handleLifecycleError } from './_errors.js';
+import { resolveVscodeCli } from './_open-in.js';
 
 export interface CodeOptions {
   // commander stores `--no-wait` / `--no-auto-terminals` under the positive
@@ -269,18 +270,21 @@ async function launchIde(folderUri: string, forced?: IdeFlavor): Promise<LaunchR
   if (cursor !== null) return cursor;
   // Neither CLI present. Last resort: protocol handler via `open`. We pick
   // vscode:// since that's the documented historical fallback.
-  log.warn('neither `code` nor `cursor` found in PATH; falling back to `open vscode://...`');
+  log.warn('neither `code` nor `cursor` found on PATH or in /Applications; falling back to `open vscode://...`');
   return launchOne('vscode', folderUri);
 }
 
 /**
- * Try the IDE's CLI. Returns null if the binary isn't in PATH so the caller
- * can try the next flavor; otherwise returns the launch result (success or
- * non-127 failure both count as "we ran this one").
+ * Try the IDE's CLI. Returns null if neither the PATH shim nor the macOS
+ * `.app` bundle CLI is present, so the caller can try the next flavor;
+ * otherwise returns the launch result (success or non-127 failure both count
+ * as "we ran this one").
  */
 async function tryCli(flavor: IdeFlavor, folderUri: string): Promise<LaunchResult | null> {
   const profile = ideProfile(flavor);
-  const code = await spawnCommand(profile.cli, ['--folder-uri', folderUri]);
+  const bin = resolveVscodeCli(profile.cli);
+  if (!bin) return null;
+  const code = await spawnCommand(bin, ['--folder-uri', folderUri]);
   if (code === 127) return null;
   return { code, flavor, via: 'cli' };
 }
@@ -292,10 +296,13 @@ async function tryCli(flavor: IdeFlavor, folderUri: string): Promise<LaunchResul
  */
 async function launchOne(flavor: IdeFlavor, folderUri: string): Promise<LaunchResult> {
   const profile = ideProfile(flavor);
-  const cliCode = await spawnCommand(profile.cli, ['--folder-uri', folderUri]);
-  if (cliCode !== 127) return { code: cliCode, flavor, via: 'cli' };
+  const bin = resolveVscodeCli(profile.cli);
+  if (bin) {
+    const cliCode = await spawnCommand(bin, ['--folder-uri', folderUri]);
+    if (cliCode !== 127) return { code: cliCode, flavor, via: 'cli' };
+  }
   log.warn(
-    `\`${profile.cli}\` not found in PATH; falling back to \`${hostOpenCommand()} ${profile.protocolScheme}://...\` (the %2B URL-encoding bug may break attach)`,
+    `\`${profile.cli}\` not found on PATH or in /Applications; falling back to \`${hostOpenCommand()} ${profile.protocolScheme}://...\` (the %2B URL-encoding bug may break attach)`,
   );
   const url = `${profile.protocolScheme}://${folderUri.replace(/^vscode-remote:\/\//, 'vscode-remote/')}`;
   const fallback = await spawnCommand(hostOpenCommand(), [url]);

--- a/apps/cli/test/open-in.test.ts
+++ b/apps/cli/test/open-in.test.ts
@@ -8,6 +8,7 @@ import {
   pathHasBinary,
   renderTargets,
   resolveCmuxBinary,
+  resolveVscodeCli,
   type DetectSeams,
 } from '../src/commands/_open-in.js';
 
@@ -88,6 +89,16 @@ describe('detectOpenTargets', () => {
     expect(detectOpenTargets(seams({})).vscode.available).toBe(false);
   });
 
+  it('detects vscode via the .app bundle when no PATH shim (fresh install)', () => {
+    const viaCode = seams({ existing: ['/Applications/Visual Studio Code.app'] });
+    expect(detectOpenTargets(viaCode).vscode.available).toBe(true);
+    const viaCursor = seams({ existing: ['/home/u/Applications/Cursor.app'] });
+    expect(detectOpenTargets(viaCursor).vscode.available).toBe(true);
+    // The bundle is a macOS-only concept — Linux still needs the PATH binary.
+    const linux = seams({ platform: 'linux', existing: ['/Applications/Visual Studio Code.app'] });
+    expect(detectOpenTargets(linux).vscode.available).toBe(false);
+  });
+
   it('detects iterm2 via the app bundle on darwin only', () => {
     const mac = seams({ existing: ['/Applications/iTerm.app'] });
     expect(detectOpenTargets(mac).iterm2).toEqual({ available: true });
@@ -145,6 +156,32 @@ describe('resolveCmuxBinary', () => {
     expect(resolveCmuxBinary(viaHome)).toBe(
       '/home/u/Applications/cmux.app/Contents/Resources/bin/cmux',
     );
+  });
+});
+
+describe('resolveVscodeCli', () => {
+  it('prefers the PATH shim', () => {
+    const s = seams({ path: '/usr/local/bin', existing: ['/usr/local/bin/code'] });
+    expect(resolveVscodeCli('code', s)).toBe('code');
+  });
+
+  it('falls back to the .app bundle CLI on darwin', () => {
+    const appCli = '/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code';
+    const s = seams({ existing: [appCli] });
+    expect(resolveVscodeCli('code', s)).toBe(appCli);
+
+    const cursorCli = '/home/u/Applications/Cursor.app/Contents/Resources/app/bin/cursor';
+    const sc = seams({ existing: [cursorCli] });
+    expect(resolveVscodeCli('cursor', sc)).toBe(cursorCli);
+  });
+
+  it('is undefined with no PATH shim and no bundle, or on linux', () => {
+    expect(resolveVscodeCli('code', seams({}))).toBeUndefined();
+    const linux = seams({
+      platform: 'linux',
+      existing: ['/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code'],
+    });
+    expect(resolveVscodeCli('code', linux)).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Problem

The tray's **Open In…** menu was hiding VS Code on otherwise-ready Macs (e.g. a clean Mac mini), and the "some boxes show Codex, others don't" confusion.

Root causes, from `apps/cli/src/commands/_open-in.ts`:

- **VS Code — a real bug.** `detectOpenTargets()` probed **PATH only** (`pathHasBinary('code') || pathHasBinary('cursor')`) with no `.app`-bundle fallback. A freshly dragged-in VS Code / Cursor has **no `code`/`cursor` shim on PATH** until the user runs *"Shell Command: Install 'code' command in PATH."* Worse, the tray spawns the CLI through `/bin/zsh -lc` (a login shell that sources `~/.zprofile` but **not `~/.zshrc`**), so PATH additions made only in `.zshrc` are invisible to the probe too. Net effect: a perfectly usable VS Code install is undetectable → the menu item disappears.

- **Codex — by design, not a bug.** `codex.providers = ['hetzner']`, so the Codex row only ever appears for **Hetzner** boxes (Codex attaches later over its own persistent SSH identity, which only Hetzner has). It also requires the **desktop app** `Codex.app` for the `codex://` deep link — the `codex` CLI alone isn't enough. So "shows for some boxes, not others" = a mix of providers, and "not on a clean Mac" = `Codex.app` not installed. Both are expected; documented here, not changed.

## Fix

Add a macOS `.app`-bundle fallback for the VS Code family, to **both** detection and launch:

- `detectOpenTargets().vscode.available` now also checks `Visual Studio Code.app` / `Cursor.app` in `/Applications` and `~/Applications`.
- New `resolveVscodeCli()` prefers the PATH shim, then the **bundled** `code`/`cursor` binary (`…/Contents/Resources/app/bin/…`). `agentbox code` / `agentbox open --in vscode` now launch via the real CLI even with no PATH shim — which also avoids the `open <scheme>://…` protocol-handler path whose `%2B` URL-encoding can break the Remote attach.
- macOS-only (Linux still needs the PATH binary — no `/Applications` there).

## Verification

- `apps/cli/test/open-in.test.ts` — added cases for bundle detection (macOS-only) and `resolveVscodeCli` (PATH → bundle → undefined). 21 tests pass.
- `pnpm typecheck` + `eslint` clean.
- Live: with `code`/`cursor` stripped from PATH but `Cursor.app` present, `agentbox open --targets --json` now reports `vscode.available: true` (was `false` before this change).

No public-doc changes — the detection specifics aren't documented on the site.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI open-target detection and IDE spawn paths with seam-injected fs checks; behavior on Linux unchanged and coverage added in unit tests.
> 
> **Overview**
> Fixes **Open In…** and **`agentbox code`** treating VS Code/Cursor as missing when only the macOS `.app` is installed (no `code`/`cursor` PATH shim).
> 
> Adds **`resolveVscodeCli`**: prefer the PATH binary, then the bundled CLI under `Visual Studio Code.app` / `Cursor.app` in `/Applications` and `~/Applications`. **`detectOpenTargets().vscode.available`** now uses the same idea (PATH or bundle). **`agentbox code`** launch paths use the resolved binary so attach goes through `--folder-uri` instead of the `open vscode://…` fallback when possible. Bundle fallback is **macOS-only**; Linux still requires PATH.
> 
> Tests cover bundle-based availability and `resolveVscodeCli` resolution order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aa5983ac1b9f49146c642d07db6206a24574139. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->