### PR TITLE
docs: lead with agentbox.localhost for the hub URL

### DIFF
--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -368,8 +368,8 @@ agentbox queue clear --all
 agentbox relay status
 agentbox relay restart
 
-# Web UI — the relay + a dashboard on http://127.0.0.1:8787
-agentbox hub                 # start + open it in the browser
+# Web UI — the relay + a dashboard at https://agentbox.localhost
+agentbox hub                 # start + open it in the browser (carries the token)
 agentbox hub status
 agentbox hub stop
 
@@ -391,7 +391,7 @@ agentbox self-update --dry-run
 
 `self-update` updates the CLI, then refreshes everything that depends on it: the host skill files, the box image (removed so it rebuilds on the next create), the relay, and the menu-bar app (reinstalled only when the published build's checksum differs from the installed one — a matching build is left running). If you update the package yourself (`npm update -g @madarco/agentbox`), the next interactive command notices the version change and offers the same refresh with a one-line prompt. Independently, at most once per day, an interactive command kicks off a small background check of the npm registry and prints "a newer agentbox is available — run `agentbox self-update`" when one is; normal CLI calls never hit the network outside that daily probe. Disable the check and the nudge with `agentbox config set update.check false` (see [configuration](/docs/configuration)).
 
-`hub` runs the **AgentBox hub** — the host relay plus a local Web UI (dashboard, box detail, live approvals) on `http://127.0.0.1:8787`, gated by a per-machine token. When [Portless](https://portless.sh) is installed it also serves at a friendly `https://agentbox.localhost`. It's a superset of the relay on the same port: `agentbox hub` takes over from a bare relay, and normal box commands reuse it. Needs Node ≥ 22.5.
+`hub` runs the **AgentBox hub** — the host relay plus a local Web UI (dashboard, box detail, live approvals) at `https://agentbox.localhost` (registered by [Portless](https://portless.sh); it falls back to `http://127.0.0.1:8787` when Portless isn't in play), gated by a per-machine token. Start it with the command rather than by typing the URL: `agentbox hub` opens the page with the token, which the hub then remembers in a cookie. It's a superset of the relay on the same port: `agentbox hub` takes over from a bare relay, and normal box commands reuse it. Needs Node ≥ 22.5.
 
 ## Control plane
 

--- a/apps/web/content/docs/hub.mdx
+++ b/apps/web/content/docs/hub.mdx
@@ -1,21 +1,25 @@
 ---
 title: Hub (Web UI)
-description: A local dashboard for your boxes — served by the host relay on http://127.0.0.1:8787
+description: A local dashboard for your boxes — served by the host relay at https://agentbox.localhost
 ---
 
 The **hub** is a local Web UI for your boxes: a dashboard, box detail views, and a
-live **approvals** inbox, served by the host relay on `http://127.0.0.1:8787`. It's
-the same `@agentbox/relay` core you already run, with a Next.js UI delegated onto
-its port — one process, no extra port opened.
+live **approvals** inbox, served by the host relay. It's the same `@agentbox/relay`
+core you already run, with a Next.js UI delegated onto its port — one process, no
+extra port opened.
 
 ```bash
 agentbox hub
 ```
 
 That starts the hub (if it isn't already running) and opens it in your browser at
-`http://127.0.0.1:8787/?token=<secret>`.
+`https://agentbox.localhost/?token=<secret>`. **Start it with the command, not by
+typing the URL** — the token is what unlocks the hub, and without it the page just
+answers `401 AgentBox hub is locked`. The first tokened visit stores the secret in
+a cookie (30 days) and strips it from the address, so from then on a plain
+`https://agentbox.localhost` gets you in.
 
-<Callout type="info" title="Friendly URL with Portless">When [Portless](https://portless.sh) is installed (the same proxy AgentBox uses for box web apps), the hub also registers a stable `https://agentbox.localhost` alias and opens that instead — no port to remember. It falls back to the loopback URL on OrbStack or when Portless isn't installed, and respects `portless.enabled: false`.</Callout>
+<Callout type="info" title="Where the friendly URL comes from">`https://agentbox.localhost` is registered by [Portless](https://portless.sh), the same proxy AgentBox uses for box web apps. Without it — on OrbStack, when Portless isn't installed, or with `portless.enabled: false` — the hub falls back to the loopback URL `http://127.0.0.1:8787`, which works exactly the same way.</Callout>
 
 <Figure src="/screenshots/hub-dashboard.png" caption="The hub dashboard — boxes grouped by project, with live status and lifecycle controls." />
 


### PR DESCRIPTION
The hub page and the CLI reference both fronted `http://127.0.0.1:8787`. The hub actually serves at `https://agentbox.localhost` (the Portless alias), so the docs now lead with that — placed **after** the `agentbox hub` example, because the URL on its own doesn't work: the per-machine token is what unlocks the hub, and the command is what carries it.

Also spells out the mechanics, verified against `apps/hub/proxy.ts`: a first visit with `?token=` stores the secret in a 30-day cookie and strips it from the address, so plain `https://agentbox.localhost` works from then on; a visit with neither answers `401 AgentBox hub is locked`. The loopback URL stays documented as the fallback for OrbStack / no-Portless.

`api.mdx` keeps `http://127.0.0.1:8787` — those are curl examples with a Bearer header, where the loopback base URL is the right thing.

https://claude.ai/code/session_015SsFHn9h1GKHVjmFTQvLsy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or security behavior changes.
> 
> **Overview**
> Updates **hub** and **CLI** docs so the primary hub URL is **`https://agentbox.localhost`** (Portless), not `http://127.0.0.1:8787`.
> 
> The **hub** page stresses starting via **`agentbox hub`** (token in the URL), documents **`?token=`** → 30-day cookie → plain URL access, and **`401`** when unlocked. The Portless callout is reframed as the default URL source, with **`http://127.0.0.1:8787`** as the OrbStack / no-Portless fallback. The **CLI** maintenance section mirrors the same URL order, token-on-open wording, and expanded **`hub`** paragraph.
> 
> No application code changes in this PR (API curl docs still use loopback per PR description).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5c2792aa0d5312350a465665fad0cbd6d25218d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->