### PR TITLE
feat(cli): minimal default --help, full list behind `agentbox help --all`

### DIFF
--- a/apps/cli/src/help.ts
+++ b/apps/cli/src/help.ts
@@ -259,6 +259,9 @@ const COMPACT_EXAMPLE = [
   '  agentbox git push 1 --host-only  # move back the branch to your pc',
   '  agentbox git pr create 1 -f      # create a PR from the box',
   '  agentbox destroy                 # remove the box',
+  '',
+  '  # Or ask your host agent (via the /agentbox-info skill) to spin up',
+  '  # boxes for subtasks and orchestrate them for you',
 ];
 
 // Rendered as a last pseudo-group inside the Commands block (same indentation

--- a/apps/cli/src/help.ts
+++ b/apps/cli/src/help.ts
@@ -17,8 +17,8 @@ export const HELP_GROUPS: HelpGroup[] = [
     title: 'Access',
     commands: ['dashboard', 'attach', 'url', 'screen', 'code', 'shell', 'open', 'logs', 'drive'],
   },
-  { title: 'Inspect', commands: ['list', 'status', 'top', 'agent'] },
-  { title: 'Lifecycle', commands: ['start', 'stop', 'destroy', 'pause', 'unpause'] },
+  { title: 'Inspect', commands: ['list', 'status', 'services', 'top', 'agent'] },
+  { title: 'Lifecycle', commands: ['start', 'stop', 'destroy', 'pause', 'unpause', 'recover'] },
   { title: 'Sync & state', commands: ['download', 'cp', 'checkpoint', 'queue'] },
   {
     title: 'Advanced',
@@ -29,15 +29,20 @@ export const HELP_GROUPS: HelpGroup[] = [
       'doctor',
       'self-update',
       'install',
+      'plugin',
       'app',
       'config',
       'git',
+      'inbound',
+      'connect',
       'relay',
+      'hub',
       'docker',
       'daytona',
       'hetzner',
       'vercel',
       'e2b',
+      'digitalocean',
     ],
   },
 ];
@@ -91,5 +96,100 @@ export function buildGroupedHelp(program: Command): string {
     }
   }
   lines.push('', 'Run `agentbox <command> --help` for command-specific options.');
+  return lines.join('\n');
+}
+
+// Compact view rendered by the default `agentbox --help`: only the core
+// start → attach → git flow → destroy workflow, with related commands
+// aggregated onto one line. Everything else lives in `agentbox help --all`
+// (which renders HELP_GROUPS above). Aggregated rows need an explicit
+// description since no single command's live description fits; single-command
+// rows may override an overly long live description.
+export interface CompactRow {
+  commands: string[];
+  /** Left column; defaults to the names joined with `|` (single command: name|aliases). */
+  term?: string;
+  /** Required when commands.length > 1; single-command rows default to the live description. */
+  description?: string;
+}
+
+export interface CompactGroup {
+  title: string;
+  rows: CompactRow[];
+}
+
+export const COMPACT_HELP: CompactGroup[] = [
+  {
+    title: 'Run an agent',
+    rows: [
+      {
+        commands: ['claude', 'codex', 'opencode'],
+        description: 'Start the agent in a new isolated box',
+      },
+    ],
+  },
+  {
+    title: 'Work with boxes',
+    rows: [
+      { commands: ['attach'], description: "Re-attach to a box's agent session" },
+      { commands: ['list'], description: 'List agent boxes (-g for all projects)' },
+      {
+        commands: ['url', 'screen', 'open', 'code'],
+        description: "Open a box's web app, VNC, files, or editor",
+      },
+      { commands: ['destroy'], description: 'Destroy a box' },
+    ],
+  },
+  {
+    title: 'Git',
+    rows: [
+      {
+        commands: ['git'],
+        term: 'git push|pull|pr',
+        description: 'Push box commits to the host, pull host changes into the box, open PRs',
+      },
+    ],
+  },
+];
+
+const COMPACT_EXAMPLE = [
+  'Example:',
+  '  agentbox claude        # start Claude Code in a new box',
+  '  agentbox attach        # re-attach to its session',
+  '  agentbox git push      # push the box\'s commits to your host repo',
+  '  agentbox destroy       # remove the box',
+];
+
+const COMPACT_FOOTER = [
+  'Run `agentbox <command> --help` for command options.',
+  'More in `agentbox help --all`: claude|codex|opencode-specific commands, drive|queue,',
+  'connect|download|services|inbound, lifecycle (pause|stop|checkpoint), providers, config, …',
+];
+
+export function buildCompactHelp(program: Command): string {
+  const byName = new Map(program.commands.map((c) => [c.name(), c] as const));
+
+  const rowTerm = (row: CompactRow): string => {
+    if (row.term) return row.term;
+    if (row.commands.length === 1) {
+      const cmd = byName.get(row.commands[0]!);
+      if (cmd) return term(cmd);
+    }
+    return row.commands.join('|');
+  };
+
+  const allTerms = COMPACT_HELP.flatMap((g) => g.rows.map(rowTerm));
+  const pad = Math.max(0, ...allTerms.map((t) => t.length)) + 3;
+
+  const lines: string[] = ['Commands:'];
+  for (const g of COMPACT_HELP) {
+    lines.push('', `  ${g.title}`);
+    for (const row of g.rows) {
+      const cmd = byName.get(row.commands[0]!);
+      const description = row.description ?? cmd?.description() ?? '';
+      lines.push(`    ${rowTerm(row).padEnd(pad)}${description}`);
+    }
+  }
+  lines.push('', ...COMPACT_EXAMPLE, '', ...COMPACT_FOOTER);
   return lines.join('\n');
 }

