### PR TITLE
fix(update): stop interrupting box commands, and stop crying wolf about the app

### DIFF
--- a/apps/cli/src/commands/install-app.ts
+++ b/apps/cli/src/commands/install-app.ts
@@ -19,6 +19,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
+import { isNewer } from '../lib/semver-lite.js';
 import { writeUpdateState } from '../lib/update-state.js';
 
 export const APP_NAME = 'AgentBox';
@@ -184,7 +185,13 @@ export function parseVersionManifest(body: string): string | undefined {
 
 export interface TrayUpdateDecision {
   update: boolean;
-  reason: 'not-installed' | 'no-latest-sha' | 'no-stamp' | 'mismatch' | 'up-to-date';
+  reason:
+    | 'not-installed'
+    | 'no-latest-sha'
+    | 'no-stamp'
+    | 'mismatch'
+    | 'older-version'
+    | 'up-to-date';
 }
 
 /**
@@ -197,35 +204,65 @@ export function decideTrayUpdate(input: {
   installed: boolean;
   stampedSha: string | undefined;
   latestSha: string | undefined;
+  /** `CFBundleShortVersionString` of the app on disk — ground truth. */
+  installedVersion?: string | undefined;
+  /** `version` from the release's version.json. */
+  latestVersion?: string | undefined;
 }): TrayUpdateDecision {
   if (!input.installed) return { update: false, reason: 'not-installed' };
+
+  // Prefer the ACTUAL versions over the sha stamp. The stamp only exists if *this*
+  // CLI did the install, so a DMG-drag install (or one predating stamping) has no
+  // stamp and used to read as "update available" forever, even on the newest app.
+  // Comparing what is really installed against what is really published cannot lie.
+  const { installedVersion, latestVersion } = input;
+  if (
+    installedVersion !== undefined &&
+    latestVersion !== undefined &&
+    isReleaseVersion(installedVersion) &&
+    isReleaseVersion(latestVersion)
+  ) {
+    return isNewer(latestVersion, installedVersion)
+      ? { update: true, reason: 'older-version' }
+      : { update: false, reason: 'up-to-date' };
+  }
+
+  // Fall back to the sha stamp when a version is unreadable (no manifest on the
+  // release, unparseable plist).
   if (input.latestSha === undefined) return { update: false, reason: 'no-latest-sha' };
   if (input.stampedSha === undefined) return { update: true, reason: 'no-stamp' };
   if (input.stampedSha !== input.latestSha) return { update: true, reason: 'mismatch' };
   return { update: false, reason: 'up-to-date' };
 }
 
+/** A real published version we can compare — excludes `0.0.0`/unparseable. */
+function isReleaseVersion(v: string): boolean {
+  const core = v.split('-', 1)[0] ?? v;
+  const parts = core.split('.');
+  return parts.length === 3 && parts.every((p) => /^\d+$/.test(p)) && core !== '0.0.0';
+}
+
 /**
- * Pure gate for the *unprompted* startup nudge (`index.ts`), as opposed to
- * `decideTrayUpdate`, which decides whether an already-consented refresh should
- * install. A tray-only release never bumps the CLI, so the version-change hook
- * alone would never surface it — this is what makes such a release reachable.
- *
- * Declining stamps the published sha, so the same release is never asked about
- * twice; a *newer* one asks again (different sha).
+ * The version of the app actually installed at `/Applications/AgentBox.app`, or
+ * undefined when it isn't there / the plist can't be read. `plutil` handles both
+ * XML and binary plists; the app is macOS-only, so this is safe to shell.
  */
