### PR TITLE
fix(cloud): mount-safe workspace seeding, root-exec extraction, bootstrap spawn guard

### DIFF
--- a/packages/ctl/src/commands/bootstrap.ts
+++ b/packages/ctl/src/commands/bootstrap.ts
@@ -223,6 +223,12 @@ function spawnDetached(cmd: string, args: string[], logFile: string): void {
     stdio: ['ignore', fd, fd],
     env: process.env,
   });
+  // A missing binary surfaces as an async 'error' event; unhandled it crashes
+  // the whole bootstrap. These daemons are best-effort (a slim base image may
+  // not ship the VNC/dockerd scripts) — log and continue.
+  child.on('error', (err) => {
+    process.stderr.write(`agentbox-ctl bootstrap: ${cmd} failed to spawn: ${err.message}\n`);
+  });
   child.unref();
 }
 

--- a/packages/sandbox-cloud/src/sync/workspace-seed.ts
+++ b/packages/sandbox-cloud/src/sync/workspace-seed.ts
@@ -281,11 +281,11 @@ export function buildCarryOverSteps(opts: {
             // Report (but don't clobber) untracked files that already exist in
             // the box tree, then extract only the new ones (--skip-old-files).
             `tar -tzf ${untracked} | while IFS= read -r p; do case "$p" in ''|*/) continue ;; esac; if [ -e ${wd}/"$p" ]; then echo "${OVERLAY_SKIP_MARKER}$p"; fi; done || true ; ` +
-            `tar -C ${wd} --skip-old-files -xzf ${untracked} || true ; ` +
+            `tar -C ${wd} --skip-old-files --no-same-owner -xzf ${untracked} || true ; ` +
             `rm -f ${untracked} ; ` +
             `fi`
         : `if [ -f ${untracked} ]; then ` +
-            `tar -C ${wd} -xzf ${untracked} && rm -f ${untracked} ; ` +
+            `tar -C ${wd} --no-same-owner -xzf ${untracked} && rm -f ${untracked} ; ` +
             `fi`,
     );
   }
@@ -446,8 +446,7 @@ async function seedFromGitClone(args: SeedFromGitCloneArgs): Promise<RepoSeedCon
     const prepSteps = args.overlay
       ? [`$SUDO rm -rf ${quoteShellArgv([gitDir])}`]
       : [
-          `$SUDO rm -rf ${quoteShellArgv([args.workspaceDir])}`,
-          `$SUDO mkdir -p ${quoteShellArgv([args.workspaceDir])}`,
+          ...wipeDirSteps(args.workspaceDir),
           `$SUDO chown "$(id -un):$(id -gn)" ${quoteShellArgv([args.workspaceDir])}`,
         ];
     const checkoutSteps = args.overlay
@@ -478,7 +477,12 @@ async function seedFromGitClone(args: SeedFromGitCloneArgs): Promise<RepoSeedCon
       // `/workspace/<rel>`, so the root clone is preserved). Overlay: rm only
       // `<dir>/.git`, preserving the warm working tree.
       ...prepSteps,
-      `tar -C ${quoteShellArgv([args.workspaceDir])} -xzf ${quoteShellArgv([remoteTar])}`,
+      // --no-same-owner (here and on every extraction in this file): clouds
+      // whose exec user is root would otherwise preserve the HOST's numeric
+      // uids from the tarball, and git then fails with "dubious ownership"
+      // on /workspace/.git. Non-root extraction already behaves this way
+      // (tar defaults to --no-same-owner unless root).
+      `tar -C ${quoteShellArgv([args.workspaceDir])} --no-same-owner -xzf ${quoteShellArgv([remoteTar])}`,
       setOrigin,
       ...checkoutSteps,
       ...carryOverSteps,
@@ -652,7 +656,7 @@ async function tryReseedRepoDelta(args: SeedFromGitCloneArgs): Promise<RepoSeedC
     // preserved by the tar so they land content-addressed.
     const lfsStep =
       deltaLfsSize > 0
