### PR TITLE
fix(carry): suppress macOS AppleDouble stubs; carry e2b + codex/opencode creds

### DIFF
--- a/agentbox.yaml
+++ b/agentbox.yaml
@@ -101,6 +101,20 @@ carry:
     dest: ~/.local/share/opencode/auth.json
     mode: 0o600
     optional: true
+  # The codex / opencode counterparts of ~/.agentbox/claude-credentials.json:
+  # newest-wins backups maintained by the relay's credential fan-out. A nested
+  # box's `stageCodexCredentialsForUpload` / `stageOpencodeCredentialsForUpload`
+  # PREFER these over the real paths above, so without them the nested box
+  # bootstraps from whatever token the real path happens to hold — possibly
+  # older than the fan-out's copy. Optional: absent before the first fan-out.
+  - src: ~/.agentbox/codex-credentials.json
+    dest: ~/.agentbox/codex-credentials.json
+    mode: 0o600
+    optional: true
+  - src: ~/.agentbox/opencode-credentials.json
+    dest: ~/.agentbox/opencode-credentials.json
+    mode: 0o600
+    optional: true
   # Notion CLI (`ntn`) file-based auth — INTERNAL AGENTBOX DEV ONLY, so a box
   # that creates NESTED boxes can act as their relay host and shell out to `ntn`.
   # Normal boxes never need this: they reach `ntn` through the host relay and
@@ -154,6 +168,10 @@ carry:
     optional: true
   - src: ~/.agentbox/docker-prepared.json
     dest: ~/.agentbox/docker-prepared.json
+    mode: 0o600
+    optional: true
+  - src: ~/.agentbox/e2b-prepared.json
+    dest: ~/.agentbox/e2b-prepared.json
     mode: 0o600
     optional: true
 

--- a/packages/sandbox-cloud/src/sync/carry.ts
+++ b/packages/sandbox-cloud/src/sync/carry.ts
@@ -100,7 +100,13 @@ async function uploadOneEntry(args: UploadOneArgs): Promise<void> {
   const tarArgs = isDir
     ? ['-C', entry.absSrc, '-cf', localTar, ...excludeArgs, '.']
     : ['-C', dirnameUnix(entry.absSrc), '-cf', localTar, fileBase];
-  const packed = await execa('tar', tarArgs, { reject: false });
+  // COPYFILE_DISABLE silences macOS BSD tar's `._*` resource-fork stubs, which
+  // would otherwise land next to every carried file in the box (`._auth.json`
+  // beside `auth.json`) and miss the entry's `mode`.
+  const packed = await execa('tar', tarArgs, {
+    reject: false,
+    env: { ...process.env, COPYFILE_DISABLE: '1' },
+  });
   if (packed.exitCode !== 0) {
     throw new Error(`tar pack failed: ${String(packed.stderr).slice(0, 300)}`);
   }

--- a/packages/sandbox-docker/src/sync/host-export.ts
+++ b/packages/sandbox-docker/src/sync/host-export.ts
@@ -773,6 +773,8 @@ async function copyOneEntry(container: string, entry: ResolvedCarryEntry): Promi
         '--no-same-owner',
         '-m',
       ],
+      // COPYFILE_DISABLE silences macOS BSD tar's `._*` resource-fork stubs.
+      { ...process.env, COPYFILE_DISABLE: '1' },
     );
     if (packed.exitCode !== 0) {
       throw new Error(`tar pack failed: ${String(packed.stderr).slice(0, 300)}`);
@@ -817,6 +819,8 @@ async function copyOneEntry(container: string, entry: ResolvedCarryEntry): Promi
         '--no-same-owner',
         '-m',
       ],
