### PR TITLE
feat(connect): --dangerously-git-credentials — post-create git independence

### DIFF
--- a/apps/cli/src/commands/connect.ts
+++ b/apps/cli/src/commands/connect.ts
@@ -3,12 +3,14 @@ import { confirm, isCancel, log } from '@clack/prompts';
 import { resolveCloudSshTarget } from '@agentbox/sandbox-core';
 import { Command } from 'commander';
 import { resolveBoxOrExit } from '../box-ref.js';
+import { runGitCredsGate } from '../lib/git-creds-gate.js';
 import { providerForBox } from '../provider/registry.js';
 import { handleLifecycleError } from './_errors.js';
 
 interface ConnectOptions {
   addKey?: string;
   exportKey?: boolean;
+  dangerouslyGitCredentials?: boolean;
   json?: boolean;
   yes?: boolean;
 }
@@ -25,7 +27,8 @@ function shellSingleQuote(s: string): string {
 export const connectCommand = new Command('connect')
   .description(
     'Print a VPS box\'s SSH connection details (to drive it from a phone / other SSH client with the laptop off), ' +
-      'add another device\'s key, or export the box key. Pair with `agentbox inbound <box> open` so the box is reachable off-network. ' +
+      'add another device\'s key, export the box key, or copy git credentials into the box so it pushes on its own ' +
+      '(--dangerously-git-credentials). Pair with `agentbox inbound <box> open` so the box is reachable off-network. ' +
       'Hetzner / DigitalOcean only.',
   )
   .argument(
@@ -40,12 +43,64 @@ export const connectCommand = new Command('connect')
     '--export-key',
     "print the box's PRIVATE key to import into a mobile SSH client (Terminus/Blink). The key leaves the host — a new trust edge; confirm required",
   )
+  .option(
+    '--dangerously-git-credentials',
+    "copy a git credential INTO a running box so it can push/pull on its own with your PC off (git.pushMode=direct) — the post-create equivalent of `create --dangerously-with-credentials`. An interactive prompt asks token (HTTPS, unsigned) vs SSH (signs, riskiest). DANGEROUS: the credential lives in the box + its snapshots. Requires a real terminal; cloud only. Restart the agent session afterward.",
+  )
   .option('--json', 'machine-readable connection bundle')
   .option('-y, --yes', 'skip the confirmation prompt for --export-key')
   .action(async (idOrName: string | undefined, opts: ConnectOptions) => {
     try {
       const box = await resolveBoxOrExit(idOrName);
       const provider = await providerForBox(box);
+
+      // --- git-credentials mode: make an already-running box push on its own ---
+      if (opts.dangerouslyGitCredentials) {
+        if (opts.addKey || opts.exportKey) {
+          log.error('--dangerously-git-credentials cannot be combined with --add-key / --export-key.');
+          process.exit(2);
+        }
+        if (!provider.enableDirectGit || !provider.buildAttach) {
+          log.error(
+            `\`connect --dangerously-git-credentials\` needs an SSH cloud box (hetzner / digitalocean) — ` +
+              `provider '${box.provider ?? 'docker'}' isn't supported here` +
+              (provider.enableDirectGit
+                ? ''
+                : ' (docker boxes bind-mount the host .git, so git direct mode is N/A)') +
+              '.',
+          );
+          process.exit(2);
+        }
+        // Resolve the credential host-side (TTY-required token-vs-ssh prompt).
+        const projectRoot = box.projectRoot ?? box.workspacePath ?? process.cwd();
+        const gate = await runGitCredsGate({ projectRoot, onLog: (l) => log.step(l) });
+        if (gate.decision === 'cancel') {
+          log.info('cancelled');
+          return;
+        }
+        if (gate.decision === 'skip' || gate.entries.length === 0) {
+          log.warn(
+            'no git credential could be resolved for this repo (no token / ssh key found); nothing was applied.',
+          );
+          return;
+        }
+        // Bring the box online (exec needs it) — reuses the SSH-support check.
+        await resolveCloudSshTarget(box, provider, {
+          bringOnline: true,
+          logInfo: (l) => log.step(l),
+        });
+        await provider.enableDirectGit(box, gate.entries, {
+          hostRepo: projectRoot,
+          onLog: (l) => log.step(l),
+        });
+        process.stdout.write(
+          `git direct mode enabled for ${box.name} — it can now \`git push\` / \`pull\` on its own with your laptop off.\n` +
+            `Restart its agent session to pick it up (new shells/sessions get it automatically):\n` +
+            `  agentbox recover ${box.name}\n`,
+        );
+        return;
+      }
+
       if (!provider.buildAttach) {
         log.error(
           `\`connect\` needs an SSH box — provider '${box.provider ?? 'docker'}' isn't reachable over SSH ` +

--- a/apps/web/content/docs/access-your-box.mdx
+++ b/apps/web/content/docs/access-your-box.mdx
@@ -191,7 +191,7 @@ agentbox connect mybox --add-key @~/phone-key.pub
 
 Then add an SSH host `vscode@<box-ip>` on the phone with that key and run `claude` / `codex` as usual. When you're back at your laptop, `agentbox inbound mybox lock` re-pins the firewall to your current IP (`--show` prints the policy). To move the box's *own* key onto the phone instead of adding a new one, `agentbox connect mybox --export-key` prints it — a new trust edge, so it asks first.
 
-This is the **inbound** half of a laptop-off box. Pair it with [`--dangerously-with-credentials`](/docs/sync-and-git#independent-boxes--dangerously-with-credentials) for the **outbound** half — the box's own `git push` / `pull` then works offline too. The two are independent axes you combine for a fully self-sufficient box.
+This is the **inbound** half of a laptop-off box. Pair it with the **outbound** half — the box's own `git push` / `pull` working offline — via [`--dangerously-with-credentials`](/docs/sync-and-git#independent-boxes--dangerously-with-credentials) at create, or on a box that's already running with `agentbox connect <box> --dangerously-git-credentials`. The two are independent axes you combine for a fully self-sufficient box.
 
 <Callout type="warn" title="open exposes port 22">
 `--inbound open` makes the box's SSH port publicly reachable. The baked sshd is key-only — no passwords, `vscode`-only, no root, the standard way internet-facing VPSes are secured — but treat the per-box key like a credential and `agentbox inbound <box> lock` once you no longer need remote access. Only Hetzner and DigitalOcean boxes have a per-box firewall + persistent key; other providers aren't reachable this way.

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -189,7 +189,7 @@ agentbox connect 1 --add-key @phone.pub   # authorize a device's key; print the 
 
 <Callout title="TIP">Prefer `pause`/`unpause` to switch between boxes — it frees CPU and RAM while frozen and resumes instantly on docker. Use `stop` when you want the box off but kept.</Callout>
 
-`inbound`/`connect` (Hetzner/DigitalOcean) let you drive a box from a phone with the laptop off. `agentbox inbound <box> open|lock|<cidr…>` sets the per-box firewall's inbound policy (`--show` prints it); `agentbox connect <box>` prints the SSH connection bundle, `--add-key <pubkey>` authorizes another device's key (the box's own key stays on the host), and `--export-key` prints the box key for a mobile client. See [remote access](/docs/access-your-box#use-a-box-with-your-laptop-offline).
+`inbound`/`connect` (Hetzner/DigitalOcean) let you drive a box from a phone with the laptop off. `agentbox inbound <box> open|lock|<cidr…>` sets the per-box firewall's inbound policy (`--show` prints it); `agentbox connect <box>` prints the SSH connection bundle, `--add-key <pubkey>` authorizes another device's key (the box's own key stays on the host), and `--export-key` prints the box key for a mobile client, and `--dangerously-git-credentials` copies a git credential into an already-running box so it pushes on its own (the post-create equivalent of `create --dangerously-with-credentials`; restart the agent afterward). See [remote access](/docs/access-your-box#use-a-box-with-your-laptop-offline) and [sync & git](/docs/sync-and-git#independent-boxes--dangerously-with-credentials).
 
 See [Checkpoints & pausing](/docs/checkpoints-and-pausing) and the provider pages for cloud pause/stop semantics.
 

--- a/apps/web/content/docs/sync-and-git.mdx
+++ b/apps/web/content/docs/sync-and-git.mdx
@@ -177,6 +177,13 @@ At create time it **asks** — at an interactive prompt — which credential to 
 
 Inside the box, `git push`/`fetch`/`pull` then run real git against the credentialed remote — the relay is never involved.
 
+**Already have a box running?** Do the same thing after the fact with **`agentbox connect <box> --dangerously-git-credentials`** (Hetzner / DigitalOcean) — the post-create equivalent. It runs the same interactive token-vs-ssh prompt, copies the credential into the live box, and flips it to direct mode. Restart the box's agent session afterward (or open a fresh `agentbox shell`) so it picks up the new mode — a session already running keeps using the relay until it restarts.
+
+```bash
+agentbox connect mybox --dangerously-git-credentials   # choose token or ssh
+agentbox recover mybox                                  # restart the agent to use it
+```
+
 <Callout type="warn" title="This copies a real credential into the box">
 `--dangerously-with-credentials` places a credential **inside the box** — where its user has passwordless sudo (no boundary) — and it is captured in **any snapshot or checkpoint** of it. Only use it for a box you trust to run unattended. For safety this is **interactive and foreground only**: it requires a real terminal and a human choosing token vs SSH at the prompt. There is deliberately **no non-interactive path** — no flag value, no env var, no `-y` — and it is **rejected with `-i` / background runs**, so automation and CI can't copy a credential without a person present.
 </Callout>

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -395,6 +395,22 @@ export interface Provider {
    * CLI. `onLog` streams the applied source list.
    */
   setInbound?(box: BoxRecord, spec: string, onLog?: (line: string) => void): Promise<InboundPolicy>;
+  /**
+   * Switch an already-running cloud box into `git.pushMode=direct` — the
+   * post-create equivalent of `--dangerously-with-credentials`. Uploads the
+   * host-resolved credential carry `entries` into the box, wires its git config
+   * (`seedGitCredentials`), sets `AGENTBOX_GIT_DIRECT=1` in the box env, and
+   * persists `cloud.gitPushMode=direct` so a resume re-kick keeps it. The
+   * caller (CLI) runs the interactive token-vs-ssh gate to produce `entries`.
+   * Optional — only cloud providers implement it; docker omits it (it
+   * bind-mounts the host `.git`, so direct mode is N/A). A currently-running
+   * agent session must be restarted to pick up the new mode.
+   */
+  enableDirectGit?(
+    box: BoxRecord,
+    entries: ResolvedCarryEntry[],
+    opts?: { hostRepo?: string; onLog?: (line: string) => void },
+  ): Promise<void>;
   pause(box: BoxRecord): Promise<void>;
   resume(box: BoxRecord): Promise<void>;
   stop(box: BoxRecord): Promise<void>;

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -32,6 +32,7 @@ import type {
   Provider,
   ProviderCheckpoint,
   ProviderSync,
+  ResolvedCarryEntry,
   ResyncResult,
   SyncTransport,
 } from '@agentbox/core';
@@ -78,7 +79,7 @@ import { readExposedServicePorts } from './expose-ports.js';
 import { downloadFromCloudBox, pullCloudDirContents, uploadToCloudBox } from './cloud-cp.js';
 import { kickCloudBootstrap } from './bootstrap-launch.js';
 import { readGitOriginUrl, registerBoxWithPlane } from './plane-register.js';
-import { quoteShellArgv } from './shell.js';
+import { bashScript, quoteShellArgv } from './shell.js';
 import { seedGitCredentials } from './sync/git-identity.js';
 import { seedCloudWorkspace } from './sync/workspace-seed.js';
 import type { SeedCloudWorkspaceResult } from './sync/workspace-seed.js';
@@ -1175,6 +1176,44 @@ export function createCloudProvider(
       const cloud = box.cloud;
       if (cloud) await recordBox({ ...box, cloud: { ...cloud, inbound: policy } });
       return policy;
+    },
+
+    async enableDirectGit(
+      box: BoxRecord,
+      entries: ResolvedCarryEntry[],
+      opts?: { hostRepo?: string; onLog?: (line: string) => void },
+    ): Promise<void> {
+      const onLog = opts?.onLog;
+      const handle = handleFor(box);
+      const ctx = makeSyncContext({
+        boxName: box.name,
+        boxId: box.id,
+        provider: 'cloud',
+        hostWorkspace: box.workspacePath,
+        boxWorkspace: CLOUD_WORKSPACE_DIR,
+        onLog,
+      });
+      // 1. Upload the host-resolved credential files + the git-direct-mode marker.
+      await makeCloudSync(backend, handle).applyCarry(ctx, entries);
+      // 2. Wire the box's git config (credential.helper / url.insteadOf for
+      // token; core.sshCommand + guarded signing for ssh) — same as create.
+      await seedGitCredentials(backend, handle, { hostRepo: opts?.hostRepo, onLog });
+      // 3. Flip the runtime flag in /etc/agentbox/box.env so future login shells
+      // (and the next agent session) push direct. Idempotent — the box env file
+      // is 0644 and AGENTBOX_GIT_DIRECT is a non-secret routing flag.
+      const flip =
+        'if ! sudo -n grep -q "^AGENTBOX_GIT_DIRECT=" /etc/agentbox/box.env 2>/dev/null; then ' +
+        'echo AGENTBOX_GIT_DIRECT=1 | sudo -n tee -a /etc/agentbox/box.env >/dev/null; fi';
+      const r = await backend.exec(handle, bashScript(flip));
+      if (r.exitCode !== 0) {
+        throw new Error(
+          `enableDirectGit: failed to set AGENTBOX_GIT_DIRECT in box env: ${r.stderr || r.stdout || `exit ${String(r.exitCode)}`}`,
+        );
+      }
+      // 4. Persist so a resume re-kick re-threads AGENTBOX_GIT_DIRECT (else the
+      // next resume rewrites box.env from the stale mode and drops it).
+      const cloud = box.cloud;
+      if (cloud) await recordBox({ ...box, cloud: { ...cloud, gitPushMode: 'direct' } });
     },
 
     async pause(box: BoxRecord): Promise<void> {

--- a/packages/sandbox-cloud/test/enable-direct-git.test.ts
+++ b/packages/sandbox-cloud/test/enable-direct-git.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type {
+  BoxRecord,
+  CloudBackend,
+  CloudExecResult,
+  CloudHandle,
+  CloudPreviewUrl,
+  CloudState,
+  ResolvedCarryEntry,
+} from '@agentbox/core';
+import { readState, removeBoxRecord } from '@agentbox/sandbox-core';
+import { createCloudProvider } from '../src/cloud-provider.js';
+
+// enableDirectGit persists via recordBox → the real ~/.agentbox/state.json
+// (STATE_FILE is frozen from homedir() at module load, so $HOME can't isolate
+// it). Use a clearly-fake box id and scrub just that entry afterwards.
+const TEST_ID = 'test-enable-direct-git-xyz';
+
+afterEach(async () => {
+  await removeBoxRecord(TEST_ID).catch(() => {});
+});
+
+function makeBackend(execCalls: string[]): CloudBackend {
+  return {
+    name: 'test-backend',
+    provision: async () => ({ sandboxId: 'sb-1' }),
+    get: async () => null,
+    start: async () => {},
+    stop: async () => {},
+    pause: async () => {},
+    resume: async () => {},
+    destroy: async () => {},
+    state: async (): Promise<CloudState> => 'running',
+    exec: async (_h: CloudHandle, cmd: string): Promise<CloudExecResult> => {
+      execCalls.push(cmd);
+      return { exitCode: 0, stdout: '', stderr: '' };
+    },
+    uploadFile: async () => {},
+    downloadFile: async () => {},
+    listFiles: async () => [],
+    previewUrl: async (_h: CloudHandle, port: number): Promise<CloudPreviewUrl> => ({
+      url: `https://${String(port)}.example`,
+    }),
+  };
+}
+
+function makeBox(): BoxRecord {
+  return {
+    id: TEST_ID,
+    name: 'test-directgit-box',
+    provider: 'test-backend',
+    workspacePath: '/tmp/does-not-matter',
+    cloud: { backend: 'test-backend', sandboxId: 'sb-1' },
+  } as unknown as BoxRecord;
+}
+
+// The carry upload tars a nonexistent src → uploadCarryPaths records a per-entry
+// error but does not throw, so the seed + env-flip + persist still run. We
+// assert on those observable effects.
+const ENTRIES: ResolvedCarryEntry[] = [
+  {
+    rawSrc: '~/.config/agentbox/git-direct-mode',
+    rawDest: '~/.config/agentbox/git-direct-mode',
+    absSrc: '/nonexistent/git-direct-mode',
+    absDest: '/home/vscode/.config/agentbox/git-direct-mode',
+    kind: 'file',
+    mode: 0o600,
+    user: 1000,
+    optional: false,
+  } as unknown as ResolvedCarryEntry,
+];
+
+describe('provider.enableDirectGit', () => {
+  it('seeds git config, flips AGENTBOX_GIT_DIRECT in box.env, and persists gitPushMode=direct', async () => {
+    const execCalls: string[] = [];
+    const provider = createCloudProvider(makeBackend(execCalls));
+
+    await provider.enableDirectGit!(makeBox(), ENTRIES, { hostRepo: '/tmp/does-not-matter' });
+
+    // The box env flip ran (idempotent AGENTBOX_GIT_DIRECT append into box.env).
+    const flip = execCalls.find((c) => c.includes('AGENTBOX_GIT_DIRECT'));
+    expect(flip, 'expected an exec that sets AGENTBOX_GIT_DIRECT').toBeTruthy();
+    expect(flip).toContain('/etc/agentbox/box.env');
+
+    // seedGitCredentials issued the git-config script.
+    expect(execCalls.some((c) => c.includes('git config'))).toBe(true);
+
+    // The record persisted gitPushMode=direct.
+    const state = await readState();
+    expect(state.boxes.find((b) => b.id === TEST_ID)?.cloud?.gitPushMode).toBe('direct');
+  });
+
+  it('wires enableDirectGit onto every cloud provider (CLI guards on it for docker)', () => {
+    expect(typeof createCloudProvider(makeBackend([])).enableDirectGit).toBe('function');
+  });
+});


### PR DESCRIPTION
## `agentbox connect <box> --dangerously-git-credentials` — inject git creds into a running box

Post-create equivalent of `create --dangerously-with-credentials`: make an **already-running** VPS box (Hetzner / DigitalOcean) push/pull on its own with your laptop off, without recreating it. Closes the asymmetry next to `connect --add-key` (post-create inbound key injection).

### What it does
Runs the **same interactive token-vs-ssh gate** as create (`runGitCredsGate`, TTY-required), then on the live box: uploads the credential files, wires the box's git config, sets `AGENTBOX_GIT_DIRECT=1`, and persists `cloud.gitPushMode=direct`. A currently-running agent session keeps using the relay until it restarts (new shells/sessions get direct mode automatically) — the command prints that caveat.

### Implementation (mostly reuse)
- **core**: `Provider.enableDirectGit?(box, entries, opts)` seam.
- **sandbox-cloud**: implement it — reuses `applyCarry` (upload creds + `git-direct-mode` marker), `seedGitCredentials` (same git config as create), an idempotent `AGENTBOX_GIT_DIRECT=1` append into `/etc/agentbox/box.env`, and `recordBox({ gitPushMode: 'direct' })` so a resume re-kick keeps it. Unit-tested against a mock backend.
- **CLI**: `--dangerously-git-credentials` on `connect` — guards cloud/SSH-only + mutual-exclusion with `--add-key`/`--export-key`, brings the box online, applies, prints the restart caveat.

### Live-verified (DigitalOcean, token mode, region fra1)
- Created a box with **no** creds → confirmed relay mode (no `AGENTBOX_GIT_DIRECT`, no cred config).
- Drove `connect --dangerously-git-credentials` (PTY harness), chose **token** → box.env stamped, `~/.git-credentials` present, `credential.helper store` + SSH→HTTPS `insteadOf` rewrites set, record `gitPushMode=direct`.
- **Stopped the host relay**, then from a fresh shell (`AGENTBOX_GIT_DIRECT=1`): `git push` pushed **directly over HTTPS** and the branch landed on GitHub (`git ls-remote` confirmed) — proving the box is fully independent with the PC off.
- Clean teardown, no orphans.

### Checks
`pnpm build + lint + typecheck + test` all green (new: `enable-direct-git.test.ts`). Docs: `sync-and-git` (independent boxes), `access-your-box` (laptop-offline), `cli`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Copies real git credentials into live boxes and snapshots (same security model as create `--dangerously-with-credentials`); mistakes or compromised boxes expose secrets, though the interactive gate blocks non-TTY automation.
> 
> **Overview**
> **Post-create git independence** for already-running SSH cloud boxes (Hetzner / DigitalOcean): `agentbox connect <box> --dangerously-git-credentials` mirrors create’s `--dangerously-with-credentials` — same TTY **token vs SSH** gate (`runGitCredsGate`), mutual exclusion with `--add-key` / `--export-key`, bring box online, then apply direct mode. Output tells users to **`agentbox recover`** so a running agent session picks up direct git.
> 
> **Provider seam:** optional `enableDirectGit(box, entries)` on `Provider`; cloud implements it by **carrying** resolved credential files, **`seedGitCredentials`**, appending **`AGENTBOX_GIT_DIRECT=1`** to `/etc/agentbox/box.env`, and persisting **`cloud.gitPushMode=direct`** so resume/re-kick keeps the mode. Docker omits the hook (bind-mounted host `.git`).
> 
> **Tests & docs:** `enable-direct-git.test.ts` mocks backend exec/state persistence; docs in sync-and-git, access-your-box, and cli describe the new flag and pairing with inbound/remote access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01c6942795c066aa2566ce9c71c89bf951a78b49. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->