### PR TITLE
chore: contributor process — CLA, CONTRIBUTING, SECURITY, CODEOWNERS

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -1,0 +1,75 @@
+# AgentBox Contributor License Agreement
+
+Thank you for contributing to AgentBox.
+
+This Contributor License Agreement ("Agreement") sets out the terms under which you contribute
+code, documentation, or any other material ("Contribution") to the AgentBox project
+(https://github.com/madarco/agentbox), maintained by Marco D'Alia ("the Maintainer").
+
+You accept this Agreement by commenting the acceptance sentence on your first pull request, as
+prompted by the CLA bot. It applies to that pull request and to every Contribution you make to the
+project afterwards. If you do not agree, please do not submit a Contribution.
+
+This is a standard, widely used agreement modeled on the Apache Individual Contributor License
+Agreement. **You keep the copyright to your work.** Nothing here is an assignment of copyright.
+
+## 1. Definitions
+
+"You" means the individual accepting this Agreement, or the legal entity on whose behalf they act.
+
+"Contribution" means any original work of authorship, including any modification of or addition to
+an existing work, that you intentionally submit to the project for inclusion in it — by pull
+request, patch, issue, or any other form of communication — excluding anything you conspicuously
+mark in writing as "Not a Contribution".
+
+## 2. Copyright license
+
+You retain ownership of the copyright in your Contribution.
+
+You grant the Maintainer a perpetual, worldwide, non-exclusive, royalty-free, irrevocable license
+to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and
+distribute your Contribution and such derivative works, **under any license terms the Maintainer
+chooses**, including as part of a larger work distributed under a different license, and including
+the right to relicense and to sublicense these rights through multiple tiers.
+
+You also grant every recipient of software distributed by the Maintainer the same rights, on the
+terms under which that software is distributed.
+
+## 3. Patent license
+
+You grant the Maintainer and every recipient of software containing your Contribution a perpetual,
+worldwide, non-exclusive, royalty-free, irrevocable patent license to make, have made, use, offer
+to sell, sell, import, and otherwise transfer your Contribution, covering only those patent claims
+you own or control that are necessarily infringed by your Contribution alone or by the combination
+of your Contribution with the project.
+
+If any entity brings patent litigation alleging that the project or a Contribution in it
+constitutes direct or contributory patent infringement, any patent license granted under this
+Agreement to that entity terminates as of the date such litigation is filed.
+
+## 4. Your right to contribute
+
+You represent that:
+
+- Each Contribution is your original creation, and you are legally entitled to grant the licenses
+  above.
+- If your employer has rights to intellectual property you create, you have received permission to
+  make the Contribution on their behalf, your employer has waived those rights, or your employer
+  has authorized you to accept this Agreement on its behalf.
+- Your Contribution does not, to your knowledge, violate any third party's copyright, patent,
+  trademark, trade secret, or other rights.
+
+If you submit work that is not your original creation, you may submit it separately from any
+Contribution, clearly identifying its source and any license or other restriction you are aware
+of, and marking it conspicuously as "Submitted on behalf of a third party: [name]".
+
+## 5. No obligation, no warranty
+
+The Maintainer is under no obligation to accept, merge, or use any Contribution. Except for the
+representations in Section 4, you provide your Contribution "AS IS", without warranties or
+conditions of any kind, express or implied.
+
+## 6. Notice
+
+You agree to notify the Maintainer if you become aware of any fact or circumstance that would make
+any representation in this Agreement inaccurate.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @madarco

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## What this changes
+
+<!-- One or two sentences. Link the issue if there is one. -->
+
+## How it was tested
+
+<!-- Commands you ran, or the manual flow you drove. `pnpm lint && pnpm build && pnpm typecheck && pnpm test` at minimum. -->
+
+## Checklist
+
+- [ ] `pnpm lint && pnpm build && pnpm typecheck && pnpm test` passes
+- [ ] Public docs updated if a command, flag, config key, or default changed (`apps/web/content/docs/`)
+- [ ] I have read and agree to the [Contributor License Agreement](https://github.com/madarco/agentbox/blob/main/.github/CLA.md)

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,36 @@
+name: CLA
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, closed]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    name: CLA
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check the contributor license agreement
+        if: (github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-document: https://github.com/madarco/agentbox/blob/main/.github/CLA.md
+          path-to-signatures: signatures/v1/cla.json
+          # Signatures are committed by the bot; they must not land on the protected main branch.
+          branch: cla-signatures
+          allowlist: madarco,*[bot]
+          custom-notsigned-prcomment: >
+            Thanks for your pull request. Before it can be merged, please read our
+            [Contributor License Agreement](https://github.com/madarco/agentbox/blob/main/.github/CLA.md)
+            and sign it by posting the comment below. You only ever have to do this once.
+          custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
+          custom-allsigned-prcomment: All contributors have signed the CLA. Thank you!

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,7 +4,9 @@ on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened, synchronize, closed]
+    # `reopened` matters: CLA is a required check, and a check that never reports is
+    # indistinguishable from one that is still pending — it would block the merge forever.
+    types: [opened, reopened, synchronize, closed]
 
 permissions:
   actions: write
@@ -16,9 +18,15 @@ jobs:
   cla:
     name: CLA
     runs-on: ubuntu-latest
+    # issue_comment fires for plain issues as well as pull requests; without the
+    # `issue.pull_request` guard the sign phrase posted on any issue would invoke the
+    # action with no pull-request context.
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event.issue.pull_request &&
+       github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')
     steps:
       - name: Check the contributor license agreement
-        if: (github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+Marco D'Alia <github@madarco.it> <madarco@gmail.com>
+Marco D'Alia <github@madarco.it> Madarco <github@madarco.it>
+# Default git identity inside an agentbox box; these commits are Marco's.
+Marco D'Alia <github@madarco.it> <smoke@agentbox.test>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing to AgentBox
+
+Thanks for taking the time. Bug reports, docs fixes, and provider work are all welcome.
+
+## Before you start
+
+For anything larger than a bug fix, open an issue first and describe what you want to do. It saves
+you from building something that doesn't fit the direction of the project.
+
+If you are adding a new sandbox backend, you probably want a **provider plugin** rather than a
+change to this repo — see [Build a provider](https://agent-box.sh/docs/build-a-provider) and
+[`docs/provider-plugins.md`](./docs/provider-plugins.md).
+
+## Development
+
+Node 22 and pnpm. [`docs/development.md`](./docs/development.md) has the full loop; the short
+version:
+
+```bash
+pnpm install
+pnpm build
+pnpm lint && pnpm typecheck && pnpm test
+```
+
+CI runs exactly those checks on every pull request, so run them locally first. Unit tests must stay
+pure — no docker, no network. Integration testing is manual for now.
+
+A few conventions worth knowing: TypeScript strict + ESM (`import type` for types), `tsup` per
+package, `vitest` for tests, `commander` + `@clack/prompts` for CLI surface, and comments only where
+the *why* is non-obvious. [`CLAUDE.md`](./CLAUDE.md) documents the architecture and the house style
+in more detail.
+
+If your change adds or alters a CLI command, flag, config key, default, or provider behavior,
+update the matching page under [`apps/web/content/docs/`](./apps/web/content/docs) in the same pull
+request. Stale public docs are treated as a bug.
+
+## Contributor License Agreement
+
+Before your first pull request can be merged, you need to accept the
+[Contributor License Agreement](./.github/CLA.md). A bot will comment on the pull request with a
+one-line sentence to post as a reply; that's the whole process, and it only happens once.
+
+You keep the copyright to your work — the CLA is a license grant, not an assignment. It exists so
+the project has a clear, written chain of rights over everything it ships.
+
+## Reporting security issues
+
+Please don't open a public issue. See [SECURITY.md](./SECURITY.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 AgentBox contributors
+Copyright (c) 2026 Marco D'Alia
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ pnpm --filter @madarco/agentbox-provider-sdk pack:test
 
 Full guide: [Build a provider](https://agent-box.sh/docs/build-a-provider) (and the authoring reference [`docs/provider-plugins.md`](./docs/provider-plugins.md)). Reference packages: [`examples/agentbox-provider-sample`](./examples/agentbox-provider-sample) (stub) and [`examples/agentbox-provider-example`](./examples/agentbox-provider-example) (a real, Vercel-backed provider).
 
+# Contributing
+
+Bug reports, docs fixes, and provider work are welcome — see [CONTRIBUTING.md](./CONTRIBUTING.md). First-time contributors sign a one-line [CLA](./.github/CLA.md) on their first pull request. Security issues go through [SECURITY.md](./SECURITY.md), not a public issue.
+
 # Author
 
 [Marco D'Alia](https://www.madarco.net) - [@madarco](https://x.com/madarco) - [Linkedin](https://www.linkedin.com/in/marcodalia/)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported versions
+
+AgentBox is pre-1.0 and moves fast. Only the latest published release of
+[`@madarco/agentbox`](https://www.npmjs.com/package/@madarco/agentbox) receives security fixes.
+Please upgrade before reporting.
+
+## Reporting a vulnerability
+
+**Do not open a public issue.**
+
+Report privately through GitHub Security Advisories:
+[Report a vulnerability](https://github.com/madarco/agentbox/security/advisories/new).
+
+Please include what an attacker can do, the steps to reproduce it, the AgentBox version, and the
+provider you were running (`docker`, `daytona`, `hetzner`, `vercel`, `e2b`, ...).
+
+You can expect an initial response within a few days. Once a fix ships, you'll be credited in the
+advisory unless you'd rather not be.
+
+## Scope notes
+
+AgentBox runs coding agents inside sandboxes so that they cannot touch the host. Things that are
+in scope, roughly:
+
+- A box escaping its isolation and reaching host files, credentials, or processes it should not.
+- Host credentials (SSH keys, git tokens, cloud API keys) leaking into a box or into a cloud
+  provider when they should have stayed on the host.
+- The host relay or the Control Hub performing a host action without the approval gate that is
+  supposed to guard it, or accepting a request without a valid per-box token.
+- Anything that lets one box read or control another box.
+
+Out of scope: what an agent does with the access you deliberately gave it inside its own box, and
+vulnerabilities in the upstream cloud providers themselves (report those to the provider).

--- a/packages/provider-sdk/LICENSE
+++ b/packages/provider-sdk/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 AgentBox contributors
+Copyright (c) 2026 Marco D'Alia
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The repo had no contributor process at all: no CLA or DCO, no CONTRIBUTING, no PR template, no branch protection (CI ran on PRs but nothing blocked a merge), and `LICENSE` named the copyright holder as "AgentBox contributors" — not a party that can hold or grant rights.

- `.github/CLA.md` + `.github/workflows/cla.yml` — CLA gate via `contributor-assistant/github-action`. No third-party service, no OAuth app: signatures are committed by the bot to a `cla-signatures` branch. Contributors keep their copyright; the grant is a license, not an assignment. `madarco` and bots are allowlisted.
- `CONTRIBUTING.md`, `SECURITY.md` (private reporting via GitHub Security Advisories), `.github/PULL_REQUEST_TEMPLATE.md`, `.github/CODEOWNERS`.
- `LICENSE` (+ the SDK's copy): copyright holder is now Marco D'Alia.
- `.mailmap` — folds the in-box `smoke test <smoke@agentbox.test>` identity (136 commits) and the older name/email variants into one author, so the authorship record is accurate.

Branch protection on `main` (required checks `ci` + `CLA`, admin bypass on) goes in once this lands and the CLA workflow has reported once.

https://claude.ai/code/session_01QnaMFuHVZUdTq5VzxiSg2L

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, GitHub automation, and license attribution only; no runtime or application code changes.
> 
> **Overview**
> Introduces a full **open-source contributor workflow** so merges can be gated on legal and process checks, not only CI.
> 
> Adds **`.github/CLA.md`** and a **`CLA` GitHub Action** (`contributor-assistant/github-action`) that requires a one-line PR comment to sign; signatures are stored on a dedicated **`cla-signatures`** branch (not `main`), with **`madarco`** and bots allowlisted. **`CONTRIBUTING.md`**, **`SECURITY.md`** (private advisories + scope), a **PR template** (test checklist + CLA link), and **`CODEOWNERS`** (`* @madarco`) document how to contribute and report issues.
> 
> **License** text in the root and **`packages/provider-sdk/LICENSE`** now names **Marco D'Alia** as copyright holder instead of “AgentBox contributors”. **`.mailmap`** normalizes alternate author identities (including in-box smoke-test commits). **README** links to the new contributing, CLA, and security docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a1a3a8fc20ebd879b55658d92c371f0d0440d7d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->