### PR TITLE
feat(connect): prompt to restart the agent after --dangerously-git-credentials

### DIFF
--- a/apps/cli/src/agent-sessions.ts
+++ b/apps/cli/src/agent-sessions.ts
@@ -55,6 +55,18 @@ async function tmuxAlive(
   return (await execRead(provider, box, `tmux has-session -t ${q} 2>/dev/null && echo y`)) === 'y';
 }
 
+/** Kill a live agent tmux session so it can be relaunched with a fresh env. */
+async function killTmuxSession(
+  provider: Provider,
+  box: BoxRecord,
+  sessionName: string,
+): Promise<void> {
+  const q = `'${sessionName.replace(/'/g, `'\\''`)}'`;
+  await provider
+    .exec(box, ['bash', '-lc', `tmux kill-session -t ${q} 2>/dev/null || true`], { user: 'vscode' })
+    .catch(() => {});
+}
+
 /**
  * The args to resume the box's recorded session for `kind`, or null if there's
  * nothing to resume. Claude resumes the exact captured id; Codex (no id) resumes
@@ -88,6 +100,14 @@ export interface RestoreOptions {
    * the fresh path here.
    */
   restoreOnly?: 'claude' | 'codex' | 'opencode';
+  /**
+   * With `restoreOnly`: if that agent's session is already alive, KILL it first
+   * and relaunch (resuming), instead of leaving the running one untouched. Used
+   * to force the agent to pick up an environment change made after it started
+   * (e.g. `connect --dangerously-git-credentials` flipping the box to git direct
+   * mode) — a running session's env is otherwise frozen.
+   */
+  force?: boolean;
 }
 
 /** Start a fresh (no-resume) detached agent session. */
@@ -181,7 +201,14 @@ export async function restoreAgentSessions(
   const only = opts.restoreOnly;
   if (only) {
     const sessionName = sessionNameFor(only);
-    if (await tmuxAlive(provider, box, sessionName)) return;
+    if (await tmuxAlive(provider, box, sessionName)) {
+      if (!opts.force) return;
+      // Force: kill the running session so it relaunches with the current box
+      // env (e.g. after flipping to git direct mode). Claude/Codex then resume
+      // the same conversation via their in-box pointer below.
+      await killTmuxSession(provider, box, sessionName);
+      opts.onLog?.(`stopped the running ${only} session to restart it`);
+    }
     if ((only === 'claude' || only === 'codex') && (await tryResume(only, sessionName))) return;
     try {
       await startFreshSession(box, only, sessionName, cfg, isDocker);

--- a/apps/cli/src/commands/connect.ts
+++ b/apps/cli/src/commands/connect.ts
@@ -3,6 +3,7 @@ import { confirm, isCancel, log } from '@clack/prompts';
 import { resolveCloudSshTarget } from '@agentbox/sandbox-core';
 import { Command } from 'commander';
 import { resolveBoxOrExit } from '../box-ref.js';
+import { restoreAgentSessions } from '../agent-sessions.js';
 import { runGitCredsGate } from '../lib/git-creds-gate.js';
 import { providerForBox } from '../provider/registry.js';
 import { handleLifecycleError } from './_errors.js';
@@ -93,10 +94,32 @@ export const connectCommand = new Command('connect')
           hostRepo: projectRoot,
           onLog: (l) => log.step(l),
         });
+        log.success(
+          `git direct mode enabled for ${box.name} — it can now \`git push\` / \`pull\` on its own with your laptop off.`,
+        );
+        // A running agent session's env is frozen, so it keeps using the relay
+        // until restarted. Offer to restart it now (resuming the conversation).
+        const lastAgent = box.lastAgent;
+        if (lastAgent && process.stdin.isTTY && !opts.yes) {
+          const restart = await confirm({
+            message: `Restart the box's ${lastAgent} session now so it uses direct mode? (it resumes the same conversation)`,
+            initialValue: true,
+          });
+          if (!isCancel(restart) && restart) {
+            await restoreAgentSessions(box, provider, {
+              restoreOnly: lastAgent,
+              force: true,
+              onLog: (l) => log.step(l),
+            });
+            log.success(`${lastAgent} restarted in the background — it now pushes direct.`);
+            return;
+          }
+        }
         process.stdout.write(
-          `git direct mode enabled for ${box.name} — it can now \`git push\` / \`pull\` on its own with your laptop off.\n` +
-            `Restart its agent session to pick it up (new shells/sessions get it automatically):\n` +
-            `  agentbox recover ${box.name}\n`,
+          lastAgent
+            ? `A running ${lastAgent} session keeps using the relay until it restarts. When you're ready:\n` +
+                `  agentbox ${lastAgent} ${box.name}   # (or: agentbox recover ${box.name})\n`
+            : 'New shells and agent sessions get direct mode automatically.\n',
         );
         return;
       }