--- a/apps/cli/src/help.ts
+++ b/apps/cli/src/help.ts
@@ -105,6 +105,13 @@ export const SHORT_DESCRIPTIONS: Record<string, string> = {
   hub: 'Run the AgentBox hub — relay + Web UI on http://127.0.0.1:8787',
 };
 
+// Left-column overrides for the grouped `agentbox help` list, keyed by the
+// HELP_GROUPS entry — for rows that read better as a full invocation than as
+// the bare (sub)command name.
+const TERM_OVERRIDES: Record<string, string> = {
+  'git pr': 'pr create -f',
+};
+
 function term(cmd: Command): string {
   const aliases = cmd.aliases();
   return aliases.length ? `${cmd.name()}|${aliases.join('|')}` : cmd.name();
@@ -145,11 +152,13 @@ export function buildGroupedHelp(program: Command): string {
     return cmd ? { cmd, depth: parts.length - 1 } : undefined;
   };
 
+  const rowTerm = (name: string, cmd: Command): string => TERM_OVERRIDES[name] ?? term(cmd);
+
   const termWidths: number[] = [];
   for (const g of groups) {
     for (const name of g.commands) {
       const row = resolve(name);
-      if (row) termWidths.push(term(row.cmd).length + row.depth * 2);
+      if (row) termWidths.push(rowTerm(name, row.cmd).length + row.depth * 2);
     }
   }
   const pad = Math.max(0, ...termWidths) + 2;
@@ -165,7 +174,7 @@ export function buildGroupedHelp(program: Command): string {
       const description = SHORT_DESCRIPTIONS[name] ?? row.cmd.description();
       const indent = '    ' + '  '.repeat(row.depth);
       lines.push(
-        `${indent}${term(row.cmd).padEnd(pad - row.depth * 2)}${clip(description, descBudget)}`,
+        `${indent}${rowTerm(name, row.cmd).padEnd(pad - row.depth * 2)}${clip(description, descBudget)}`,
       );
     }
   }
@@ -240,7 +249,10 @@ export const COMPACT_HELP: CompactGroup[] = [
 const COMPACT_EXAMPLE = [
   'Example:',
   '  agentbox claude                  # launch Claude, one box per task/branch',
-  '  agentbox attach 1                # re-attach to the <N> box',
+  '  agentbox hetzner|e2b|… claude    # launch Claude on a specific provider',
+  '  ! agentbox fork hetzner|e2b|…    # from Claude chat: teleport the current session',
+  '',
+  '  agentbox attach 1                # detach with Ctrl+a d, then re-attach',
   '',
   '  # Then ask your agent to push/pr or do it from your pc:',
   '  agentbox git push 1              # push to remote',

--- a/apps/cli/src/help.ts
+++ b/apps/cli/src/help.ts
@@ -19,33 +19,82 @@ export const HELP_GROUPS: HelpGroup[] = [
   },
   { title: 'Inspect', commands: ['list', 'status', 'services', 'top', 'agent'] },
   { title: 'Lifecycle', commands: ['start', 'stop', 'destroy', 'pause', 'unpause', 'recover'] },
-  { title: 'Sync & state', commands: ['download', 'cp', 'checkpoint', 'queue'] },
+  { title: 'Git & sync', commands: ['git', 'download', 'cp', 'checkpoint', 'queue'] },
   {
-    title: 'Advanced',
+    title: 'Providers',
     commands: [
       'prepare',
-      'wait',
-      'prune',
-      'doctor',
-      'self-update',
-      'install',
-      'plugin',
-      'app',
-      'config',
-      'git',
-      'inbound',
-      'connect',
-      'relay',
-      'hub',
       'docker',
       'daytona',
       'hetzner',
       'vercel',
       'e2b',
       'digitalocean',
+      'plugin',
+      'inbound',
+      'connect',
+    ],
+  },
+  {
+    title: 'Advanced',
+    commands: [
+      'wait',
+      'prune',
+      'doctor',
+      'self-update',
+      'install',
+      'app',
+      'config',
+      'relay',
+      'hub',
     ],
   },
 ];
+
+// Short one-line descriptions for the grouped `agentbox help` list. The
+// commands' own (often multi-sentence) descriptions stay untouched — they
+// still render in full on `agentbox <command> --help`. Only commands whose
+// live description would wrap need an entry; buildGroupedHelp falls back to
+// the live description and clips as a safety net either way.
+export const SHORT_DESCRIPTIONS: Record<string, string> = {
+  create: 'Create and start a new agent box (no agent launched)',
+  claude: 'Create a box and launch Claude Code (detachable tmux session)',
+  codex: 'Create a box and launch OpenAI Codex (detachable tmux session)',
+  opencode: 'Create a box and launch OpenCode (detachable tmux session)',
+  fork: 'Fork the current host agent session into a new box and resume it there',
+  attach: 'Attach to the running agent tmux session in a box',
+  url: "Open a box's web app URL in the browser",
+  shell: 'Open an interactive shell in a box (detachable tmux session)',
+  open: 'Mount a box /workspace in Finder (sshfs), or open it in a host app',
+  drive: 'Drive a box tmux session: snapshot screen, send keys, wait for output',
+  top: 'Live resource monitor (cpu/mem/disk) for a box, project, or all boxes',
+  agent: "Query and wait on the in-box coding agent's state",
+  start: 'Start a stopped box',
+  stop: 'Stop a box (disk preserved)',
+  destroy: 'Destroy a box and discard its writable layer',
+  pause: 'Pause a box (docker cgroup freeze / cloud archive)',
+  unpause: 'Resume a paused box',
+  recover: 'Reconnect to an already-running box without power-cycling it',
+  download: "Download a box's /workspace back to the host (gitignore-aware)",
+  cp: 'Copy files between host and box (like `docker cp`)',
+  checkpoint: 'List and manage project checkpoints (warm state new boxes start from)',
+  prepare: "Build provider base images / snapshots, or show what's prepared",
+  docker: 'Local Docker provider (the default) — sugar for `--provider docker`',
+  daytona: 'Daytona cloud provider — credentials + `--provider daytona` sugar',
+  hetzner: 'Hetzner Cloud VPS provider — credentials, firewall + provider sugar',
+  vercel: 'Vercel Sandbox provider — credentials + `--provider vercel` sugar',
+  e2b: 'E2B sandbox provider — credentials + `--provider e2b` sugar',
+  digitalocean: 'DigitalOcean Droplet provider — credentials, firewall + provider sugar',
+  inbound: "Set a VPS box's inbound-access policy (per-box firewall)",
+  connect: "Print a VPS box's SSH details to drive it from another device",
+  prune: 'Clean up orphan state records (--all: orphan docker resources)',
+  doctor: 'Diagnose system compatibility and provider readiness',
+  'self-update': 'Update agentbox, host skills, box image, relay/hub, and the tray app',
+  install: 'Interactive setup wizard: pick a provider, log in, prepare its image',
+  app: 'Control the AgentBox menu-bar app',
+  config: 'Read / write layered config (global, project, workspace)',
+  hub: 'Run the AgentBox hub — relay + Web UI on http://127.0.0.1:8787',
+};
 
 function term(cmd: Command): string {
   const aliases = cmd.aliases();
@@ -84,6 +133,7 @@ export function buildGroupedHelp(program: Command): string {
     }
   }
   const pad = Math.max(0, ...terms.map((t) => t.length)) + 2;
+  const descBudget = MAX_HELP_LINE - 4 - pad;
 
   const lines: string[] = ['Commands:'];
   for (const g of groups) {
@@ -92,11 +142,23 @@ export function buildGroupedHelp(program: Command): string {
     for (const name of g.commands) {
       const cmd = byName.get(name);
       if (!cmd) continue;
-      lines.push(`    ${term(cmd).padEnd(pad)}${cmd.description()}`);
+      const description = SHORT_DESCRIPTIONS[name] ?? cmd.description();
+      lines.push(`    ${term(cmd).padEnd(pad)}${clip(description, descBudget)}`);
     }
   }
   lines.push('', 'Run `agentbox <command> --help` for command-specific options.');
   return lines.join('\n');
+}
+
+// Hard ceiling for a rendered help line — one row per command, no wrapping
+// even on modest terminals. Descriptions past the budget clip at a word
+// boundary; the curated SHORT_DESCRIPTIONS above should make this a no-op.
+const MAX_HELP_LINE = 100;
+
+function clip(text: string, budget: number): string {
+  if (text.length <= budget) return text;
+  const cut = text.lastIndexOf(' ', budget - 1);
+  return `${text.slice(0, cut > budget / 2 ? cut : budget - 1).trimEnd()}…`;
 }
 
 // Compact view rendered by the default `agentbox --help`: only the core
@@ -146,7 +208,7 @@ export const COMPACT_HELP: CompactGroup[] = [
       {
         commands: ['git'],
         term: 'git push|pull|pr',
-        description: 'Push box commits to the host, pull host changes into the box, open PRs',
+        description: 'Push box commits to the remote, pull host changes into the box, open PRs',
       },
     ],
   },
