### PR TITLE
fix(sync): force host static-config stages user-writable (read-only source → EACCES)

### DIFF
--- a/packages/sandbox-core/src/sync/host-stage.ts
+++ b/packages/sandbox-core/src/sync/host-stage.ts
@@ -100,6 +100,18 @@ async function mkStageDir(prefix: string): Promise<string> {
   return mkdtemp(join(tmpdir(), `agentbox-${prefix}-stage-`));
 }
 
+// A stage dir is a throwaway scratch copy that we rewrite in place (filter
+// settings.json, sanitize config.toml, rewrite plugin paths) and then `rm`.
+// `rsync -a` implies `-p`, so it preserves the *source's* modes — and when the
+// source is read-only (skill/plugin symlinks into the Nix store, or any
+// root-owned / 0444 dotfiles), the copy comes out read-only too. That breaks us
+// two ways: the in-place `writeFile` rewrites fail with EACCES, and `rm` can't
+// unlink children of a 0555 dir (`EACCES unlink .../skills/*/SKILL.md`). Force
+// the copy user-writable — a scratch dir has no business inheriting the store's
+// perms. Only GNU rsync honors this; macOS's openrsync ignores it (and doesn't
+// hit the read-only-source case in practice), so it's a safe no-op there.
+const STAGE_WRITABLE_CHMOD = '--chmod=Du+rwx,Fu+rw';
+
 function emptyResult(warnings: string[] = []): StageResult {
   return { tarballPath: null, cleanup: async () => {}, warnings };
 }
@@ -298,6 +310,7 @@ export async function stageClaudeStaticForUpload(
     ];
     await execa('rsync', [
       '-a',
+      STAGE_WRITABLE_CHMOD,
       '--copy-unsafe-links',
       ...excludes,
       `${hostClaude}/`,
@@ -444,6 +457,7 @@ export async function stageCodexStaticForUpload(
     const codexBroken = await findBrokenSymlinks(hostCodex);
     await execa('rsync', [
       '-a',
+      STAGE_WRITABLE_CHMOD,
       '-L',
       ...codexBroken.map((r) => `--exclude=/${r}`),
       ...CODEX_STATIC_EXCLUDES.map((p) => `--exclude=${p}`),
@@ -490,6 +504,7 @@ export async function stageAgentsStaticForUpload(
     const broken = await findBrokenSymlinks(hostAgents);
     await execa('rsync', [
       '-a',
+      STAGE_WRITABLE_CHMOD,
       '-L',
       ...broken.map((r) => `--exclude=/${r}`),
       `${hostAgents}/`,
@@ -574,6 +589,7 @@ export async function stageOpencodeStaticForUpload(
       const dataBroken = await findBrokenSymlinks(hostData);
       await execa('rsync', [
         '-a',
+        STAGE_WRITABLE_CHMOD,
         '-L',
         ...dataBroken.map((r) => `--exclude=/${r}`),
         ...OPENCODE_DATA_EXCLUDES.map((p) => `--exclude=${p}`),
@@ -586,6 +602,7 @@ export async function stageOpencodeStaticForUpload(
       const cfgBroken = await findBrokenSymlinks(hostConfig);
       await execa('rsync', [
         '-a',
+        STAGE_WRITABLE_CHMOD,
         '-L',
         ...cfgBroken.map((r) => `--exclude=/${r}`),
         `${hostConfig}/`,


### PR DESCRIPTION
## Problem

`agentbox prepare` (and the docker/cloud seeds) fail for anyone whose agent config is managed **declaratively** — Nix/home-manager, Ansible, chezmoi, or just root-owned/read-only dotfiles:

```
prepare failed: EACCES: permission denied, unlink
  '/var/folders/.../agentbox-claude-static-stage-wV1H1q/skills/1password/SKILL.md'
```

## Root cause

The static-config stages (`stage{Claude,Codex,Agents,Opencode}StaticForUpload` in `packages/sandbox-core/src/sync/host-stage.ts`) rsync `~/.claude`, `~/.codex`, `~/.agents`, and `~/.local/share/opencode` into a throwaway scratch dir, then **rewrite it in place** (filter `settings.json`, sanitize `config.toml`, rewrite plugin paths) and finally **`rm`** it.

Every one of those rsyncs runs `rsync -a`, which implies `-p` and preserves the **source's** modes. When the source is read-only — skill/plugin symlinks into the Nix store (`0444`/`0555`), or any root-owned / `0444` dotfile — the scratch copy is read-only too. That breaks the stage two ways:

1. the in-place `writeFile` rewrites fail with `EACCES`; and
2. cleanup's `rm` can't unlink a child of a `0555` directory → the `unlink .../skills/*/SKILL.md` above.

A normal writable `~/.claude` never hits it, which is why it only bites declaratively-managed hosts.

## Fix

A scratch dir has no business inheriting the source's perms. Add `--chmod=Du+rwx,Fu+rw` (via a shared, documented `STAGE_WRITABLE_CHMOD` constant) to each of the 5 stage rsyncs. GNU rsync honors it; macOS's openrsync ignores it and doesn't hit the read-only-source case in practice, so it's a safe no-op there.

Scoped to the static-config stages only — the workspace export rsync is untouched, so its `-i` itemized output (parsed by `parseItemizedChanges`) is unchanged.

## Reproduce

On a host where `~/.claude/skills/*` are read-only symlinks into a read-only store (e.g. home-manager), or synthetically:

```sh
mkdir -p /tmp/ro/skills/x && echo hi > /tmp/ro/skills/x/SKILL.md
chmod -R a-w /tmp/ro/skills
rsync -a /tmp/ro/ /tmp/stage/ && rm -rf /tmp/stage   # EACCES on the rm
rsync -a --chmod=Du+rwx,Fu+rw /tmp/ro/ /tmp/stage2/ && rm -rf /tmp/stage2   # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)