### PR TITLE
feat(hub): host 'open in' app launchers on the box detail page

### DIFF
--- a/apps/hub/app/(dashboard)/api/v1/boxes/[id]/open/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/boxes/[id]/open/route.ts
@@ -1,0 +1,32 @@
+// POST /api/v1/boxes/:id/open — launch the box in a host app (Codex, VS Code,
+// cmux, Herdr, iTerm2) by re-shelling the installed `agentbox open --in <app>`.
+// Host-GUI only: works on a localhost hub on macOS; the backend refuses otherwise
+// (and the Postgres/plane path 503s, like the other mutating routes).
+import { backendOrNull } from '../../../lib/backend';
+import { fail, failFromAction, ok } from '../../../lib/envelope';
+import { parseOpenIn, readJson } from '../../../lib/validate';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: Request, ctx: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await ctx.params;
+  // In-flight create jobs surface as synthetic `job:` boxes with no real
+  // container yet — reject with a clear 409 instead of a backend error.
+  if (id.startsWith('job:')) {
+    return fail('conflict', `box ${id} is still being created; open-in is not available yet`, {
+      jobId: id.slice('job:'.length),
+    });
+  }
+  const backend = backendOrNull();
+  if (!backend) return fail('backend_unavailable', 'hub backend unavailable (run the hub server)');
+
+  const parsedBody = await readJson(req);
+  if (!parsedBody.ok) return fail('invalid_request', parsedBody.message);
+  const p = parseOpenIn(parsedBody.value);
+  if (!p.ok) return fail('invalid_request', p.message, p.details);
+
+  const res = await backend.openIn(id, p.value.app);
+  if (!res.ok) return failFromAction(res.error);
+  return ok({ ok: true });
+}

--- a/apps/hub/app/(dashboard)/api/v1/lib/openapi.ts
+++ b/apps/hub/app/(dashboard)/api/v1/lib/openapi.ts
@@ -201,6 +201,71 @@ export function buildOpenApi(): Record<string, unknown> {
           },
         },
       },