@@ -154,16 +216,20 @@ export const COMPACT_HELP: CompactGroup[] = [
 
 const COMPACT_EXAMPLE = [
   'Example:',
-  '  agentbox claude        # start Claude Code in a new box',
-  '  agentbox attach        # re-attach to its session',
-  '  agentbox git push      # push the box\'s commits to your host repo',
-  '  agentbox destroy       # remove the box',
+  '  agentbox claude                  # launch Claude, one box per task/branch',
+  '  agentbox attach 1                # re-attach to the <N> box',
+  '',
+  '  # Then ask your agent to push/pr or do it from your pc:',
+  '  agentbox git push 1              # push to remote',
+  '  agentbox git push 1 --host-only  # move back the branch to your pc',
+  '  agentbox git pr create 1 -f      # create a PR from the box',
+  '  agentbox destroy                 # remove the box',
 ];
 
 const COMPACT_FOOTER = [
   'Run `agentbox <command> --help` for command options.',
-  'More in `agentbox help`: claude|codex|opencode-specific commands, drive|queue,',
-  'connect|download|services|inbound, lifecycle (pause|stop|checkpoint), providers, config, …',
+  'More in `agentbox help`: dashboard, pause|stop|checkpoint, claude|codex|opencode, ',
+  'connect|download|services|inbound, drive|queue, config, …',
 ];
 
 export function buildCompactHelp(program: Command): string {

--- a/apps/cli/src/help.ts
+++ b/apps/cli/src/help.ts
@@ -226,11 +226,16 @@ const COMPACT_EXAMPLE = [
   '  agentbox destroy                 # remove the box',
 ];
 
-const COMPACT_FOOTER = [
-  'Run `agentbox <command> --help` for command options.',
-  'More in `agentbox help`: dashboard, pause|stop|checkpoint, claude|codex|opencode, ',
-  'connect|download|services|inbound, drive|queue, config, …',
+// Rendered as a last pseudo-group inside the Commands block (same indentation
+// as the real groups) so the pointer to the full list doesn't get lost in the
+// footer text.
+const COMPACT_MORE = [
+  '  More in `agentbox help`',
+  '    dashboard, pause|stop|checkpoint, claude|codex|opencode,',
+  '    connect|download|services|inbound, drive|queue, config, …',
 ];
+
+const COMPACT_FOOTER = ['Run `agentbox <command> --help` for command options.'];
 
 export function buildCompactHelp(program: Command): string {
   const byName = new Map(program.commands.map((c) => [c.name(), c] as const));
@@ -256,6 +261,6 @@ export function buildCompactHelp(program: Command): string {
       lines.push(`    ${rowTerm(row).padEnd(pad)}${description}`);
     }
   }
-  lines.push('', ...COMPACT_EXAMPLE, '', ...COMPACT_FOOTER);
+  lines.push('', ...COMPACT_MORE, '', ...COMPACT_EXAMPLE, '', ...COMPACT_FOOTER);
   return lines.join('\n');
 }

--- a/apps/cli/src/help.ts
+++ b/apps/cli/src/help.ts
@@ -101,7 +101,7 @@ export function buildGroupedHelp(program: Command): string {
 
 // Compact view rendered by the default `agentbox --help`: only the core
 // start → attach → git flow → destroy workflow, with related commands
-// aggregated onto one line. Everything else lives in `agentbox help --all`
+// aggregated onto one line. Everything else lives in `agentbox help`
 // (which renders HELP_GROUPS above). Aggregated rows need an explicit
 // description since no single command's live description fits; single-command
 // rows may override an overly long live description.
@@ -162,7 +162,7 @@ const COMPACT_EXAMPLE = [
 
 const COMPACT_FOOTER = [
   'Run `agentbox <command> --help` for command options.',
-  'More in `agentbox help --all`: claude|codex|opencode-specific commands, drive|queue,',
+  'More in `agentbox help`: claude|codex|opencode-specific commands, drive|queue,',
   'connect|download|services|inbound, lifecycle (pause|stop|checkpoint), providers, config, …',
 ];
 

--- a/apps/cli/src/help.ts
+++ b/apps/cli/src/help.ts
@@ -11,15 +11,23 @@ export interface HelpGroup {
   commands: string[];
 }
 
+// A `parent sub` entry (e.g. 'git push') renders that subcommand as a nested
+// row under its parent — only the parent name must exist at the top level.
 export const HELP_GROUPS: HelpGroup[] = [
-  { title: 'Create & run', commands: ['create', 'claude', 'fork', 'codex', 'opencode'] },
+  {
+    title: 'Create & run',
+    commands: ['create', 'attach', 'fork', 'claude', 'codex', 'opencode'],
+  },
   {
     title: 'Access',
-    commands: ['dashboard', 'attach', 'url', 'screen', 'code', 'shell', 'open', 'logs', 'drive'],
+    commands: ['dashboard', 'url', 'screen', 'code', 'shell', 'open', 'logs', 'drive'],
   },
   { title: 'Inspect', commands: ['list', 'status', 'services', 'top', 'agent'] },
   { title: 'Lifecycle', commands: ['start', 'stop', 'destroy', 'pause', 'unpause', 'recover'] },
-  { title: 'Git & sync', commands: ['git', 'download', 'cp', 'checkpoint', 'queue'] },
+  {
+    title: 'Git & sync',
+    commands: ['git', 'git push', 'git pull', 'git pr', 'download', 'cp', 'checkpoint', 'queue'],
+  },
   {
     title: 'Providers',
     commands: [
@@ -78,6 +86,7 @@ export const SHORT_DESCRIPTIONS: Record<string, string> = {
   download: "Download a box's /workspace back to the host (gitignore-aware)",
   cp: 'Copy files between host and box (like `docker cp`)',
   checkpoint: 'List and manage project checkpoints (warm state new boxes start from)',
+  'git pull': 'Fetch via the relay then merge in /workspace (or switch branch first)',
   prepare: "Build provider base images / snapshots, or show what's prepared",
   docker: 'Local Docker provider (the default) — sugar for `--provider docker`',
   daytona: 'Daytona cloud provider — credentials + `--provider daytona` sugar',
@@ -119,20 +128,31 @@ function isHiddenCommand(cmd: Command): boolean {
 export function buildGroupedHelp(program: Command): string {
   const visible = program.commands.filter((c) => !isHiddenCommand(c));
   const byName = new Map(visible.map((c) => [c.name(), c] as const));
-  const grouped = new Set(HELP_GROUPS.flatMap((g) => g.commands));
+  const grouped = new Set(HELP_GROUPS.flatMap((g) => g.commands.map((n) => n.split(' ')[0]!)));
   const orphans = visible.map((c) => c.name()).filter((n) => !grouped.has(n));
 
   const groups: HelpGroup[] = [...HELP_GROUPS];
   if (orphans.length) groups.push({ title: 'Other', commands: orphans });
 
-  const terms: string[] = [];
+  // 'parent sub' entries resolve to the nested Command; depth drives the
+  // extra indent that renders them as a tree under their parent row.
+  const resolve = (name: string): { cmd: Command; depth: number } | undefined => {
+    const parts = name.split(' ');
+    let cmd = byName.get(parts[0]!);
+    for (const part of parts.slice(1)) {
+      cmd = cmd?.commands.find((c) => c.name() === part || c.aliases().includes(part));
+    }
+    return cmd ? { cmd, depth: parts.length - 1 } : undefined;
+  };
+
+  const termWidths: number[] = [];
   for (const g of groups) {
     for (const name of g.commands) {
-      const cmd = byName.get(name);
-      if (cmd) terms.push(term(cmd));
+      const row = resolve(name);
+      if (row) termWidths.push(term(row.cmd).length + row.depth * 2);
     }
   }
-  const pad = Math.max(0, ...terms.map((t) => t.length)) + 2;
+  const pad = Math.max(0, ...termWidths) + 2;
   const descBudget = MAX_HELP_LINE - 4 - pad;
 
   const lines: string[] = ['Commands:'];
@@ -140,10 +160,13 @@ export function buildGroupedHelp(program: Command): string {
     const title = g.hint ? `${g.title}  (${g.hint})` : g.title;
     lines.push('', `  ${title}`);
     for (const name of g.commands) {
-      const cmd = byName.get(name);
-      if (!cmd) continue;
-      const description = SHORT_DESCRIPTIONS[name] ?? cmd.description();
-      lines.push(`    ${term(cmd).padEnd(pad)}${clip(description, descBudget)}`);
+      const row = resolve(name);
+      if (!row) continue;
+      const description = SHORT_DESCRIPTIONS[name] ?? row.cmd.description();
+      const indent = '    ' + '  '.repeat(row.depth);
+      lines.push(
+        `${indent}${term(row.cmd).padEnd(pad - row.depth * 2)}${clip(description, descBudget)}`,
+      );
     }
   }
   lines.push('', 'Run `agentbox <command> --help` for command-specific options.');

--- a/apps/cli/src/help.ts
+++ b/apps/cli/src/help.ts
@@ -249,8 +249,8 @@ export const COMPACT_HELP: CompactGroup[] = [
 const COMPACT_EXAMPLE = [
   'Example:',
   '  agentbox claude                  # launch Claude, one box per task/branch',
-  '  agentbox hetzner|e2b|… claude    # launch Claude on a specific provider',
-  '  ! agentbox fork hetzner|e2b|…    # from Claude chat: teleport the current session',
+  '  agentbox hetzner|e2b|… codex     # launch with other agents or providers',
+  '  ! agentbox fork hetzner|e2b|…    # teleport the current session from the chat',
   '',
   '  agentbox attach 1                # detach with Ctrl+a d, then re-attach',
   '',

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -35,7 +35,7 @@ import { fileURLToPath as _fileURLToPath } from 'node:url';
 
 import { Command } from 'commander';
 import { applyEngineOverrideAtStartup } from './engine-override.js';
-import { buildGroupedHelp } from './help.js';
+import { buildCompactHelp, buildGroupedHelp } from './help.js';
 import { agentCommand } from './commands/agent.js';
 import { appCommand } from './commands/app.js';
 import { attachCommand } from './commands/attach.js';
@@ -188,7 +188,36 @@ program.addCommand(pluginCommand);
 program.addCommand(doctorCommand);
 
 program.configureHelp({ visibleCommands: () => [] });
-program.addHelpText('after', () => '\n' + buildGroupedHelp(program));
+program.addHelpText('after', () => '\n' + buildCompactHelp(program));
+
+// The default `--help` shows only the core workflow (buildCompactHelp);
+// the full grouped list moved behind `agentbox help --all`. commander's
+// built-in help command can't take extra flags, so replace it with our own
+// (hidden — the compact footer references it, no need to list it too).
+program.helpCommand(false);
+program.addCommand(
+  new Command('help')
+    .description('Show help; --all lists every command, grouped')
+    .argument('[command]', 'command to show help for')
+    .option('-a, --all', 'list every command, grouped')
+    .action((name: string | undefined, opts: { all?: boolean }) => {
+      if (name) {
+        const sub = program.commands.find(
+          (c) => c.name() === name || c.aliases().includes(name),
+        );
+        if (!sub) program.error(`unknown command '${name}'`);
+        sub!.help();
+      }
+      if (opts.all) {
+        // helpInformation() yields the usage/options header without the
+        // addHelpText blocks, so the compact view isn't duplicated here.
+        process.stdout.write(program.helpInformation() + '\n' + buildGroupedHelp(program) + '\n');
+        return;
+      }
+      program.help();
+    }),
+  { hidden: true },
+);
 
 await applyEngineOverrideAtStartup();
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -191,16 +191,15 @@ program.configureHelp({ visibleCommands: () => [] });
 program.addHelpText('after', () => '\n' + buildCompactHelp(program));
 
 // The default `--help` shows only the core workflow (buildCompactHelp);
-// the full grouped list moved behind `agentbox help --all`. commander's
-// built-in help command can't take extra flags, so replace it with our own
-// (hidden — the compact footer references it, no need to list it too).
+// the full grouped list is `agentbox help`. commander's built-in help command
+// would render the compact view, so replace it with our own (hidden — the
+// compact footer references it, no need to list it too).
 program.helpCommand(false);
 program.addCommand(
   new Command('help')
-    .description('Show help; --all lists every command, grouped')
+    .description('List every command, grouped; `help <command>` for one command')
     .argument('[command]', 'command to show help for')
-    .option('-a, --all', 'list every command, grouped')
-    .action((name: string | undefined, opts: { all?: boolean }) => {
+    .action((name: string | undefined) => {
       if (name) {
         const sub = program.commands.find(
           (c) => c.name() === name || c.aliases().includes(name),
@@ -208,13 +207,9 @@ program.addCommand(
         if (!sub) program.error(`unknown command '${name}'`);
         sub!.help();
       }
-      if (opts.all) {
-        // helpInformation() yields the usage/options header without the
-        // addHelpText blocks, so the compact view isn't duplicated here.
-        process.stdout.write(program.helpInformation() + '\n' + buildGroupedHelp(program) + '\n');
-        return;
-      }
-      program.help();
+      // helpInformation() yields the usage/options header without the
+      // addHelpText blocks, so the compact view isn't duplicated here.
+      process.stdout.write(program.helpInformation() + '\n' + buildGroupedHelp(program) + '\n');
     }),
   { hidden: true },
 );

--- a/apps/cli/test/help.test.ts
+++ b/apps/cli/test/help.test.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { describe, expect, it } from 'vitest';
-import { HELP_GROUPS, buildGroupedHelp } from '../src/help.js';
+import { COMPACT_HELP, HELP_GROUPS, buildCompactHelp, buildGroupedHelp } from '../src/help.js';
 import { agentCommand } from '../src/commands/agent.js';
 import { appCommand } from '../src/commands/app.js';
 import { attachCommand } from '../src/commands/attach.js';
@@ -18,12 +18,16 @@ import { dockerCommand } from '../src/commands/docker.js';
 import { hetznerCommand } from '@agentbox/sandbox-hetzner/cli';
 import { vercelCommand } from '@agentbox/sandbox-vercel/cli';
 import { e2bCommand } from '@agentbox/sandbox-e2b/cli';
+import { digitaloceanCommand } from '@agentbox/sandbox-digitalocean/cli';
+import { connectCommand } from '../src/commands/connect.js';
 import { destroyCommand } from '../src/commands/destroy.js';
 import { doctorCommand } from '../src/commands/doctor.js';
 import { downloadCommand } from '../src/commands/download.js';
 import { driveCommand } from '../src/commands/drive.js';
 import { forkCommand } from '../src/commands/fork.js';
 import { gitCommand } from '../src/commands/git.js';
+import { hubCommand } from '../src/commands/hub.js';
+import { inboundCommand } from '../src/commands/inbound.js';
 import { installCommand } from '../src/commands/install.js';
 import { listCommand } from '../src/commands/list.js';
 import { logsCommand } from '../src/commands/logs.js';
@@ -31,11 +35,14 @@ import { openCommand } from '../src/commands/open.js';
 import { urlCommand } from '../src/commands/url.js';
 import { screenCommand } from '../src/commands/screen.js';
 import { pauseCommand } from '../src/commands/pause.js';
+import { pluginCommand } from '../src/commands/plugin.js';
 import { prepareCommand } from '../src/commands/prepare.js';
 import { pruneCommand } from '../src/commands/prune.js';
 import { queueCommand } from '../src/commands/queue.js';
+import { recoverCommand } from '../src/commands/recover.js';
 import { relayCommand } from '../src/commands/relay.js';
 import { runQueuedJobCommand } from '../src/commands/_run-queued-job.js';
+import { servicesCommand } from '../src/commands/services.js';
 import { shellCommand } from '../src/commands/shell.js';
 import { startCommand } from '../src/commands/start.js';
 import { statusCommand } from '../src/commands/status.js';
@@ -66,6 +73,7 @@ function buildProgram(): Command {
     downloadCommand,
     cpCommand,
     statusCommand,
+    servicesCommand,
     topCommand,
     dashboardCommand,
     driveCommand,
@@ -74,8 +82,11 @@ function buildProgram(): Command {
     logsCommand,
     pauseCommand,
     unpauseCommand,
+    inboundCommand,
+    connectCommand,
     stopCommand,
     startCommand,
+    recoverCommand,
     destroyCommand,
     prepareCommand,
     pruneCommand,
@@ -83,16 +94,19 @@ function buildProgram(): Command {
     configCommand,
     queueCommand,
     relayCommand,
+    hubCommand,
     daytonaCommand,
     hetznerCommand,
     dockerCommand,
     vercelCommand,
     e2bCommand,
+    digitaloceanCommand,
     gitCommand,
     doctorCommand,
     updateCommand,
     installCommand,
     appCommand,
+    pluginCommand,
   ]) {
     program.addCommand(cmd);
   }
@@ -141,5 +155,52 @@ describe('grouped --help', () => {
     expect(help).toMatch(/^\s+screen\s/m);
     // `path` was folded into `open --path`; not a standalone command.
     expect(help).not.toMatch(/^\s+path\s/m);
+  });
+});
+
+describe('compact --help (default view)', () => {
+  it('every compact row command resolves to a registered command', () => {
+    const registered = new Set(buildProgram().commands.map((c) => c.name()));
+    for (const g of COMPACT_HELP) {
+      for (const row of g.rows) {
+        for (const name of row.commands) {
+          expect(registered.has(name), `${name} in compact group "${g.title}"`).toBe(true);
+        }
+      }
+    }
+  });
+
+  it('aggregated rows carry an explicit description', () => {
+    for (const g of COMPACT_HELP) {
+      for (const row of g.rows) {
+        if (row.commands.length > 1) {
+          expect(row.description, `aggregated row ${row.commands.join('|')}`).toBeTruthy();
+        }
+      }
+    }
+  });
+
+  it('shows the core workflow, an example, and the help --all recap', () => {
+    const help = buildCompactHelp(buildProgram());
+    expect(help).toContain('claude|codex|opencode');
+    expect(help).toContain('url|screen|open|code');
+    expect(help).toContain('git push|pull|pr');
+    expect(help).toMatch(/^\s+list\|ls\s/m);
+    expect(help).toMatch(/^\s+destroy\|rm\s/m);
+    expect(help).toContain('Example:');
+    expect(help).toContain('agentbox git push');
+    expect(help).toContain('Run `agentbox <command> --help`');
+    expect(help).toContain('`agentbox help --all`');
+    expect(help).toContain('drive|queue');
+    expect(help).toContain('connect|download|services|inbound');
+  });
+
+  it('hides advanced commands from the compact view', () => {
+    const help = buildCompactHelp(buildProgram());
+    for (const name of ['drive', 'queue', 'pause', 'prepare', 'daytona', 'checkpoint']) {
+      expect(help, `${name} must not be a compact row`).not.toMatch(
+        new RegExp(String.raw`^\s+${name}\s`, 'm'),
+      );
+    }
   });
 });

--- a/apps/cli/test/help.test.ts
+++ b/apps/cli/test/help.test.ts
@@ -180,7 +180,7 @@ describe('compact --help (default view)', () => {
     }
   });
 
-  it('shows the core workflow, an example, and the help --all recap', () => {
+  it('shows the core workflow, an example, and the `agentbox help` recap', () => {
     const help = buildCompactHelp(buildProgram());
     expect(help).toContain('claude|codex|opencode');
     expect(help).toContain('url|screen|open|code');
@@ -190,7 +190,7 @@ describe('compact --help (default view)', () => {
     expect(help).toContain('Example:');
     expect(help).toContain('agentbox git push');
     expect(help).toContain('Run `agentbox <command> --help`');
-    expect(help).toContain('`agentbox help --all`');
+    expect(help).toContain('`agentbox help`');
     expect(help).toContain('drive|queue');
     expect(help).toContain('connect|download|services|inbound');
   });

--- a/apps/cli/test/help.test.ts
+++ b/apps/cli/test/help.test.ts
@@ -1,6 +1,12 @@
 import { Command } from 'commander';
 import { describe, expect, it } from 'vitest';
-import { COMPACT_HELP, HELP_GROUPS, buildCompactHelp, buildGroupedHelp } from '../src/help.js';
+import {
+  COMPACT_HELP,
+  HELP_GROUPS,
+  SHORT_DESCRIPTIONS,
+  buildCompactHelp,
+  buildGroupedHelp,
+} from '../src/help.js';
 import { agentCommand } from '../src/commands/agent.js';
 import { appCommand } from '../src/commands/app.js';
 import { attachCommand } from '../src/commands/attach.js';
@@ -148,13 +154,29 @@ describe('grouped --help', () => {
   it('renders each group title and the help footer', () => {
     const help = buildGroupedHelp(buildProgram());
     for (const g of HELP_GROUPS) expect(help).toContain(g.title);
-    expect(help).toContain('Advanced');
+    expect(help).toContain('Providers');
     expect(help).toContain('Run `agentbox <command> --help`');
     // url/screen are top-level commands listed under Access.
     expect(help).toMatch(/^\s+url\s/m);
     expect(help).toMatch(/^\s+screen\s/m);
+    // Provider commands render as rows in the Providers group.
+    expect(help).toMatch(/^\s+hetzner\s/m);
+    expect(help).toMatch(/^\s+digitalocean\s/m);
     // `path` was folded into `open --path`; not a standalone command.
     expect(help).not.toMatch(/^\s+path\s/m);
+  });
+
+  it('every SHORT_DESCRIPTIONS key resolves to a registered command', () => {
+    const registered = new Set(buildProgram().commands.map((c) => c.name()));
+    for (const name of Object.keys(SHORT_DESCRIPTIONS)) {
+      expect(registered.has(name), `${name} in SHORT_DESCRIPTIONS`).toBe(true);
+    }
+  });
+
+  it('no rendered line wraps (all lines within the width budget)', () => {
+    for (const line of buildGroupedHelp(buildProgram()).split('\n')) {
+      expect(line.length, `line too long: "${line}"`).toBeLessThanOrEqual(100);
+    }
   });
 });
 

--- a/apps/cli/test/help.test.ts
+++ b/apps/cli/test/help.test.ts
@@ -125,10 +125,16 @@ function buildProgram(): Command {
 
 describe('grouped --help', () => {
   it('every group command name resolves to a registered command', () => {
-    const registered = new Set(buildProgram().commands.map((c) => c.name()));
+    const program = buildProgram();
     for (const g of HELP_GROUPS) {
       for (const name of g.commands) {
-        expect(registered.has(name), `${name} in group "${g.title}"`).toBe(true);
+        // 'parent sub' entries resolve through the parent's subcommands.
+        const [parent, ...subs] = name.split(' ');
+        let cmd = program.commands.find((c) => c.name() === parent);
+        for (const sub of subs) {
+          cmd = cmd?.commands.find((c) => c.name() === sub || c.aliases().includes(sub));
+        }
+        expect(cmd, `${name} in group "${g.title}"`).toBeDefined();
       }
     }
   });
@@ -136,7 +142,10 @@ describe('grouped --help', () => {
   it('groups cover every registered command (no Other group / drift)', () => {
     const help = buildGroupedHelp(buildProgram());
     expect(help).not.toContain('Other');
-    const grouped = HELP_GROUPS.flatMap((g) => g.commands).sort();
+    // Nested 'parent sub' rows count as their parent for coverage.
+    const grouped = [
+      ...new Set(HELP_GROUPS.flatMap((g) => g.commands.map((n) => n.split(' ')[0]!))),
+    ].sort();
     // Hidden internal commands (e.g. `_run-queued-job`) are intentionally
     // excluded from HELP_GROUPS; mirror that filter when comparing.
     const registered = buildProgram()
@@ -162,14 +171,23 @@ describe('grouped --help', () => {
     // Provider commands render as rows in the Providers group.
     expect(help).toMatch(/^\s+hetzner\s/m);
     expect(help).toMatch(/^\s+digitalocean\s/m);
+    // git subcommands render as nested rows (extra indent) under git.
+    expect(help).toMatch(/^\s{6}push\s/m);
+    expect(help).toMatch(/^\s{6}pull\s/m);
+    expect(help).toMatch(/^\s{6}pr\s/m);
     // `path` was folded into `open --path`; not a standalone command.
     expect(help).not.toMatch(/^\s+path\s/m);
   });
 
   it('every SHORT_DESCRIPTIONS key resolves to a registered command', () => {
-    const registered = new Set(buildProgram().commands.map((c) => c.name()));
+    const program = buildProgram();
     for (const name of Object.keys(SHORT_DESCRIPTIONS)) {
-      expect(registered.has(name), `${name} in SHORT_DESCRIPTIONS`).toBe(true);
+      const [parent, ...subs] = name.split(' ');
+      let cmd = program.commands.find((c) => c.name() === parent);
+      for (const sub of subs) {
+        cmd = cmd?.commands.find((c) => c.name() === sub || c.aliases().includes(sub));
+      }
+      expect(cmd, `${name} in SHORT_DESCRIPTIONS`).toBeDefined();
     }
   });
 

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -193,7 +193,7 @@ agentbox connect 1 --add-key @phone.pub   # authorize a device's key; print the 
 
 See [Checkpoints & pausing](/docs/checkpoints-and-pausing) and the provider pages for cloud pause/stop semantics.
 
-## Sync & state
+## Git & sync
 
 ```bash
 # Pull the box's /workspace back to the host (gitignore-aware)

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -5,7 +5,7 @@ description: Every agentbox command grouped by task, with the flags you reach fo
 
 This is the command catalog. Conceptual depth lives in the linked task pages — here you get what each command does and the flags worth knowing.
 
-<Callout title="TIP">Run `agentbox --help` for the grouped command list, or `agentbox <command> --help` for every flag on a specific command. This page covers the commands you'll reach for most.</Callout>
+<Callout title="TIP">`agentbox --help` shows only the core workflow (start an agent, attach, git flow, list, destroy). Run `agentbox help --all` for the full grouped list of every command, or `agentbox <command> --help` for every flag on a specific command.</Callout>
 
 ## Two conventions that apply everywhere
 

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -5,7 +5,7 @@ description: Every agentbox command grouped by task, with the flags you reach fo
 
 This is the command catalog. Conceptual depth lives in the linked task pages — here you get what each command does and the flags worth knowing.
 
-<Callout title="TIP">`agentbox --help` shows only the core workflow (start an agent, attach, git flow, list, destroy). Run `agentbox help --all` for the full grouped list of every command, or `agentbox <command> --help` for every flag on a specific command.</Callout>
+<Callout title="TIP">`agentbox --help` shows only the core workflow (start an agent, attach, git flow, list, destroy). Run `agentbox help` for the full grouped list of every command, or `agentbox <command> --help` for every flag on a specific command.</Callout>
 
 ## Two conventions that apply everywhere
 


### PR DESCRIPTION
## What

Reorganizes the CLI help so it's no longer confusing or overwhelming.

**`agentbox --help`** (and bare `agentbox`) shows only the core workflow — start an agent, attach, list, open, destroy, git flow — with similar commands aggregated onto one line, a short example block, and a recap of what the full help adds:

```
Commands:

  Run an agent
    claude|codex|opencode   Start the agent in a new isolated box

  Work with boxes
    attach                  Re-attach to a box's agent session
    list|ls                 List agent boxes (-g for all projects)
    url|screen|open|code    Open a box's web app, VNC, files, or editor
    destroy|rm              Destroy a box

  Git
    git push|pull|pr        Push box commits to the remote, pull host changes into the box, open PRs

Example:
  agentbox claude                # launch Claude, one box per task/branch
  agentbox attach 1              # re-attach to the <N> box
  agentbox git push              # push to remote
  agentbox git push --host-only  # move back the branch to your pc
  agentbox git pr create         # create a PR from the box
  agentbox destroy               # remove the box

Also ask your agent to do these things from inside the box

Run `agentbox <command> --help` for command options.
More in `agentbox help`: dashboard, claude|codex|opencode-specific commands, drive|queue,
connect|download|services|inbound, lifecycle (pause|stop|checkpoint), providers, config, …
```

**`agentbox help`** shows the full grouped list, itself reorganized:

- New **Providers** group: `prepare`, `docker`, `daytona`, `hetzner`, `vercel`, `e2b`, `digitalocean`, `plugin`, `inbound`, `connect`.
- `git` moved from Advanced into the renamed **Git & sync** group.
- **One line per command**: curated `SHORT_DESCRIPTIONS` replace the long live descriptions in the grouped list (previously 27 lines exceeded 110 chars, worst 386 — wrapping 2-4 times even on wide terminals). Per-command `--help` still shows the full description. A word-boundary clip caps every line at 100 chars as a safety net, enforced by a test.

commander's built-in help command is replaced with a custom one; `agentbox help <command>` still delegates to that command's help.

## Also fixed

`services`, `recover`, `inbound`, `connect`, `hub`, `digitalocean`, and `plugin` were registered but missing from `HELP_GROUPS`, so the real binary rendered them in a stray "Other" group. The drift test didn't catch it because its mirror program omitted the same 7 commands — both are reconciled now, so the guard actually guards.

## Verification

- `--help`, bare `agentbox`, `help`, `help claude`, `help nope` all exercised on the built CLI (output + exit codes correct, no "Other" group, max rendered line = 100 chars, `agentbox hetzner --help` still shows the full long description).
- New tests: compact rows resolve to registered commands, aggregated rows carry descriptions, advanced commands absent from the compact view, `SHORT_DESCRIPTIONS` keys resolve, every extended-help line within the 100-char budget.
- `pnpm --filter ./apps/cli exec vitest run` (829 passed) and `pnpm typecheck` green.
- Docs: `apps/web/content/docs/cli.mdx` tip updated + "Sync & state" section renamed "Git & sync".

https://claude.ai/code/session_01QnaMFuHVZUdTq5VzxiSg2L