### PR TITLE
feat(digitalocean): place boxes in a chosen DigitalOcean Project

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -9,6 +9,17 @@ Entries are generated from the commit history with `/release-notes` and then
 hand-reviewed — they describe what changed for someone using the `agentbox`
 CLI, not the raw commits.
 
+## [0.24.4] - 2026-07-12
+
+### Added
+
+- **DigitalOcean Projects** — `box.digitaloceanProject` (a project name or UUID)
+  places boxes in a specific DigitalOcean Project instead of the account's default;
+  pick it at `agentbox digitalocean login`, in the hub/app settings, or per repo in
+  `agentbox.yaml`. Unset keeps the old behavior.
+- (Provider plugins) `@madarco/agentbox-provider-sdk` 2.2.0: `CloudProvisionRequest`
+  gains an optional `project` field. Additive; must be republished separately.
+
 ## [0.24.3] - 2026-07-12
 
 ### Fixed

--- a/apps/cli/src/lib/cloud-sizing.ts
+++ b/apps/cli/src/lib/cloud-sizing.ts
@@ -24,6 +24,9 @@ export interface CloudSizingFlags {
  *   `box.hetznerLocation`.
  * - **digitalocean**: `location` — region, `--location` flag first, else
  *   `box.digitaloceanRegion`.
+ * - **digitalocean**: `project` — the DO Project the box is placed in (name or
+ *   UUID), from `box.digitaloceanProject`. Config-only, no flag. Absent = the
+ *   account's default project.
  * - **hetzner + digitalocean**: `inbound` — per-box firewall access policy
  *   (`locked`/`open`/CIDR list), `--inbound` flag first, else `box.inbound`.
  * - **vercel**: `timeoutMs` (session length before auto-snapshot), `networkPolicy`.
@@ -49,6 +52,13 @@ export function cloudSizingProviderOptions(
   if (providerName === 'digitalocean') {
     const location = (flags.location?.trim() || cfg.box.digitaloceanRegion || '').trim();
     if (location.length > 0) out.location = location;
+    // DigitalOcean Project (name or UUID). Config-only — there is no flag, since
+    // "project" already means the host repo in AgentBox and the layered config
+    // (workspace > project > global) already gives per-repo control. Absent = the
+    // account's default project, which is DO's own behavior, so the common case
+    // emits nothing.
+    const project = (cfg.box.digitaloceanProject || '').trim();
+    if (project.length > 0) out.project = project;
   }
   // VPS-only inbound-access policy (`--inbound` / `box.inbound`). Passed through
   // to the backend's per-box firewall; other providers ignore it. Only emitted

--- a/apps/cli/test/cloud-sizing.test.ts
+++ b/apps/cli/test/cloud-sizing.test.ts
@@ -101,3 +101,27 @@ describe('cloudSizingProviderOptions', () => {
     expect(cloudSizingProviderOptions('daytona', cfg, { location: 'fsn1' })).toEqual({});
   });
 });
+
+describe('digitalocean project', () => {
+  it('passes box.digitaloceanProject through as providerOptions.project', () => {
+    const cfg = makeCfg({ digitaloceanRegion: 'nyc3', digitaloceanProject: 'client-x' });
+    expect(cloudSizingProviderOptions('digitalocean', cfg)).toEqual({
+      location: 'nyc3',
+      project: 'client-x',
+    });
+  });
+
+  // Unset must emit nothing: an absent project means "the account's default",
+  // which is DigitalOcean's own behavior and costs no API call in the backend.
+  it('emits nothing when unset', () => {
+    const cfg = makeCfg({ digitaloceanRegion: 'nyc3', digitaloceanProject: '' });
+    expect(cloudSizingProviderOptions('digitalocean', cfg)).toEqual({ location: 'nyc3' });
+  });
+
+  it('is ignored for every other provider', () => {
+    const cfg = makeCfg({ digitaloceanProject: 'client-x' });
+    for (const p of ['hetzner', 'daytona', 'vercel', 'e2b', 'docker']) {
+      expect(cloudSizingProviderOptions(p, cfg).project).toBeUndefined();
+    }
+  });
+});

--- a/apps/hub/app/(dashboard)/settings/components/provider-actions.tsx
+++ b/apps/hub/app/(dashboard)/settings/components/provider-actions.tsx
@@ -38,12 +38,14 @@ const CRED_FIELDS: Record<string, CredField[]> = {
   ],
   digitalocean: [
     { key: 'token', label: 'API token', placeholder: 'personal access token (read+write)' },
-    // Not a secret — this writes the `box.digitaloceanProject` config key. Optional:
-    // blank leaves boxes in the account's default project.
+    // Not a secret — this writes the `box.digitaloceanProject` config key. Blank means
+    // "leave as-is", NOT "clear": the form drops empty fields before sending and never
+    // shows the saved value, so treating blank as a clear would wipe the setting on any
+    // save. Clearing is `agentbox config unset box.digitaloceanProject`.
     {
       key: 'project',
       label: 'Project',
-      placeholder: 'name or UUID (optional)',
+      placeholder: 'name or UUID — blank leaves it unchanged',
       optional: true,
     },
   ],

--- a/apps/hub/app/(dashboard)/settings/components/provider-actions.tsx
+++ b/apps/hub/app/(dashboard)/settings/components/provider-actions.tsx
@@ -36,7 +36,17 @@ const CRED_FIELDS: Record<string, CredField[]> = {
     { key: 'teamId', label: 'Team ID', placeholder: 'team_… (optional)', optional: true },
     { key: 'projectId', label: 'Project ID', placeholder: 'prj_… (optional)', optional: true },
   ],