-        ? `tar -C ${quoteShellArgv([`${args.workspaceDir}/.git`])} -xzf ${quoteShellArgv([REMOTE_DELTA_LFS])}`
+        ? `tar -C ${quoteShellArgv([`${args.workspaceDir}/.git`])} --no-same-owner -xzf ${quoteShellArgv([REMOTE_DELTA_LFS])}`
         : ': # no delta lfs objects';
     const SUDO = `if command -v sudo >/dev/null 2>&1; then SUDO='sudo -n'; else SUDO=''; fi`;
     const script = [
@@ -925,6 +929,17 @@ async function readOriginUrl(hostRepo: string): Promise<string | null> {
   return out.length > 0 ? out : null;
 }
 
+/**
+ * Fresh-seed wipe of the extraction dir. Clears the dir's contents instead of
+ * `rm -rf`-ing the dir itself: some clouds mount the workspace dir into the
+ * sandbox, so removing it fails with "Device or resource busy". Expects the
+ * caller's script to have defined `$SUDO`.
+ */
+function wipeDirSteps(dir: string): string[] {
+  const q = quoteShellArgv([dir]);
+  return [`$SUDO mkdir -p ${q}`, `$SUDO find ${q} -mindepth 1 -maxdepth 1 -exec rm -rf {} +`];
+}
+
 interface SeedFromTarArgs {
   backend: CloudBackend;
   handle: CloudHandle;
@@ -949,10 +964,9 @@ async function seedFromTar(args: SeedFromTarArgs): Promise<void> {
       // (index-pack) fails with "Unable to read current working directory".
       `cd /tmp`,
       SUDO,
-      `$SUDO rm -rf ${quoteShellArgv([args.workspaceDir])}`,
-      `$SUDO mkdir -p ${quoteShellArgv([args.workspaceDir])}`,
+      ...wipeDirSteps(args.workspaceDir),
       `$SUDO chown "$(id -un):$(id -gn)" ${quoteShellArgv([args.workspaceDir])}`,
-      `tar -C ${quoteShellArgv([args.workspaceDir])} -xzf ${quoteShellArgv([remoteTar])}`,
+      `tar -C ${quoteShellArgv([args.workspaceDir])} --no-same-owner -xzf ${quoteShellArgv([remoteTar])}`,
       `rm -f ${quoteShellArgv([remoteTar])}`,
     ].join('\n');
     const r = await args.backend.exec(args.handle, bashScript(script));


### PR DESCRIPTION
## Summary

Three generic cloud-backend robustness fixes, found by live-testing a provider whose sandbox shape differs from the built-ins' assumptions. Each one is a latent bug for any current or future `CloudBackend`:

- **Mount-safe workspace seeding** (`workspace-seed.ts`, git + tar paths): the fresh-seed wipe used to `rm -rf` the workspace dir and recreate it. A cloud that **mounts** the workspace dir into the sandbox fails that with `rm: cannot remove '/workspace': Device or resource busy`. The wipe now clears the dir's *contents* (`mkdir -p` + `find -mindepth 1 -maxdepth 1 -exec rm -rf`), which is equivalent for a fresh seed and works on both plain dirs and mountpoints.
- **`--no-same-owner` on every in-box tar extraction** (`workspace-seed.ts`, 5 sites): on a cloud whose exec user is **root**, GNU tar preserves the *host's* numeric uids from the seeding tarball, so `/workspace/.git` lands owned by a foreign uid and git fails with `fatal: detected dubious ownership`. Non-root extraction (all built-in clouds run as `vscode`) already behaves like `--no-same-owner`, so this is a no-op for them.
- **Bootstrap spawn guard** (`ctl` `bootstrap.ts`): `spawnDetached` had no `error` handler, so a *missing* best-effort daemon binary (e.g. `agentbox-vnc-start` on a slim base image without the VNC stack) surfaced as an unhandled async `spawn ENOENT` and crashed the whole bootstrap — turning a should-be-soft-failure (dockerd/VNC are documented best-effort) into a fatal create failure. It now logs and continues; only a dead ctl daemon remains fatal.

## Verification

- `pnpm --filter @agentbox/sandbox-cloud --filter @agentbox/ctl test` — 112 + 348 pass.
- Live end-to-end on a cloud sandbox exhibiting all three traits (mounted `/workspace`, root exec, no VNC stack in the image): `agentbox create` previously failed at each of these steps in turn; with the fixes it completes — git-clone seeding onto the per-box branch, credentials seeded, `ctl=up`, `agentbox.yaml` install task + web service ready, public preview URL serving, pause/resume, destroy.

https://claude.ai/code/session_0156d47n9hxNTCAuyjX7rEch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provisioning scripts that wipe and extract `/workspace` on every cloud create/restore; wrong wipe or ownership behavior could break seeding, but scope is limited to cloud seed paths and best-effort bootstrap spawns.
> 
> **Overview**
> Hardens **cloud sandbox bring-up** for providers that mount `/workspace`, run exec as **root**, or ship slim images without optional daemons.
> 
> **Workspace seeding** (`workspace-seed.ts`): fresh-seed prep no longer `rm -rf` the workspace directory—it uses new `wipeDirSteps` (`mkdir -p` + `find … -exec rm -rf`) so mounted workspace paths don’t hit “Device or resource busy.” Every in-sandbox `tar` extract (git clone seed, tar seed, carry-over untracked, delta LFS) now passes **`--no-same-owner`** so root exec doesn’t preserve host numeric UIDs and trigger git “dubious ownership” on `.git`.
> 
> **Bootstrap** (`bootstrap.ts`): `spawnDetached` registers a **`child.on('error')`** handler so a missing best-effort daemon binary (e.g. VNC on a minimal image) logs instead of crashing the whole bootstrap with an unhandled `spawn ENOENT`; ctl daemon failure remains fatal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b512bf74f394e6ed8c76adf9cbeb4b48f3f1015f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->