-export function shouldPromptTrayUpdate(input: {
-  installed: boolean;
-  stampedSha: string | undefined;
-  latestSha: string | undefined;
-  declinedSha: string | undefined;
-}): boolean {
-  if (input.declinedSha !== undefined && input.declinedSha === input.latestSha) return false;
-  return decideTrayUpdate({
-    installed: input.installed,
-    stampedSha: input.stampedSha,
-    latestSha: input.latestSha,
-  }).update;
+export async function readInstalledTrayVersion(): Promise<string | undefined> {
+  if (!trayInstalled()) return undefined;
+  try {
+    const { stdout } = await execa('plutil', [
+      '-extract',
+      'CFBundleShortVersionString',
+      'raw',
+      '-o',
+      '-',
+      join(APP_PATH, 'Contents', 'Info.plist'),
+    ]);
+    const v = stdout.trim();
+    return v.length > 0 ? v : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /** True while the tray process is running. `pgrep -x` exits 1 (rejects) when nothing matches. */

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -81,9 +81,14 @@ import { runQueuedJobCommand } from './commands/_run-queued-job.js';
 import { runQueuedPrepareCommand } from './commands/_run-queued-prepare.js';
 import { claudeLoginWorkerCommand } from './commands/_claude-login-worker.js';
 import { postUpdateRefreshCommand } from './commands/_post-update-refresh.js';
-import { maybeUpdateTray, runPostUpdateRefresh } from './lib/post-update-refresh.js';
-import { shouldPromptTrayUpdate, trayInstalled } from './commands/install-app.js';
-import { maybeStartRemoteCheck, nudgeMessage, updateCheckEnabled } from './lib/update-check.js';
+import { runPostUpdateRefresh } from './lib/post-update-refresh.js';
+import { readInstalledTrayVersion } from './commands/install-app.js';
+import {
+  maybeStartRemoteCheck,
+  nudgeMessage,
+  trayNudgeMessage,
+  updateCheckEnabled,
+} from './lib/update-check.js';
 import { readUpdateState, writeUpdateState } from './lib/update-state.js';
 import { confirm } from './lib/prompt.js';
 import { detectExecutionMethod } from './exec-method.js';
@@ -209,6 +214,35 @@ const FIRST_RUN_EXEMPT = new Set([
   'screen',
 ]);
 
+// Commands that START or ATTACH to work. An update prompt here lands in the middle
+// of what you actually came to do — you asked for a box, not a maintenance chore —
+// so the post-update refresh never interrupts them. It asks on the next quiet
+// command instead (`list`, `config`, …), and both updates are always reported by
+// the passive one-line nudge, which never blocks.
+const UPDATE_PROMPT_EXEMPT = new Set([
+  'create',
+  'claude',
+  'codex',
+  'opencode',
+  'shell',
+  'sh',
+  'attach',
+  'exec',
+  'run',
+  'open',
+  'fork',
+  'url',
+  'connect',
+]);
+
+/** True when an update prompt would interrupt the command the user actually ran. */
+function isUpdatePromptEligible(args: readonly string[]): boolean {
+  if (!isFirstRunHookEligible(args)) return false;
+  const cmd = args[2];
+  if (typeof cmd !== 'string') return false;
+  return !UPDATE_PROMPT_EXEMPT.has(cmd) && cmd !== 'self-update';
+}
+
 function isFirstRunHookEligible(args: readonly string[]): boolean {
   if (!process.stdin.isTTY || !process.stdout.isTTY) return false;
   const rest = args.slice(2);
@@ -245,11 +279,7 @@ if (AGENTBOX_VERSION !== '0.0.0-dev') {
     // Baseline for installs that predate the stamp: written on any invocation,
     // silently — we can't know the previous version, so never prompt.
     writeUpdateState({ lastRunVersion: AGENTBOX_VERSION });
-  } else if (
-    state.lastRunVersion !== AGENTBOX_VERSION &&
-    isFirstRunHookEligible(argv) &&
-    argv[2] !== 'self-update'
-  ) {
+  } else if (state.lastRunVersion !== AGENTBOX_VERSION && isUpdatePromptEligible(argv)) {
     versionPromptShown = true;
     try {
       const yes = await confirm({
@@ -266,44 +296,11 @@ if (AGENTBOX_VERSION !== '0.0.0-dev') {
         `post-update refresh failed: ${err instanceof Error ? err.message : String(err)}\n`,
       );
     }
-  } else if (
-    isFirstRunHookEligible(argv) &&
-    argv[2] !== 'self-update' &&
-    shouldPromptTrayUpdate({
-      installed: trayInstalled(),
-      stampedSha: state.traySha,
-      latestSha: state.remoteCheck?.trayLatestSha,
-      declinedSha: state.trayDeclinedSha,
-    })
-  ) {
-    // The menu-bar app ships on its own cadence, so a tray-only release bumps
-    // no CLI version and the hook above never fires for it. Reads the daily
-    // cache — no network here. Only the app is stale, so only the app is
-    // touched: `runPostUpdateRefresh` would also drop the box image and bounce
-    // the relay, which no one asked for by installing a new menu-bar app.
-    const latestSha = state.remoteCheck?.trayLatestSha;
-    const latestVersion = state.remoteCheck?.trayLatestVersion;
-    versionPromptShown = true;
-    try {
-      const yes = await confirm({
-        message: latestVersion
-          ? `the AgentBox menu-bar app has an update (${latestVersion}) — install it now?`
-          : 'the AgentBox menu-bar app has an update — install it now?',
-        initialValue: true,
-      });
-      if (yes) {
-        await maybeUpdateTray((msg) => {
-          process.stdout.write(`${msg}\n`);
-        });
-      } else {
-        writeUpdateState({ trayDeclinedSha: latestSha });
-      }
-    } catch (err) {
-      process.stderr.write(
-        `menu-bar app update failed: ${err instanceof Error ? err.message : String(err)}\n`,
-      );
-    }
   }
+  // A stale menu-bar app is NOT prompted for. It ships on its own cadence, so it
+  // would interrupt whatever you were doing, on a command that has nothing to do
+  // with it, to ask about something you can act on any time. It's reported as a
+  // one-line nudge after the command instead (see `nudgeMessage`).
 }
 
 // Daily update check: no-op while the cached result is < 24h old (zero
@@ -315,18 +312,27 @@ if (isFirstRunHookEligible(argv)) {
 
 program.parseAsync(argv).then(
   async () => {
-    // "Newer version available" nudge — printed from the cache only, after
-    // the command finished, on interactive runs of an installed build.
-    if (versionPromptShown || !isFirstRunHookEligible(argv)) return;
-    const msg = nudgeMessage(
-      readUpdateState(),
-      detectExecutionMethod({
-        userAgent: process.env.npm_config_user_agent,
-        argv1: process.argv[1],
-      }),
-    );
-    if (msg !== null && (await updateCheckEnabled())) {
-      process.stderr.write(`\n${msg}\n`);
+    // "Newer version available" nudges — printed from the cache only, after the
+    // command finished, on interactive runs of an installed build. Both the CLI
+    // and the menu-bar app report here; neither ever blocks.
+    //
+    // Gated on the same exempt list as the prompt: a box-flow command
+    // (`create` / `claude` / …) says nothing about updates at all. You asked for
+    // a box, and trailing maintenance chatter on the way out is still noise.
+    if (versionPromptShown || !isUpdatePromptEligible(argv)) return;
+    const state = readUpdateState();
+    const lines = [
+      nudgeMessage(
+        state,
+        detectExecutionMethod({
+          userAgent: process.env.npm_config_user_agent,
+          argv1: process.argv[1],
+        }),
+      ),
+      trayNudgeMessage(state, await readInstalledTrayVersion()),
+    ].filter((l): l is string => l !== null);
+    if (lines.length > 0 && (await updateCheckEnabled())) {
+      process.stderr.write(`\n${lines.join('\n')}\n`);
     }
   },
   (err: unknown) => {

--- a/apps/cli/src/lib/post-update-refresh.ts
+++ b/apps/cli/src/lib/post-update-refresh.ts
@@ -26,6 +26,7 @@ import {
   decideTrayUpdate,
   fetchTraySidecarSha,
   installTray,
+  readInstalledTrayVersion,
   trayInstalled,
 } from '../commands/install-app.js';
 import { AGENTBOX_VERSION } from '../version.js';
@@ -51,6 +52,8 @@ export async function maybeUpdateTray(say: (msg: string) => void): Promise<void>
     installed: true,
     stampedSha: state.traySha,
     latestSha,
+    installedVersion: await readInstalledTrayVersion(),
+    latestVersion: state.remoteCheck?.trayLatestVersion,
   });
   if (!decision.update) {
     say(

--- a/apps/cli/src/lib/update-check.ts
+++ b/apps/cli/src/lib/update-check.ts
@@ -150,6 +150,25 @@ export function maybeStartRemoteCheck(): Promise<void> | null {
   return run().catch(() => undefined);
 }
 
+/**
+ * The menu-bar app nudge, or null. Never prompts and never blocks — a stale app
+ * is worth one line after the command, not an interruption in the middle of one.
+ *
+ * `installedVersion` is read off the installed bundle, so this is decided on what
+ * is really installed vs what is really published — NOT on the sha stamp, which
+ * only exists when this CLI did the install and therefore reported a phantom
+ * update forever on a DMG-drag install.
+ */
+export function trayNudgeMessage(
+  state: UpdateState,
+  installedVersion: string | undefined,
+): string | null {
+  const latest = state.remoteCheck?.trayLatestVersion;
+  if (!latest || !installedVersion) return null;
+  if (!isNewer(latest, installedVersion)) return null;
+  return `a newer AgentBox app (${latest}, you have ${installedVersion}) is available — run \`agentbox install app\``;
+}
+
 /** The nudge line to print after the command, or null. Reads the cache only. */
 export function nudgeMessage(
   state: UpdateState,

--- a/apps/cli/src/lib/update-state.ts
+++ b/apps/cli/src/lib/update-state.ts
@@ -28,11 +28,6 @@ export interface UpdateState {
   lastRunVersion?: string;
   /** sha256 of the AgentBox.zip the installed tray app came from. */
   traySha?: string;
-  /**
-   * sha256 of a published tray zip the user declined. Without this the
-   * app-update prompt re-fires on every single command after a decline.
-   */
-  trayDeclinedSha?: string;
   remoteCheck?: RemoteCheck;
 }
 
@@ -48,7 +43,6 @@ export function readUpdateState(): UpdateState {
     const state: UpdateState = { version: STATE_VERSION };
     if (typeof parsed.lastRunVersion === 'string') state.lastRunVersion = parsed.lastRunVersion;
     if (typeof parsed.traySha === 'string') state.traySha = parsed.traySha;
-    if (typeof parsed.trayDeclinedSha === 'string') state.trayDeclinedSha = parsed.trayDeclinedSha;
     if (
       parsed.remoteCheck !== undefined &&
       typeof parsed.remoteCheck === 'object' &&

--- a/apps/cli/test/tray-update.test.ts
+++ b/apps/cli/test/tray-update.test.ts
@@ -3,9 +3,8 @@ import {
   decideTrayUpdate,
   parseSidecarSha,
   parseVersionManifest,
-  shouldPromptTrayUpdate,
 } from '../src/commands/install-app.js';
-import { mergeRemoteCheck } from '../src/lib/update-check.js';
+import { mergeRemoteCheck, trayNudgeMessage } from '../src/lib/update-check.js';
 
 const SHA_A = 'a'.repeat(64);
 const SHA_B = 'b'.repeat(64);
@@ -74,78 +73,6 @@ describe('parseVersionManifest', () => {
   });
 });
 
-describe('shouldPromptTrayUpdate', () => {
-  // The regression this whole feature exists for: a tray-only release bumps no CLI version, so
-  // nothing else in the CLI would ever surface it.
-  it('prompts when the published tray differs from the installed one', () => {
-    expect(
-      shouldPromptTrayUpdate({
-        installed: true,
-        stampedSha: SHA_A,
-        latestSha: SHA_B,
-        declinedSha: undefined,
-      }),
-    ).toBe(true);
-  });
-
-  it('stays silent when the app is current', () => {
-    expect(
-      shouldPromptTrayUpdate({
-        installed: true,
-        stampedSha: SHA_A,
-        latestSha: SHA_A,
-        declinedSha: undefined,
-      }),
-    ).toBe(false);
-  });
-
-  it('stays silent when the published sha is unknown (offline / no cache yet)', () => {
-    expect(
-      shouldPromptTrayUpdate({
-        installed: true,
-        stampedSha: SHA_A,
-        latestSha: undefined,
-        declinedSha: undefined,
-      }),
-    ).toBe(false);
-  });
-
-  it('stays silent when the app is not installed', () => {
-    expect(
-      shouldPromptTrayUpdate({
-        installed: false,
-        stampedSha: undefined,
-        latestSha: SHA_B,
-        declinedSha: undefined,
-      }),
-    ).toBe(false);
-  });
-
-  // Anti-nag: without the decline stamp this prompt re-fires on every single command.
-  it('does not re-ask about a release the user declined', () => {
-    expect(
-      shouldPromptTrayUpdate({
-        installed: true,
-        stampedSha: SHA_A,
-        latestSha: SHA_B,
-        declinedSha: SHA_B,
-      }),
-    ).toBe(false);
-  });
-
-  it('asks again once a NEWER release lands after a decline', () => {
-    const SHA_C = 'c'.repeat(64);
-    expect(
-      shouldPromptTrayUpdate({
-        installed: true,
-        stampedSha: SHA_A,
-        latestSha: SHA_C,
-        declinedSha: SHA_B,
-      }),
-    ).toBe(true);
-  });
-});
-
 describe('mergeRemoteCheck', () => {
   const prev = {
     checkedAt: '2026-07-11T00:00:00.000Z',
@@ -186,5 +113,81 @@ describe('mergeRemoteCheck', () => {
 
   it('is empty on a first-ever probe that fetched nothing', () => {
     expect(mergeRemoteCheck({}, undefined)).toEqual({});
+  });
+});
+
+describe('decideTrayUpdate — version beats the sha stamp', () => {
+  // The false positive: the app was installed by dragging the DMG (or by a CLI
+  // that predated sha stamping), so there is no stamp — and the old sha-only
+  // logic reported "update available" forever, even on the newest app.
+  it('does NOT claim an update when the installed app is already the published one', () => {
+    expect(
+      decideTrayUpdate({
+        installed: true,
+        stampedSha: undefined, // never installed by this CLI
+        latestSha: SHA_B,
+        installedVersion: '0.1.12',
+        latestVersion: '0.1.12',
+      }),
+    ).toEqual({ update: false, reason: 'up-to-date' });
+  });
+
+  it('claims an update when the installed app is genuinely older', () => {
+    expect(
+      decideTrayUpdate({
+        installed: true,
+        stampedSha: SHA_A,
+        latestSha: SHA_B,
+        installedVersion: '0.1.11',
+        latestVersion: '0.1.12',
+      }),
+    ).toEqual({ update: true, reason: 'older-version' });
+  });
+
+  // A stale stamp must not override the versions: a reinstall of the same build
+  // changes the zip sha, but the app is still current.
+  it('trusts the versions over a mismatched stamp', () => {
+    expect(
+      decideTrayUpdate({
+        installed: true,
+        stampedSha: SHA_A,
+        latestSha: SHA_B,
+        installedVersion: '0.1.12',
+        latestVersion: '0.1.12',
+      }),
+    ).toEqual({ update: false, reason: 'up-to-date' });
+  });
+
+  it('falls back to the sha when a version is unreadable', () => {
+    expect(
+      decideTrayUpdate({
+        installed: true,
+        stampedSha: SHA_A,
+        latestSha: SHA_B,
+        installedVersion: undefined,
+        latestVersion: '0.1.12',
+      }),
+    ).toEqual({ update: true, reason: 'mismatch' });
+  });
+});
+
+describe('trayNudgeMessage', () => {
+  const st = (v?: string) => ({
+    version: 1 as const,
+    remoteCheck: { checkedAt: '2026-07-12T00:00:00.000Z', trayLatestVersion: v },
+  });
+
+  it('is silent when the installed app is current', () => {
+    expect(trayNudgeMessage(st('0.1.12'), '0.1.12')).toBeNull();
+  });
+
+  it('names both versions when behind', () => {
+    expect(trayNudgeMessage(st('0.1.12'), '0.1.11')).toContain('0.1.12');
+    expect(trayNudgeMessage(st('0.1.12'), '0.1.11')).toContain('agentbox install app');
+  });
+
+  it('is silent when either version is unknown', () => {
+    expect(trayNudgeMessage(st(undefined), '0.1.11')).toBeNull();
+    expect(trayNudgeMessage(st('0.1.12'), undefined)).toBeNull();
   });
 });

--- a/apps/cli/test/update-state.test.ts
+++ b/apps/cli/test/update-state.test.ts
@@ -78,9 +78,8 @@ describe('update-state', () => {
     expect(state.remoteCheck).toBeUndefined();
   });
 
-  it('round-trips the tray decline stamp and the published tray version', () => {
+  it('round-trips the published tray version', () => {
     writeUpdateState({
-      trayDeclinedSha: 'd'.repeat(64),
       remoteCheck: {
         checkedAt: '2026-07-07T00:00:00.000Z',
         trayLatestSha: 'e'.repeat(64),
@@ -88,7 +87,6 @@ describe('update-state', () => {
       },
     });
     const state = readUpdateState();
-    expect(state.trayDeclinedSha).toBe('d'.repeat(64));
     expect(state.remoteCheck?.trayLatestSha).toBe('e'.repeat(64));
     expect(state.remoteCheck?.trayLatestVersion).toBe('0.1.10');
   });
@@ -98,7 +96,6 @@ describe('update-state', () => {
       updateStatePath(),
       JSON.stringify({
         version: 1,
-        trayDeclinedSha: 7,
         remoteCheck: {
           checkedAt: '2026-07-07T00:00:00.000Z',
           trayLatestSha: 'e'.repeat(64),
@@ -107,7 +104,6 @@ describe('update-state', () => {
       }),
     );
     const state = readUpdateState();
-    expect(state.trayDeclinedSha).toBeUndefined();
     expect(state.remoteCheck?.trayLatestVersion).toBeUndefined();
     expect(state.remoteCheck?.trayLatestSha).toBe('e'.repeat(64));
   });


### PR DESCRIPTION
Two reports, one cause each.

## "It gets in the way"

The post-update prompt fired on any interactive command — including `create` / `claude` / `codex`. You asked for a box and got a maintenance question instead.

- **Box-flow commands now say nothing about updates at all** — no prompt, and no trailing nudge either (`create`, `claude`, `codex`, `opencode`, `shell`, `attach`, `exec`, `run`, `open`, `fork`, `url`, `connect`).
- **The menu-bar app is never prompted for.** It ships on its own cadence, it isn't urgent, and you can act on it whenever — so it's a one-line nudge after a quiet command instead: `a newer AgentBox app (0.1.13, you have 0.1.12) is available — run 'agentbox install app'`.
- The CLI's refresh prompt survives (it does real work — skills, box image, relay) but only asks on a quiet command like `list`.

## "It says there's a new app version, but I'm on the latest"

A real bug. Staleness was decided by a **sha stamp**, which only exists when *this CLI* did the install. An app installed by dragging the DMG (or by a CLI predating stamping) has no stamp and hit this branch:

```ts
if (input.stampedSha === undefined) return { update: true, reason: 'no-stamp' };
```

…which reads as "update available" **forever**, on the newest possible app. It was never comparing versions at all.

It now decides on the **versions**: the installed bundle's `CFBundleShortVersionString` (via `plutil`) vs the published `version.json`. What is really installed against what is really published cannot lie. The sha remains a fallback for when a version can't be read (no manifest on the release, unparseable plist).

## Verification

- Reproduced the exact false positive — app 0.1.12, published 0.1.12, **no stamp** — and confirmed it now claims **0** updates. The old code prompted here.
- Genuinely stale app on `list` → one nudge line naming both versions, **0** blocking prompts.
- `agentbox shell no-such-box` (a real box-flow invocation, not `--help`) → **0** update mentions.
- New unit tests pin the regression: version beats a missing stamp, version beats a *mismatched* stamp, and the sha still drives the decision when a version is unreadable.

## Cleanup

Drops `shouldPromptTrayUpdate` and the `trayDeclinedSha` decline-stamp — both existed only to make the app prompt bearable, and there is no app prompt now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI startup and post-command messaging only; tray install logic is more accurate but still best-effort with sha fallback.
> 
> **Overview**
> **Update UX** no longer interrupts box workflows. Post-update **CLI** prompts and trailing nudges are skipped for work commands (`create`, `claude`, `shell`, `attach`, etc.); the refresh prompt only appears on quieter commands. The **menu-bar app** is never blocking-prompted—only a one-line stderr nudge after eligible commands, alongside the existing CLI nudge.
> 
> **Tray staleness** is decided by comparing the installed bundle’s `CFBundleShortVersionString` (`readInstalledTrayVersion` via `plutil`) to the published `version.json`, using `isNewer` when both are valid release versions. That fixes the permanent “update available” case when the app was DMG-installed and had **no** `traySha` stamp (previously `no-stamp` always meant update). SHA comparison remains the fallback when versions are missing; `maybeUpdateTray` passes both version sources into `decideTrayUpdate`.
> 
> **Cleanup:** removes `shouldPromptTrayUpdate`, `trayDeclinedSha` from update state, and related tests; adds tests for version-first tray decisions and `trayNudgeMessage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1795042ce40fa90f2a450e996e49f1b39fec9f5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->