-  digitalocean: [{ key: 'token', label: 'API token', placeholder: 'personal access token (read+write)' }],
+  digitalocean: [
+    { key: 'token', label: 'API token', placeholder: 'personal access token (read+write)' },
+    // Not a secret — this writes the `box.digitaloceanProject` config key. Optional:
+    // blank leaves boxes in the account's default project.
+    {
+      key: 'project',
+      label: 'Project',
+      placeholder: 'name or UUID (optional)',
+      optional: true,
+    },
+  ],
 };
 
 export function ProvidersSection() {

--- a/apps/web/content/docs/configuration.mdx
+++ b/apps/web/content/docs/configuration.mdx
@@ -124,6 +124,7 @@ See [local Docker](/docs/local-docker), [Hetzner](/docs/hetzner), [Daytona](/doc
 | `box.sizeDocker` | string (advanced) | empty | reserved — docker uses `box.memory` / `box.cpus` / `box.disk` |
 | `box.hetznerLocation` | string | `nbg1` | Hetzner datacenter new boxes are created in (`nbg1`, `fsn1`, `hel1`, `ash`); override per box with `--location`. Hetzner-only |
 | `box.digitaloceanRegion` | string | `nyc3` | DigitalOcean region new boxes are created in (`nyc3`, `sfo3`, `ams3`, `fra1`, …); override per box with `--location`. DigitalOcean-only |
+| `box.digitaloceanProject` | string | empty | the [DigitalOcean Project](/docs/digitalocean#projects) new boxes are placed in — a project name or its UUID. Empty leaves them in the account's default project. Pick it at `agentbox digitalocean login`, or set it per repo in `agentbox.yaml`. DigitalOcean-only |
 | `box.inbound` | string | `locked` | inbound-access policy for the VPS per-box firewall. `locked` = SSH from your host egress IP only; `open` = SSH from anywhere (`0.0.0.0/0`, key-only — reach a box from a phone with the laptop off); a CIDR list (e.g. `203.0.113.5/32`) = host egress plus those. Override per box with `--inbound` or after create with `agentbox inbound <box>`. Hetzner/DigitalOcean-only. See [remote access](/docs/access-your-box#use-a-box-with-your-laptop-offline) |
 
 ### Box image

--- a/apps/web/content/docs/digitalocean.mdx
+++ b/apps/web/content/docs/digitalocean.mdx
@@ -113,6 +113,32 @@ Before AgentBox creates any billable resource (firewall, SSH key, Droplet), it v
 New DigitalOcean accounts start with a low Droplet limit. If DigitalOcean refuses the create because you've hit it, AgentBox surfaces the limits explanation and points you at the DigitalOcean Console (**Account → your team → Droplet limit**) to request an increase. An out-of-capacity error suggests trying another `--location`.
 </Callout>
 
+## Projects
+
+DigitalOcean groups resources into **Projects** (for billing and visibility). By default every box lands in your account's **default project** — which is fine until you keep client or environment work separate.
+
+`agentbox digitalocean login` asks which project new boxes should go into (when your account has more than one) and stores the answer in `box.digitaloceanProject`. You can also set it directly, with either the project's name or its UUID:
+
+```bash
+agentbox config set box.digitaloceanProject client-x
+```
+
+Because it's a normal config key it follows the usual [precedence](/docs/configuration) — so a repo can put its own boxes in their own project via `agentbox.yaml`, while everything else uses your global choice:
+
+```yaml
+defaults:
+  box:
+    digitaloceanProject: client-x
+```
+
+Leave it unset for today's behavior (the account default project). A name that doesn't match any of your projects fails **before** anything is created, listing the real ones.
+
+<Callout title="Placement is best-effort">
+DigitalOcean has no project field on Droplet-create, so AgentBox assigns the box to its project immediately *after* creating it. If that one call fails (an API blip, a token without project write), the box is still created and fully usable — it just stays in the default project, and the create log says so. A working box is never torn down over a grouping error.
+</Callout>
+
+The temporary Droplet that `agentbox prepare` bakes the base snapshot on is placed in the same project, so it doesn't show up in the default one for the few minutes it lives.
+
 ## Firewall
 
 Each box gets its own DigitalOcean Cloud Firewall with a single inbound rule: TCP port 22 from your host's egress IP only (plus the mandatory allow-all outbound rules DigitalOcean requires, or the Droplet would have no egress). All box traffic flows over SSH, so port 22 from your IP is genuinely all that's exposed inbound.

--- a/apps/web/content/docs/digitalocean.mdx
+++ b/apps/web/content/docs/digitalocean.mdx
@@ -131,7 +131,13 @@ defaults:
     digitaloceanProject: client-x
 ```
 
-Leave it unset for today's behavior (the account default project). A name that doesn't match any of your projects fails **before** anything is created, listing the real ones.
+Leave it unset for today's behavior (the account default project). A name that doesn't match any of your projects fails **before** anything is created, listing the real ones. To go back to the default project later:
+
+```bash
+agentbox config unset box.digitaloceanProject
+```
+
+(The settings form's **Project** field can set or change the project, but not clear it — a blank field there means "leave unchanged", since the form doesn't show the saved value. `agentbox digitalocean login` can clear it, by choosing *Skip*.)
 
 <Callout title="Placement is best-effort">
 DigitalOcean has no project field on Droplet-create, so AgentBox assigns the box to its project immediately *after* creating it. If that one call fails (an API blip, a token without project write), the box is still created and fully usable — it just stays in the default project, and the create log says so. A working box is never torn down over a grouping error.

--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -40,6 +40,11 @@ build images from a Dockerfile). Three things differ from Hetzner:
 
 Defaults: size `s-2vcpu-4gb`, region `nyc3`, stock image `ubuntu-24-04-x64`.
 Override per box with `box.sizeDigitalocean` / `AGENTBOX_DIGITALOCEAN_REGION`.
+**DO Project**: `box.digitaloceanProject` (name or UUID; picked at `digitalocean login`) places boxes
+in a specific DigitalOcean Project. DO has no project field on droplet-create, so the backend resolves
+the name in the create preflight (fail-fast on a typo, before anything bills) and then assigns via
+`POST /projects/{id}/resources` **best-effort** after the droplet exists — a failed assign warns and
+keeps the box rather than tearing a working box down. Unset = the account's default project.
 
 ## 1. The provider abstraction
 

--- a/packages/config/schema/user-config.schema.json
+++ b/packages/config/schema/user-config.schema.json
@@ -50,6 +50,7 @@
         "bundleDepth": { "type": "integer", "minimum": 0 },
         "hetznerLocation": { "type": "string", "minLength": 1 },
         "digitaloceanRegion": { "type": "string", "minLength": 1 },
+        "digitaloceanProject": { "type": "string", "minLength": 1 },
         "inbound": { "type": "string", "minLength": 1 },
         "vercelTimeoutMs": { "type": "integer", "minimum": 1 },
         "vercelNetworkPolicy": { "type": "string" },

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -124,6 +124,7 @@ export interface UserConfig {
     bundleDepth?: number;
     hetznerLocation?: string;
     digitaloceanRegion?: string;
+    digitaloceanProject?: string;
     vercelTimeoutMs?: number;
     vercelNetworkPolicy?: string;
     e2bTimeoutMs?: number;
@@ -282,6 +283,7 @@ export interface EffectiveConfig {
     bundleDepth: number | undefined;
     hetznerLocation: string;
     digitaloceanRegion: string;
+    digitaloceanProject: string;
     vercelTimeoutMs: number;
     vercelNetworkPolicy: string;
     e2bTimeoutMs: number;
@@ -447,6 +449,9 @@ export const BUILT_IN_DEFAULTS: EffectiveConfig = {
     bundleDepth: undefined,
     hetznerLocation: 'nbg1',
     digitaloceanRegion: 'nyc3',
+    // Empty = leave boxes in the account's default project (DigitalOcean's own
+    // behavior). There is no sane default id to pick — it differs per account.
+    digitaloceanProject: '',
     vercelTimeoutMs: 2_700_000,
     vercelNetworkPolicy: '',
     e2bTimeoutMs: 2_700_000,
@@ -743,6 +748,12 @@ export const KEY_REGISTRY: readonly KeyDescriptor[] = [
     type: 'string',
     description:
       'DigitalOcean region new --provider digitalocean boxes are created in (e.g. `nyc3`, `nyc1`, `sfo3`, `ams3`, `fra1`). Default `nyc3`. Overridable per-create with `--location`. DigitalOcean-only; ignored by other providers.',
+  },
+  {
+    key: 'box.digitaloceanProject',
+    type: 'string',
+    description:
+      "DigitalOcean Project new --provider digitalocean boxes are placed in — a name or the project's UUID. Unset (the default) leaves boxes in the account's default project. Set it per repo via `agentbox.yaml`, or globally at `agentbox digitalocean login`. DigitalOcean-only; ignored by other providers.",
   },
   {
     key: 'box.vercelTimeoutMs',

--- a/packages/config/test/schema-drift.test.ts
+++ b/packages/config/test/schema-drift.test.ts
@@ -85,6 +85,7 @@ maintenance:
   { name: 'box claudeInstall npm', yaml: 'box:\n  claudeInstall: npm\n' },
   { name: 'box claudeInstall native', yaml: 'box:\n  claudeInstall: native\n' },
   { name: 'box hetznerLocation', yaml: 'box:\n  hetznerLocation: fsn1\n' },
+  { name: 'box digitaloceanProject', yaml: 'box:\n  digitaloceanProject: client-x\n' },
   { name: 'maintenance only', yaml: 'maintenance:\n  pruneProjectConfigs: true\n' },
   { name: 'portless only', yaml: 'portless:\n  enabled: true\n' },
   { name: 'portless stateDir', yaml: 'portless:\n  enabled: false\n  stateDir: /tmp/portless\n' },
@@ -158,6 +159,10 @@ const INVALID: Fixture[] = [
   {
     name: 'box.hetznerLocation wrong type',
     yaml: 'box:\n  hetznerLocation: 4\n',
+  },
+  {
+    name: 'box.digitaloceanProject wrong type',
+    yaml: 'box:\n  digitaloceanProject: 7\n',
   },
   {
     name: 'box claudeInstall unknown enum value',

--- a/packages/core/src/cloud-backend.ts
+++ b/packages/core/src/cloud-backend.ts
@@ -63,6 +63,12 @@ export interface CloudProvisionRequest {
    */
   location?: string;
   /**
+   * Backend-interpreted resource grouping to place the box in. Only DigitalOcean
+   * reads it today (a Project name or UUID, from `box.digitaloceanProject`);
+   * unset leaves the box in the account's default grouping.
+   */
+  project?: string;
+  /**
    * Max session length in ms before the backend auto-snapshots/stops the
    * sandbox. Backends that don't model a session timeout ignore it; Vercel
    * maps it to `Sandbox.create({ timeout })`.

--- a/packages/provider-sdk/package.json
+++ b/packages/provider-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madarco/agentbox-provider-sdk",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Public SDK for building AgentBox sandbox providers as installable community packages",
   "license": "MIT",
   "author": "Marco D'Alia",

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -579,6 +579,10 @@ export function createCloudProvider(
       const inboundOpt = req.providerOptions?.['inbound'];
       const inbound =
         typeof inboundOpt === 'string' && inboundOpt.trim() !== '' ? inboundOpt.trim() : undefined;
+      // Cloud resource grouping (DigitalOcean's `--do-project` / `box.digitaloceanProject`).
+      const projectOpt = req.providerOptions?.['project'];
+      const project =
+        typeof projectOpt === 'string' && projectOpt.trim() !== '' ? projectOpt.trim() : undefined;
 
       // Per-box tokens: `relayToken` authenticates the in-box agent to its
       // in-sandbox relay (`/events`, `/rpc` bearer); `bridgeToken` separately
@@ -670,6 +674,7 @@ export function createCloudProvider(
           resources,
           size,
           location,
+          project,
           inbound,
           timeoutMs,
           exposePorts: exposeServicePorts,

--- a/packages/sandbox-digitalocean/src/backend.ts
+++ b/packages/sandbox-digitalocean/src/backend.ts
@@ -46,7 +46,11 @@ import {
   syncFirewallSource,
 } from './firewall.js';
 import { pollUntil } from './poll.js';
-import { mapDigitalOceanProvisionError, validateSizeChoice } from './preflight.js';
+import {
+  mapDigitalOceanProvisionError,
+  resolveProjectChoice,
+  validateSizeChoice,
+} from './preflight.js';
 import { readPreparedState } from './prepared-state.js';
 import { ensureDigitalOceanBaseSnapshot } from './prepare.js';
 import { mintSshKey } from './ssh-key.js';
@@ -322,6 +326,17 @@ export const digitaloceanBackend: CloudBackend = {
     validateSizeChoice(choice, sizeCatalog, snapshotMeta);
     const plan = sizeCatalog.find((s) => s.slug === size);
 
+    // The DO Project the box should land in (`--do-project` / `box.digitaloceanProject`),
+    // resolved from a name-or-id to an id here. This has to be a *preflight* check:
+    // DigitalOcean has no project field on droplet-create, so the assignment can
+    // only run once the Droplet exists — far too late to tell someone they typed
+    // the project name wrong. Unset (the common case) costs no API call.
+    const projectWanted = (req.project ?? '').trim();
+    let projectId: string | null = null;
+    if (projectWanted.length > 0) {
+      projectId = resolveProjectChoice(projectWanted, await c.listProjects());
+    }
+
     // 2. Resolve the inbound-access policy (`--inbound` / `box.inbound`) into
     // the firewall's source CIDRs. `locked`/`whitelist` need the host egress IP
     // (env override wins, else detect); `open` (0.0.0.0/0) skips detection.
@@ -397,6 +412,26 @@ export const digitaloceanBackend: CloudBackend = {
       }
       dropletId = created.droplet.id;
       progress(`droplet ${String(dropletId)} created; waiting for it to boot`);
+
+      // 6b. Place the droplet in its DO Project. DigitalOcean has no project field
+      // on droplet-create, so this can only happen now — which means it can fail on
+      // a droplet that is otherwise perfectly good. Best-effort by design: a box
+      // that works but sits in the wrong project is a cosmetic/billing annoyance,
+      // whereas throwing here would hit the catch below and tear the whole box down.
+      // The project *name* was already validated in the preflight, so anything that
+      // fails here is a live API problem, not a typo.
+      if (projectId !== null) {
+        try {
+          await c.assignProjectResources(projectId, [`do:droplet:${String(dropletId)}`]);
+          progress(`droplet ${String(dropletId)} assigned to project ${projectWanted}`);
+        } catch (assignErr) {
+          onLog(
+            `digitalocean: WARN — could not assign droplet ${String(dropletId)} to project ` +
+              `${projectWanted} (continuing; it stays in the account's default project): ` +
+              `${assignErr instanceof Error ? assignErr.message : String(assignErr)}`,
+          );
+        }
+      }
 
       // 7. Poll until the droplet is active AND has a public IPv4 (DigitalOcean
       // returns neither at create time).

--- a/packages/sandbox-digitalocean/src/backend.ts
+++ b/packages/sandbox-digitalocean/src/backend.ts
@@ -326,7 +326,7 @@ export const digitaloceanBackend: CloudBackend = {
     validateSizeChoice(choice, sizeCatalog, snapshotMeta);
     const plan = sizeCatalog.find((s) => s.slug === size);
 
-    // The DO Project the box should land in (`--do-project` / `box.digitaloceanProject`),
+    // The DO Project the box should land in (`box.digitaloceanProject`),
     // resolved from a name-or-id to an id here. This has to be a *preflight* check:
     // DigitalOcean has no project field on droplet-create, so the assignment can
     // only run once the Droplet exists — far too late to tell someone they typed

--- a/packages/sandbox-digitalocean/src/cli.ts
+++ b/packages/sandbox-digitalocean/src/cli.ts
@@ -15,7 +15,7 @@
  */
 
 import { log } from '@clack/prompts';
-import { findProjectRoot } from '@agentbox/config';
+import { findProjectRoot, loadEffectiveConfig } from '@agentbox/config';
 import { readState, resolveBoxRef } from '@agentbox/sandbox-core';
 import { Command } from 'commander';
 import { makeDigitalOceanClient, type DigitalOceanDroplet } from './client.js';
@@ -45,7 +45,7 @@ const loginSub = new Command('login')
   .action(async (opts: LoginOpts) => {
     try {
       if (opts.status) {
-        printStatus();
+        await printStatus();
         return;
       }
       if (!process.stdin.isTTY) {
@@ -68,7 +68,7 @@ const loginSub = new Command('login')
     }
   });
 
-function printStatus(): void {
+async function printStatus(): Promise<void> {
   const s = readDigitalOceanCredStatus();
   if (s.source === 'none') {
     process.stdout.write(
@@ -81,6 +81,11 @@ function printStatus(): void {
   if (s.source === 'secrets.env') lines.push(`  file:   ${secretsPath()}`);
   if (s.token) lines.push(`  token:  ${maskKey(s.token)}`);
   if (s.endpoint) lines.push(`  api:    ${s.endpoint}`);
+  // Where boxes land. An unset key is meaningful (DigitalOcean's own default
+  // project), so state it rather than omitting the line — which project boxes
+  // went into being invisible is the whole reason for this feature.
+  const project = (await loadEffectiveConfig(process.cwd())).effective.box.digitaloceanProject;
+  lines.push(`  project: ${project || '(account default)'}`);
   process.stdout.write(lines.join('\n') + '\n');
 }
 

--- a/packages/sandbox-digitalocean/src/client.ts
+++ b/packages/sandbox-digitalocean/src/client.ts
@@ -90,6 +90,19 @@ export interface DigitalOceanSize {
 }
 
 /**
+ * A DigitalOcean Project — the account's resource-grouping unit (billing /
+ * visibility). `id` is a UUID. Exactly one project has `is_default`, and every
+ * resource lands there unless assigned elsewhere. See GET /v2/projects.
+ */
+export interface DigitalOceanProject {
+  id: string;
+  name: string;
+  is_default: boolean;
+  purpose?: string;
+  environment?: string;
+}
+
+/**
  * A firewall rule's source (inbound) / destination (outbound) selector.
  * `addresses` accepts IPv4/IPv6 + CIDR; `tags` auto-includes droplets.
  */
@@ -205,6 +218,16 @@ export interface DigitalOceanClient {
   deleteSnapshot(id: string): Promise<void>;
   /** GET /sizes — the Droplet-plan catalog (paginated). Used by the create preflight. */
   listSizes(): Promise<DigitalOceanSize[]>;
+  /** GET /projects — the account's projects (paginated). Used by the create preflight + login picker. */
+  listProjects(): Promise<DigitalOceanProject[]>;
+  /** GET /projects/default — the project resources land in when unassigned. Returns null on 404. */
+  getDefaultProject(): Promise<DigitalOceanProject | null>;
+  /**
+   * POST /projects/{id}/resources — move resources into a project. DO has no
+   * project field on droplet-create, so this is the only way in, and it can only
+   * run once the droplet exists.
+   */
+  assignProjectResources(projectId: string, urns: string[]): Promise<void>;
   /** POST /firewalls. */
   createFirewall(req: CreateFirewallRequest): Promise<DigitalOceanFirewall>;
   /** GET /firewalls/{id}. Returns null on 404. */
@@ -388,6 +411,18 @@ export function makeDigitalOceanClient(opts: MakeClientOptions = {}): DigitalOce
     },
     async listSizes() {
       return paginate<DigitalOceanSize>(withPerPage('/sizes'), 'sizes');
+    },
+    async listProjects() {
+      return paginate<DigitalOceanProject>(withPerPage('/projects'), 'projects');
+    },
+    async getDefaultProject() {
+      const r = await req<{ project: DigitalOceanProject }>('GET', '/projects/default');
+      return r?.project ?? null;
+    },
+    async assignProjectResources(projectId, urns) {
+      await req<unknown>('POST', `/projects/${encodeURIComponent(projectId)}/resources`, {
+        resources: urns,
+      });
     },
     async createFirewall(reqBody) {
       const r = await reqExpect<{ firewall: DigitalOceanFirewall }>('POST', '/firewalls', reqBody);

--- a/packages/sandbox-digitalocean/src/credentials.ts
+++ b/packages/sandbox-digitalocean/src/credentials.ts
@@ -25,6 +25,7 @@ import {
 import { loadEffectiveConfig, setConfigValue } from '@agentbox/config';
 import { makeDigitalOceanClient, type DigitalOceanProject } from './client.js';
 import { ensureDigitalOceanEnvLoaded } from './env-loader.js';
+import { resolveProjectChoice } from './preflight.js';
 
 // Ctrl+C at a prompt resolves with the cancel symbol; turn that into a real
 // quit so the command never silently continues as if the user answered "No".
@@ -294,6 +295,29 @@ export async function setDigitalOceanCredentials(
     };
   }
   persistCredentials(creds);
+
+  // The optional Project field from the hub / tray settings form. It is NOT a
+  // secret and must not land in secrets.env: `box.digitaloceanProject` is the
+  // single source of truth (it also has to layer, so a repo can override it).
+  // Resolve the name to an id here so a typo is reported inline in the form
+  // rather than surfacing much later as a failed create.
+  const project = (fields.project ?? '').trim();
+  if (project.length > 0) {
+    try {
+      const client = makeDigitalOceanClient({ token: creds.token, endpoint: creds.endpoint });
+      const projectId = resolveProjectChoice(project, await client.listProjects());
+      await setConfigValue('global', 'box.digitaloceanProject', projectId, process.cwd());
+    } catch (err) {
+      // The token is already saved and good — only the project is bad, so say
+      // exactly that rather than implying the credentials were rejected.
+      return {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+        status: { configured: true, label: 'token (project not set)' },
+      };
+    }
+  }
+
   const label = result.ok ? 'token' : 'token (unvalidated)';
   return { ok: true, status: { configured: true, label } };
 }

--- a/packages/sandbox-digitalocean/src/credentials.ts
+++ b/packages/sandbox-digitalocean/src/credentials.ts
@@ -22,7 +22,7 @@ import {
   select,
   spinner,
 } from '@clack/prompts';
-import { loadEffectiveConfig, setConfigValue } from '@agentbox/config';
+import { loadEffectiveConfig, setConfigValue, unsetConfigValue } from '@agentbox/config';
 import { makeDigitalOceanClient, type DigitalOceanProject } from './client.js';
 import { ensureDigitalOceanEnvLoaded } from './env-loader.js';
 import { resolveProjectChoice } from './preflight.js';
@@ -165,6 +165,11 @@ async function promptForProject(creds: Credentials): Promise<void> {
   );
 
   if (choice === SKIP_PROJECT) {
+    // "Use the account's default" has to actually mean that. A previously saved
+    // global key would otherwise keep sending boxes to the old project while this
+    // line claims the opposite — so clear it rather than just not writing one.
+    // (A repo-level override in agentbox.yaml still wins; that is the point of it.)
+    if (current) await unsetConfigValue('global', 'box.digitaloceanProject', process.cwd());
     log.info("Boxes will go into your account's default DigitalOcean project.");
     return;
   }

--- a/packages/sandbox-digitalocean/src/credentials.ts
+++ b/packages/sandbox-digitalocean/src/credentials.ts
@@ -19,9 +19,11 @@ import {
   note,
   outro,
   password,
+  select,
   spinner,
 } from '@clack/prompts';
-import { makeDigitalOceanClient } from './client.js';
+import { loadEffectiveConfig, setConfigValue } from '@agentbox/config';
+import { makeDigitalOceanClient, type DigitalOceanProject } from './client.js';
 import { ensureDigitalOceanEnvLoaded } from './env-loader.js';
 
 // Ctrl+C at a prompt resolves with the cancel symbol; turn that into a real
@@ -95,6 +97,7 @@ export async function ensureDigitalOceanCredentials(
     if (result.ok) {
       persistCredentials(creds);
       log.success(`DigitalOcean credentials saved to ${secretsPath()}`);
+      await promptForProject(creds);
       outro('Setup complete.');
       return;
     }
@@ -113,6 +116,64 @@ export async function ensureDigitalOceanCredentials(
     throw new Error(`DigitalOcean credentials rejected: ${result.message}`);
   }
 }
+
+/**
+ * Offer to pick the DigitalOcean **Project** new boxes land in, right after the
+ * token validates — the one moment we hold a known-good token.
+ *
+ * The choice goes to the **global config** (`box.digitaloceanProject`), not
+ * `secrets.env`: it is a placement preference, not a secret, and it has to take
+ * part in config layering so a repo can override it in `agentbox.yaml`.
+ *
+ * Entirely optional. Skipping (or an account with a single project, or a
+ * failure to list them) leaves the key unset, which means DigitalOcean's own
+ * behavior: everything lands in the account's default project. A network blip
+ * here must never fail an otherwise-good login.
+ */
+async function promptForProject(creds: Credentials): Promise<void> {
+  let projects: DigitalOceanProject[];
+  try {
+    const client = makeDigitalOceanClient({ token: creds.token, endpoint: creds.endpoint });
+    projects = await client.listProjects();
+  } catch (err) {
+    log.warn(
+      `Could not list your DigitalOcean projects (${err instanceof Error ? err.message : String(err)}) — ` +
+        "boxes will use the account's default project. Set it later with " +
+        '`agentbox config set box.digitaloceanProject <name|id>`.',
+    );
+    return;
+  }
+
+  // Nothing to choose between — don't ask a question with one answer.
+  if (projects.length < 2) return;
+
+  const current = (await loadEffectiveConfig(process.cwd())).effective.box.digitaloceanProject;
+  const choice = exitOnCancel(
+    await select({
+      message: 'Which DigitalOcean project should new boxes go into?',
+      initialValue: current || SKIP_PROJECT,
+      options: [
+        ...projects.map((p) => ({
+          value: p.id,
+          label: p.is_default ? `${p.name} (account default)` : p.name,
+          hint: p.id,
+        })),
+        { value: SKIP_PROJECT, label: "Skip — use the account's default project" },
+      ],
+    }),
+  );
+
+  if (choice === SKIP_PROJECT) {
+    log.info("Boxes will go into your account's default DigitalOcean project.");
+    return;
+  }
+
+  await setConfigValue('global', 'box.digitaloceanProject', choice, process.cwd());
+  const picked = projects.find((p) => p.id === choice);
+  log.success(`New boxes will be created in the "${picked?.name ?? choice}" project.`);
+}
+
+const SKIP_PROJECT = '__skip__';
 
 function hasUsableCredentials(): boolean {
   return typeof process.env.DIGITALOCEAN_TOKEN === 'string' && process.env.DIGITALOCEAN_TOKEN.length > 0;

--- a/packages/sandbox-digitalocean/src/index.ts
+++ b/packages/sandbox-digitalocean/src/index.ts
@@ -97,11 +97,13 @@ export {
   type DigitalOceanFirewall,
   type DigitalOceanInboundRule,
   type DigitalOceanOutboundRule,
+  type DigitalOceanProject,
   type DigitalOceanSize,
   type DigitalOceanSnapshot,
 } from './client.js';
 export {
   validateSizeChoice,
+  resolveProjectChoice,
   mapDigitalOceanProvisionError,
   type SizeChoice,
 } from './preflight.js';

--- a/packages/sandbox-digitalocean/src/preflight.ts
+++ b/packages/sandbox-digitalocean/src/preflight.ts
@@ -11,7 +11,12 @@
  */
 
 import { UserFacingError } from '@agentbox/core';
-import { DigitalOceanApiError, type DigitalOceanSize, type DigitalOceanSnapshot } from './client.js';
+import {
+  DigitalOceanApiError,
+  type DigitalOceanProject,
+  type DigitalOceanSize,
+  type DigitalOceanSnapshot,
+} from './client.js';
 
 export interface SizeChoice {
   size: string;
@@ -81,6 +86,50 @@ export function validateSizeChoice(
         'Pick one with `--location <slug>` or `agentbox config set box.digitaloceanRegion <slug>`.',
     );
   }
+}
+
+/**
+ * Resolve `box.digitaloceanProject` (a project **name or id**) to a project id,
+ * throwing a `UserFacingError` listing the real projects when it matches
+ * nothing.
+ *
+ * This runs in the create preflight, before any billable resource exists,
+ * because the assignment itself cannot: DigitalOcean has no project field on
+ * droplet-create, so the assign only happens once the Droplet is up — far too
+ * late to tell someone they typed the project name wrong.
+ *
+ * Name matching is case-insensitive; an exact id match wins over a name match so
+ * a project literally named like another's id can't shadow it.
+ */
+export function resolveProjectChoice(project: string, projects: DigitalOceanProject[]): string {
+  const wanted = project.trim();
+  if (wanted.length === 0) {
+    throw new UserFacingError('DigitalOcean project must not be empty.');
+  }
+
+  const byId = projects.find((p) => p.id === wanted);
+  if (byId) return byId.id;
+
+  const matches = projects.filter((p) => p.name.toLowerCase() === wanted.toLowerCase());
+  if (matches.length === 1) return matches[0]!.id;
+
+  if (matches.length > 1) {
+    throw new UserFacingError(
+      `DigitalOcean project name "${wanted}" is ambiguous — ${String(matches.length)} projects share it.\n` +
+        `Use the id instead: ${matches.map((p) => p.id).join(', ')}.\n` +
+        'Set it with `agentbox config set box.digitaloceanProject <id>`.',
+    );
+  }
+
+  const known = projects
+    .map((p) => (p.is_default ? `${p.name} (default)` : p.name))
+    .join(', ');
+  throw new UserFacingError(
+    `DigitalOcean project "${wanted}" not found on this account.\n` +
+      (known.length > 0 ? `Your projects: ${known}.\n` : 'This account has no projects.\n') +
+      'Set it with `agentbox config set box.digitaloceanProject <name|id>`, ' +
+      'or unset it to use the account default.',
+  );
 }
 
 /**

--- a/packages/sandbox-digitalocean/src/prepare.ts
+++ b/packages/sandbox-digitalocean/src/prepare.ts
@@ -207,9 +207,14 @@ export async function prepareDigitalOcean(
     // surface in the account's default project for the 5-30 min it lives. Wholly
     // best-effort: a bake is expensive, and neither a project typo nor an API blip
     // is worth failing one over — the create path reports a bad project loudly.
+    // Resolve config against the host workspace, NOT process.cwd(): a bake driven
+    // by the hub's queued worker runs from the daemon's directory, which is not the
+    // repo — so cwd would miss a per-repo `box.digitaloceanProject` and quietly bake
+    // in the wrong project.
     const wantedProject = (
       opts.project ??
-      (await loadEffectiveConfig(process.cwd())).effective.box.digitaloceanProject
+      (await loadEffectiveConfig(opts.hostWorkspace ?? process.cwd())).effective.box
+        .digitaloceanProject
     ).trim();
     if (wantedProject.length > 0) {
       try {

--- a/packages/sandbox-digitalocean/src/prepare.ts
+++ b/packages/sandbox-digitalocean/src/prepare.ts
@@ -35,9 +35,11 @@ import {
   stageOpencodeStaticForUpload,
   type StageResult,
 } from '@agentbox/sandbox-cloud';
+import { loadEffectiveConfig } from '@agentbox/config';
 import { ensureDigitalOceanCredentials } from './credentials.js';
 import { detectEgressIp } from './egress-ip.js';
 import { createPerBoxFirewall, deletePerBoxFirewall, normalizeSourceCidr } from './firewall.js';
+import { resolveProjectChoice } from './preflight.js';
 import { makeDigitalOceanClient, type DigitalOceanClient } from './client.js';
 import { generatePrepareCloudInit } from './cloud-init.js';
 import { preparedStatePath, readPreparedState, writePreparedState } from './prepared-state.js';
@@ -59,6 +61,12 @@ export interface PrepareDigitalOceanOptions {
   region?: string;
   /** Droplet size slug (defaults to `s-2vcpu-4gb` — 2 vCPU / 4 GB / 80 GB). */
   size?: string;
+  /**
+   * DigitalOcean Project (name or id) for the temp bake Droplet. Defaults to
+   * `box.digitaloceanProject`, so the bake doesn't show up in the account's
+   * default project while every box lands somewhere else.
+   */
+  project?: string;
   /**
    * How the bake installs Claude Code: `native` (default) or `npm`. Threaded
    * into install-box.sh via `AGENTBOX_CLAUDE_INSTALL`. The `npm` escape hatch
@@ -194,6 +202,27 @@ export async function prepareDigitalOcean(
       ipv6: false,
     });
     dropletId = created.droplet.id;
+
+    // 3b. Place the bake Droplet in the same DO Project as the boxes, so it doesn't
+    // surface in the account's default project for the 5-30 min it lives. Wholly
+    // best-effort: a bake is expensive, and neither a project typo nor an API blip
+    // is worth failing one over — the create path reports a bad project loudly.
+    const wantedProject = (
+      opts.project ??
+      (await loadEffectiveConfig(process.cwd())).effective.box.digitaloceanProject
+    ).trim();
+    if (wantedProject.length > 0) {
+      try {
+        const projectId = resolveProjectChoice(wantedProject, await client.listProjects());
+        await client.assignProjectResources(projectId, [`do:droplet:${String(dropletId)}`]);
+        progress(`bake droplet assigned to project ${wantedProject}`);
+      } catch (assignErr) {
+        progress(
+          `WARN — could not assign the bake droplet to project ${wantedProject} (continuing): ` +
+            `${assignErr instanceof Error ? assignErr.message : String(assignErr)}`,
+        );
+      }
+    }
 
     // 4. Wait for the droplet to become active + expose a public IPv4, then ssh.
     progress(`droplet ${String(dropletId)} created; waiting for it to boot`);

--- a/packages/sandbox-digitalocean/test/client.test.ts
+++ b/packages/sandbox-digitalocean/test/client.test.ts
@@ -136,3 +136,47 @@ describe('makeDigitalOceanClient', () => {
     await expect(client.deleteTag('agentbox-box-x')).resolves.toBeUndefined();
   });
 });
+
+describe('projects', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    fetchMock = vi.fn();
+  });
+
+  it('paginates listProjects', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          projects: [{ id: 'p1', name: 'first-project', is_default: true }],
+          links: { pages: { next: 'https://api.digitalocean.com/v2/projects?page=2' } },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, { projects: [{ id: 'p2', name: 'client-x', is_default: false }] }),
+      );
+
+    const projects = await makeClient(fetchMock as unknown as typeof fetch).listProjects();
+    expect(projects.map((p) => p.id)).toEqual(['p1', 'p2']);
+  });
+
+  it('returns null when there is no default project (404)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(404, { message: 'not found' }));
+    const p = await makeClient(fetchMock as unknown as typeof fetch).getDefaultProject();
+    expect(p).toBeNull();
+  });
+
+  // The URN shape is the whole contract of the assign call — DigitalOcean has no
+  // project field on droplet-create, so this request is the only way a box ever
+  // reaches its project.
+  it('assigns a droplet by URN', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { resources: [] }));
+    await makeClient(fetchMock as unknown as typeof fetch).assignProjectResources('p2', [
+      'do:droplet:123',
+    ]);
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.digitalocean.com/v2/projects/p2/resources');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({ resources: ['do:droplet:123'] });
+  });
+});

--- a/packages/sandbox-digitalocean/test/preflight.test.ts
+++ b/packages/sandbox-digitalocean/test/preflight.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { UserFacingError } from '@agentbox/core';
 import { DigitalOceanApiError, type DigitalOceanSize, type DigitalOceanSnapshot } from '../src/client.js';
-import { mapDigitalOceanProvisionError, validateSizeChoice } from '../src/preflight.js';
+import { mapDigitalOceanProvisionError, validateSizeChoice, resolveProjectChoice } from '../src/preflight.js';
 
 function size(over: Partial<DigitalOceanSize> & { slug: string }): DigitalOceanSize {
   return {
@@ -106,5 +106,52 @@ describe('mapDigitalOceanProvisionError', () => {
   it('passes an unrecognized DO error through unchanged', () => {
     const err = new DigitalOceanApiError(400, 'bad_request', 'something else');
     expect(mapDigitalOceanProvisionError(err, choice)).toBe(err);
+  });
+});
+
+describe('resolveProjectChoice', () => {
+  const projects = [
+    { id: '8bab37f1-46a2-4ffb-a496-0e9bf27d1334', name: 'first-project', is_default: true },
+    { id: 'ffffffff-0000-1111-2222-333333333333', name: 'client-x', is_default: false },
+  ];
+
+  it('resolves a project by name, case-insensitively', () => {
+    expect(resolveProjectChoice('client-x', projects)).toBe(projects[1]!.id);
+    expect(resolveProjectChoice('Client-X', projects)).toBe(projects[1]!.id);
+  });
+
+  it('passes an id straight through', () => {
+    expect(resolveProjectChoice(projects[0]!.id, projects)).toBe(projects[0]!.id);
+  });
+
+  // This is the whole reason the check is a *preflight*: DO can only assign a
+  // project after the Droplet exists, so a typo has to be caught before we spend
+  // money, not after.
+  it('throws and lists the real projects when the name is unknown', () => {
+    expect(() => resolveProjectChoice('typo', projects)).toThrow(/not found/i);
+    try {
+      resolveProjectChoice('typo', projects);
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toContain('first-project (default)');
+      expect(msg).toContain('client-x');
+      expect(msg).toContain('box.digitaloceanProject');
+    }
+  });
+
+  it('refuses an ambiguous name rather than guessing', () => {
+    const dupes = [
+      { id: 'a', name: 'same', is_default: false },
+      { id: 'b', name: 'same', is_default: false },
+    ];
+    expect(() => resolveProjectChoice('same', dupes)).toThrow(/ambiguous/i);
+  });
+
+  it('an exact id match wins over a name that collides with it', () => {
+    const tricky = [
+      { id: 'abc', name: 'zzz', is_default: false },
+      { id: 'xyz', name: 'abc', is_default: false },
+    ];
+    expect(resolveProjectChoice('abc', tricky)).toBe('abc');
   });
 });


### PR DESCRIPTION
## Problem

Setting up DigitalOcean only ever asked for an API token, so **every Droplet landed in the account's default project**. For anyone using DO Projects as a billing or access boundary (client work, prod vs. play), boxes piled into the wrong bucket with no fix but moving them by hand in the console.

## What you get

`box.digitaloceanProject` — a project **name or UUID**. `agentbox digitalocean login` offers a picker once the token validates (skipped when the account has only one project — no question with one answer), and the hub/tray settings form gains an optional **Project** field. Being a normal config key it layers, so a repo can send its boxes to their own project via `agentbox.yaml`. Unset = today's behavior.

No CLI flag: "project" already means the host repo in AgentBox, and the layered config already gives per-repo control.

## The API constraint that shaped it

Verified against DigitalOcean's OpenAPI spec: **`POST /v2/droplets` has no project field**. Assignment is a separate `POST /v2/projects/{id}/resources` (`{"resources":["do:droplet:<id>"]}`) that can only run *after* the Droplet exists. That splits failure handling:

- A bad project **name** is caught in the create **preflight**, before anything bills, listing the real projects.
- The **assign call itself** is best-effort. It acts on a Droplet that already provisioned fine, so a transient failure warns and keeps the box. A box in the wrong project is a grouping annoyance; tearing down a working box over one would not be.

The bake Droplet (`prepare`) is assigned too — wholly best-effort, since a project typo must not fail a 20-minute bake.

## Not stored like Vercel's project id — on purpose

Vercel persists `VERCEL_PROJECT_ID` to `secrets.env`. A DO project is **not a secret**, and `box.digitaloceanProject` is already the source of truth (it has to layer). Writing it to `secrets.env` as well would create two places that can disagree. The settings-form save path therefore resolves the name to an id and writes the **config key** — which also lets it validate at save time, so a typo appears in the form instead of surfacing later as a failed create.

## Verification (live, against a real account)

- **Placement:** box created with the key set → `do:droplet:584061563` in `agentbox-proj-test`; the default project had **0** resources. Log: `digitalocean: droplet 584061563 assigned to project agentbox-proj-test`.
- **Fail-fast:** a bogus name failed with *"not found… Your projects: first-project (default)"* and **created no Droplet** — nothing billed.
- **No regression:** key unset → box lands in the default project, exactly as before.
- **Settings form** (the same hub API the tray calls): bad name → inline `project "does-not-exist" not found`, key untouched; good name → resolved to its id and written.

All test resources destroyed afterwards; the account is back to its starting state. Full suite green, lint + typecheck clean.

## Provider SDK — republish required

`CloudProvisionRequest` gains one optional field (`project?: string`). Diffed the built `.d.ts` against the published 2.1.0: **purely additive** (only `+` lines), so **2.2.0**, `SDK_API_VERSION` unchanged at 2. `pack:test` passes.

Companion tray change ships in the tray repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cloud provision/create paths and external DO API assignment after billing starts; design is fail-fast on bad names and best-effort assign so working droplets are not destroyed on grouping failures.
> 
> **Overview**
> Adds **`box.digitaloceanProject`** so new DigitalOcean boxes can land in a specific DO Project (name or UUID) instead of always using the account default.
> 
> **Config & CLI path:** The key is in the user config schema/types, documented in configuration and DigitalOcean docs, and threaded from `cloudSizingProviderOptions` into `providerOptions.project` for digitalocean only. **`@madarco/agentbox-provider-sdk` 2.2.0** adds optional `project` on `CloudProvisionRequest` (additive).
> 
> **Backend:** Create **preflight** resolves the project with `resolveProjectChoice` (fail-fast on typos/ambiguity). After the droplet exists, **`POST /projects/{id}/resources`** assigns it **best-effort** — failures warn and keep the box. **Prepare** assigns the temporary bake droplet to the same project (best-effort, using host workspace for layered config).
> 
> **UX:** `agentbox digitalocean login` offers a project picker when the account has multiple projects; **Skip** clears a saved global key. Hub provider settings get an optional **Project** field (writes config, blank = leave unchanged). `digitalocean login --status` shows the effective project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 670c0575bb7da6a863e368e7d46bcd5d93203846. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->