### PR TITLE
fix(git-shim): pass local/file:// clones through to real git

### DIFF
--- a/packages/ctl/test/gh-and-shims.test.ts
+++ b/packages/ctl/test/gh-and-shims.test.ts
@@ -627,6 +627,62 @@ describe('git-shim arg whitelist + passthrough', () => {
     }
   });
 
+  // Options we don't model also take a value. If the scan guessed flag arity,
+  // that value would read as the clone source and hand real git a REMOTE clone,
+  // slipping the relay and the whitelist. Classify every token instead.
+  it.each([
+    ['--reference', '/tmp/ref'],
+    ['--separate-git-dir', '/tmp/gitdir'],
+    ['--upload-pack', '/usr/bin/git-upload-pack'],
+    ['--reference-if-able', '/tmp/ref'],
+  ])('clone %s <path> before a remote url does not bypass the gate', (flag, value) => {
+    const env = makeStubShell();
+    try {
+      const realGit = makeRealGitStub(env);
+      const out = runShim(GIT_SHIM, ['clone', flag, value, 'https://github.com/x/y.git'], env, {
+        AGENTBOX_REAL_GIT_PATH: realGit,
+      });
+      expect(out.code).toBe(2);
+      expect(out.stderr).toMatch(/unsupported flag/);
+      expect(out.stdout).not.toContain('REAL_GIT:');
+      expect(out.stdout).not.toContain('STUB:');
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  // scp-style and ssh:// remotes must not be mistaken for local paths either.
+  it.each([['git@github.com:owner/name.git'], ['ssh://git@host/owner/name.git']])(
+    'clone %s is treated as remote, not local',
+    (url) => {
+      const env = makeStubShell();
+      try {
+        const realGit = makeRealGitStub(env);
+        const out = runShim(GIT_SHIM, ['clone', url, '/tmp/dest'], env, {
+          AGENTBOX_REAL_GIT_PATH: realGit,
+        });
+        expect(out.stdout).not.toContain('REAL_GIT:');
+      } finally {
+        env.cleanup();
+      }
+    },
+  );
+
+  // Ambiguous/unrecognized source (no local token at all) ⇒ gate, not real git.
+  it('clone of a bare remote name falls to the gate, not real git', () => {
+    const env = makeStubShell();
+    try {
+      const realGit = makeRealGitStub(env);
+      const out = runShim(GIT_SHIM, ['clone', 'myremote'], env, {
+        AGENTBOX_REAL_GIT_PATH: realGit,
+      });
+      expect(out.stdout).not.toContain('REAL_GIT:');
+      expect(out.stdout).toContain('STUB: git clone myremote');
+    } finally {
+      env.cleanup();
+    }
+  });
+
   it('clone of owner/name shorthand still relays to ctl', () => {
     const env = makeStubShell();
     try {

--- a/packages/ctl/test/gh-and-shims.test.ts
+++ b/packages/ctl/test/gh-and-shims.test.ts
@@ -77,6 +77,7 @@ function runShim(
   shimPath: string,
   args: string[],
   env: StubShellEnv,
+  extraEnv: Record<string, string> = {},
 ): { code: number; stdout: string; stderr: string } {
   const res = spawnSync('bash', [shimPath, ...args], {
     cwd: env.tmpDir,
@@ -84,10 +85,24 @@ function runShim(
       ...process.env,
       AGENTBOX_CTL_PATH: env.ctlPath,
       AGENTBOX_REAL_GIT_PATH: '/usr/bin/git',
+      ...extraEnv,
     },
     encoding: 'utf8',
   });
   return { code: res.status ?? -1, stdout: res.stdout, stderr: res.stderr };
+}
+
+/**
+ * Stub `git` that prints `REAL_GIT: <argv>` — lets a test prove the shim fell
+ * through to the real binary instead of relaying to `agentbox-ctl`.
+ */
+function makeRealGitStub(env: StubShellEnv): string {
+  const p = join(env.tmpDir, 'real-git-stub');
+  writeFileSync(p, `#!/usr/bin/env bash\nprintf 'REAL_GIT: %s\\n' "$*"\nexit 0\n`, {
+    mode: 0o755,
+  });
+  chmodSync(p, 0o755);
+  return p;
 }
 
 describe('agentbox-ctl gh pr * wire shape', () => {
@@ -541,6 +556,87 @@ describe('git-shim arg whitelist + passthrough', () => {
       const out = runShim(GIT_SHIM, ['clone', '--recurse-submodules', 'https://x/y.git'], env);
       expect(out.code).toBe(2);
       expect(out.stderr).toMatch(/unsupported flag '--recurse-submodules'/);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  // A local clone touches no credentials, so it must bypass the relay entirely
+  // — flag gate included. This is the exact call agentbox's own cloud workspace
+  // seeding makes, which is what lets `create --provider <cloud>` run in a box.
+  it('clone from file:// falls through to real git with --no-checkout intact', () => {
+    const env = makeStubShell();
+    try {
+      const realGit = makeRealGitStub(env);
+      const out = runShim(
+        GIT_SHIM,
+        ['clone', '--no-checkout', '--quiet', '--depth=200', 'file:///workspace', '/tmp/clone'],
+        env,
+        { AGENTBOX_REAL_GIT_PATH: realGit },
+      );
+      expect(out.code).toBe(0);
+      expect(out.stdout).toContain(
+        'REAL_GIT: clone --no-checkout --quiet --depth=200 file:///workspace /tmp/clone',
+      );
+      expect(out.stdout).not.toContain('STUB:');
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  it('clone from an absolute path falls through to real git', () => {
+    const env = makeStubShell();
+    try {
+      const realGit = makeRealGitStub(env);
+      const out = runShim(GIT_SHIM, ['clone', '/srv/repo.git'], env, {
+        AGENTBOX_REAL_GIT_PATH: realGit,
+      });
+      expect(out.code).toBe(0);
+      expect(out.stdout).toContain('REAL_GIT: clone /srv/repo.git');
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  // `--branch <val>` consumes its value, so the source scan must not mistake a
+  // branch name for the clone source and wrongly fall through.
+  it('clone --branch <name> from a remote still relays to ctl', () => {
+    const env = makeStubShell();
+    try {
+      const realGit = makeRealGitStub(env);
+      const out = runShim(GIT_SHIM, ['clone', '--branch', 'main', 'https://x/y.git'], env, {
+        AGENTBOX_REAL_GIT_PATH: realGit,
+      });
+      expect(out.code).toBe(0);
+      expect(out.stdout).toContain('STUB: git clone https://x/y.git --branch main');
+      expect(out.stdout).not.toContain('REAL_GIT:');
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  // The fall-through must not become a hole: a real remote keeps the flag gate.
+  it('clone --no-checkout from a remote url is still rejected', () => {
+    const env = makeStubShell();
+    try {
+      const out = runShim(GIT_SHIM, ['clone', '--no-checkout', 'https://x/y.git'], env);
+      expect(out.code).toBe(2);
+      expect(out.stderr).toMatch(/unsupported flag '--no-checkout'/);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  it('clone of owner/name shorthand still relays to ctl', () => {
+    const env = makeStubShell();
+    try {
+      const realGit = makeRealGitStub(env);
+      const out = runShim(GIT_SHIM, ['clone', 'owner/name', '/abs/dest'], env, {
+        AGENTBOX_REAL_GIT_PATH: realGit,
+      });
+      expect(out.code).toBe(0);
+      expect(out.stdout).toContain('STUB: git clone owner/name /abs/dest');
+      expect(out.stdout).not.toContain('REAL_GIT:');
     } finally {
       env.cleanup();
     }

--- a/packages/sandbox-docker/scripts/git-shim
+++ b/packages/sandbox-docker/scripts/git-shim
@@ -90,25 +90,32 @@ case "$1" in
     # the flag gate. agentbox's own cloud workspace seeding does exactly this
     # (`git clone --no-checkout --quiet file:///workspace <tmp>`), which is how
     # `agentbox create --provider <cloud>` runs from inside a box.
-    # Only --branch/--depth take a separate value; any other `-*` is a bare flag
-    # here (strict_flags rejects it below if we take the relay path).
-    clone_src=''
-    skip_value=0
+    #
+    # Do NOT try to find "the repo positional" by skipping known flag values:
+    # options we don't model take a value too (`--reference <path>`,
+    # `--separate-git-dir <path>`, `--upload-pack <cmd>`), and that path would
+    # then read as the source — handing the real git a REMOTE clone and slipping
+    # both the relay and the whitelist. Instead classify EVERY non-flag token
+    # (values included) and only fall through when something is unmistakably
+    # local and nothing looks remote. Unknown/ambiguous ⇒ no fall-through ⇒ the
+    # strict gate below rejects it loudly. Fail-closed by default.
+    clone_local=0
+    clone_remote=0
     for arg in "$@"; do
-      if [ "$skip_value" = "1" ]; then
-        skip_value=0
-        continue
-      fi
       case "$arg" in
-        --branch|--depth) skip_value=1 ;;
-        --) ;;
-        -*) ;;
-        *) clone_src="$arg"; break ;;
+        -*) continue ;;
+      esac
+      case "$arg" in
+        # file:// first: it also matches the `*://*` remote pattern below.
+        file://*|/*|./*|../*|~/*) clone_local=1 ;;
+        # scheme://, scp-style host:path / user@host:path, and the bare
+        # `owner/name` github shorthand that `agentbox-ctl git clone` accepts.
+        *://*|*:*|*/*) clone_remote=1 ;;
       esac
     done
-    case "$clone_src" in
-      file://*|/*|./*|../*|~/*) exec "$REAL_GIT" clone "$@" ;;
-    esac
+    if [ "$clone_local" = "1" ] && [ "$clone_remote" = "0" ]; then
+      exec "$REAL_GIT" clone "$@"
+    fi
 
     strict_flags "git clone" "--branch|--depth" "$@"
     # Walk argv: split into (url, dir, flags) so we can hand them to ctl

--- a/packages/sandbox-docker/scripts/git-shim
+++ b/packages/sandbox-docker/scripts/git-shim
@@ -84,6 +84,32 @@ case "$1" in
     ;;
   clone)
     shift
+    # A clone whose source is a filesystem path or `file://` URL needs no host
+    # credentials, and `agentbox-ctl git clone` only speaks github — so relaying
+    # it would be wrong, not merely strict. Fall through to the real git before
+    # the flag gate. agentbox's own cloud workspace seeding does exactly this
+    # (`git clone --no-checkout --quiet file:///workspace <tmp>`), which is how
+    # `agentbox create --provider <cloud>` runs from inside a box.
+    # Only --branch/--depth take a separate value; any other `-*` is a bare flag
+    # here (strict_flags rejects it below if we take the relay path).
+    clone_src=''
+    skip_value=0
+    for arg in "$@"; do
+      if [ "$skip_value" = "1" ]; then
+        skip_value=0
+        continue
+      fi
+      case "$arg" in
+        --branch|--depth) skip_value=1 ;;
+        --) ;;
+        -*) ;;
+        *) clone_src="$arg"; break ;;
+      esac
+    done
+    case "$clone_src" in
+      file://*|/*|./*|../*|~/*) exec "$REAL_GIT" clone "$@" ;;
+    esac
+
     strict_flags "git clone" "--branch|--depth" "$@"
     # Walk argv: split into (url, dir, flags) so we can hand them to ctl
     # in commander's expected shape (positionals first, then options).


### PR DESCRIPTION
## Problem

`agentbox create --provider <any cloud>` fails immediately when agentbox itself runs **inside an agentbox box** (the documented agentbox-in-agentbox workflow):

```
agentbox git shim: unsupported flag '--no-checkout' for 'git clone'. Allowed: --branch, --depth
```

The in-box `git` shim (`packages/sandbox-docker/scripts/git-shim`, installed at `/usr/local/bin/git` ahead of the real git, and shipped verbatim by **all five providers**) intercepts *every* `git clone` and routes it to `agentbox-ctl git clone` → host relay.

But agentbox's own cloud workspace seeding runs a purely local, credential-free clone — `runShallowClone` in `packages/sandbox-cloud/src/sync/workspace-seed.ts`:

```
git clone --no-checkout --quiet [--depth=N] file:///workspace <tmpdir>
```

It calls `execa('git', ...)`, which resolves through PATH and hits the shim.

## Why not just allow `--no-checkout`

Because relaying it would still be wrong. `agentbox-ctl git clone`'s own help says *"Clone a **github** repo into the box. Host runs `git clone` with its creds."* A `file://` clone touches no credentials and has no business going to the host.

So: identify the clone source **before** the flag gate, and `exec` the real git when it's a filesystem path or `file://` URL. Remote URLs and `owner/name` shorthand keep the existing gate, unchanged and fail-closed.

This is not a privilege boundary — `/usr/bin/git` is already on PATH behind the shim, so a local clone was never something the shim prevented. Only the source scan is new; `--branch`/`--depth` value-consumption is handled so a branch name can't be mistaken for the source.

## Verification

- `packages/ctl` suite: **326/326** pass with the fixed shim as PATH's git. 5 new tests cover file:// fall-through with `--no-checkout` intact, absolute-path fall-through, `--branch <name>` not desyncing the scan, remote `--no-checkout` still rejected, and `owner/name` still relayed.
- **Live**: with only the fixed shim on PATH (no bypass), `agentbox create --provider vercel` from inside a box now succeeds and seeds `/workspace` on the correct `agentbox/<name>` branch at the right HEAD. Box destroyed after.
- Side effect: `packages/ctl/test/bootstrap.test.ts` (which shells out to `git clone --bare`) currently **fails inside a box** on nightly because of the same shim. This fixes that too.

## Scope

One canonical file — every provider (docker / daytona / hetzner / vercel / e2b) installs this same script, so the fix lands everywhere at once. Takes effect for existing boxes only after the base images are re-baked (`agentbox prepare --provider <name> --force`).

## Not fixed here

The docker provider separately fails in-box: it bind-mounts the host repo's `.git` at its identical absolute path (`create.ts:724`), which inside a box is `/workspace/.git` and collides with the container's own `/workspace` worktree mount. `create` exits 0 with a silently broken git. Confirmed via control test (same provider, repo at a non-`/workspace` path → works). Left for a separate change.

https://claude.ai/code/session_01K3PimZHyJjxVhuCfbHoZqX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes routing for `git clone` in a credential-sensitive shim, but only widens passthrough for local paths; remote URLs remain gated and fail-closed on disallowed flags.
> 
> **Overview**
> Fixes **agentbox-in-agentbox** cloud creates that die on workspace seeding: the box `git` shim used to send every `git clone` to `agentbox-ctl` and reject flags like `--no-checkout`, but seeding runs a local `file:///workspace` clone that should never hit the host relay.
> 
> **`git-shim`** now finds the clone source before the flag whitelist. Sources that look like `file://`, absolute paths, or relative/`~` paths **`exec` real git** with the full argv (including `--no-checkout`). GitHub URLs, `https://…`, and `owner/name` still go through **`agentbox-ctl`** with the same strict flags; remote `--no-checkout` stays rejected. **`--branch` / `--depth`** values are skipped when picking the source so a branch name is not treated as the URL.
> 
> **`gh-and-shims.test.ts`** adds `makeRealGitStub`, optional `extraEnv` on `runShim`, and five tests for fall-through vs relay behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e23996bcd9fdfdb1b3d67305b8c0bf4a03b40e61. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->