+      '/boxes/{id}/open': {
+        post: {
+          tags: ['Box services'],
+          summary: 'Open the box in a host app',
+          description:
+            'Launch the box in a host GUI app (Codex, VS Code/Cursor, cmux, Herdr, iTerm2) by re-shelling `agentbox open --in <app>`. Only works on a localhost hub running on macOS; a remote hub / non-macOS host refuses. An app must be installed and provider-eligible (e.g. Codex is Hetzner-only) — see GET /open-targets.',
+          parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: { app: { type: 'string', enum: ['codex', 'herdr', 'cmux', 'vscode', 'iterm2'] } },
+                  required: ['app'],
+                },
+              },
+            },
+          },
+          responses: {
+            '200': { description: 'Launched', content: { 'application/json': { schema: { type: 'object', properties: { ok: { const: true } }, required: ['ok'] } } } },
+            '400': errorResponse,
+            '401': errorResponse,
+            '404': errorResponse,
+            '409': errorResponse,
+            '503': errorResponse,
+          },
+        },
+      },
+      '/open-targets': {
+        get: {
+          tags: ['Box services'],
+          summary: 'Which host apps this hub can open a box in',
+          description:
+            'Reports whether the hub can launch host GUI apps (`supported` — true only on a localhost hub on macOS) and, if so, which of Codex/Herdr/cmux/VS Code/iTerm2 are installed plus their provider eligibility. Backs the box detail page "Apps" launchers.',
+          responses: {
+            '200': {
+              description: 'Open targets',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      supported: { type: 'boolean' },
+                      targets: {
+                        type: ['object', 'null'],
+                        additionalProperties: {
+                          type: 'object',
+                          properties: {
+                            available: { type: 'boolean' },
+                            providers: { type: 'array', items: { type: 'string' } },
+                          },
+                          required: ['available'],
+                        },
+                      },
+                    },
+                    required: ['supported', 'targets'],
+                  },
+                },
+              },
+            },
+            '401': errorResponse,
+          },
+        },
+      },
       '/projects': {
         get: {
           tags: ['Projects'],

--- a/apps/hub/app/(dashboard)/api/v1/lib/validate.ts
+++ b/apps/hub/app/(dashboard)/api/v1/lib/validate.ts
@@ -144,6 +144,24 @@ export function isGitOp(v: string): v is GitOp {
   return (GIT_OPS as readonly string[]).includes(v);
 }
 
+// Host apps a box can be launched in (mirrors OPEN_IN_APPS in the CLI's
+// _open-in.ts; hardcoded to keep @agentbox/* out of the Next bundle).
+export const OPEN_IN_APPS = ['codex', 'herdr', 'cmux', 'vscode', 'iterm2'] as const;
+export type OpenInApp = (typeof OPEN_IN_APPS)[number];
+
+export function isOpenInApp(v: string): v is OpenInApp {
+  return (OPEN_IN_APPS as readonly string[]).includes(v);
+}
+
+export function parseOpenIn(body: unknown): Parsed<{ app: OpenInApp }> {
+  if (!isObject(body)) return { ok: false, message: 'body must be a JSON object' };
+  const { app } = body;
+  if (typeof app !== 'string' || !isOpenInApp(app)) {
+    return { ok: false, message: `app must be one of ${OPEN_IN_APPS.join(', ')}`, details: { got: app } };
+  }
+  return { ok: true, value: { app } };
+}
+
 function optionalString(v: unknown, field: string): Parsed<string | undefined> {
   if (v === undefined) return { ok: true, value: undefined };
   if (typeof v !== 'string') return { ok: false, message: `${field} must be a string` };

--- a/apps/hub/app/(dashboard)/api/v1/open-targets/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/open-targets/route.ts
@@ -1,0 +1,17 @@
+// GET /api/v1/open-targets — which host apps this hub can launch a box in, and
+// whether it can at all (`supported`). Backs the detail-page "Open in" menu.
+// A remote hub / no in-process backend reports `supported: false`.
+import { backendOrNull } from '../lib/backend';
+import { ok } from '../lib/envelope';
+import type { OpenTargets } from '@/lib/boxes/backend-types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(): Promise<Response> {
+  const backend = backendOrNull();
+  const result: OpenTargets = backend
+    ? await backend.openTargets()
+    : { supported: false, targets: null };
+  return ok(result);
+}

--- a/apps/hub/app/(dashboard)/boxes/[id]/page.tsx
+++ b/apps/hub/app/(dashboard)/boxes/[id]/page.tsx
@@ -71,12 +71,9 @@ export default function BoxDetailPage() {
         <Stat k="Last activity" v={<Ago ms={box.lastActivity} />} mono />
       </StatGrid>
 
-      {box.webUrl || box.vncUrl ? (
-        <>
-          <SectionLabel>Access</SectionLabel>
-          <Access webUrl={box.webUrl} vncUrl={box.vncUrl} />
-        </>
-      ) : null}
+      {/* Access owns its "Access" heading and self-hides when the box has no
+          web/VNC endpoint and no launchable host app. */}
+      <Access box={box} />
 
       <SectionLabel>Git operations</SectionLabel>
       <GitActions box={box} />

--- a/apps/hub/app/(dashboard)/boxes/components/access.tsx
+++ b/apps/hub/app/(dashboard)/boxes/components/access.tsx
@@ -141,7 +141,7 @@ export function Access({ box }: { box: Box }) {
           <div className="flex flex-wrap items-center gap-3 px-4.5 p-3.5">
             <div className="min-w-[150px] flex-1">
               <div className="text-[13.5px] font-medium">Apps</div>
-              <div className="mt-0.5 text-[11.5px] text-muted-foreground">Open the box in a host app</div>
+              <div className="mt-0.5 text-[11.5px] text-muted-foreground">Open the box project from the host</div>
             </div>
             <div className="flex flex-none flex-wrap justify-end gap-1.5">
               {eligible.map(({ app, label, icon }) => {

--- a/apps/hub/app/(dashboard)/boxes/components/access.tsx
+++ b/apps/hub/app/(dashboard)/boxes/components/access.tsx
@@ -4,6 +4,20 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Icons } from '@/components/icons';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import type { OpenInApp, OpenTargets } from '@/lib/boxes/backend-types';
+import type { Box } from '@/lib/boxes/types';
+import { SectionLabel } from './section-label';
+
+// Display order + labels for the five host "open in" apps (mirrors the tray's
+// Open In menu and the CLI's OPEN_IN_APPS). Codex gets its glyph; the terminal
+// multiplexers share the terminal icon; VS Code/Cursor uses the external glyph.
+const APPS: { app: OpenInApp; label: string; icon: keyof typeof Icons }[] = [
+  { app: 'codex', label: 'Codex', icon: 'codex' },
+  { app: 'vscode', label: 'VS Code', icon: 'ext' },
+  { app: 'cmux', label: 'cmux', icon: 'terminal' },
+  { app: 'herdr', label: 'Herdr', icon: 'terminal' },
+  { app: 'iterm2', label: 'iTerm2', icon: 'terminal' },
+];
 
 function CopyButton({ url }: { url: string }) {
   const [copied, setCopied] = useState(false);
@@ -32,31 +46,120 @@ function CopyButton({ url }: { url: string }) {
   );
 }
 
-export function Access({ webUrl, vncUrl }: { webUrl?: string | null; vncUrl?: string | null }) {
-  if (!webUrl && !vncUrl) return null;
+// Launch the box in a host app by POSTing to the open endpoint (which re-shells
+// `agentbox open --in <app>`). Availability comes from the host probe
+// (`/api/v1/open-targets`); each app is offered only when installed AND eligible
+// for this box's provider (e.g. Codex is Hetzner-only).
+function useOpenIn(box: Box) {
+  const [targets, setTargets] = useState<OpenTargets | null>(null);
+  const [pending, setPending] = useState<OpenInApp | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    void (async () => {
+      try {
+        const r = await fetch('/api/v1/open-targets', { credentials: 'same-origin' });
+        if (alive) setTargets(r.ok ? ((await r.json()) as OpenTargets) : null);
+      } catch {
+        if (alive) setTargets(null);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const launch = useCallback(
+    async (app: OpenInApp) => {
+      setPending(app);
+      try {
+        const r = await fetch(`/api/v1/boxes/${encodeURIComponent(box.id)}/open`, {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ app }),
+        });
+        if (!r.ok) {
+          const detail = (await r.json().catch(() => null)) as { error?: { message?: string } } | null;
+          window.alert(`Open in ${app} failed: ${detail?.error?.message ?? `HTTP ${r.status}`}`);
+        }
+      } catch (err) {
+        window.alert(`Open in ${app} failed: ${err instanceof Error ? err.message : String(err)}`);
+      } finally {
+        setPending(null);
+      }
+    },
+    [box.id],
+  );
+
+  const report = targets?.supported ? targets.targets : null;
+  const eligible = report
+    ? APPS.filter(({ app }) => {
+        const info = report[app];
+        return info.available && (!info.providers || info.providers.includes(box.provider));
+      })
+    : [];
+
+  return { eligible, pending, launch };
+}
+
+export function Access({ box }: { box: Box }) {
+  const { webUrl, vncUrl } = box;
+  const { eligible, pending, launch } = useOpenIn(box);
+
+  // Nothing to show: no reachable web/VNC endpoint and no launchable host app.
+  if (!webUrl && !vncUrl && eligible.length === 0) return null;
+
   return (
-    <Card className="divide-y divide-border/60 overflow-hidden">
-      <div className="flex flex-wrap items-center gap-3 px-4.5 p-3.5">
-        <div className="min-w-[150px] flex-1">
-          <div className="text-[13.5px] font-medium">{webUrl ? 'Web' : 'VNC'}</div>
-          <div className="mt-0.5 break-all font-mono text-[11.5px] text-muted-foreground">{webUrl ?? 'Remote desktop'}</div>
-        </div>
-        <div className="flex flex-none flex-wrap gap-1.5">
-          {webUrl ? (
-            <Button variant="outline" size="sm" href={webUrl} target="_blank" rel="noreferrer">
-              <Icons.ext />
-              Open web
-            </Button>
-          ) : null}
-          {webUrl ? <CopyButton url={webUrl} /> : null}
-          {vncUrl ? (
-            <Button variant="outline" size="sm" href={vncUrl} target="_blank" rel="noreferrer">
-              <Icons.ext />
-              Open VNC
-            </Button>
-          ) : null}
-        </div>
-      </div>
-    </Card>
+    <>
+      <SectionLabel>Access</SectionLabel>
+      <Card className="divide-y divide-border/60 overflow-hidden">
+        {webUrl || vncUrl ? (
+          <div className="flex flex-wrap items-center gap-3 px-4.5 p-3.5">
+            <div className="min-w-[150px] flex-1">
+              <div className="text-[13.5px] font-medium">{webUrl ? 'Web' : 'VNC'}</div>
+              <div className="mt-0.5 break-all font-mono text-[11.5px] text-muted-foreground">{webUrl ?? 'Remote desktop'}</div>
+            </div>
+            <div className="flex flex-none flex-wrap gap-1.5">
+              {webUrl ? (
+                <Button variant="outline" size="sm" href={webUrl} target="_blank" rel="noreferrer">
+                  <Icons.ext />
+                  Open web
+                </Button>
+              ) : null}
+              {webUrl ? <CopyButton url={webUrl} /> : null}
+              {vncUrl ? (
+                <Button variant="outline" size="sm" href={vncUrl} target="_blank" rel="noreferrer">
+                  <Icons.ext />
+                  Open VNC
+                </Button>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+        {eligible.length > 0 ? (
+          <div className="flex flex-wrap items-center gap-3 px-4.5 p-3.5">
+            <div className="min-w-[150px] flex-1 text-[13.5px] font-medium">Apps</div>
+            <div className="flex flex-none flex-wrap justify-end gap-1.5">
+              {eligible.map(({ app, label, icon }) => {
+                const Icon = Icons[icon];
+                return (
+                  <Button
+                    key={app}
+                    variant="outline"
+                    size="sm"
+                    disabled={pending !== null}
+                    onClick={() => void launch(app)}
+                  >
+                    <Icon />
+                    {label}
+                  </Button>
+                );
+              })}
+            </div>
+          </div>
+        ) : null}
+      </Card>
+    </>
   );
 }

--- a/apps/hub/app/(dashboard)/boxes/components/access.tsx
+++ b/apps/hub/app/(dashboard)/boxes/components/access.tsx
@@ -139,7 +139,10 @@ export function Access({ box }: { box: Box }) {
         ) : null}
         {eligible.length > 0 ? (
           <div className="flex flex-wrap items-center gap-3 px-4.5 p-3.5">
-            <div className="min-w-[150px] flex-1 text-[13.5px] font-medium">Apps</div>
+            <div className="min-w-[150px] flex-1">
+              <div className="text-[13.5px] font-medium">Apps</div>
+              <div className="mt-0.5 text-[11.5px] text-muted-foreground">Open the box in a host app</div>
+            </div>
             <div className="flex flex-none flex-wrap justify-end gap-1.5">
               {eligible.map(({ app, label, icon }) => {
                 const Icon = Icons[icon];

--- a/apps/hub/lib/boxes/backend-types.ts
+++ b/apps/hub/lib/boxes/backend-types.ts
@@ -9,6 +9,29 @@ export type ActionResult = { ok: true } | { ok: false; error: string };
 // output; on failure `error` is the trimmed stderr (or a resolve error).
 export type BoxOpResult = { ok: true; stdout?: string; stderr?: string } | { ok: false; error: string };
 
+// Host apps a box can be opened in (`agentbox open --in <app>`). Mirrors the
+// CLI's OPEN_IN_APPS (apps/cli/src/commands/_open-in.ts); duplicated here to keep
+// @agentbox/* packages out of the Next bundle, like AGENTS/PROVIDERS in validate.ts.
+export type OpenInApp = 'codex' | 'herdr' | 'cmux' | 'vscode' | 'iterm2';
+
+// One app's install/eligibility, as reported by the CLI's `open --targets --json`.
+// `providers` (when present) limits the app to boxes on those providers (e.g.
+// codex -> ['hetzner']); omitted means any provider.
+export interface OpenTargetInfo {
+  available: boolean;
+  providers?: string[];
+}
+
+export type OpenTargetsReport = Record<OpenInApp, OpenTargetInfo>;
+
+// `supported` is false when the hub can't launch host GUI apps at all (a remote
+// hub profile, or a non-macOS host) — the UI then shows no Open-in controls.
+// `targets` is null in that case, or when the host probe failed.
+export interface OpenTargets {
+  supported: boolean;
+  targets: OpenTargetsReport | null;
+}
+
 // One supervised service, normalized from either a live `agentbox-ctl status`
 // pull or the persisted box-status snapshot. Fields absent in the persisted
 // snapshot (pid/restarts/lastExitCode/command) are filled with nulls/defaults.
@@ -198,4 +221,13 @@ export interface HubBackend {
   getServices(id: string): Promise<ServicesResult>;
   // Restart one service by name, or every service when name is omitted.
   restartService(id: string, name?: string): Promise<BoxOpResult>;
+
+  // ── host "open in" launchers (localhost hub on macOS only) ──
+  // Which host apps are installed + provider-eligible, for the detail-page menu.
+  // `supported: false` when the hub can't launch host GUIs (remote/non-macOS).
+  openTargets(): Promise<OpenTargets>;
+  // Launch the box in a host app by re-shelling the installed `agentbox open
+  // <id> --in <app>` (which owns all the SSH-alias / deep-link / terminal-spawn
+  // logic). Refuses when openTargets() would report unsupported.
+  openIn(id: string, app: OpenInApp): Promise<ActionResult>;
 }

--- a/apps/hub/lib/boxes/postgres-source.ts
+++ b/apps/hub/lib/boxes/postgres-source.ts
@@ -81,6 +81,8 @@ function mapBox(r: Registration, s: Snapshot | undefined): Box {
     createdAt,
     lastActivity: createdAt,
     host: r.backend ? `${r.kind ?? 'cloud'} · ${r.backend}` : (r.kind ?? 'cloud'),
+    // Hosted source never offers host "open in" (remote hub) — value is informational.
+    provider: r.kind ?? 'docker',
     commits: null,
     filesTouched: null,
     error: deriveStatus(s) === 'error' ? (claude?.sessionTitle ?? 'Agent reported an error') : null,

--- a/apps/hub/lib/boxes/types.ts
+++ b/apps/hub/lib/boxes/types.ts
@@ -19,6 +19,9 @@ export interface Box {
   createdAt: number;
   lastActivity: number;
   host: string;
+  // Sandbox provider (docker | daytona | hetzner | vercel | e2b). Drives which
+  // host "open in" targets are offered for this box on the detail page.
+  provider: string;
   // null when the metric has no host-side source yet (rendered as "—").
   commits: number | null;
   filesTouched: number | null;

--- a/apps/hub/lib/hub-backend.ts
+++ b/apps/hub/lib/hub-backend.ts
@@ -66,8 +66,12 @@ import type {
   DirEntry,
   GitInfo,
   HubBackend,
+  OpenInApp,
+  OpenTargets,
+  OpenTargetsReport,
   ServicesResult,
 } from './boxes/backend-types';
+import { hubProfile } from './auth-config';
 import type { Approval, Box, BoxStatus, GithubState, HubState, Project, ProviderOption, User } from './boxes/types';
 
 /*
@@ -159,6 +163,7 @@ function mapBox(b: ListedBox): Box {
     createdAt,
     lastActivity: createdAt,
     host: hostLabel(b),
+    provider: b.provider ?? 'docker',
     commits: null,
     filesTouched: null,
     error: status === 'error' ? (b.claudeSessionTitle ?? 'Agent reported an error') : null,
@@ -314,6 +319,7 @@ function mapJobToBox(job: QueueJob, status: BoxStatus): Box {
     createdAt,
     lastActivity: createdAt,
     host: job.providerName === 'docker' ? 'local · docker' : job.providerName,
+    provider: job.providerName ?? 'docker',
     commits: null,
     filesTouched: null,
     error: status === 'error' ? (job.reason ?? 'create failed') : null,
@@ -777,6 +783,60 @@ function parseGitStatus(out: string): GitInfo {
   return { ok: true, branch: branch === '(detached)' ? undefined : branch, dirty, ahead, behind };
 }
 
+// ── host "open in" launchers ──
+// These re-shell the installed CLI (`agentbox open ...`), which owns the SSH
+// alias / codex:// deep link / terminal-spawn / IDE-launch logic — the same
+// pattern the relay uses for cp/checkpoint host actions (host-actions.ts). They
+// launch host GUI apps, so they only work on a localhost hub on macOS.
+
+/** Whether this hub can launch host GUI apps: the user's own Mac, not a remote profile. */
+function canOpenInHostApps(): boolean {
+  return hubProfile() === 'localhost' && process.platform === 'darwin';
+}
+
+/**
+ * Turn an execFile rejection from a re-shelled `agentbox` command into a
+ * human-readable error. The CLI reports failures through clack `log.error`,
+ * which lands on stdout wrapped in gutter glyphs and ANSI codes, so prefer
+ * stdout over stderr, strip the decoration, and drop empty lines.
+ */
+function cleanCliError(e: { stderr?: string; stdout?: string; message?: string }): string {
+  const raw = e.stdout?.trim() || e.stderr?.trim() || e.message || 'command failed';
+  const cleaned = raw
+    .replace(/[\u0000-\u001f]+/g, '\n') // ANSI/control bytes (incl. ESC) -> line breaks
+    .replace(/\[[0-9;]*m/g, '') // leftover ANSI colour codes
+    .split('\n')
+    .map((line) => line.replace(/^[^\p{L}\p{N}'"(]+/u, '').trim()) // drop leading gutter glyphs/punct
+    .filter((line) => line.length > 0)
+    .join(' ');
+  return cleaned || 'command failed';
+}
+
+// Cache the target probe: it spawns a `node` process (`open --targets`), and app
+// installs change rarely, so a page load shouldn't re-spawn it every time.
+const OPEN_TARGETS_TTL_MS = 60_000;
+let openTargetsCache: { at: number; value: OpenTargetsReport } | null = null;
+
+/** Probe installed host apps via the CLI's `open --targets --json` (cached). */
+async function probeOpenTargets(): Promise<OpenTargetsReport | null> {
+  const now = Date.now();
+  if (openTargetsCache && now - openTargetsCache.at < OPEN_TARGETS_TTL_MS) {
+    return openTargetsCache.value;
+  }
+  const entry = process.env['AGENTBOX_CLI_ENTRY'];
+  if (!entry) return null;
+  try {
+    const { stdout } = await execFileAsync(process.execPath, [entry, 'open', '--targets', '--json'], {
+      timeout: 10_000,
+    });
+    const value = JSON.parse(stdout) as OpenTargetsReport;
+    openTargetsCache = { at: now, value };
+    return value;
+  } catch {
+    return null;
+  }
+}
+
 export function createHubBackend(handle: RelayServerHandle): HubBackend {
   return {
     // authMode is layered on by source.ts (an env-derived concern), so the host
@@ -1087,6 +1147,33 @@ export function createHubBackend(handle: RelayServerHandle): HubBackend {
         return failed.length > 0 ? { ok: false, error: `failed to restart: ${failed.join(', ')}` } : { ok: true };
       } catch (err) {
         return { ok: false, error: errMsg(err) };
+      }
+    },
+
+    async openTargets(): Promise<OpenTargets> {
+      if (!canOpenInHostApps()) return { supported: false, targets: null };
+      return { supported: true, targets: await probeOpenTargets() };
+    },
+
+    async openIn(id, app: OpenInApp): Promise<ActionResult> {
+      if (!canOpenInHostApps()) {
+        return { ok: false, error: 'open-in actions require a local hub running on macOS' };
+      }
+      const entry = process.env['AGENTBOX_CLI_ENTRY'];
+      if (!entry) return { ok: false, error: 'hub is missing AGENTBOX_CLI_ENTRY; cannot launch host apps' };
+      try {
+        // Re-shell `agentbox open <id> --in <app>` (routes vscode -> code, the
+        // rest to their host-app launchers). It launches and returns; the timeout
+        // guards against a hung launcher, not the app staying open.
+        await execFileAsync(process.execPath, [entry, 'open', id, '--in', app], { timeout: 20_000 });
+        return { ok: true };
+      } catch (err) {
+        // execFile rejects on non-zero exit. The CLI prints its real error via
+        // clack (stdout, with gutter glyphs), not stderr — clean that up so the
+        // UI shows the reason (e.g. the codex "only Hetzner boxes qualify" gate)
+        // rather than execFile's generic "Command failed: node …".
+        const e = err as { stderr?: string; stdout?: string; message?: string };
+        return { ok: false, error: cleanCliError(e) };
       }
     },
   };

--- a/apps/web/content/docs/hub.mdx
+++ b/apps/web/content/docs/hub.mdx
@@ -25,11 +25,15 @@ That starts the hub (if it isn't already running) and opens it in your browser a
   (running / paused / stopped / error) and per-box **pause / resume / stop /
   destroy** controls.
 - **Box detail** — a box's task, agent, branch, host, and timestamps, plus common
-  box operations: **Git** (pull, push, [push to the host repo only](/docs/sync-and-git),
+  box operations: **Access** (open the box's [web / VNC URL](/docs/web-apps-and-tunnels),
+  and, on a local hub running on macOS, an **Apps** row that opens the box in a host
+  app — Codex, VS Code / Cursor, cmux, Herdr, or iTerm2, whichever are installed and
+  supported for the box's provider; the same as [`agentbox open --in`](/docs/access-your-box)),
+  **Git** (pull, push, [push to the host repo only](/docs/sync-and-git),
   change branch, create a new `agentbox/*` branch) and **Services** (live state of the
   box's [`agentbox.yaml` services](/docs/services-and-tasks), with restart-one and
   restart-all). The same operations are on the [REST API](/docs/api) and the
-  [CLI](/docs/cli) (`agentbox git`, `agentbox services`).
+  [CLI](/docs/cli) (`agentbox git`, `agentbox services`, `agentbox open`).
 - **Approvals** — the host-action requests a box is blocked on (a `git push` to a
   protected branch, `cp`, `download`, gh/integration writes). **Approve** unblocks
   the box; **Deny** returns an error to it. This is the same gate the relay prompts


### PR DESCRIPTION
## What

Adds the tray's **Open In** host-app launchers to the web hub. The box detail **Access** section now has an **Apps** row that opens the box in a host app — **Codex, VS Code/Cursor, cmux, Herdr, iTerm2** — right-aligned next to the existing Open web / Open VNC.

![Access section with Apps row](docs-note: Web row + Apps row; buttons right-aligned)

Each app appears only when it's **installed on the host** AND **eligible for the box's provider** (e.g. Codex is Hetzner-only, so it's hidden on docker boxes).

## How

- **Reuse without extraction.** The hub server already receives `AGENTBOX_CLI_ENTRY` (the same env the relay uses to re-shell cp/checkpoint host actions), so the backend re-shells `agentbox open <id> --in <app>` and `agentbox open --targets --json`. This reuses all the CLI's SSH-alias / `codex://` deep-link / terminal-spawn / IDE-launch logic verbatim — no CLI-internal code moved into a shared package.
- **Localhost + macOS only.** Host-GUI launches only make sense on the user's own machine, so the backend gates on `hubProfile() === 'localhost' && process.platform === 'darwin'`. A remote (hetzner/vercel) or non-macOS hub reports `supported: false` and the Apps row hides.
- **REST, not Server Actions** (per the hub convention that new features go behind `/api/v1` with client fetch):
  - `GET /api/v1/open-targets` — which apps are launchable (cached ~60s host probe).
  - `POST /api/v1/boxes/:id/open` — launch `{ app }`.
- The `Box` view-model gains a `provider` field so the client can gate per-box.
- CLI error output (clack on stdout, with gutter glyphs) is cleaned so failures like the Codex Hetzner-only gate surface as a readable message, not `execFile`'s "Command failed".

## Verify

- `GET /api/v1/open-targets` on this Mac → `supported: true` with the five apps + provider eligibility.
- `POST …/open {app:"iterm2"}` on a docker box → `{ok:true}` and a real `agentbox attach … --inline` process spawned in a new iTerm2 window (verified via `ps`, not just the 200).
- `POST …/open {app:"codex"}` on a docker box → 409 with the clean "only Hetzner cloud boxes qualify" message; invalid app → 400.
- Browser: the detail page renders the **Apps** row (VS Code / cmux / Herdr / iTerm2; Codex correctly absent on docker), right-aligned in the Access card.
- `pnpm --filter @agentbox/hub typecheck` + eslint clean.

## Docs

- OpenAPI spec (`/api/v1/openapi.json`) gains both endpoints.
- `apps/web/content/docs/hub.mdx` Box-detail bullet documents the Access **Apps** launchers + the localhost/macOS gate.

No CLI surface changed (reuses `agentbox open --in`), so no CLI-reference or tray changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and localhost-only host app spawning via existing CLI; no auth or data-model changes beyond an informational `provider` field on boxes.
> 
> **Overview**
> Brings the tray/CLI **Open In** flow to the web hub: the box detail **Access** card gains an **Apps** row (alongside web/VNC) with buttons for Codex, VS Code/Cursor, cmux, Herdr, and iTerm2 when the host reports them installed and eligible for the box’s **provider** (new `provider` field on the `Box` view model).
> 
> New **`GET /api/v1/open-targets`** (cached ~60s host probe) and **`POST /api/v1/boxes/:id/open`** with `{ app }` validation; OpenAPI and hub docs updated. The Node backend implements `openTargets` / `openIn` by re-shelling `agentbox open --targets --json` and `agentbox open <id> --in <app>` via `AGENTBOX_CLI_ENTRY`, only when `hubProfile() === 'localhost'` and `darwin`; remote/Postgres hubs return `supported: false` and mutating open 503s like other host-only routes. Synthetic `job:` boxes get **409** on open; CLI clack stdout is cleaned for readable API errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 079afbb68e3a0f0e11ba8636b6afae88bd6fcbe2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->