+      // COPYFILE_DISABLE silences macOS BSD tar's `._*` resource-fork stubs.
+      { ...process.env, COPYFILE_DISABLE: '1' },
     );
     if (packed.exitCode !== 0) {
       throw new Error(`tar pack failed: ${String(packed.stderr).slice(0, 300)}`);


### PR DESCRIPTION
## What

Two fixes to the `carry:` path, both found while dogfooding agentbox-in-agentbox on a hetzner box.

### 1. macOS AppleDouble stubs leak into every box

Both carry implementations tar'd the host source **without** `COPYFILE_DISABLE=1`, unlike every other `tar` call in the repo (`cloud-cp.ts`, `box-cp.ts`, `workspace-seed.ts`, `host-stage.ts`, `concerns/dynamic.ts` — several with a comment explaining exactly why).

On a macOS host, BSD tar therefore emitted a `._<name>` resource-fork stub beside each carried file. A live box had **14 of them**, in `~/.agentbox/`, `~/.codex/`, `~/.config/notion/`, `~/.config/linear/`, and the Vercel CLI store — sitting next to credential files at mode `0644` rather than the entry's declared `0600`.

They contain only xattrs (`com.apple.provenance`, `com.docker.grpcfuse.ownership`), **no secret material**. Cosmetic, but they land in credential directories and some tools glob those.

Fixed in:
- `packages/sandbox-cloud/src/sync/carry.ts` — `uploadCarryPaths`
- `packages/sandbox-docker/src/sync/host-export.ts` — `copyCarryPathsToBox`, both the file and directory branches. `streamTarPipe` already took a `producerEnv` parameter; nothing was passing it.

### 2. `carry:` block is missing three files

`agentbox.yaml`'s `carry:` block predates the E2B provider. It ships `E2B_API_KEY` (via `secrets.env`) but omits `~/.agentbox/e2b-prepared.json`, so E2B *looks* configured while `agentbox doctor` in-box reports `[warn] e2b base template not baked` — every other provider's prepared-state file is carried.

Also adds the `codex` / `opencode` newest-wins credential backups that the relay's credential fan-out maintains. `stageCodexCredentialsForUpload` / `stageOpencodeCredentialsForUpload` **prefer** `~/.agentbox/{codex,opencode}-credentials.json` over the real `auth.json` paths, so without them a nested box bootstraps from whatever the real path happens to hold — possibly older than the fan-out's copy. Only `claude-credentials.json` was carried.

## Verification

- `typecheck` clean, `eslint` clean on both changed files.
- Full suites pass: 267 tests (`sandbox-docker`), 112 tests (`sandbox-cloud`).
- `agentbox.yaml` re-parsed with the repo's `yaml` lib: 20 entries, all mode `0o600`, all `optional`.

The AppleDouble bug **cannot reproduce on Linux** — GNU tar never emits the stubs, only macOS BSD tar does. Rather than claim an unobservable end-to-end fix, I verified the mechanism directly: a `tar` shim on `PATH` that logs its environment, driving all three real code paths — docker file-branch and dir-branch against a live container, and `uploadCarryPaths` against a stub `CloudBackend`. Each logged `COPYFILE_DISABLE=[1]`, and carry still landed the file correctly (`/home/vscode/.codex/auth.json`, mode `-rw-------`, contents intact).

## Notes

- Does not clean up `._*` files already present in existing boxes; it prevents new ones.
- Unrelated gap found in the same session, **not** fixed here: `agentbox.yaml`'s `build` task runs only `pnpm build`, which builds neither the hub standalone bundle nor `apps/cli/runtime/`, so `agentbox hub start` fails in a fresh box until `pnpm --filter @agentbox/hub build:standalone` is run by hand.
- Also observed: `api.e2b.dev` hard-403s a hetzner box's egress IPv4 (Cloud Armor, no AAAA fallback), so `--provider e2b` can't work from inside a hetzner box regardless of this carry fix.

https://claude.ai/code/session_01AffCU7Rnv1bC9jXMJXFaer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted carry/bootstrap fixes with no auth logic changes; only affects what files are copied and macOS tar metadata behavior.
> 
> **Overview**
> **Carry** on macOS hosts now sets **`COPYFILE_DISABLE=1`** when packing host sources into tarballs, matching other tar paths in the repo. Without it, BSD tar emitted `._*` AppleDouble stubs next to carried credential files (wrong mode, clutter in `~/.agentbox` and agent config dirs).
> 
> **`agentbox.yaml` `carry:`** gains three optional **`0o600`** entries: **`~/.agentbox/e2b-prepared.json`** (E2B prepare fast-path parity with other providers), plus **`codex-credentials.json`** and **`opencode-credentials.json`** so nested boxes prefer the relay fan-out’s newest-wins backups over possibly stale live `auth.json` paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7c82965923404b451c2748082efba573d3ced5f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->