--- a/apps/cli/src/commands/connect.ts
+++ b/apps/cli/src/commands/connect.ts
@@ -102,7 +102,7 @@ export const connectCommand = new Command('connect')
         const lastAgent = box.lastAgent;
         if (lastAgent && process.stdin.isTTY && !opts.yes) {
           const restart = await confirm({
-            message: `Restart the box's ${lastAgent} session now so it uses direct mode? (it resumes the same conversation)`,
+            message: `Restart the box's ${lastAgent} session now so it uses direct mode? (resumes your conversation; starts fresh if it can't)`,
             initialValue: true,
           });
           if (!isCancel(restart) && restart) {


### PR DESCRIPTION
## DX: prompt to restart the agent after `connect --dangerously-git-credentials`

Follow-up to #194. A running agent session's env is frozen, so after enabling git direct mode it keeps using the relay until it restarts. Instead of only printing that caveat, the command now **offers to restart the agent right there** (resuming the same conversation) so it picks up direct mode immediately.

### Change
- **agent-sessions**: `RestoreOptions.force` — with `restoreOnly`, kill the live session first, then relaunch/resume it (a running session's env can't be refreshed in place). Reuses the existing resume-or-fresh logic (`restoreAgentSessions`, same path as `agentbox recover`).
- **connect**: after `enableDirectGit`, if the box has a `lastAgent` and we're on a TTY, `confirm()` to restart it and call `restoreAgentSessions({ restoreOnly, force })`; `-y` / non-TTY / no-agent skip the prompt and print how to restart.

### Live-verified (DigitalOcean, box running a detached claude session)
- Baseline: claude session alive (pid 4628), **no** `AGENTBOX_GIT_DIRECT` in its env.
- Drove `connect --dangerously-git-credentials` (PTY harness): token prompt → inject → then the new **"Restart the box's claude session now?"** prompt appeared → chose Yes.
- After restart: old session killed, new claude (pid 5418) alive with a healthy prompt and **`AGENTBOX_GIT_DIRECT=1` in its process env** — i.e. the restart refreshed the env to direct mode, exactly the goal.
- Clean teardown, no orphans.

(For this `-i` test box the trivial session couldn't be resumed so it started fresh — the same resume-or-fresh fallback `recover` uses; real conversations resume. The prompt copy says so.)

### Checks
`pnpm build + lint + typecheck + test` all green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Kills live agent tmux sessions and relaunches agents on user confirmation; mistakes could interrupt work, though resume pointers limit conversation loss.
> 
> **Overview**
> After **`connect --dangerously-git-credentials`** enables git direct mode, a **TTY** flow can **restart the box’s `lastAgent` session in place** so it picks up the new env (running tmux sessions keep the old relay env until restarted).
> 
> **`restoreAgentSessions`** gains **`force`** with **`restoreOnly`**: if that agent’s tmux session is already alive, it is **killed** via new **`killTmuxSession`**, then the existing **resume-or-fresh** path runs instead of returning early. **`connect`** calls this when the user confirms; **`-y`**, non-TTY, or no **`lastAgent`** skip the prompt and print how to restart manually.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6ccb2dbc70a85821a396611e993c0a1e1fa1aae. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->