### PR TITLE
test: verify the CLA gate (throwaway)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @madarco
+


### PR DESCRIPTION
Throwaway PR to verify the CLA gate blocks an unsigned contributor. Will be closed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Whitespace-only edit to CODEOWNERS with no change to review ownership or application behavior.
> 
> **Overview**
> Adds a single trailing blank line to `.github/CODEOWNERS`. Ownership rules are unchanged (`* @madarco`).
> 
> This is a **throwaway PR** to exercise the CLA gate for unsigned contributors, not a product or workflow change beyond that test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10ee778f41d8a26c717947cb28f5042953ca264f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->