### PR TITLE
fix(self-update): restart the hub, not just the relay

### DIFF
--- a/apps/cli/src/lib/post-update-refresh.ts
+++ b/apps/cli/src/lib/post-update-refresh.ts
@@ -14,8 +14,11 @@
 
 import {
   DEFAULT_BOX_IMAGE,
+  ensureHub,
   ensureRelay,
+  getHubStatus,
   removeImage,
+  stopHub,
   stopRelay,
 } from '@agentbox/sandbox-docker';
 import { installHostSkills } from '../commands/install.js';
@@ -109,13 +112,33 @@ export async function runPostUpdateRefresh(
     warn('box image removal', err);
   }
 
+  // The hub and the relay are separate long-lived processes with separate pid
+  // files, and BOTH must be restarted here. An update replaces the installed
+  // package directory underneath whichever one is still running, which leaves it
+  // in a directory that no longer exists — so it fails on anything it loads
+  // lazily ("Cannot find module .../dist-<hash>.js", the bundle's chunks were
+  // replaced) and any worker it spawns dies on `process.cwd()`. The hub was
+  // previously skipped entirely, so a hub running across an update stayed broken
+  // until someone restarted it by hand.
+  //
+  // The hub serves the relay on the same port, so restart the hub when it's the
+  // one running and leave the relay path alone — starting a bare relay under a
+  // live hub would just fight over the port.
   try {
-    const stop = await stopRelay();
-    say(stop.stopped ? `stopped relay (pid ${String(stop.pid)})` : 'relay was not running');
-    const ep = await ensureRelay();
-    say(`relay back up on ${ep.hostUrl}`);
+    const hub = await getHubStatus();
+    if (hub.running || hub.pidAlive) {
+      const stop = await stopHub();
+      say(stop.stopped ? `stopped hub (pid ${String(stop.pid)})` : 'hub was not running');
+      const ep = await ensureHub();
+      say(`hub back up on ${ep.hostUrl}`);
+    } else {
+      const stop = await stopRelay();
+      say(stop.stopped ? `stopped relay (pid ${String(stop.pid)})` : 'relay was not running');
+      const ep = await ensureRelay();
+      say(`relay back up on ${ep.hostUrl}`);
+    }
   } catch (err) {
-    warn('relay reload', err);
+    warn('relay/hub reload', err);
   }
 
   try {

--- a/apps/cli/src/lib/post-update-refresh.ts
+++ b/apps/cli/src/lib/post-update-refresh.ts
@@ -126,7 +126,12 @@ export async function runPostUpdateRefresh(
   // live hub would just fight over the port.
   try {
     const hub = await getHubStatus();
-    if (hub.running || hub.pidAlive) {
+    // `running` is NOT the test: it only means /healthz answered on the shared
+    // port, which a bare relay does too. Gating on it would send a relay-only
+    // host down the hub branch and let `ensureHub` quietly promote it to a full
+    // hub on update. `ui` (healthz reported the Next UI) and a live hub pid are
+    // what actually identify a hub.
+    if (hub.ui || hub.pidAlive) {
       const stop = await stopHub();
       say(stop.stopped ? `stopped hub (pid ${String(stop.pid)})` : 'hub was not running');
       const ep = await ensureHub();


### PR DESCRIPTION
## The report

Destroying a box failed with:

```
Cannot find module '/…/apps/hub/dist-standalone/apps/hub/dist-XULFTIMT.js'
imported from /…/apps/hub/dist-standalone/apps/hub/server.js
```

## Real bug, not a test artifact

The hub and the relay are **separate processes with separate pid files** (`hub.pid`, `relay.pid`), and `runPostUpdateRefresh` only ever restarted the **relay** — it never mentioned the hub.

An update replaces the installed package directory *underneath* whatever is still running. A hub left alive across `agentbox self-update` (which runs `npm install -g`) therefore keeps executing a bundle whose files no longer exist:

- **Lazily-imported chunks vanish.** The bundle's chunk names are content-hashed, so a rebuild writes `dist-<newhash>.js` and deletes the old ones. The running process only resolves them when a code path first needs one — which is why this surfaced on `destroy` rather than at startup.
- **Its cwd is deleted**, so every worker it spawns dies on `process.cwd()` (the `uv_cwd` crash fixed in #202 — same family, different process).

It stayed broken until someone restarted the hub by hand, which is not something a user would know to do.

## The fix

Restart the hub when it is the one running. The hub serves the relay on the same port, so the relay branch is left as-is for a bare-relay host — starting a second process there would just fight over 8787.

## Verification

Ran the real refresh against a live hub:

```
●  stopped hub (pid 32525)
●  hub back up on https://agentbox.localhost
```

pid changed 32525 → 41650, `/api/v1/health` reports the current version, and `/api/v1/boxes` (a route that had been failing on the missing chunk) serves again. Full suite green, lint + typecheck clean.

Companion to #202 — that one stopped a *poisoned hub* from killing the workers it spawned; this stops the hub from being poisoned in the first place.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches long-lived process lifecycle on self-update; logic is gated to avoid promoting relay-only hosts to a hub, but mis-detection could still cause a brief port conflict or wrong restart path.
> 
> **Overview**
> **Post-update refresh** now restarts the **hub** when that is what is actually running, instead of always cycling only the relay.
> 
> After `npm install -g`, the old hub process could keep running from a deleted install tree, which broke lazy-loaded bundle chunks and worker `cwd` until a manual restart. The refresh path uses `getHubStatus()` and branches on **`ui` or a live hub pid** (not bare `/healthz` `running`, which relay-only hosts also satisfy): **stopHub → ensureHub** for hub hosts, **stopRelay → ensureRelay** unchanged for relay-only hosts so nothing fights over the shared port.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 355ca08989d63b161f4265419780f10ccdd97c66. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->