### PR TITLE
feat(hub): show AgentBox version in settings footer

### DIFF
--- a/apps/hub/app/(dashboard)/api/v1/health/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/health/route.ts
@@ -7,5 +7,12 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export function GET(): Response {
-  return ok({ ok: true, apiVersion: 'v1', profile: hubProfile() });
+  return ok({
+    ok: true,
+    apiVersion: 'v1',
+    // The hub runs the CLI's version (inherited via AGENTBOX_CLI_VERSION at spawn);
+    // apps/hub's own package.json is a 0.0.0 placeholder, so don't read that.
+    version: process.env.AGENTBOX_CLI_VERSION ?? 'dev',
+    profile: hubProfile(),
+  });
 }

--- a/apps/hub/app/(dashboard)/settings/page.tsx
+++ b/apps/hub/app/(dashboard)/settings/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { Ago } from '@/components/ago';
 import { Icons, LangDot } from '@/components/icons';
 import { Badge } from '@/components/ui/badge';
@@ -13,6 +14,21 @@ import { ProvidersSection } from './components/provider-actions';
 export default function SettingsPage() {
   const { state } = useStore();
   const gh = state.github;
+  const [version, setVersion] = useState<string | null>(null);
+
+  // Pure REST: read the running hub's version off the public health probe.
+  useEffect(() => {
+    let alive = true;
+    fetch('/api/v1/health', { credentials: 'same-origin' })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j: { version?: string } | null) => {
+        if (alive && j?.version) setVersion(j.version);
+      })
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, []);
 
   return (
     <div className="mx-auto w-full max-w-[1080px] px-8 pb-16 pt-8 max-sm:px-4">
@@ -101,6 +117,10 @@ export default function SettingsPage() {
           </Card>
         </>
       )}
+
+      <div className="mt-10 text-center font-mono text-[11px] text-muted-foreground">
+        AgentBox {version ?? '…'}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## What

Adds a quiet version footer to the bottom of the **hub** Settings page (this repo) and the **tray** Settings window (companion change already pushed to `madarco/agentbox-tray@main`).

- **Hub:** `/api/v1/health` now returns a `version` field (read from the inherited `AGENTBOX_CLI_VERSION`; `apps/hub`'s own `package.json` is a `0.0.0` placeholder). The settings page fetches it client-side and renders `AgentBox <version>` — matching the "hub web = pure REST client" convention (feature behind `/api/v1`, no server action).
- **Tray** (separate repo): footer shows `Tray <build> · AgentBox <hub version>`, fetching the hub version off the same `/api/v1/health` probe and degrading to the tray version alone when the hub is unreachable.

The hub's version *is* the AgentBox version — same string surfaced in both places.

## Verify

- `curl -s localhost:8787/api/v1/health` → `{"ok":true,"apiVersion":"v1","version":"0.23.0","profile":"localhost"}`
- Rebuilt hub standalone + `hub restart`; `/settings` renders the `AgentBox 0.23.0` footer.
- Tray: `swift build` clean; footer verified in code against existing `HubClient.get` + `BoxSource` patterns (visual check is manual on a built `.app` bundle since `CFBundleShortVersionString` needs the bundle).

Docs: UI-only footer, no CLI/flag/config surface change, so no `apps/web` docs update needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only display plus a non-sensitive version string on an already-public health endpoint; no auth or data-path changes.
> 
> **Overview**
> Exposes the running **AgentBox** version on the public **`GET /api/v1/health`** probe via a new **`version`** field sourced from **`AGENTBOX_CLI_VERSION`** (fallback **`dev`**), instead of the hub app’s placeholder package version.
> 
> The hub **Settings** page fetches that probe client-side and renders a small **`AgentBox <version>`** footer, with **`…`** while loading or on failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1809ddf18f3f57ed8e36063a90d8ed800e7c67e3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->