### PR TITLE
fix(queue): pin the worker cwd, reap dead workers, heartbeat the log stream

### DIFF
--- a/apps/hub/lib/job-log-stream.ts
+++ b/apps/hub/lib/job-log-stream.ts
@@ -9,21 +9,35 @@ import type { HubBackend } from './boxes/backend-types';
 
 const POLL_MS = 500;
 const TERMINAL = new Set(['done', 'failed', 'cancelled']);
+// Emit an SSE comment after this much silence. A create is legitimately quiet for
+// minutes at a stretch — the cloud providers log nothing while a VM boots or while
+// waiting for SSH — and a silent connection looks dead to a client with a request
+// timeout. The tray times out at 120s, reconnects, and the tail replays from offset
+// 0, which double-counts every line into its progress bar. Comments are ignored by
+// every SSE parser (a line starting with ':'), so this costs nothing but keeps the
+// connection provably alive.
+const HEARTBEAT_MS = 15_000;
 
 export function streamJobLog(req: Request, id: string, backend: HubBackend, logPath: string): Response {
   const enc = new TextEncoder();
   let offset = 0;
   let residual = '';
   let closed = false;
+  let lastEmitAt = Date.now();
 
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
-      const emit = (event: string, data: unknown): void => {
+      const write = (chunk: string): void => {
         try {
-          controller.enqueue(enc.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
+          controller.enqueue(enc.encode(chunk));
+          lastEmitAt = Date.now();
         } catch {
           /* stream already closed */
         }
+      };
+
+      const emit = (event: string, data: unknown): void => {
+        write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
       };
 
       // Read any bytes appended since the last offset and emit whole lines.
@@ -69,6 +83,7 @@ export function streamJobLog(req: Request, id: string, backend: HubBackend, logP
       const timer = setInterval(() => {
         void (async () => {
           await drain().catch(() => {});
+          if (!closed && Date.now() - lastEmitAt >= HEARTBEAT_MS) write(':ping\n');
           const cur = await backend.getJob(id).catch(() => null);
           // Surface the Claude re-login sub-state (phase/url/error) on change so the
           // UI can show the login banner + clickable link while the job is running.

--- a/packages/relay/src/queue.ts
+++ b/packages/relay/src/queue.ts
@@ -707,6 +707,14 @@ export function startQueueLoop(deps: QueueLoopDeps): QueueLoopHandle {
         });
       }
 
+      // Flip jobs whose worker died mid-flight to `failed`. Must run before the
+      // no-queued-work early return below, or a dead worker with nothing else
+      // queued is never noticed — which is precisely the case that leaves a UI
+      // progress card waiting on a job that will never finish.
+      await recoverOrphanedWorkers(log, onStatusChange, true).catch((err) => {
+        log(`queue: orphan reap failed: ${err instanceof Error ? err.message : String(err)}`);
+      });
+
       const jobs = await loadQueue();
       const hasQueued = jobs.some((j) => j.status === 'queued');
       if (!hasQueued) return;
@@ -863,15 +871,29 @@ export function startQueueLoop(deps: QueueLoopDeps): QueueLoopHandle {
  * host reboot or a relay crash mid-flight. The slot is recouped automatically
  * because `countRunning` reads live provider state, but the manifest must be
  * advanced or `agentbox queue list` keeps lying about what's in progress.
+ *
+ * `requirePid` distinguishes the two callers:
+ * - startup (`false`): a `running` manifest with no PID at all was orphaned by a
+ *   relay that died between marking the job running and recording the PID. There
+ *   is no worker to wait for, so fail it.
+ * - every tick (`true`): only reap a PID we know is dead. A `running` job whose
+ *   PID isn't written *yet* is in the spawn window of the current tick — reaping
+ *   that would kill jobs as they start.
+ *
+ * Running this per-tick is what makes a worker that dies mid-flight visible. It
+ * used to run only at startup, so a crashed worker left the job `running`
+ * forever: no terminal status, no SSE `end`, and a UI progress card that waits
+ * on a job that is never coming back.
  */
 async function recoverOrphanedWorkers(
   log: (line: string) => void,
   onChange?: (job: QueueJob) => void,
+  requirePid = false,
 ): Promise<void> {
   const jobs = await loadQueue();
   for (const j of jobs) {
     if (j.status !== 'running') continue;
-    if (typeof j.pid === 'number' && processAlive(j.pid)) continue;
+    if (typeof j.pid === 'number' ? processAlive(j.pid) : requirePid) continue;
     const failed: QueueJob = {
       ...j,
       status: 'failed',
@@ -1104,10 +1126,19 @@ async function defaultSpawnWorker(job: QueueJob): Promise<number | null> {
   const fd = openSync(job.logPath, 'a');
   // A prepare (image-bake) job runs a different worker; both stream to logPath.
   const command = job.kind === 'prepare' ? '_run-queued-prepare' : '_run-queued-job';
+  // Pin an explicit cwd. Without one the worker inherits the daemon's, and this
+  // daemon is long-lived while its own directory is not: `npm install -g` (what
+  // `self-update` runs) replaces the package tree, so a relay/hub that keeps
+  // running across an update sits in a deleted directory. The child then dies on
+  // `process.cwd()` at startup — `ENOENT: uv_cwd` — before any of our code runs,
+  // which reads as a create that hangs with a Node stack trace for a status line.
+  // STATE_DIR is ours and always exists; the worker takes its workspace from the
+  // job manifest, never from cwd.
   const child = spawn(process.execPath, [entry, command, job.id], {
     detached: true,
     stdio: ['ignore', fd, fd],
     env: process.env,
+    cwd: STATE_DIR,
   });
   child.unref();
   // The fd stays open in the child; close our own copy.

--- a/packages/relay/test/queue.test.ts
+++ b/packages/relay/test/queue.test.ts
@@ -537,3 +537,73 @@ describe('loadQueue / writeJob round trip', () => {
     }
   });
 });
+
+describe('orphan reaping (worker died mid-flight)', () => {
+  // A worker that dies after being spawned used to leave its manifest `running`
+  // forever: the reaper only ran at startup. No terminal status meant no SSE
+  // `end`, so a UI progress card sat there advancing against a job that was
+  // never coming back. Reaping per-tick is what makes the failure visible.
+  it('flips a running job whose pid is dead to failed', async () => {
+    const { QUEUE_DIR } = await import('../src/queue.js');
+    const id = `queue-vitest-${String(process.pid)}-dead`;
+    const changed: QueueJob[] = [];
+    try {
+      // 999999 is above the OS pid ceiling, so it can never be alive.
+      await writeJob(job({ id, status: 'running', pid: 999999 }));
+      const handle = startQueueLoop({
+        log: () => {},
+        loadConfig: async () => ({
+          enabled: true,
+          maxConcurrent: 1,
+          maxWorking: 0,
+          idleGraceMs: 15_000,
+        }),
+        countRunning: async () => 0,
+        spawnWorker: async () => 123,
+        onStatusChange: (j) => changed.push(j),
+        intervalMs: 10,
+      });
+      await new Promise((r) => setTimeout(r, 80));
+      await handle.stop();
+
+      const reaped = (await loadQueue()).find((j) => j.id === id);
+      expect(reaped?.status).toBe('failed');
+      expect(reaped?.reason).toBe('worker-died');
+      // The UI only learns about it through this callback.
+      expect(changed.some((j) => j.id === id && j.status === 'failed')).toBe(true);
+    } finally {
+      await rm(join(QUEUE_DIR, `${id}.json`), { force: true });
+    }
+  });
+
+  // The spawn window: between marking a job `running` and recording its pid it
+  // has no pid. Reaping those on a tick would kill jobs as they start.
+  it('leaves a running job with no pid alone on a tick', async () => {
+    const { QUEUE_DIR } = await import('../src/queue.js');
+    const id = `queue-vitest-${String(process.pid)}-nopid`;
+    try {
+      const handle = startQueueLoop({
+        log: () => {},
+        loadConfig: async () => ({
+          enabled: true,
+          maxConcurrent: 1,
+          maxWorking: 0,
+          idleGraceMs: 15_000,
+        }),
+        countRunning: async () => 0,
+        spawnWorker: async () => 123,
+        intervalMs: 10,
+      });
+      // Written AFTER the loop's startup pass, so only the per-tick reaper sees it.
+      await new Promise((r) => setTimeout(r, 30));
+      await writeJob(job({ id, status: 'running' }));
+      await new Promise((r) => setTimeout(r, 80));
+      await handle.stop();
+
+      const still = (await loadQueue()).find((j) => j.id === id);
+      expect(still?.status).toBe('running');
+    } finally {
+      await rm(join(QUEUE_DIR, `${id}.json`), { force: true });
+    }
+  });
+});


### PR DESCRIPTION
## The report

Creating a box from the macOS app showed the status line stuck on `Nodejs v24.1.0` while the progress bar kept advancing.

## What it actually was

Not a display bug — **the create crashed instantly** and the app was faithfully showing the last line the worker ever printed: Node's crash footer.

```
Error: ENOENT: no such file or directory, uv_cwd
    at process.wrappedCwd [as cwd] (node:internal/bootstrap/...)
Node.js v24.1.0
```

The tell: `v24.1.0` is the **host's** nvm Node, not the box's (boxes run 24.18.0). So the line came from the host-side worker dying, not from anything in the sandbox. Nothing DigitalOcean-specific — any provider fails the same way.

Root cause: the relay/hub is a long-lived daemon whose own directory is **not** long-lived. `npm install -g` (what `self-update` runs) replaces the package tree, so a daemon surviving an update ends up sitting in a **deleted directory**. `defaultSpawnWorker` passed no `cwd`, so every worker inherited it and died on `process.cwd()` during ESM bootstrap — before any of our code ran.

## Three faults

1. **The crash** (`packages/relay/src/queue.ts`) — spawn the worker with an explicit `cwd: STATE_DIR`. The worker takes its workspace from the job manifest, never from cwd, so pinning it is free.
2. **The silence** (`packages/relay/src/queue.ts`) — a worker that died mid-flight stayed `running` **forever**: the orphan reaper only ran at daemon startup. No terminal status ⇒ no SSE `end` ⇒ the UI progress card waits on a job that is never coming back. Now reaped per-tick as well — but only PIDs known to be dead, or the reaper would kill jobs inside their own spawn window. (Runs *before* the no-queued-work early return, or a dead worker with an empty queue is never noticed.)
3. **The creeping bar** (`apps/hub/lib/job-log-stream.ts`) — the tail never heartbeats, and a create is legitimately silent for minutes (a droplet boots for ~53s logging nothing). A silent connection looks dead to a client with a request timeout: the tray drops it at 120s, reconnects, and the tail replays from offset 0 — which the tray counts *again*, advancing the bar while re-rendering the same last line. Emit an SSE comment every 15s of silence. (Companion tray-side fixes ship separately in the tray repo.)

## Verification

- **Reproduced the crash and the fix side by side**: with a deleted daemon cwd, an ESM child exits 1 with `ENOENT uv_cwd` and its last line is literally `Node.js v24.1.0`; with `cwd` pinned it starts clean.
- **A real create through the hub reached `end: {"status":"done"}`** — proves the worker spawns correctly *and* that the new per-tick reaper does not wrongly kill healthy jobs during their spawn window.
- **A deliberately quiet running job produced exactly 2 `:ping` heartbeats over 40s of silence** (the 15s cadence).
- New unit tests: a dead-PID job flips to `failed`/`worker-died` and notifies; a running job with no PID yet is left alone on a tick.
- Full suite green, lint + typecheck clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core queue scheduling and worker spawn behavior; changes are targeted with spawn-window guards and tests, but incorrect reaping could fail in-flight jobs.
> 
> **Overview**
> Fixes **stuck create progress** when the queue worker dies instantly or mid-flight and the UI keeps tailing logs.
> 
> **Queue worker spawn** now uses `cwd: STATE_DIR` so children do not inherit a deleted daemon directory after `npm install -g` / self-update (avoids immediate `ENOENT: uv_cwd` and a misleading last log line like `Node.js v24.1.0`).
> 
> **Orphan recovery** runs on every scheduler tick (not only at relay startup), before the “no queued work” early return, and marks `running` jobs with a **dead PID** as `failed` with `worker-died`. Tick reaping uses `requirePid: true` so jobs in the spawn window (running but PID not written yet) are not failed; startup still fails PID-less orphans.
> 
> **Job log SSE** sends `:ping` comment heartbeats every 15s during silence so clients do not time out, reconnect, and replay the tail from offset 0 (which inflated progress).
> 
> New unit tests cover dead-PID reaping and the no-PID spawn window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f58956a6b16efa2a81df006103d0c612ee78952. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->