### PR TITLE
Phase 3: Hetzner deploy ships the full hub + resident create worker

### DIFF
--- a/apps/cli/src/commands/control-plane.ts
+++ b/apps/cli/src/commands/control-plane.ts
@@ -452,7 +452,7 @@ const workerSub = new Command('worker')
  * admin bearer (`AGENTBOX_RELAY_ADMIN_TOKEN` > the setup-written env file).
  * Returns null and prints an actionable error when either is missing.
  */
-async function resolveCustodyTarget(
+export async function resolveCustodyTarget(
   urlFlag: string | undefined,
 ): Promise<{ url: string; adminToken: string } | null> {
   const cfg = await loadEffectiveConfig(process.cwd());

--- a/apps/cli/src/commands/control-plane.ts
+++ b/apps/cli/src/commands/control-plane.ts
@@ -68,6 +68,42 @@ async function waitForHealthz(url: string, deadlineMs: number): Promise<boolean>
   return false;
 }
 
+/**
+ * The hetzner hub-auth env block appended to `control-plane.env`. The full-hub
+ * compose sets the profile literally, but these secrets (`BETTER_AUTH_SECRET`,
+ * admin email/password) are read from the `.env` by the compose file, so a
+ * network-reachable hub is login-gated.
+ */
+function hetznerAuthBody(hubAuth: {
+  AGENTBOX_HUB_AUTH: string;
+  BETTER_AUTH_SECRET: string;
+  AGENTBOX_HUB_ADMIN_EMAIL: string;
+  AGENTBOX_HUB_ADMIN_PASSWORD: string;
+}): string {
+  return (
+    `AGENTBOX_HUB_PROFILE=hetzner\n` +
+    `AGENTBOX_HUB_AUTH=${hubAuth.AGENTBOX_HUB_AUTH}\n` +
+    `BETTER_AUTH_SECRET=${hubAuth.BETTER_AUTH_SECRET}\n` +
+    `AGENTBOX_HUB_ADMIN_EMAIL=${hubAuth.AGENTBOX_HUB_ADMIN_EMAIL}\n` +
+    `AGENTBOX_HUB_ADMIN_PASSWORD=${hubAuth.AGENTBOX_HUB_ADMIN_PASSWORD}\n`
+  );
+}
+
+/**
+ * Ensure `control-plane.env` carries the hub-auth block (a prior `setup --deploy
+ * none` writes only the App creds). Appends it when `BETTER_AUTH_SECRET` is
+ * absent; returns false only if the operator cancels the login prompt.
+ */
+async function ensureHetznerHubAuth(): Promise<boolean> {
+  const body = existsSync(ENV_PATH) ? readFileSync(ENV_PATH, 'utf8') : '';
+  if (/^BETTER_AUTH_SECRET=/m.test(body)) return true;
+  const hubAuth = await resolveHubAuthEnv();
+  if (!hubAuth) return false;
+  await writeFile(ENV_PATH, body + hetznerAuthBody(hubAuth), { mode: 0o600 });
+  await chmod(ENV_PATH, 0o600);
+  return true;
+}
+
 type DeployTarget = 'vercel' | 'hetzner' | 'none';
 
 interface SetupOpts {
@@ -145,13 +181,7 @@ const setupSub = new Command('setup')
         // hetzner reads ENV_PATH (written to the VPS .env); append the auth env +
         // the Postgres auth profile so docker-compose enforces login there too.
         if (target === 'hetzner' && hubAuth) {
-          const authBody =
-            `AGENTBOX_HUB_PROFILE=vercel\n` +
-            `AGENTBOX_HUB_AUTH=${hubAuth.AGENTBOX_HUB_AUTH}\n` +
-            `BETTER_AUTH_SECRET=${hubAuth.BETTER_AUTH_SECRET}\n` +
-            `AGENTBOX_HUB_ADMIN_EMAIL=${hubAuth.AGENTBOX_HUB_ADMIN_EMAIL}\n` +
-            `AGENTBOX_HUB_ADMIN_PASSWORD=${hubAuth.AGENTBOX_HUB_ADMIN_PASSWORD}\n`;
-          await writeFile(ENV_PATH, envBody + authBody, { mode: 0o600 });
+          await writeFile(ENV_PATH, envBody + hetznerAuthBody(hubAuth), { mode: 0o600 });
           await chmod(ENV_PATH, 0o600);
         }
         try {
@@ -640,10 +670,70 @@ const custodyCmd = new Command('custody')
   .addCommand(custodyListSub)
   .addCommand(custodyPullSub);
 
+interface DeployOpts {
+  ref?: string;
+  repo?: string;
+}
+
+// Re-deploy the FULL hub to a fresh Hetzner VPS, REUSING the existing
+// ~/.agentbox/control-plane App creds + env — no GitHub-App manifest flow. Pins
+// the VPS clone to --ref so a feature branch can be deployed for live verify.
+const deployHetznerSub = new Command('hetzner')
+  .description('Deploy the full hub to a new Hetzner VPS, reusing the App creds from `control-plane setup`')
+  .option('--ref <ref>', 'branch / tag / sha the VPS clones + builds', DEFAULT_DEPLOY_REF)
+  .option('--repo <url>', 'git repo the VPS clones', DEFAULT_DEPLOY_REPO)
+  .action(async (opts: DeployOpts) => {
+    try {
+      if (!existsSync(ENV_PATH)) {
+        log.error('No control-plane env found. Run `agentbox control-plane setup` first (it creates the GitHub App + admin token).');
+        process.exitCode = 1;
+        return;
+      }
+      if (!(await ensureHetznerHubAuth())) {
+        log.warn('login prompt cancelled — deploying without web-UI auth.');
+      }
+      // `--repo` accepts an owner/repo slug or a full git URL; the VPS clones a URL.
+      const repoSpec = opts.repo ?? DEFAULT_DEPLOY_REPO;
+      const repoUrl = repoSpec.includes('://') ? repoSpec : `https://github.com/${repoSpec}.git`;
+      const ds = spinner();
+      ds.start('deploying the control box to hetzner');
+      let deployedUrl: string;
+      try {
+        deployedUrl = (
+          await runHetznerDeploy({
+            envPath: ENV_PATH,
+            repoRef: opts.ref ?? DEFAULT_DEPLOY_REF,
+            repoUrl,
+            log: (line) => ds.message(line),
+          })
+        ).url;
+        ds.stop(`deployed: ${deployedUrl}`);
+      } catch (e) {
+        ds.stop('deploy failed');
+        log.error(e instanceof Error ? e.message : String(e));
+        process.exitCode = 1;
+        return;
+      }
+      const url = await applyControlPlaneUrl(deployedUrl);
+      log.success(`Pointed the CLI at ${url} (relay.controlPlaneUrl).`);
+      const ok = await waitForHealthz(url, 60_000);
+      log[ok ? 'success' : 'warn'](
+        ok ? `Control box is healthy (${url}/healthz).` : `Could not confirm ${url}/healthz yet — check the deployment.`,
+      );
+    } catch (err) {
+      handleLifecycleError(err);
+    }
+  });
+
+const deployCmd = new Command('deploy')
+  .description('Deploy the full hub to a VPS, reusing the App creds from `control-plane setup`')
+  .addCommand(deployHetznerSub);
+
 export const controlPlaneCommand = new Command('control-plane')
   .description('EXPERIMENTAL - Set up + manage the hosted control plane (GitHub App, deploy config, reachability)')
   .addCommand(statusSub, { isDefault: true })
   .addCommand(setupSub)
+  .addCommand(deployCmd)
   .addCommand(setUrlSub)
   .addCommand(unsetUrlSub)
   .addCommand(addSub)

--- a/apps/cli/src/commands/create.ts
+++ b/apps/cli/src/commands/create.ts
@@ -41,6 +41,8 @@ import {
 import { evaluateBaseFreshness } from '../checkpoint-lookup.js';
 import { runPrepare } from './prepare.js';
 import { claudeCommand } from './claude.js';
+import { resolveCustodyTarget } from './control-plane.js';
+import { enqueueCreateViaHub, pollHubJob } from '../control-plane/hub-enqueue.js';
 
 interface CreateOptions {
   workspace: string;
@@ -89,6 +91,10 @@ interface CreateOptions {
   /** --dangerously-with-credentials: copy a git credential into the box (git.pushMode=direct); cloud only.
    *  The token-vs-SSH choice is made ONLY at the interactive prompt (TTY required). */
   dangerouslyWithCredentials?: boolean;
+  /** --via-hub: enqueue the create on the control box instead of building locally. */
+  viaHub?: boolean;
+  /** --url <url>: control-plane URL for --via-hub (else relay.controlPlaneUrl). */
+  url?: string;
 }
 
 function buildCliOverrides(opts: CreateOptions): Partial<UserConfig> {
@@ -153,6 +159,69 @@ async function attachShell(record: BoxRecord): Promise<never> {
     mode: 'shell',
   });
   process.exit(code);
+}
+
+/** The project's `origin` remote URL — the repo the hub worker clones VPS-side. */
+function originUrl(projectRoot: string): string | null {
+  try {
+    return execSync('git config --get remote.origin.url', { cwd: projectRoot }).toString().trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `--via-hub` path: enqueue a create job on the control box and stream its
+ * progress. Never touches a local provider. Exits the process with the job's
+ * outcome (0 on done, 1 on failure), mirroring how the local path exits.
+ */
+async function runCreateViaHub(
+  opts: CreateOptions,
+  providerName: string,
+  projectRoot: string,
+  cmdLog: ReturnType<typeof openCommandLog>,
+): Promise<void> {
+  if (providerName === 'docker') {
+    log.error('--via-hub needs a cloud provider (a docker box runs on this machine). Try --provider hetzner|e2b|vercel|daytona.');
+    cmdLog.close();
+    process.exit(1);
+  }
+  const repoUrl = originUrl(projectRoot);
+  if (!repoUrl) {
+    log.error('--via-hub needs a git `origin` remote (the hub worker clones it VPS-side). None found in this project.');
+    cmdLog.close();
+    process.exit(1);
+  }
+  const target = await resolveCustodyTarget(opts.url);
+  if (!target) {
+    cmdLog.close();
+    process.exit(1);
+  }
+  const request = {
+    repoUrl,
+    provider: providerName,
+    branch: opts.fromBranch?.trim() || undefined,
+    name: opts.name?.trim() || undefined,
+  };
+  try {
+    const jobId = await enqueueCreateViaHub(target, request);
+    log.info(`enqueued on the control plane (job ${jobId})`);
+    const job = await pollHubJob(target, jobId, {
+      onStatus: (j) => log.step(`job ${jobId}: ${j.status}`),
+    });
+    if (job.status === 'done') {
+      outro(`box created on the control plane: ${job.result?.boxId ?? '(id pending)'}`);
+      cmdLog.close();
+      process.exit(0);
+    }
+    log.error(`create job failed: ${job.result?.error ?? 'unknown error'}`);
+    cmdLog.close();
+    process.exit(1);
+  } catch (err) {
+    log.error(err instanceof Error ? err.message : String(err));
+    cmdLog.close();
+    process.exit(1);
+  }
 }
 
 export const createCommand = new Command('create')
@@ -262,6 +331,11 @@ export const createCommand = new Command('create')
     '-v, --verbose',
     'also stream the raw provider output (docker build / Daytona snapshot create) to stderr. The same content always lands in ~/.agentbox/logs/create.log — pass -v when you want to watch it live without tailing the log.',
   )
+  .option(
+    '--via-hub',
+    "enqueue the create on the control box (POST /remote/boxes) instead of building it on this machine; the resident hub worker provisions the box VPS-side. Cloud providers only. Needs a control plane configured (`control-plane set-url`) + admin token.",
+  )
+  .option('--url <url>', 'control-plane URL for --via-hub (default: relay.controlPlaneUrl)')
   .action(async (opts: CreateOptions) => {
     const cmdLog = openCommandLog('create');
     intro('Setting up a new box...');
@@ -286,6 +360,16 @@ export const createCommand = new Command('create')
       opts.provider ?? cfg.effective.box.provider ?? 'docker',
     );
     const remoteHost = opts.remoteHost ?? specRemoteHost;
+
+    // --via-hub: hand the create to the control box's queue instead of building
+    // it here. The resident hub worker clones the repo VPS-side and provisions
+    // the box, so this returns once the job is enqueued/finished — no local
+    // provider work. Cloud providers only (a docker box runs on THIS machine).
+    if (opts.viaHub) {
+      await runCreateViaHub(opts, providerName, projectRoot, cmdLog);
+      return;
+    }
+
     // `direct` push mode (box holds a copy of your git credentials) is only
     // meaningful for cloud boxes: a docker box runs on your host machine and
     // bind-mounts the host `.git`, so it is never independent of the host.

--- a/apps/cli/src/control-plane/create-box.ts
+++ b/apps/cli/src/control-plane/create-box.ts
@@ -1,58 +1,7 @@
-import type { CreateJobRequest } from '@agentbox/relay';
-
 /**
- * The control-plane worker's box-creation step. The worker is a long-running
- * host (it runs the cloud poller for the boxes it makes), so instead of
- * cloning inside a serverless function it clones the repo LOCALLY with a leased
- * GitHub-App token and hands that fresh checkout to the normal, tested
- * `provider.create()` as the workspace — origin-clone seeding without touching
- * the host-coupled create flow. All side-effecting steps are injected so the
- * orchestration is unit-testable without a cloud or GitHub.
+ * The control-plane worker's box-creation orchestration now lives in
+ * `@agentbox/relay` (`create-worker.ts`) so BOTH the laptop `control-plane
+ * worker` command and the resident hub worker can build a `CreateBoxFn` from it
+ * (an app can't import another app). Re-exported here for the CLI's callers.
  */
-export interface CreateBoxDeps {
-  /** Mint an authed HTTPS remote URL for the repo (App lease → x-access-token URL). */
-  leaseRemoteUrl(repoUrl: string): Promise<string>;
-  /**
-   * Clone `authedUrl` into `dest` (checking out `branch` when given), then scrub
-   * the remote back to the bare `repoUrl`.
-   */
-  cloneRepo(authedUrl: string, repoUrl: string, dest: string, branch?: string): Promise<void>;
-  /** Provision the cloud box from the local checkout. Returns the new box id. */
-  createBox(opts: {
-    workspacePath: string;
-    name: string | undefined;
-    provider: string;
-    onLog?: (line: string) => void;
-  }): Promise<{ id: string }>;
-  /** Make a per-job temp dir path. */
-  tmpDir(jobId: string): string;
-  /** Remove the temp checkout (best-effort). */
-  cleanup(dir: string): Promise<void>;
-  log?: (line: string) => void;
-}
-
-export function makeControlPlaneCreateBox(
-  deps: CreateBoxDeps,
-): (request: CreateJobRequest, jobId: string) => Promise<{ boxId: string }> {
-  return async (request, jobId) => {
-    const log = deps.log ?? (() => {});
-    const dir = deps.tmpDir(jobId);
-    try {
-      log(`leasing a push token for ${request.repoUrl}`);
-      const authedUrl = await deps.leaseRemoteUrl(request.repoUrl);
-      log(`cloning ${request.repoUrl}${request.branch ? `@${request.branch}` : ''} into ${dir}`);
-      await deps.cloneRepo(authedUrl, request.repoUrl, dir, request.branch);
-      log(`provisioning ${request.provider} box from the clone`);
-      const box = await deps.createBox({
-        workspacePath: dir,
-        name: request.name,
-        provider: request.provider,
-        onLog: deps.log,
-      });
-      log(`created box ${box.id}`);
-      return { boxId: box.id };
-    } finally {
-      await deps.cleanup(dir);
-    }
-  };
-}
+export { makeControlPlaneCreateBox, type CreateBoxDeps } from '@agentbox/relay';

--- a/apps/cli/src/control-plane/deploy-hetzner.ts
+++ b/apps/cli/src/control-plane/deploy-hetzner.ts
@@ -13,6 +13,8 @@ export interface HetznerDeployOptions {
   envPath: string;
   /** Branch / tag / sha of the agentbox repo to deploy (default `main`). */
   repoRef?: string;
+  /** Git repo the VPS clones (default the public agentbox repo). */
+  repoUrl?: string;
   log: (line: string) => void;
 }
 
@@ -24,6 +26,7 @@ export async function runHetznerDeploy(opts: HetznerDeployOptions): Promise<{ ur
   const result = await deployControlPlaneToHetzner({
     envContent,
     repoRef: opts.repoRef,
+    repoUrl: opts.repoUrl,
     onLog: opts.log,
   });
   const deployPath = join(homedir(), '.agentbox', 'control-plane', 'deploy.json');

--- a/apps/cli/src/control-plane/hub-enqueue.ts
+++ b/apps/cli/src/control-plane/hub-enqueue.ts
@@ -1,0 +1,90 @@
+/**
+ * `agentbox create --via-hub`: instead of creating a box locally, enqueue a
+ * create job on the control box (`POST /remote/boxes`) and stream its progress
+ * (`GET /remote/boxes/:id`). The resident hub worker claims the job and
+ * provisions the box VPS-side, so a box can be created with the PC's providers
+ * unconfigured (or the PC off after the enqueue).
+ */
+
+import type { CreateJobRequest, CreateJobRow } from '@agentbox/relay/control-plane';
+
+export interface HubTarget {
+  url: string;
+  adminToken: string;
+  fetchImpl?: typeof fetch;
+}
+
+async function safeText(res: Response): Promise<string> {
+  try {
+    return (await res.text()).slice(0, 500);
+  } catch {
+    return '';
+  }
+}
+
+/** Enqueue a create job; returns the job id. */
+export async function enqueueCreateViaHub(target: HubTarget, request: CreateJobRequest): Promise<string> {
+  const base = target.url.replace(/\/+$/, '');
+  const f = target.fetchImpl ?? fetch;
+  const res = await f(`${base}/remote/boxes`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${target.adminToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+  });
+  if (res.status !== 202) {
+    throw new Error(`enqueue failed: ${res.status} ${await safeText(res)}`);
+  }
+  return ((await res.json()) as { jobId: string }).jobId;
+}
+
+/** Fetch one job's current row. */
+export async function getHubJob(target: HubTarget, jobId: string): Promise<CreateJobRow | null> {
+  const base = target.url.replace(/\/+$/, '');
+  const f = target.fetchImpl ?? fetch;
+  const res = await f(`${base}/remote/boxes/${encodeURIComponent(jobId)}`, {
+    headers: { Authorization: `Bearer ${target.adminToken}` },
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`job status failed: ${res.status} ${await safeText(res)}`);
+  return (await res.json()) as CreateJobRow;
+}
+
+export interface PollOptions {
+  intervalMs?: number;
+  /** Give up after this long. Default 30 min (a real cloud create can be slow). */
+  timeoutMs?: number;
+  onStatus?: (job: CreateJobRow) => void;
+  /** Injectable for tests. */
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+}
+
+/**
+ * Poll a job until it reaches `done`/`failed` (or the timeout). Reports each
+ * observed status transition via `onStatus`.
+ */
+export async function pollHubJob(
+  target: HubTarget,
+  jobId: string,
+  opts: PollOptions = {},
+): Promise<CreateJobRow> {
+  const intervalMs = opts.intervalMs ?? 3000;
+  const timeoutMs = opts.timeoutMs ?? 30 * 60_000;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+  const now = opts.now ?? Date.now;
+  const deadline = now() + timeoutMs;
+  let lastStatus = '';
+  for (;;) {
+    const job = await getHubJob(target, jobId);
+    if (!job) throw new Error(`job ${jobId} disappeared from the control plane`);
+    if (job.status !== lastStatus) {
+      lastStatus = job.status;
+      opts.onStatus?.(job);
+    }
+    if (job.status === 'done' || job.status === 'failed') return job;
+    if (now() >= deadline) {
+      throw new Error(`timed out waiting for job ${jobId} (last status: ${job.status})`);
+    }
+    await sleep(intervalMs);
+  }
+}

--- a/apps/cli/test/hub-enqueue.test.ts
+++ b/apps/cli/test/hub-enqueue.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { enqueueCreateViaHub, getHubJob, pollHubJob } from '../src/control-plane/hub-enqueue.js';
+import type { CreateJobRow } from '@agentbox/relay/control-plane';
+
+// Pure — a fake fetch, no network, no HOME (apps/cli tests share the real HOME).
+
+const target = { url: 'https://hub.example/', adminToken: 'admin-secret' };
+
+function jsonRes(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
+describe('enqueueCreateViaHub', () => {
+  it('POSTs the create request with the admin bearer and returns the job id', async () => {
+    let seen: { url: string; init: RequestInit } | undefined;
+    const fetchImpl = ((url: string, init: RequestInit) => {
+      seen = { url, init };
+      return Promise.resolve(jsonRes(202, { jobId: 'job-1' }));
+    }) as unknown as typeof fetch;
+    const id = await enqueueCreateViaHub(
+      { ...target, fetchImpl },
+      { repoUrl: 'https://x/r.git', provider: 'e2b', branch: 'main' },
+    );
+    expect(id).toBe('job-1');
+    expect(seen?.url).toBe('https://hub.example/remote/boxes');
+    expect((seen?.init.headers as Record<string, string>).Authorization).toBe('Bearer admin-secret');
+    expect(JSON.parse(seen?.init.body as string)).toMatchObject({ provider: 'e2b', branch: 'main' });
+  });
+
+  it('throws on a non-202 response', async () => {
+    const fetchImpl = (() => Promise.resolve(jsonRes(401, { error: 'invalid admin token' }))) as unknown as typeof fetch;
+    await expect(enqueueCreateViaHub({ ...target, fetchImpl }, { repoUrl: 'x', provider: 'e2b' })).rejects.toThrow(/401/);
+  });
+});
+
+describe('getHubJob', () => {
+  it('returns null on 404', async () => {
+    const fetchImpl = (() => Promise.resolve(jsonRes(404, { error: 'no such job' }))) as unknown as typeof fetch;
+    expect(await getHubJob({ ...target, fetchImpl }, 'missing')).toBeNull();
+  });
+});
+
+describe('pollHubJob', () => {
+  it('polls until done, reporting each status transition', async () => {
+    const states: CreateJobRow['status'][] = ['queued', 'running', 'done'];
+    let i = 0;
+    const fetchImpl = (() => {
+      const status = states[Math.min(i++, states.length - 1)]!;
+      const row: CreateJobRow = {
+        id: 'job-1',
+        status,
+        request: { repoUrl: 'x', provider: 'e2b' },
+        createdAt: '2026-01-01T00:00:00Z',
+        ...(status === 'done' ? { result: { boxId: 'box-9' } } : {}),
+      };
+      return Promise.resolve(jsonRes(200, row));
+    }) as unknown as typeof fetch;
+    const seen: string[] = [];
+    const job = await pollHubJob({ ...target, fetchImpl }, 'job-1', {
+      sleep: () => Promise.resolve(),
+      onStatus: (j) => seen.push(j.status),
+    });
+    expect(job.result?.boxId).toBe('box-9');
+    expect(seen).toEqual(['queued', 'running', 'done']);
+  });
+
+  it('times out if the job never finishes', async () => {
+    const fetchImpl = (() =>
+      Promise.resolve(
+        jsonRes(200, { id: 'j', status: 'running', request: { repoUrl: 'x', provider: 'e2b' }, createdAt: 'x' }),
+      )) as unknown as typeof fetch;
+    let clock = 0;
+    await expect(
+      pollHubJob({ ...target, fetchImpl }, 'j', {
+        sleep: () => Promise.resolve(),
+        now: () => (clock += 60_000),
+        timeoutMs: 120_000,
+      }),
+    ).rejects.toThrow(/timed out/);
+  });
+});

--- a/apps/hub/Dockerfile
+++ b/apps/hub/Dockerfile
@@ -1,28 +1,35 @@
-# AgentBox hub — self-host image.
-# Build context is the REPO ROOT (the app needs its workspace dep @agentbox/relay):
-#   docker build -f apps/hub/Dockerfile -t agentbox-hub .
+# AgentBox hub — self-host / control-box image.
+# Build context is the REPO ROOT (the app needs its workspace deps):
+#   docker build --network=host -f apps/hub/Dockerfile -t agentbox-hub .
 # Or via the bundled compose: `docker compose up` from apps/hub/.
+#
+# Ships the FULL hub: server.ts (relay daemon + Next UI + resident create worker)
+# from the standalone build — the same artifact `agentbox hub` spawns — NOT the
+# `next start` [...path] plane. SQLite store (no Postgres container).
 
 FROM node:22-slim AS build
 WORKDIR /repo
 RUN corepack enable
 COPY . .
 RUN pnpm install --frozen-lockfile
-# Build the app + its workspace deps in dependency order via turbo. The relay
-# bundles @agentbox/config / sandbox-core / integrations, so those packages must
-# build (emit dist/) before the relay does — `--filter` pulls in `^build` deps.
+# Build the app's workspace deps (dist/) in dependency order, then assemble the
+# spawnable standalone hub (next build + esbuild-bundled server.ts + chunks).
 RUN pnpm turbo run build --filter=@agentbox/hub
+RUN pnpm --filter @agentbox/hub build:standalone
 
 FROM node:22-slim AS runtime
 WORKDIR /repo
 RUN corepack enable
+# git + openssh-client: the resident create worker clones the repo VPS-side and
+# a hetzner box needs ssh/scp on PATH for its ControlMaster.
+RUN apt-get update && apt-get install -y --no-install-recommends git openssh-client ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 ENV NODE_ENV=production
-ENV PORT=3000
-# The whole built monorepo (reliable for a pnpm workspace; not size-optimized).
+# The whole built monorepo: the standalone bundle ships no node_modules, so its
+# externals (next, react, pg, better-auth, the cloud SDKs) resolve from the
+# workspace node_modules present here. Not size-optimized; fine for a VPS.
 COPY --from=build /repo .
-WORKDIR /repo/apps/hub
 EXPOSE 3000
-# Create/upgrade the auth tables + seed the admin (self-skips when auth is off,
-# i.e. no BETTER_AUTH_SECRET), then serve the production build. Runs at boot (not
-# build) so it sees the container's POSTGRES_URL + auth env.
-CMD ["sh", "-c", "pnpm run db:auth-migrate && pnpm exec next start -p 3000"]
+# server.ts self-migrates auth (ensureAuthReady) + the store on boot, so there is
+# no separate migrate step. It anchors its own cwd from required-server-files.json.
+CMD ["node", "apps/hub/dist-standalone/apps/hub/server.js"]

--- a/apps/hub/docker-compose.yml
+++ b/apps/hub/docker-compose.yml
@@ -1,48 +1,44 @@
-# Self-host recipe for the AgentBox hosted control plane: Postgres + the Next
-# app, the SAME code that deploys to Vercel. Run from this directory:
+# Self-host / control-box recipe for the AgentBox hub — the FULL hub (relay
+# daemon + Next UI + resident create worker) on SQLite, the same code
+# `agentbox control-plane deploy hetzner` ships to a VPS. No Postgres container.
+# Run from this directory:
 #
 #   export AGENTBOX_RELAY_ADMIN_TOKEN=$(openssl rand -hex 32)
 #   docker compose up --build
 #
 # Point boxes/CLI at it: `agentbox control-plane set-url http://<host>:8787`.
 services:
-  db:
-    image: postgres:16
-    environment:
-      POSTGRES_PASSWORD: pw
-      POSTGRES_DB: agentbox
-    volumes:
-      - cpdata:/var/lib/postgresql/data
-    healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U postgres']
-      interval: 3s
-      timeout: 3s
-      retries: 20
-
   app:
     build:
-      # Repo root — the app needs its @agentbox/relay workspace dep.
+      # Repo root — the app needs its @agentbox/* workspace deps.
       context: ../..
       dockerfile: apps/hub/Dockerfile
+    restart: unless-stopped
     environment:
-      POSTGRES_URL: postgres://postgres:pw@db:5432/agentbox
+      # Full-hub profile: better-auth password login, non-loopback bind, SQLite
+      # store (no POSTGRES_URL), and the resident create worker.
+      AGENTBOX_HUB_PROFILE: hetzner
+      AGENTBOX_HUB_HOST: 0.0.0.0
+      AGENTBOX_HUB_PORT: '3000'
+      AGENTBOX_HUB_WORKER: ${AGENTBOX_HUB_WORKER:-on}
+      HOME: /root
+      # Secrets (from the compose env-file / shell). Login is secret-gated: with
+      # no BETTER_AUTH_SECRET the UI stays open; the deploy sets these so a
+      # network-reachable hub is gated.
       AGENTBOX_RELAY_ADMIN_TOKEN: ${AGENTBOX_RELAY_ADMIN_TOKEN:?set AGENTBOX_RELAY_ADMIN_TOKEN}
-      GITHUB_APP_ID: ${GITHUB_APP_ID:-}
-      GITHUB_APP_PRIVATE_KEY: ${GITHUB_APP_PRIVATE_KEY:-}
-      # Web-UI auth (Postgres store — the same shape as the Vercel deploy). Login
-      # is secret-gated: with no BETTER_AUTH_SECRET the UI stays open (unchanged);
-      # the CLI deploy path (control-plane setup --deploy hetzner) sets these +
-      # BETTER_AUTH_SECRET so a network-reachable/Caddy-HTTPS hub is gated.
-      AGENTBOX_HUB_PROFILE: ${AGENTBOX_HUB_PROFILE:-vercel}
-      AGENTBOX_HUB_AUTH: ${AGENTBOX_HUB_AUTH:-}
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-}
       AGENTBOX_HUB_ADMIN_EMAIL: ${AGENTBOX_HUB_ADMIN_EMAIL:-}
       AGENTBOX_HUB_ADMIN_PASSWORD: ${AGENTBOX_HUB_ADMIN_PASSWORD:-}
+      GITHUB_APP_ID: ${GITHUB_APP_ID:-}
+      GITHUB_APP_PRIVATE_KEY: ${GITHUB_APP_PRIVATE_KEY:-}
+      # Public URL a hub-created box registers against (control-plane topology)
+      # and the admin PC egress CIDR added to a hetzner box's firewall.
+      AGENTBOX_HUB_PUBLIC_URL: ${AGENTBOX_HUB_PUBLIC_URL:-}
+      AGENTBOX_HUB_ADMIN_CIDR: ${AGENTBOX_HUB_ADMIN_CIDR:-}
+    volumes:
+      # Persistent ~/.agentbox: store.db, auth.db, custody/, boxes/<id>/ssh,
+      # secrets.env (provider creds), logs. A HOST path so the deploy can scp
+      # provider secrets in before `compose up`.
+      - ${AGENTBOX_HUB_DATA_DIR:-./hub-data}:/root/.agentbox
     ports:
       - '8787:3000'
-    depends_on:
-      db:
-        condition: service_healthy
-
-volumes:
-  cpdata:

--- a/apps/hub/lib/hub-worker.ts
+++ b/apps/hub/lib/hub-worker.ts
@@ -1,0 +1,225 @@
+/**
+ * Resident create worker for the control box (hetzner profile). Runs IN the hub
+ * process — the SQLite single-writer constraint (phase 1) means the queue's
+ * consumer must share the store, not contend on the file from a second
+ * container. Gated by `AGENTBOX_HUB_WORKER=on`; the localhost profile never
+ * starts it.
+ *
+ * It builds a `CreateBoxFn` from the shared `makeControlPlaneCreateBox`
+ * orchestration (lease → local clone → `provider.create`) and drains the
+ * `/remote/boxes` queue on an interval. Node-only — loaded by `server.ts`, never
+ * by Next.
+ */
+import { execFile } from 'node:child_process';
+import { mkdir, readdir, rm, writeFile } from 'node:fs/promises';
+import { hostname, tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { promisify } from 'node:util';
+import { isProviderKind, type ProviderKind } from '@agentbox/config';
+import {
+  drainCreateJobs,
+  FsCustodyStore,
+  GitHubAppLeaser,
+  loadGitHubAppConfig,
+  makeControlPlaneCreateBox,
+  parseGitRemote,
+  toAuthedHttpsUrl,
+  type CreateBoxFn,
+  type Store,
+} from '@agentbox/relay/control-plane';
+import { AGENT_SYNC_SPECS, defaultBoxSshDir } from '@agentbox/sandbox-core';
+import type { ProviderModule } from '@agentbox/sandbox-core';
+
+const execFileAsync = promisify(execFile);
+
+// Same provider importer map the hub backend uses (an app can't reach
+// apps/cli's provider registry). Only cloud providers make sense for the worker.
+const IMPORTERS: Record<ProviderKind, () => Promise<{ providerModule: ProviderModule }>> = {
+  docker: () => import('@agentbox/sandbox-docker'),
+  daytona: () => import('@agentbox/sandbox-daytona'),
+  hetzner: () => import('@agentbox/sandbox-hetzner'),
+  vercel: () => import('@agentbox/sandbox-vercel'),
+  e2b: () => import('@agentbox/sandbox-e2b'),
+  digitalocean: () => import('@agentbox/sandbox-digitalocean'),
+  'remote-docker': () => import('@agentbox/sandbox-remote-docker'),
+};
+
+async function runGit(args: string[]): Promise<void> {
+  await execFileAsync('git', args, { maxBuffer: 64 * 1024 * 1024 });
+}
+
+/**
+ * Materialize the custody `agents/` scope into the host credential-backup files
+ * `provider.create`'s seed step reads (`~/.agentbox/<id>-credentials.json`). So a
+ * PC `credentials push` (phase 2) is what logs hub-created boxes in — one code
+ * path, no second credential list.
+ */
+async function seedHostBackupsFromCustody(custody: FsCustodyStore, log: (l: string) => void): Promise<void> {
+  for (const spec of AGENT_SYNC_SPECS) {
+    const custodyPath = `agents/${spec.id}/${spec.credential.boxRelPath}`;
+    try {
+      const found = await custody.get(custodyPath);
+      if (!found) continue;
+      await mkdir(dirname(spec.credential.hostBackup), { recursive: true });
+      await writeFile(spec.credential.hostBackup, found.data, { mode: 0o600 });
+      log(`seeded ${spec.id} credentials from custody`);
+    } catch (err) {
+      log(`seed ${spec.id} from custody failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+}
+
+/**
+ * Mirror a just-created box's minted SSH key material into custody
+ * `boxes/<boxId>/ssh/` so phase 4's `hub pull` can fetch it. Only the VPS
+ * backends (hetzner / digitalocean) mint a per-box keypair; the SDK backends
+ * (e2b / vercel) don't, so this is a best-effort no-op for them.
+ */
+async function mirrorBoxSshToCustody(
+  custody: FsCustodyStore,
+  boxId: string,
+  provider: string,
+  sandboxId: string | undefined,
+  log: (l: string) => void,
+): Promise<void> {
+  if (!sandboxId || (provider !== 'hetzner' && provider !== 'digitalocean')) return;
+  const sshDir = defaultBoxSshDir(sandboxId, provider);
+  try {
+    const files = await readdir(sshDir, { withFileTypes: true }).catch(() => []);
+    const { readFile } = await import('node:fs/promises');
+    for (const f of files) {
+      if (!f.isFile()) continue;
+      const data = await readFile(join(sshDir, f.name));
+      await custody.put(`boxes/${boxId}/ssh/${f.name}`, data);
+    }
+    if (files.length > 0) log(`mirrored ${provider} box ${boxId} ssh keys to custody`);
+  } catch (err) {
+    log(`ssh-mirror ${boxId} failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+export interface HubWorkerOptions {
+  store: Store;
+  log: (line: string) => void;
+  /** Public hub URL a created box registers against (control-plane topology). */
+  publicUrl?: string;
+  /** Admin PC egress CIDR added to a hetzner box's firewall (dual-IP reach). */
+  adminCidr?: string;
+  /** Poll cadence. Default 5s. */
+  intervalMs?: number;
+  /**
+   * Test seam: return a fake box id instead of touching a real cloud, so the
+   * in-box docker smoke can drive the queue end-to-end offline. On when
+   * `AGENTBOX_HUB_WORKER_MOCK=1`.
+   */
+  mockCreate?: boolean;
+}
+
+export interface HubWorkerHandle {
+  stop: () => Promise<void>;
+}
+
+/** Build the worker's `CreateBoxFn` (exported for the offline smoke/tests). */
+export function makeHubCreateBox(opts: HubWorkerOptions): CreateBoxFn {
+  const { log } = opts;
+  const custody = new FsCustodyStore();
+
+  if (opts.mockCreate) {
+    // Offline path: skip lease/clone/provider entirely, return a synthetic id.
+    return (request, jobId) => {
+      log(`[mock] created box for job ${jobId} (${request.provider} ${request.repoUrl})`);
+      return Promise.resolve({ boxId: `mock-${jobId.slice(0, 8)}` });
+    };
+  }
+
+  const appCfg = loadGitHubAppConfig();
+  if (!appCfg) throw new Error('no GitHub App configured (AGENTBOX_GITHUB_APP_* / control-plane.env)');
+  const leaser = new GitHubAppLeaser(appCfg);
+  const extraInboundCidrs = opts.adminCidr ? [opts.adminCidr] : undefined;
+
+  return makeControlPlaneCreateBox({
+    leaseRemoteUrl: async (repoUrl) => {
+      const { path } = parseGitRemote(repoUrl);
+      const [owner, repo] = path.replace(/\.git$/, '').split('/');
+      if (!owner || !repo) throw new Error(`cannot derive owner/repo from ${repoUrl}`);
+      const { token } = await leaser.leaseRepoToken(owner, repo);
+      return toAuthedHttpsUrl(repoUrl, token);
+    },
+    cloneRepo: async (authedUrl, repoUrl, dest, branch) => {
+      await runGit(branch ? ['clone', '--branch', branch, authedUrl, dest] : ['clone', authedUrl, dest]);
+      await runGit(['-C', dest, 'remote', 'set-url', 'origin', repoUrl]);
+    },
+    createBox: async ({ workspacePath, name, provider, onLog }) => {
+      if (!isProviderKind(provider)) throw new Error(`unknown provider ${provider}`);
+      const mod = (await IMPORTERS[provider]()).providerModule;
+      if (mod.ensureCredentials) await mod.ensureCredentials();
+      // Seed agent creds from custody just before create, so provider.create's
+      // seed step reads a logged-in host backup.
+      await seedHostBackupsFromCustody(custody, log);
+      const created = await mod.provider.create({
+        workspacePath,
+        name,
+        projectRoot: workspacePath,
+        // Register the box on THIS hub (control-plane topology) so the phone UI
+        // sees it and approvals route back here.
+        controlPlaneUrl: opts.publicUrl,
+        ...(extraInboundCidrs ? { providerOptions: { extraInboundCidrs } } : {}),
+        onLog,
+      });
+      await mirrorBoxSshToCustody(
+        custody,
+        created.record.id,
+        provider,
+        created.record.cloud?.sandboxId,
+        log,
+      );
+      return { id: created.record.id };
+    },
+    tmpDir: (jobId) => join(tmpdir(), `agentbox-hub-worker-${jobId}`),
+    cleanup: (dir) => rm(dir, { recursive: true, force: true }),
+    log,
+  });
+}
+
+/** Start the resident worker loop. Returns a handle to stop it on shutdown. */
+export function startHubWorker(opts: HubWorkerOptions): HubWorkerHandle {
+  const { store, log } = opts;
+  if (!store.claimNextCreateJob || !store.completeCreateJob) {
+    log('worker: store has no create-job queue; not starting');
+    return { stop: () => Promise.resolve() };
+  }
+  const createBox = makeHubCreateBox(opts);
+  const workerId = `hub-${hostname()}`;
+  const intervalMs = opts.intervalMs ?? 5000;
+  let ticking = false;
+  let stopped = false;
+  let inFlight: Promise<void> = Promise.resolve();
+
+  async function tick(): Promise<void> {
+    if (ticking) return;
+    ticking = true;
+    try {
+      const n = await drainCreateJobs(store, createBox, workerId);
+      if (n > 0) log(`worker: processed ${String(n)} create job(s)`);
+    } catch (err) {
+      log(`worker: tick error: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      ticking = false;
+    }
+  }
+
+  const timer = setInterval(() => {
+    if (stopped) return;
+    inFlight = tick();
+  }, intervalMs);
+  timer.unref();
+  log(`worker: draining create jobs as ${workerId}`);
+
+  return {
+    stop: async () => {
+      stopped = true;
+      clearInterval(timer);
+      await inFlight.catch(() => {});
+    },
+  };
+}

--- a/apps/hub/server.ts
+++ b/apps/hub/server.ts
@@ -125,6 +125,22 @@ async function main(): Promise<void> {
     process.stdout.write('agentbox-hub: auth ready\n');
   }
 
+  // Resident create worker (control box). Gated on AGENTBOX_HUB_WORKER=on so the
+  // localhost profile never starts it; runs in-process because SQLite is
+  // single-writer (phase 1). Node-only module, dynamically imported so Next
+  // never sees the provider/git graph.
+  let worker: { stop: () => Promise<void> } | undefined;
+  if (process.env.AGENTBOX_HUB_WORKER === 'on') {
+    const { startHubWorker } = await import('./lib/hub-worker');
+    worker = startHubWorker({
+      store: daemon.handle.store,
+      log: (line) => process.stdout.write(`agentbox-hub-worker: ${line}\n`),
+      publicUrl: process.env.AGENTBOX_HUB_PUBLIC_URL,
+      adminCidr: process.env.AGENTBOX_HUB_ADMIN_CIDR,
+      mockCreate: process.env.AGENTBOX_HUB_WORKER_MOCK === '1',
+    });
+  }
+
   process.stdout.write(`agentbox-hub: listening on ${host}:${String(port)} (dev=${String(dev)})\n`);
   if (mode === 'token') {
     process.stdout.write(`agentbox-hub: open http://${host}:${String(port)}/?token=${process.env.AGENTBOX_HUB_TOKEN ?? ''}\n`);
@@ -132,7 +148,7 @@ async function main(): Promise<void> {
 
   const shutdown = (signal: string): void => {
     process.stdout.write(`agentbox-hub: ${signal} — shutting down\n`);
-    daemon.stop().finally(() => process.exit(0));
+    void (worker?.stop() ?? Promise.resolve()).finally(() => daemon.stop().finally(() => process.exit(0)));
   };
   process.on('SIGTERM', () => shutdown('SIGTERM'));
   process.on('SIGINT', () => shutdown('SIGINT'));

--- a/apps/web/content/docs/control-plane.mdx
+++ b/apps/web/content/docs/control-plane.mdx
@@ -12,7 +12,7 @@ The **control plane** is an optional hosted service that takes over the *central
 - **permission state** — pending approvals live in the plane's database; boxes poll for the verdict and you answer from anywhere (CLI or the deployment).
 - **registry / events / status** — one cross-machine view of every box.
 
-It is the same `@agentbox/relay` core wrapped as a **Next.js + Postgres app**. The identical code deploys to **Vercel** (managed) or **self-hosts on a VPS** (Postgres + `next start` via docker-compose) — only the host differs. It is stateless per request and does **no host execution**: host-local actions (`cp`, `download`, `checkpoint`) stay on the laptop relay; cloud boxes push to GitHub directly with a leased token.
+It is the same `@agentbox/relay` core in two shapes. On **Vercel** (managed) it is a stateless **Next.js + Postgres** app that does no host execution. On a **Hetzner VPS** it is the **control box** — the full always-on hub (relay daemon + web UI + a resident create worker) on **SQLite**, a full host that can provision boxes itself. Host-local actions your laptop must do (`cp`, `download`, `checkpoint`) stay on the laptop relay; cloud boxes push to GitHub directly with a leased token.
 
 <Callout type="info" title="Cloud boxes only">Only **cloud** boxes (hetzner, vercel, e2b, daytona) get the laptop-off guarantee. Local **docker** boxes still need the laptop relay for host-local actions (they bind-mount the host `.git`), so a docker box on a sleeping laptop is simply offline.</Callout>
 
@@ -45,9 +45,18 @@ Requires `agentbox vercel login` (and `gh auth login` for the auto-fork — with
 
 <Callout type="info" title="Boots before it's wired">The control plane is built to **boot even with no secrets set** — a fresh deploy answers `/healthz` (reporting what's configured) and never 500s; admin/leasing endpoints return a clean 503 until the env is set + redeployed. So the button flow (deploy bare → AgentBox sets secrets → redeploy) is never a broken state. Deploying the published repo means you deploy a fork; re-sync it (`gh repo sync`) or re-run with `--ref` for updates.</Callout>
 
-### Hetzner
+### Hetzner — the control box
 
-`--deploy hetzner` provisions a small VPS (cloud-init installs Docker and `git clone`s `--repo` at `--ref`), brings up the docker-compose (Postgres + the app + Caddy), and serves it over **HTTPS at `https://<ip>.sslip.io`** — Caddy auto-obtains a Let's Encrypt cert, so there's no DNS to configure. The firewall locks SSH to your egress IP and opens `:80`/`:443`. Needs `agentbox hetzner login`. No repo ownership required (the VPS clones the public repo).
+`--deploy hetzner` provisions a small VPS and ships the **full hub** — the same `server.ts` (relay daemon + web UI + a resident create worker) that `agentbox hub` runs locally, not the stateless Vercel plane. cloud-init installs Docker and `git clone`s `--repo` at `--ref`; the docker-compose is just **the app + Caddy** (no Postgres — the hub uses **SQLite** at `~/.agentbox/hub/store.db`), served over **HTTPS at `https://<ip>.sslip.io`** (Caddy auto-obtains a Let's Encrypt cert, no DNS to configure). A persistent host volume holds `~/.agentbox` (store, auth, custody, box SSH keys), so the hub + queue survive a VPS reboot. The firewall locks SSH to your egress IP and opens `:80`/`:443`. Needs `agentbox hetzner login`.
+
+Already ran `setup`? Re-deploy the control box without re-creating the GitHub App:
+
+```bash
+agentbox control-plane deploy hetzner            # reuses ~/.agentbox/control-plane creds
+agentbox control-plane deploy hetzner --ref my-branch   # pin the VPS clone to a ref
+```
+
+The deploy also copies the provider credentials the worker needs (`HCLOUD_TOKEN`, `E2B_API_KEY`, `DAYTONA_API_KEY`/`DAYTONA_ORG_ID`) from your host `~/.agentbox/secrets.env` into the VPS data volume, and records **your PC's egress IP** so a hetzner box the control box creates still allows direct SSH from your laptop.
 
 ### Self-host (docker-compose)
 
@@ -56,7 +65,7 @@ Skip the deploy step and run the written env anywhere:
 ```bash
 cd apps/hub
 docker compose --env-file ~/.agentbox/control-plane/control-plane.env up --build
-# Postgres + the app on :8787
+# the full hub (SQLite, no Postgres) on :8787
 agentbox control-plane set-url http://<host>:8787
 ```
 
@@ -72,12 +81,20 @@ agentbox control-plane add
 
 You don't usually need to run it: when you launch `agentbox claude` / `codex` / `opencode` against a configured control plane, AgentBox checks whether the project's repo is authorized and, if not, prompts you to open the add-repo page (asked once per project; unattended runs only warn).
 
-## Creating boxes from the plane
+## Creating boxes from the control box
 
-The plane can enqueue box creation (`POST /remote/boxes`, admin-bearer) and return a job id. A long-running **worker** drains that queue and provisions the boxes — it leases a token, clones the repo, and hands the checkout to the normal provider create path:
+The hub enqueues box creation (`POST /remote/boxes`, admin-bearer) and returns a job id. On the **Hetzner control box** a **resident worker runs inside the hub process** (no separate command) — it claims each job, leases a token, clones the repo, and hands the checkout to the normal provider create path. Enqueue from your laptop instead of building locally:
 
 ```bash
-# Run alongside the plane (self-host) or as a scheduled job; needs the App key + provider creds
+agentbox create --provider e2b --via-hub
+```
+
+This POSTs the job to the control box and streams its progress; the box is provisioned VPS-side, so you can create one even with the provider's credentials unconfigured on your laptop (or the laptop off after the enqueue). The hub web UI's create button enqueues the same way. The worker registers each box on the control box, so it shows up in the web UI and its approvals are answerable from your phone. Agent credentials come from what you [pushed to custody](#) (`credentials push`), so hub-created boxes are logged in.
+
+For a self-hosted plane (or Vercel), the worker can also run as a standalone command:
+
+```bash
+# needs the App key + provider creds; drains the same /remote/boxes queue
 agentbox control-plane worker --store "$POSTGRES_URL"
 agentbox control-plane worker --store "$POSTGRES_URL" --once   # drain once and exit
 ```

--- a/docs/control-box-plan.md
+++ b/docs/control-box-plan.md
@@ -506,6 +506,217 @@ logged-in `claude -p` turn (box *usable*, not just ready — established convent
 are answerable from the phone UI; VPS reboot → hub + worker come back (compose
 `restart: unless-stopped`) with registry/queue intact (SQLite volume). Destroy leaves no orphans.
 
+### Phase 3 — implementation plan (box cbx-phase3)
+
+Two mandatory blockers first (from the [Backlog](#backlog)), then the six deploy/worker items.
+This plan resolves the design questions the phase text left open; deviations from the text above
+are called out inline.
+
+#### Blocker A — background loops + hub backend must see a durable store's state
+
+**The problem, precisely.** The daemon's loops (`startAutopauseLoop`, `startCloudKeepaliveLoop`,
+`startQueueLoop`) and `createHubBackend` read the **concrete** in-memory `handle.registry` /
+`handle.statusStore` / `handle.events` / `handle.prompts` objects, never the `Store`. On the
+laptop that is correct — `MemoryStore` *wraps those very instances* (`memory-store.ts`), so a
+write through `store.setStatus` and a read via `statusStore.get` hit the same map. But inject a
+durable `SqliteStore` and the handlers write to SQLite while the concrete instances stay empty:
+`cloud-keepalive` sees `registry.list() === []` (never renews a cloud box), and
+`createHubBackend.getData()` reads `handle.statusStore.get(id) === undefined` (the phone UI shows
+no agent status). (autopause is docker-only — it `docker inspect`s a `containerName`, which a
+VPS-created cloud box never has — so it is inert on the control box either way; keepalive + hub
+status are the live symptoms.)
+
+**Design chosen: write-through the durable store into the in-memory caches + hydrate on boot.**
+Of the two options the backlog offers ("route the consumers through the Store" vs "make the
+durable stores write through to the in-process caches"), write-through is the *least invasive*
+and the only one that keeps the localhost/MemoryStore profile byte-identical:
+
+- **Consumers are untouched.** autopause / keepalive / queue-loop / hub-backend keep reading the
+  concrete `registry`/`statusStore`/`events` synchronously — no async-store rewrite, no risk of
+  changing localhost timing/behavior.
+- **localhost is literally the same code path.** The write-through wrapper is only constructed
+  when `opts.store` is a *durable* store; a loginless localhost hub and every unit test still get
+  `new MemoryStore({ registry, events, statusStore })` verbatim.
+- **Single-writer makes the mirror safe.** Phase 1 already constrains the control box to one hub
+  process (SQLite single-writer). One writer ⇒ the in-memory mirror can never go stale behind
+  another process; DB is the source of truth across restarts, the mirror is a within-process cache.
+
+Implementation:
+
+- New `packages/relay/src/store/write-through-store.ts` — `class WriteThroughStore implements
+  Store`. It delegates every read to the inner durable store and, on each **mutating** call, also
+  applies the change to the injected `{ registry, events, statusStore }`:
+  `registerBox → registry.register`, `forgetBox → registry.forget`, `setStatus →
+  statusStore.set`, `deleteStatus → statusStore.delete`, `appendEvent → events.append`. Prompt +
+  create-job methods are pure delegation (they have no in-memory mirror the loops read). It also
+  forwards `migrate()` and the off-interface `listStatuses()`.
+- `hydrate()` on the wrapper: `for (const reg of await inner.listBoxes()) registry.register(reg)`,
+  then (when `inner.listStatuses`) re-populate `statusStore` (name/projectIndex looked up from the
+  just-hydrated registry). Events are a ring buffer — ephemeral, not hydrated.
+- Wiring: in `createRelayServer`, `const store = opts.store ? new WriteThroughStore(opts.store,
+  { registry, events, statusStore }) : new MemoryStore({ registry, events, statusStore })`.
+  `startRelayServer` (the async one) awaits `store.hydrate?.()` right after the socket bind and
+  before returning, so the daemon's loops start against a populated registry.
+- Prompts need **no** change: the control box runs `mode: 'host'` + `promptMode: 'block'`, so a
+  box's host-action blocks in-process on `PendingPrompts` (`handle.prompts`) and the hub backend
+  reads it there — exactly as on localhost. (The store's `createPrompt` mailbox is the poll-mode
+  path, unused by the block-mode control box.)
+
+#### Blocker B — retention sweep (answered prompts + finished jobs)
+
+- Two new **optional** `Store` methods: `prunePrompts(beforeIso)` — delete rows that are
+  `answered` OR past their `expires_at` and older than `beforeIso`; `pruneCreateJobs(beforeIso)` —
+  delete `done`/`failed` jobs whose `finishedAt < beforeIso`. Implemented on `SqliteStore` +
+  `PostgresStore` (one drizzle `delete` each); absent on `MemoryStore` (process-lifetime memory —
+  nothing to sweep) and `WriteThroughStore` forwards them.
+- New `packages/relay/src/retention.ts` — `startRetentionLoop({ store, log, intervalMs })`: an
+  hourly tick that calls the two prune methods when present, `beforeIso = now − RETENTION_MS`
+  (24 h). Started in `startRelayDaemon` after the other loops; a no-op when the store lacks the
+  methods (localhost). Constants (not a config key) for now — internal housekeeping, not a
+  user-facing tunable; noted in the Backlog if it needs to become one.
+
+#### 1. Deploy the full hub (Dockerfile + compose + `control-plane-deploy.ts`)
+
+- **`apps/hub/Dockerfile`** — build stage: `pnpm install --frozen-lockfile` → `pnpm turbo run
+  build --filter=@agentbox/hub` (builds the workspace-dep `dist/`) → `pnpm --filter @agentbox/hub
+  build:standalone` (produces `apps/hub/dist-standalone/apps/hub/server.js`, the same artifact
+  `agentbox hub` spawns). Runtime stage keeps the whole built monorepo (`COPY --from=build /repo
+  .`) so the standalone's *externals* (`next`, `react`, `pg`, `better-auth`, the cloud SDKs)
+  resolve from the workspace `node_modules`, and adds `git` + `openssh-client` (the worker's clone
+  step + hetzner box ssh/scp). New `CMD ["node", "apps/hub/dist-standalone/apps/hub/server.js"]`
+  — the standalone `server.ts` runs `ensureAuthReady()` itself at boot, so the old
+  `db:auth-migrate` CMD step is dropped.
+- **`apps/hub/docker-compose.yml`** — rewritten to **app-only** (Postgres + the `db` service
+  dropped; unreleased, so no back-compat alias). `app` env: `AGENTBOX_HUB_PROFILE=hetzner`,
+  `AGENTBOX_HUB_HOST=0.0.0.0`, `AGENTBOX_HUB_PORT=3000` (Caddy already proxies `app:3000`),
+  `AGENTBOX_HUB_WORKER=on`, `HOME=/root`, plus the secret env passed through from the compose
+  env-file (`AGENTBOX_RELAY_ADMIN_TOKEN`, `BETTER_AUTH_SECRET`, admin email/password,
+  `GITHUB_APP_*`, `AGENTBOX_HUB_ADMIN_CIDR`). `restart: unless-stopped`. A **host bind mount**
+  `${AGENTBOX_HUB_DATA_DIR:-/opt/agentbox/hub-data}:/root/.agentbox` is the persistent volume —
+  it holds `hub/store.db`, `hub/auth.db`, `hub/custody/…`, `boxes/<id>/ssh/…`, `secrets.env`,
+  logs, and (crucially) is a **host path** so the deploy can `scp` provider secrets into it before
+  `compose up`.
+- **`control-plane-deploy.ts`** — same firewall / cloud-init / Caddy+sslip.io / `deploy.json`
+  shape, with: (a) the scp'd `.env` gains the worker/profile/admin-CIDR keys; (b) a new scp of the
+  **provider secrets** subset (`HCLOUD_TOKEN`, `E2B_API_KEY`, `DAYTONA_API_KEY`,
+  `DAYTONA_ORG_ID`) filtered from the host `~/.agentbox/secrets.env` into
+  `<data-dir>/secrets.env` (0600) on the VPS; (c) the deploy detects the **PC egress IP** (reuse
+  `detectEgressIp`) and writes it as `AGENTBOX_HUB_ADMIN_CIDR` into the `.env`; (d) `mkdir -p` the
+  host data dir before the secrets scp. The app service now needs the data-dir bind, so the
+  compose overlay/base is updated accordingly.
+
+#### 2. Resident in-process worker
+
+- **Promote `makeControlPlaneCreateBox`** (pure lease→clone→create orchestration, only imports a
+  relay type) from `apps/cli/src/control-plane/create-box.ts` into `@agentbox/relay`
+  (`create-worker.ts`), so both the CLI `worker` command *and* the hub can build a `CreateBoxFn`
+  from it (an app can't import another app). The CLI command re-imports it from the package.
+- **`apps/hub/lib/hub-worker.ts`** (new, Node-only, loaded by `server.ts`): builds the hub's
+  `CreateBoxFn` deps — `leaseRemoteUrl` via `GitHubAppLeaser`(`loadGitHubAppConfig()`),
+  `cloneRepo` via `git`, and `createBox` via the hub's own provider `IMPORTERS` map (mirrors
+  `hub-backend.ts`), calling `provider.create({ workspacePath, name, projectRoot,
+  controlPlaneUrl: <hub public URL>, extraInboundCidrs: <admin CIDR>, onLog })`. Around
+  `provider.create` it wraps the two custody steps below.
+- **`server.ts`**: after `startRelayDaemon`, when `process.env.AGENTBOX_HUB_WORKER === 'on'` and
+  the store supports the queue, start an interval loop `drainCreateJobs(store, createBox,
+  os.hostname())`. Stopped on shutdown alongside the daemon.
+- **Agent-credential seed from custody** (the phase text's "point that path at the custody
+  `agents/` scope"): before `provider.create`, a `seedHostBackupsFromCustody()` step reads the
+  in-process `FsCustodyStore` `agents/<id>/<credential.boxRelPath>` for each `AGENT_SYNC_SPECS`
+  entry and writes it to that spec's `credential.hostBackup` (`~/.agentbox/<id>-credentials.json`)
+  — the exact file `provider.create`'s existing seed step reads. So a PC `credentials push`
+  (phase 2) is what logs hub-created boxes in, no second code path.
+- **SSH-key mirror to custody**: after `provider.create`, copy `~/.agentbox/boxes/<id>/ssh/*`
+  into custody `boxes/<id>/ssh/*` (via `FsCustodyStore.put`) so phase 4's `hub pull` can fetch a
+  hub-created hetzner box's key.
+
+#### 3. Provider credentials + runtime bits (folded into 1 + 2)
+
+Covered by the secrets scp (item 1c) landing at `<data-dir>/secrets.env` → the container's
+`~/.agentbox/secrets.env`, which the provider modules' `ensureCredentials()`/`env-loader` read;
+and by `git` + `openssh-client` in the runtime image (item 1). `providerForCreate` is replaced in
+the hub by the `IMPORTERS` map it already uses elsewhere.
+
+#### 4. Dual-IP firewall
+
+- Add optional `extraInboundCidrs?: string[]` to the box create options
+  (`CreateBoxInput`/whatever `provider.create` accepts) → thread through `CloudProvisionRequest`
+  → in `hetznerBackend.provision`, when `req.controlPlaneUrl` is set and the inbound mode isn't
+  `open`, append `req.extraInboundCidrs` (normalized) to the computed `sources` before
+  `createPerBoxFirewall`. `sshOnlyInboundRule` already accepts multiple `source_ips`, so the VPS
+  egress + the admin CIDR land on one `:22` rule. Fail-loud egress detection unchanged. The
+  worker (item 2) supplies the admin CIDR from `AGENTBOX_HUB_ADMIN_CIDR`.
+
+#### 5. Enqueue from the PC + shared `/remote/boxes` dispatcher
+
+- **The `/remote/boxes` endpoints live only in `core/handler.ts` (the Vercel plane); the control
+  box runs `server.ts`, which 404s `/remote/*`.** So extract a shared
+  `handleRemoteBoxesRequest(req, { store, adminToken, createProviders, log })` (mirrors phase 2's
+  custody `handleCustodyRequest` shared-dispatcher pattern) and mount it in **both** `server.ts`
+  (admin-bearer gated, using `opts.adminToken`) and `core/handler.ts`. Same POST-enqueue /
+  GET-status semantics, same `CreateJobRequest` body.
+- **`agentbox create --via-hub`**: a new branch in `apps/cli/src/commands/create.ts` that, instead
+  of creating locally, resolves `{ url, adminToken }` (same resolver as custody), builds a
+  `CreateJobRequest` from the resolved create args (`repoUrl` = the project's git origin,
+  `provider`, `branch` = from-branch, `name`, `agent`, `prompt`), `POST`s `/remote/boxes`, then
+  polls `GET /remote/boxes/:id` and streams job status until `done`/`failed`. The hub UI create
+  modal already enqueues via `enqueueQueueJob`/the backend — no new UI.
+
+#### 6. Deploy ergonomics — `agentbox control-plane deploy hetzner [--ref <ref>]`
+
+- A new `deploy` subcommand that **reuses** the existing `~/.agentbox/control-plane/`
+  (`control-plane.env` + `github-app.pem`) without re-running the GitHub-App manifest flow:
+  fail with a clear message if `control-plane.env` is absent (run `setup` first); ensure the
+  hub-auth block is present (append via `resolveHubAuthEnv()` if missing, same as `setup`); then
+  `runHetznerDeploy({ envPath: ENV_PATH, repoRef: ref, log })`. `--ref` (default `main`) pins the
+  VPS clone — **the host runs `--ref agentbox/cbx-phase3` for the live verify**.
+
+#### Files
+
+New: `packages/relay/src/store/write-through-store.ts`, `packages/relay/src/retention.ts`,
+`packages/relay/src/remote-boxes.ts` (shared dispatcher), `apps/hub/lib/hub-worker.ts`.
+Moved: `makeControlPlaneCreateBox` → `packages/relay/src/create-worker.ts`.
+Touched: `packages/relay/src/{server,daemon,store/store,store/sqlite-store,store/postgres-store,
+core/handler,index,control-plane}.ts`; `packages/sandbox-hetzner/src/{control-plane-deploy,backend}.ts`
++ cloud-provider/core types for `extraInboundCidrs`; `apps/hub/{Dockerfile,docker-compose.yml,
+server.ts}`; `apps/cli/src/{commands/create,commands/control-plane,control-plane/create-box}.ts`;
+`apps/web/content/docs/{control-plane,hub}.mdx`.
+
+#### Tests (docker-free vitest)
+
+- `write-through-store.test.ts` — the store conformance suite against a `WriteThroughStore` over a
+  `:memory:` `SqliteStore`, plus assertions that a `registerBox`/`setStatus` mutation is visible
+  on the injected concrete `registry`/`statusStore`, and that `hydrate()` re-populates them.
+- Retention: unit-test `prunePrompts`/`pruneCreateJobs` on the SQLite store, and `startRetentionLoop`
+  with an injected fake store + clock.
+- `remote-boxes` shared dispatcher: 401 without bearer, 400 bad body, 202 enqueue, GET job — over
+  both handlers (in-process, injected store), mirroring the custody route tests.
+- CLI: a `--via-hub` request-builder unit test (repoUrl/branch/agent mapping), fake-fetch client.
+
+#### In-box docker smoke (manual; not a vitest test)
+
+1. `docker build --network=host -f apps/hub/Dockerfile -t agentbox-hub .` at the repo root
+   (validates item 7: the image builds self-contained from the `--ref` checkout).
+2. Run the container with `AGENTBOX_HUB_PROFILE=hetzner`, `AGENTBOX_HUB_HOST=0.0.0.0`,
+   `AGENTBOX_HUB_PORT=3000`, `AGENTBOX_HUB_WORKER=on`, auth on with a seeded admin, a tmpfs/host
+   volume for `/root/.agentbox`, **no `POSTGRES_URL`**, and a **mock/injected `CreateBoxFn`**
+   (via an `AGENTBOX_HUB_WORKER_MOCK=1` seam so the box never touches a real cloud). Assert:
+   `/healthz` → `db:true`; better-auth signup/login; custody push/pull round-trip over HTTP;
+   `POST /remote/boxes` enqueues; the resident worker claims the job and drives the mock to
+   `done`; a retention tick removes an aged answered-prompt + finished-job row; `docker restart`
+   the container → registry/queue/auth survive on the volume.
+3. **Localhost regression**: `AGENTBOX_HUB_PROFILE` unset (`agentbox hub` on MemoryStore) — the hub
+   backend still sees status + prompts (the loop/backend routing change is the risk; test both
+   profiles).
+4. `pnpm test` + `pnpm typecheck` + `pnpm lint` at the repo root, all green.
+
+#### Live hetzner verify — PENDING-HOST
+
+The end-to-end live checklist (real VPS, real e2b + hetzner boxes, phone-UI login/approvals,
+`claude -p` usable-box turn, `git ls-remote` push check, reboot persistence, destroy-no-orphans)
+runs on the host, since this box can't reach the real clouds from inside. The host runs:
+`agentbox control-plane deploy hetzner --ref agentbox/cbx-phase3` (App creds already set up).
+
 ## Phase 4 — The PC operates through the control box
 
 **Why last:** it consumes everything above — the PC becomes a *peer* that syncs custody material

--- a/docs/control-box-plan.md
+++ b/docs/control-box-plan.md
@@ -452,7 +452,20 @@ sha matches); list returns a 2-entry manifest with **no `data` field**; pull byt
 identical; an unchanged re-push returns `changed:false` (hash hit); on-disk modes are 0600 files
 / 0700 dirs; an unknown scope (`secrets/…`) is 400.
 
-## Phase 3 — The Hetzner deploy ships the full hub + resident create worker
+## Phase 3 — The Hetzner deploy ships the full hub + resident create worker — CODE DONE (box `cbx-phase3`, 2026-07-14); live-hetzner verify PENDING-HOST
+
+- [x] Blocker A — write-through durable store into the in-memory caches + boot hydration (loops + hub backend see state on a hetzner+SQLite hub; localhost byte-identical).
+- [x] Blocker B — retention sweep (answered prompts + finished create jobs) on a periodic daemon loop.
+- [x] Deploy the full hub, not the plane: standalone `server.ts` Dockerfile, app+Caddy compose (Postgres dropped), SQLite, persistent `~/.agentbox` volume.
+- [x] Resident in-process worker (gated `AGENTBOX_HUB_WORKER=on`); seeds agent creds from custody `agents/`, mirrors box SSH keys to custody, registers boxes on the hub.
+- [x] Dual-IP firewall: control-plane-topology hetzner creates add the admin PC egress CIDR to the box firewall.
+- [x] Enqueue from the PC: `agentbox create --via-hub` + a shared `/remote/boxes` dispatcher mounted in `server.ts`.
+- [x] Deploy ergonomics: `agentbox control-plane deploy hetzner [--ref]` reusing the existing App creds.
+- [x] In-box docker smoke green (build + boot + auth + custody + enqueue→worker + restart persistence).
+- [ ] **Live hetzner verify (real VPS + real e2b/hetzner boxes, phone-UI, usable-box `claude -p` + ls-remote push) — PENDING-HOST.**
+
+Result + deviations recorded under [what actually shipped](#phase-3--what-actually-shipped);
+open items went to the [Backlog](#backlog).
 
 **Why third:** with SQLite (no db container) and custody (creds available VPS-side), the deploy
 can finally ship the real thing.
@@ -717,6 +730,69 @@ The end-to-end live checklist (real VPS, real e2b + hetzner boxes, phone-UI logi
 runs on the host, since this box can't reach the real clouds from inside. The host runs:
 `agentbox control-plane deploy hetzner --ref agentbox/cbx-phase3` (App creds already set up).
 
+### Phase 3 — what actually shipped
+
+Everything above landed as planned. Notes + deviations:
+
+- **Blocker A is a write-through wrapper only around durable stores.** `WriteThroughStore`
+  (`packages/relay/src/store/write-through-store.ts`) delegates reads to the inner store and mirrors
+  mutations into the concrete `registry`/`events`/`statusStore`; `startRelayServer` calls
+  `store.hydrate()` before the daemon loops start. The localhost path never constructs it
+  (`opts.store` is undefined → `MemoryStore` verbatim), so it is byte-identical — confirmed by the
+  in-box smoke booting the *localhost* logic through the same relay suite (342 relay tests green).
+  Prompts needed no change: the control box runs host mode + block-mode prompts, so approvals live in
+  the in-process `PendingPrompts` the hub backend already reads.
+- **`/remote/boxes` had to become a shared dispatcher** (`packages/relay/src/remote-boxes.ts`),
+  because it lived only in `core/handler.ts` (the Vercel plane) and the control box runs `server.ts`,
+  which 404s `/remote/*`. Same shape as phase 2's custody dispatcher; mounted in both, admin-bearer
+  gated, fail-closed. `core/handler.ts`'s inline handler was replaced by a call to it.
+- **`makeControlPlaneCreateBox` moved into `@agentbox/relay`** (`create-worker.ts`) so the hub
+  (`apps/hub/lib/hub-worker.ts`) and the CLI `control-plane worker` command share one orchestration;
+  the CLI's `control-plane/create-box.ts` is now a thin re-export. The hub worker resolves providers
+  via its own `IMPORTERS` map (an app can't import the CLI's provider registry).
+- **The worker sets `controlPlaneUrl` on its creates** (so a hub-made box registers on the control
+  box and its approvals route to the phone UI). This makes the box **control-plane topology** while
+  the workspace is still host-seeded (local clone). That combination is the resident-worker shape;
+  the host live-verify should confirm the seeded control-plane box pushes on `agentbox/*` and its
+  approvals surface — flagged in the Backlog.
+- **Dual-IP firewall rides `providerOptions.extraInboundCidrs`** → gated at the cloud-provider layer
+  on `req.controlPlaneUrl` → a new `CloudProvisionRequest.extraInboundCidrs` the hetzner backend
+  appends to the firewall `sources`. No new top-level `CreateBoxRequest` field; the admin CIDR is the
+  deploying PC's egress (reused from the firewall's own `detectEgressIp`).
+- **The deploy keeps provider secrets out of compose env.** They are scp'd from the host
+  `~/.agentbox/secrets.env` (only `HCLOUD_TOKEN`/`E2B_API_KEY`/`DAYTONA_*`) into the data volume as
+  `~/.agentbox/secrets.env`, which the provider modules load — so they never appear in `docker
+  inspect`/compose logs. `AGENTBOX_HUB_PROFILE`/`AGENTBOX_HUB_HOST`/`AGENTBOX_HUB_PORT`/
+  `AGENTBOX_HUB_WORKER` are set literally in the compose `environment:`; only the auth secrets +
+  data-dir/public-url/admin-CIDR ride the scp'd `.env`.
+- **Retention window is constants, not a config key** (24 h keep / hourly sweep) — internal
+  housekeeping, not a user-facing tunable. Promote to a `hub.retention*` key if it ever needs tuning
+  (Backlog).
+
+**Verification (all green, from inside the box):**
+
+| check | result |
+| --- | --- |
+| `pnpm test` (repo root, 29 tasks) | relay 342/1skip, cli 845/1skip |
+| `pnpm typecheck` (31 tasks) | green |
+| `pnpm lint` (17 tasks) | green |
+| New unit tests | write-through (13), retention (4), remote-boxes (8), hub-enqueue (5) |
+| In-box docker smoke (below) | green |
+
+**In-box docker smoke** (manual; `docker build --network=host -f apps/hub/Dockerfile -t
+agentbox-hub .` then a container with `AGENTBOX_HUB_PROFILE=hetzner`, `AGENTBOX_HUB_WORKER=on`,
+`AGENTBOX_HUB_WORKER_MOCK=1`, a seeded admin, a host `~/.agentbox` volume, no `POSTGRES_URL`):
+`/healthz` → `ok:true` (SQLite, zero Postgres); better-auth admin login `200`; custody PUT/GET
+round-trips identical (manifest carries no values); `POST /remote/boxes` enqueues; the resident
+worker claims the job and drives the mock `CreateBoxFn` to `done` with a boxId; `docker restart` →
+the job row, custody, and better-auth all survive on the volume (`store.db`/`auth.db`/`custody/`
+present). Retention correctness is covered by the deterministic `retention.test.ts` (the loop's
+24 h/hourly cadence makes an in-container demonstration impractical).
+
+**Localhost regression:** unaffected by construction — `WriteThroughStore` is only built for a durable
+`opts.store`, `hydrate()` runs only for it, and `startRetentionLoop` no-ops when the store lacks the
+prune methods (MemoryStore). The relay suite exercises the MemoryStore/host-mode path.
+
 ## Phase 4 — The PC operates through the control box
 
 **Why last:** it consumes everything above — the PC becomes a *peer* that syncs custody material
@@ -779,20 +855,34 @@ unaffected throughout (`pnpm --filter @agentbox/relay test` + a local docker smo
 
 Findings and follow-ups discovered while implementing, kept out of the phase they were found in.
 
-- **The daemon's background loops and the hub backend still read in-memory state, not the `Store`
-  (phase 3 blocker).** `startRelayServer` only falls back to `MemoryStore` — inject any other store
-  and the handlers write to it, but the `BoxRegistry` / `EventBuffer` / `BoxStatusStore` instances on
-  the handle stay empty. The autopause loop, the cloud-keepalive loop, the queue loop, and
-  `createHubBackend` (`handle.statusStore.get(id)`, `handle.prompts`) all read those objects. On the
-  localhost profile nothing changes (MemoryStore *is* those objects), but on the control box
-  (hetzner + SQLite) a box's live status reaches `store.setStatus` and no further: autopause would
-  never fire and the hub UI would show no agent status. Phase 3 must route those consumers through
-  the `Store` (or have the durable stores write through to the in-process caches). Phase 1 does not
-  regress anything here — it just makes the gap load-bearing for the first time.
-- **Prompt and create-job rows are never deleted.** Neither durable store prunes answered prompts or
-  finished jobs (events are ring-trimmed; prompts/jobs are not). On the laptop that memory is
-  process-lifetime; on an always-on control box the tables only grow. Add a retention sweep (and use
-  the `expires_at` column already on the row) when the worker becomes resident in phase 3.
+- **(phase 3) A hub-created box is control-plane topology but host-seeded (local clone).** The
+  resident worker sets `controlPlaneUrl` (so the box registers on the control box) yet hands
+  `provider.create` a locally-cloned workspace rather than `inBoxClone`. That mix is untested against
+  a real cloud from inside a box — the host live-verify must confirm a seeded control-plane box
+  completes a `claude -p` turn and pushes on `agentbox/*` (ls-remote). If it misbehaves, switch the
+  worker to `inBoxClone` (leased URL) for control-plane creates.
+- **(phase 3) SSH-key mirror to custody is best-effort + hetzner/DO-only.** `mirrorBoxSshToCustody`
+  reads `defaultBoxSshDir(sandboxId, provider)` after create; e2b/vercel mint no keypair (no-op). Not
+  exercised by the mock smoke — verify on the host that a hub-created hetzner box's keys land in
+  custody `boxes/<id>/ssh/` (phase 4's `hub pull` depends on it). No destroy-time custody GC yet
+  (compounds the phase-2 `custody rm` gap).
+- **(phase 3) Retention window is hard-coded** (24 h keep, hourly sweep). Promote to a
+  `hub.retentionHours` config key if tuning is ever wanted; today it's internal housekeeping.
+- **(phase 3) Worker seeds host credential-backup files, not a per-box isolate.**
+  `seedHostBackupsFromCustody` writes `~/.agentbox/<id>-credentials.json` on the VPS before each
+  create, so concurrent creates share one backup set. Fine for the single-writer control box; revisit
+  if the worker ever runs creates in parallel.
+- **(phase 3) The hub runtime image is the whole built monorepo (~2 GB).** The standalone bundle
+  ships no node_modules, so the image keeps `/repo` for the externals (next/react/pg/SDKs) to resolve
+  from. Correct but unoptimized; a traced prod-deps prune would shrink it if VPS disk matters.
+- **~~The daemon's background loops and the hub backend still read in-memory state, not the `Store`
+  (phase 3 blocker).~~ DONE (phase 3)** — `WriteThroughStore` mirrors a durable store's writes into
+  the in-memory `registry`/`events`/`statusStore` and hydrates them on boot, so the loops + hub
+  backend see state on a hetzner+SQLite hub. localhost is unchanged (the wrapper is only built for a
+  durable `opts.store`).
+- **~~Prompt and create-job rows are never deleted.~~ DONE (phase 3)** — optional
+  `Store.prunePrompts`/`pruneCreateJobs` (SQLite+Postgres, using `expires_at`/`finishedAt`) swept by
+  `startRetentionLoop` in the daemon.
 - **`listStatuses()` is off-interface.** Both durable stores implement it and the hub's
   `postgres-source.ts` calls it on the concrete class. Promote it to `Store` when phase 4 retargets
   the PC's shared state, so the hub can read statuses without knowing the backend.

--- a/packages/core/src/cloud-backend.ts
+++ b/packages/core/src/cloud-backend.ts
@@ -114,6 +114,15 @@ export interface CloudProvisionRequest {
    * firewall's inbound sources; other backends ignore it. Absent ⇒ `locked`.
    */
   inbound?: string;
+  /**
+   * Extra inbound source CIDRs added to the per-box firewall on top of whatever
+   * `inbound` resolves to (VPS backends only). Used for control-plane-topology
+   * creates: a box the control-box VPS provisions locks to the VPS egress IP,
+   * so the admin's PC egress CIDR is added here to keep direct PC→box SSH
+   * working. Ignored unless the inbound mode is not `open` and the backend has a
+   * per-box firewall (hetzner / digitalocean). Absent ⇒ no extra sources.
+   */
+  extraInboundCidrs?: string[];
   /** Env vars baked into the sandbox at provision time. */
   env?: Record<string, string>;
   /** Persistent volumes to attach. Backends without a volume API ignore this. */

--- a/packages/relay/src/control-plane.ts
+++ b/packages/relay/src/control-plane.ts
@@ -17,6 +17,7 @@ export {
   DEFAULT_SQLITE_STORE_PATH,
 } from './store/sqlite-store.js';
 export { PG_SCHEMA_SQL, SQLITE_SCHEMA_SQL } from './store/schema.js';
+export { WriteThroughStore, type WriteThroughParts } from './store/write-through-store.js';
 export { makeStore } from './store/index.js';
 export { MemoryStore } from './store/memory-store.js';
 export { type Store, type PromptRow } from './store/store.js';

--- a/packages/relay/src/control-plane.ts
+++ b/packages/relay/src/control-plane.ts
@@ -26,11 +26,20 @@ export {
   loadGitHubAppConfig,
   type GitHubAppConfig,
 } from './github-app.js';
-export { drainOneCreateJob, drainCreateJobs, type CreateBoxFn } from './create-worker.js';
+export {
+  drainOneCreateJob,
+  drainCreateJobs,
+  makeControlPlaneCreateBox,
+  type CreateBoxFn,
+  type CreateBoxDeps,
+} from './create-worker.js';
 export { type CreateJobRequest, type CreateJobRow } from './store/store.js';
+export { toAuthedHttpsUrl, parseGitRemote, repoSlugFromRemote } from './git-pat.js';
 export {
   type CustodyStore,
   type CustodyEntry,
   type CustodyPutResult,
+  CUSTODY_SCOPES,
+  normalizeCustodyPath,
 } from './custody/store.js';
 export { FsCustodyStore, DEFAULT_CUSTODY_DIR } from './custody/fs-store.js';

--- a/packages/relay/src/core/handler.ts
+++ b/packages/relay/src/core/handler.ts
@@ -1,4 +1,4 @@
-import { randomUUID, timingSafeEqual } from 'node:crypto';
+import { timingSafeEqual } from 'node:crypto';
 import type { GitHubAppLeaser } from '../github-app.js';
 import { leaseTokenResult } from '../lease.js';
 import { gateApproval } from '../permission.js';
@@ -7,8 +7,8 @@ import type { Store } from '../store/store.js';
 import { applyStoreOp, isStoreRpcMethod, type StoreRpcRequest } from '../store/store-rpc.js';
 import { resolveWorktree } from '../worktree.js';
 import { handleCustodyRequest, type CustodyRouteDeps } from '../custody/routes.js';
+import { handleRemoteBoxesRequest } from '../remote-boxes.js';
 import type { CustodyStore } from '../custody/store.js';
-import type { CreateJobRequest } from '../store/store.js';
 import { isScratchBranch } from '@agentbox/core';
 import type {
   BoxRegistration,
@@ -296,45 +296,16 @@ export async function handleRelayRequest(
     return ok({ result: result ?? null });
   }
 
-  if (req.method === 'POST' && req.path === '/remote/boxes') {
-    // Enqueue a durable create job; a worker (self-host loop / Vercel cron)
-    // drains it and clones the repo into a fresh cloud box via a leased token.
-    if (!store.enqueueCreateJob) return err(501, 'create-job queue not available on this store');
-    const body = parseJson<CreateJobRequest>(req.bodyText);
-    if (!body || typeof body.repoUrl !== 'string' || typeof body.provider !== 'string') {
-      return err(400, 'expected {repoUrl, provider, branch?, name?, agent?, prompt?}');
-    }
-    const allowed = deps.createProviders;
-    if (allowed && allowed.length > 0 && !allowed.includes(body.provider)) {
-      return err(
-        400,
-        `provider '${body.provider}' is not supported by this control plane (allowed: ${allowed.join(', ')})`,
-      );
-    }
-    const id = randomUUID();
-    await store.enqueueCreateJob({
-      id,
-      status: 'queued',
-      request: {
-        repoUrl: body.repoUrl,
-        provider: body.provider,
-        branch: body.branch,
-        name: body.name,
-        agent: body.agent,
-        prompt: body.prompt,
-      },
-      createdAt: new Date().toISOString(),
-    });
-    log(`enqueued create job ${id} (${body.provider} ${body.repoUrl})`);
-    return ok({ jobId: id }, 202);
-  }
-
-  if (req.method === 'GET' && req.path.startsWith('/remote/boxes/')) {
-    if (!store.getCreateJob) return err(501, 'create-job queue not available on this store');
-    const id = decodeURIComponent(req.path.slice('/remote/boxes/'.length));
-    const job = await store.getCreateJob(id);
-    return job ? ok(job) : err(404, 'no such job');
-  }
+  // Create-queue surface (`/remote/boxes`) — a shared dispatcher mounted in both
+  // this hosted-plane handler and the relay daemon (`server.ts`), so the control
+  // box and the Vercel plane serve identical enqueue/status semantics.
+  const remote = await handleRemoteBoxesRequest(req, {
+    store,
+    adminToken: deps.adminToken,
+    createProviders: deps.createProviders,
+    log,
+  });
+  if (remote) return remote.body === undefined ? { status: remote.status } : ok(remote.body, remote.status);
 
   return err(404, 'not found');
 }

--- a/packages/relay/src/create-worker.ts
+++ b/packages/relay/src/create-worker.ts
@@ -10,6 +10,64 @@ import type { CreateJobRequest, Store } from './store/store.js';
 export type CreateBoxFn = (request: CreateJobRequest, jobId: string) => Promise<{ boxId: string }>;
 
 /**
+ * Side-effecting steps a {@link makeControlPlaneCreateBox} needs, all injected
+ * so the orchestration is unit-testable without a cloud or GitHub. The worker
+ * (laptop `control-plane worker`, or the resident hub worker) clones the repo
+ * LOCALLY with a leased GitHub-App token and hands the fresh checkout to the
+ * normal, tested `provider.create()` as the workspace — origin-clone seeding
+ * without touching the host-coupled create flow.
+ */
+export interface CreateBoxDeps {
+  /** Mint an authed HTTPS remote URL for the repo (App lease → x-access-token URL). */
+  leaseRemoteUrl(repoUrl: string): Promise<string>;
+  /**
+   * Clone `authedUrl` into `dest` (checking out `branch` when given), then scrub
+   * the remote back to the bare `repoUrl`.
+   */
+  cloneRepo(authedUrl: string, repoUrl: string, dest: string, branch?: string): Promise<void>;
+  /** Provision the cloud box from the local checkout. Returns the new box id. */
+  createBox(opts: {
+    workspacePath: string;
+    name: string | undefined;
+    provider: string;
+    onLog?: (line: string) => void;
+  }): Promise<{ id: string }>;
+  /** Make a per-job temp dir path. */
+  tmpDir(jobId: string): string;
+  /** Remove the temp checkout (best-effort). */
+  cleanup(dir: string): Promise<void>;
+  log?: (line: string) => void;
+}
+
+/**
+ * Build a {@link CreateBoxFn} from injected side-effecting steps: lease a push
+ * token, clone the repo locally, provision the box from that checkout, clean up.
+ */
+export function makeControlPlaneCreateBox(deps: CreateBoxDeps): CreateBoxFn {
+  return async (request, jobId) => {
+    const log = deps.log ?? (() => {});
+    const dir = deps.tmpDir(jobId);
+    try {
+      log(`leasing a push token for ${request.repoUrl}`);
+      const authedUrl = await deps.leaseRemoteUrl(request.repoUrl);
+      log(`cloning ${request.repoUrl}${request.branch ? `@${request.branch}` : ''} into ${dir}`);
+      await deps.cloneRepo(authedUrl, request.repoUrl, dir, request.branch);
+      log(`provisioning ${request.provider} box from the clone`);
+      const box = await deps.createBox({
+        workspacePath: dir,
+        name: request.name,
+        provider: request.provider,
+        onLog: deps.log,
+      });
+      log(`created box ${box.id}`);
+      return { boxId: box.id };
+    } finally {
+      await deps.cleanup(dir);
+    }
+  };
+}
+
+/**
  * Claim + run ONE queued create job. Returns the processed job id, or null when
  * the queue is empty (or the store has no create-job support). A throwing
  * `createBox` marks the job failed (never throws out of here).

--- a/packages/relay/src/daemon.ts
+++ b/packages/relay/src/daemon.ts
@@ -2,6 +2,7 @@ import { startRelayServer, type RelayServerHandle, type RelayServerOptions } fro
 import { startAutopauseLoop } from './autopause.js';
 import { startCloudKeepaliveLoop } from './cloud-keepalive.js';
 import { startQueueLoop } from './queue.js';
+import { startRetentionLoop } from './retention.js';
 
 export interface RelayDaemonHandle {
   /** The underlying relay server (url, store, close, …). */
@@ -43,6 +44,9 @@ export async function startRelayDaemon(opts: RelayServerOptions): Promise<RelayD
     // then transitions creating → running without waiting for the 15s SSE ping.
     onStatusChange: () => handle.hubNotifier.notify(),
   });
+  // Sweep answered prompts + finished create jobs on a resident control box
+  // (durable store). A no-op when the store lacks the prune methods (localhost).
+  const retention = startRetentionLoop({ store: handle.store, log });
   // `poke` isn't on the declared QueueLoopHandle (only `stop` is); same cast bin.ts used.
   handle.setQueuePoke(() => {
     (queue as { poke?: () => void }).poke?.();
@@ -51,7 +55,12 @@ export async function startRelayDaemon(opts: RelayServerOptions): Promise<RelayD
   return {
     handle,
     stop: async () => {
-      await Promise.allSettled([autopause.stop(), cloudKeepalive.stop(), queue.stop()]);
+      await Promise.allSettled([
+        autopause.stop(),
+        cloudKeepalive.stop(),
+        queue.stop(),
+        retention.stop(),
+      ]);
       await handle.close();
     },
   };

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -53,7 +53,13 @@ export {
 } from './permission.js';
 export { resolveWorktree } from './worktree.js';
 export { leaseTokenResult } from './lease.js';
-export { drainOneCreateJob, drainCreateJobs, type CreateBoxFn } from './create-worker.js';
+export {
+  drainOneCreateJob,
+  drainCreateJobs,
+  makeControlPlaneCreateBox,
+  type CreateBoxFn,
+  type CreateBoxDeps,
+} from './create-worker.js';
 export { type CreateJobRequest, type CreateJobRow } from './store/store.js';
 export { toAuthedHttpsUrl, parseGitRemote, repoSlugFromRemote } from './git-pat.js';
 export {

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -98,6 +98,14 @@ export {
   type CustodyRouteDeps,
 } from './custody/routes.js';
 export {
+  handleRemoteBoxesRequest,
+  isRemoteBoxesPath,
+  REMOTE_BOXES_PREFIX,
+  type RemoteBoxesRequest,
+  type RemoteBoxesResponse,
+  type RemoteBoxesDeps,
+} from './remote-boxes.js';
+export {
   askPrompt,
   type AutoApprovePolicy,
   isPromptAnswerBody,

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -69,6 +69,7 @@ export {
   DEFAULT_SQLITE_STORE_PATH,
 } from './store/sqlite-store.js';
 export { PG_SCHEMA_SQL, SQLITE_SCHEMA_SQL } from './store/schema.js';
+export { WriteThroughStore, type WriteThroughParts } from './store/write-through-store.js';
 export { RemoteStore, type RemoteStoreOptions } from './store/remote-store.js';
 export {
   applyStoreOp,
@@ -183,6 +184,11 @@ export {
   type KeepaliveScanEntry,
   type RenewDecision,
 } from './cloud-keepalive.js';
+export {
+  startRetentionLoop,
+  type RetentionLoopDeps,
+  type RetentionLoopHandle,
+} from './retention.js';
 export {
   countWorkingSlots,
   defaultCountRunningBoxes,

--- a/packages/relay/src/remote-boxes.ts
+++ b/packages/relay/src/remote-boxes.ts
@@ -1,0 +1,133 @@
+/**
+ * The `/remote/boxes` create-queue surface, as a framework-agnostic dispatcher
+ * mounted by BOTH relay front-ends: the hosted-plane handler (`core/handler.ts`,
+ * Next/Vercel) and the relay daemon (`server.ts`, node:http — what the control
+ * box actually runs). One implementation, one gate, both profiles.
+ *
+ * Like custody, the **admin bearer is the only proof** — never loopback (the
+ * control box sits behind Caddy on the same host, so every proxied request looks
+ * loopback). Missing admin token → 503 (not configured); wrong token → 401; a
+ * store without the create-job queue → 501.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { timingSafeEqual } from 'node:crypto';
+import type { CreateJobRequest, Store } from './store/store.js';
+
+/** Structurally identical to `RelayResponse` in `core/handler.ts` (kept local to avoid a cycle). */
+export interface RemoteBoxesResponse {
+  status: number;
+  body?: unknown;
+}
+
+export interface RemoteBoxesRequest {
+  method: string;
+  /** URL pathname, e.g. `/remote/boxes` or `/remote/boxes/<jobId>`. */
+  path: string;
+  /** Bearer token as presented ('' when absent). */
+  bearer: string;
+  /** Raw request body ('' for GET). */
+  bodyText: string;
+}
+
+export interface RemoteBoxesDeps {
+  store: Store;
+  /** Admin bearer. Empty/absent → not configured (503). */
+  adminToken?: string;
+  /**
+   * Providers this plane can CREATE boxes on. `undefined`/empty → all allowed
+   * (the full-host control box). A serverless plane sets the SDK-native set.
+   */
+  createProviders?: string[];
+  log?: (line: string) => void;
+}
+
+export const REMOTE_BOXES_PREFIX = '/remote/boxes';
+
+/** True when `path` addresses the create-queue surface. */
+export function isRemoteBoxesPath(path: string): boolean {
+  return path === REMOTE_BOXES_PREFIX || path.startsWith(`${REMOTE_BOXES_PREFIX}/`);
+}
+
+function timingSafeEqualStr(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'utf8');
+  const bb = Buffer.from(b, 'utf8');
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+function parseJson<T>(text: string): T | null {
+  if (text.length === 0) return {} as T;
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Dispatch one `/remote/boxes` request. Returns `null` when `req.path` is not a
+ * create-queue path, so a host router falls through to its own routes unchanged.
+ */
+export async function handleRemoteBoxesRequest(
+  req: RemoteBoxesRequest,
+  deps: RemoteBoxesDeps,
+): Promise<RemoteBoxesResponse | null> {
+  if (!isRemoteBoxesPath(req.path)) return null;
+  const log = deps.log ?? (() => {});
+  const { store } = deps;
+
+  const adminToken = deps.adminToken ?? '';
+  if (adminToken.length === 0) {
+    return { status: 503, body: { error: 'control plane not configured: admin token unset' } };
+  }
+  if (!timingSafeEqualStr(req.bearer, adminToken)) {
+    return { status: 401, body: { error: 'invalid admin token' } };
+  }
+
+  if (req.method === 'POST' && req.path === REMOTE_BOXES_PREFIX) {
+    if (!store.enqueueCreateJob) {
+      return { status: 501, body: { error: 'create-job queue not available on this store' } };
+    }
+    const body = parseJson<CreateJobRequest>(req.bodyText);
+    if (!body || typeof body.repoUrl !== 'string' || typeof body.provider !== 'string') {
+      return { status: 400, body: { error: 'expected {repoUrl, provider, branch?, name?, agent?, prompt?}' } };
+    }
+    const allowed = deps.createProviders;
+    if (allowed && allowed.length > 0 && !allowed.includes(body.provider)) {
+      return {
+        status: 400,
+        body: {
+          error: `provider '${body.provider}' is not supported by this control plane (allowed: ${allowed.join(', ')})`,
+        },
+      };
+    }
+    const id = randomUUID();
+    await store.enqueueCreateJob({
+      id,
+      status: 'queued',
+      request: {
+        repoUrl: body.repoUrl,
+        provider: body.provider,
+        branch: body.branch,
+        name: body.name,
+        agent: body.agent,
+        prompt: body.prompt,
+      },
+      createdAt: new Date().toISOString(),
+    });
+    log(`enqueued create job ${id} (${body.provider} ${body.repoUrl})`);
+    return { status: 202, body: { jobId: id } };
+  }
+
+  if (req.method === 'GET' && req.path.startsWith(`${REMOTE_BOXES_PREFIX}/`)) {
+    if (!store.getCreateJob) {
+      return { status: 501, body: { error: 'create-job queue not available on this store' } };
+    }
+    const id = decodeURIComponent(req.path.slice(`${REMOTE_BOXES_PREFIX}/`.length));
+    const job = await store.getCreateJob(id);
+    return job ? { status: 200, body: job } : { status: 404, body: { error: 'no such job' } };
+  }
+
+  return { status: 405, body: { error: 'method not allowed' } };
+}

--- a/packages/relay/src/retention.ts
+++ b/packages/relay/src/retention.ts
@@ -1,0 +1,77 @@
+import type { Store } from './store/store.js';
+
+/**
+ * Periodic housekeeping for a resident control box: sweep answered prompts and
+ * finished create jobs so the durable tables don't grow without bound. Events
+ * are already ring-trimmed on append; prompts + jobs are not.
+ *
+ * A no-op unless the store implements the prune methods (durable stores only —
+ * the laptop's MemoryStore is process-lifetime, nothing to sweep). Modeled on
+ * the other daemon loops (timer, `unref`, never crashes the process).
+ */
+
+/** Rows are kept this long after they finish before a sweep removes them. */
+const DEFAULT_RETENTION_MS = 24 * 60 * 60_000;
+const DEFAULT_INTERVAL_MS = 60 * 60_000;
+
+export interface RetentionLoopDeps {
+  store: Store;
+  log: (line: string) => void;
+  /** How long a finished row survives before it's swept. Default 24h. */
+  retentionMs?: number;
+  /** Sweep cadence. Default hourly. */
+  intervalMs?: number;
+  /** Injectable for tests; defaults to `Date.now`. */
+  now?: () => number;
+}
+
+export interface RetentionLoopHandle {
+  stop: () => Promise<void>;
+}
+
+export function startRetentionLoop(deps: RetentionLoopDeps): RetentionLoopHandle {
+  const { store, log } = deps;
+  const retentionMs = deps.retentionMs ?? DEFAULT_RETENTION_MS;
+  const intervalMs = deps.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const nowFn = deps.now ?? Date.now;
+
+  // Nothing to sweep on a store without the prune methods (localhost/tests).
+  if (!store.prunePrompts && !store.pruneCreateJobs) {
+    return { stop: () => Promise.resolve() };
+  }
+
+  let ticking = false;
+  let stopped = false;
+  let inFlight: Promise<void> = Promise.resolve();
+
+  async function tick(): Promise<void> {
+    if (ticking) return;
+    ticking = true;
+    try {
+      const before = new Date(nowFn() - retentionMs).toISOString();
+      const prompts = (await store.prunePrompts?.(before)) ?? 0;
+      const jobs = (await store.pruneCreateJobs?.(before)) ?? 0;
+      if (prompts > 0 || jobs > 0) {
+        log(`retention: pruned ${String(prompts)} prompt(s), ${String(jobs)} create job(s)`);
+      }
+    } catch (err) {
+      log(`retention: tick error: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      ticking = false;
+    }
+  }
+
+  const timer = setInterval(() => {
+    if (stopped) return;
+    inFlight = tick();
+  }, intervalMs);
+  timer.unref();
+
+  return {
+    stop: async () => {
+      stopped = true;
+      clearInterval(timer);
+      await inFlight.catch(() => {});
+    },
+  };
+}

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -68,6 +68,7 @@ import { BoxRegistry, EventBuffer } from './registry.js';
 import { CREDENTIALS_UPDATED_EVENT, CredentialsFanout } from './credentials-fanout.js';
 import { BoxStatusStore, isValidBoxStatus } from './status-store.js';
 import { MemoryStore } from './store/memory-store.js';
+import { WriteThroughStore } from './store/write-through-store.js';
 import type { Store } from './store/store.js';
 import { DEFAULT_BOX_RELAY_PORT } from './types.js';
 import { buildCpArgv, cpFlags, normalizeCpParams } from './cp-rpc.js';
@@ -315,7 +316,15 @@ export function createRelayServer(opts: RelayServerOptions): RelayServerHandle {
   // hosted control plane injects a Postgres-backed store instead. Handlers go
   // through `store.*`; the concrete instances stay exposed on the handle for
   // the autopause / queue loops (bin.ts) and the unit tests that read them.
-  const store: Store = opts.store ?? new MemoryStore({ registry, events, statusStore });
+  // Persisted-state seam. localhost/tests get a MemoryStore wrapping the concrete
+  // instances above (byte-identical to the pre-seam relay). A control box injects
+  // a durable store (SQLite/Postgres); wrap it so every write also mirrors into
+  // those instances — the daemon's loops + the hub backend read them synchronously
+  // and would otherwise see an empty registry/statusStore (Backlog: phase-3
+  // blocker A). `startRelayServer` hydrates the mirror from the store on boot.
+  const store: Store = opts.store
+    ? new WriteThroughStore(opts.store, { registry, events, statusStore })
+    : new MemoryStore({ registry, events, statusStore });
   // Per-box `box.autoApproveHostActions`: when a box registered with the flag,
   // host-action confirms resolve to 'y' without a prompt, but every bypass
   // lands in the event ring buffer (visible via `/admin/events`) so it's
@@ -2176,6 +2185,10 @@ function runHostCommand(
 
 export async function startRelayServer(opts: RelayServerOptions): Promise<RelayServerHandle> {
   const handle = createRelayServer(opts);
+  // Hydrate the in-memory mirror from a durable store before the caller starts
+  // the daemon loops, so a control box's registry/statusStore survive a restart
+  // (no-op for the MemoryStore laptop path — it has no `hydrate`).
+  if (handle.store instanceof WriteThroughStore) await handle.store.hydrate();
   await new Promise<void>((resolve, reject) => {
     handle.server.once('error', reject);
     handle.server.listen(opts.port, opts.host ?? '0.0.0.0', () => {

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -62,6 +62,7 @@ import { leaseTokenResult } from './lease.js';
 import { gateApproval, type GateDeps, type PromptMode } from './permission.js';
 import { resolveWorktree } from './worktree.js';
 import { handleCustodyRequest } from './custody/routes.js';
+import { handleRemoteBoxesRequest, isRemoteBoxesPath } from './remote-boxes.js';
 import type { CustodyStore } from './custody/store.js';
 import { askPrompt, isPromptAnswerBody, PendingPrompts, PromptSubscribers } from './prompts.js';
 import { BoxRegistry, EventBuffer } from './registry.js';
@@ -517,12 +518,33 @@ export function createRelayServer(opts: RelayServerOptions): RelayServerHandle {
       }
     }
 
+    // Create-queue surface (`/remote/boxes`) — admin-bearer-gated like custody
+    // (not loopback: the control box is behind Caddy). The shared dispatcher is
+    // the SAME one the Vercel plane's `core/handler.ts` mounts, so the PC can
+    // `agentbox create --via-hub` against the control box exactly as against the
+    // hosted plane. Runs before the loopback rejection below.
+    if (isRemoteBoxesPath(url.pathname)) {
+      const bodyText = req.method === 'POST' ? await readRawBody(req) : '';
+      const remoteRes = await handleRemoteBoxesRequest(
+        {
+          method: req.method ?? 'GET',
+          path: url.pathname,
+          bearer: bearerToken(req),
+          bodyText,
+        },
+        { store, adminToken: custodyAdminToken, log },
+      );
+      if (remoteRes) {
+        send(res, remoteRes.status, remoteRes.body ?? null);
+        return;
+      }
+    }
+
     // Admin endpoints are reachable from loopback only. The relay binds to
     // 0.0.0.0 so containers can reach /events and /rpc via host.docker.internal,
     // but admin operations (register-box, forget-box, list events, etc.) are
-    // for the host CLI and must not be exposed to boxes. `/remote/*` is a
-    // hosted-control-plane surface (box creation) served by the Next.js app's
-    // handler, not the laptop relay — so it does not exist here.
+    // for the host CLI and must not be exposed to boxes. Any other `/remote/*`
+    // is a hosted-plane surface not served by this relay.
     if (url.pathname.startsWith('/admin/') || url.pathname.startsWith('/remote/')) {
       if (url.pathname.startsWith('/remote/')) {
         send(res, 404, { error: 'not found', route });

--- a/packages/relay/src/store/index.ts
+++ b/packages/relay/src/store/index.ts
@@ -7,6 +7,7 @@ export type { Store } from './store.js';
 export { MemoryStore, type MemoryStoreParts } from './memory-store.js';
 export { PostgresStore, type PostgresStoreOptions } from './postgres-store.js';
 export { SqliteStore, type SqliteStoreOptions, DEFAULT_SQLITE_STORE_PATH } from './sqlite-store.js';
+export { WriteThroughStore, type WriteThroughParts } from './write-through-store.js';
 export { PG_SCHEMA_SQL, SQLITE_SCHEMA_SQL } from './schema.js';
 
 /**

--- a/packages/relay/src/store/postgres-store.ts
+++ b/packages/relay/src/store/postgres-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gt, inArray, lte } from 'drizzle-orm';
+import { and, asc, eq, gt, inArray, isNotNull, lt, lte, or } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import type { Pool } from 'pg';
 import type { BoxStatusSnapshot } from '../status-store.js';
@@ -340,5 +340,38 @@ export class PostgresStore implements Store {
       .update(pgCreateJobs)
       .set({ status, result, finishedAt: new Date() })
       .where(eq(pgCreateJobs.id, id));
+  }
+
+  // --- retention (timestamptz columns compare against a Date) ---
+
+  async prunePrompts(beforeIso: string): Promise<number> {
+    const db = await this.db();
+    const before = new Date(beforeIso);
+    const rows = await db
+      .delete(pgPrompts)
+      .where(
+        or(
+          and(eq(pgPrompts.status, 'answered'), lt(pgPrompts.createdAt, before)),
+          and(isNotNull(pgPrompts.expiresAt), lt(pgPrompts.expiresAt, before)),
+        ),
+      )
+      .returning({ id: pgPrompts.id });
+    return rows.length;
+  }
+
+  async pruneCreateJobs(beforeIso: string): Promise<number> {
+    const db = await this.db();
+    const before = new Date(beforeIso);
+    const rows = await db
+      .delete(pgCreateJobs)
+      .where(
+        and(
+          inArray(pgCreateJobs.status, ['done', 'failed']),
+          isNotNull(pgCreateJobs.finishedAt),
+          lt(pgCreateJobs.finishedAt, before),
+        ),
+      )
+      .returning({ id: pgCreateJobs.id });
+    return rows.length;
   }
 }

--- a/packages/relay/src/store/sqlite-store.ts
+++ b/packages/relay/src/store/sqlite-store.ts
@@ -2,7 +2,7 @@ import { mkdirSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { STATE_DIR } from '@agentbox/config';
-import { and, asc, eq, gt, inArray, lte } from 'drizzle-orm';
+import { and, asc, eq, gt, inArray, isNotNull, lt, lte, or } from 'drizzle-orm';
 import type { SqliteRemoteDatabase } from 'drizzle-orm/sqlite-proxy';
 import type { BoxStatusSnapshot } from '../status-store.js';
 import type { BoxRegistration, GitRpcResult, RelayEvent } from '../types.js';
@@ -414,5 +414,36 @@ export class SqliteStore implements Store {
       .update(sqliteCreateJobs)
       .set({ status, result, finishedAt: new Date().toISOString() })
       .where(eq(sqliteCreateJobs.id, id));
+  }
+
+  // --- retention (ISO strings compare lexicographically, matching the columns) ---
+
+  async prunePrompts(beforeIso: string): Promise<number> {
+    const db = await this.db();
+    const rows = await db
+      .delete(sqlitePrompts)
+      .where(
+        or(
+          and(eq(sqlitePrompts.status, 'answered'), lt(sqlitePrompts.createdAt, beforeIso)),
+          and(isNotNull(sqlitePrompts.expiresAt), lt(sqlitePrompts.expiresAt, beforeIso)),
+        ),
+      )
+      .returning({ id: sqlitePrompts.id });
+    return rows.length;
+  }
+
+  async pruneCreateJobs(beforeIso: string): Promise<number> {
+    const db = await this.db();
+    const rows = await db
+      .delete(sqliteCreateJobs)
+      .where(
+        and(
+          inArray(sqliteCreateJobs.status, ['done', 'failed']),
+          isNotNull(sqliteCreateJobs.finishedAt),
+          lt(sqliteCreateJobs.finishedAt, beforeIso),
+        ),
+      )
+      .returning({ id: sqliteCreateJobs.id });
+    return rows.length;
   }
 }

--- a/packages/relay/src/store/store.ts
+++ b/packages/relay/src/store/store.ts
@@ -133,4 +133,12 @@ export interface Store {
     status: 'done' | 'failed',
     result: { boxId?: string; error?: string },
   ): Promise<void>;
+
+  // --- retention (durable stores only; the laptop's memory is process-lifetime).
+  // A resident control box runs forever, so answered prompts + finished jobs must
+  // be swept or the tables only grow. Both return the number of rows removed. ---
+  /** Delete answered prompts (and expired-past-`expires_at` rows) older than `beforeIso`. */
+  prunePrompts?(beforeIso: string): Promise<number>;
+  /** Delete done/failed create jobs whose `finishedAt` is older than `beforeIso`. */
+  pruneCreateJobs?(beforeIso: string): Promise<number>;
 }

--- a/packages/relay/src/store/write-through-store.ts
+++ b/packages/relay/src/store/write-through-store.ts
@@ -1,0 +1,197 @@
+import type { BoxRegistry, EventBuffer } from '../registry.js';
+import type { BoxStatusSnapshot, BoxStatusStore } from '../status-store.js';
+import type { BoxRegistration, GitRpcResult, RelayEvent } from '../types.js';
+import type { CreateJobRow, PromptRow, Store } from './store.js';
+
+export interface WriteThroughParts {
+  registry: BoxRegistry;
+  events: EventBuffer;
+  statusStore: BoxStatusStore;
+}
+
+/** A durable store that also exposes the off-interface bulk-status read. */
+interface StoreWithStatuses extends Store {
+  listStatuses?(): Promise<Array<{ boxId: string; status: BoxStatusSnapshot }>>;
+  prunePrompts?(beforeIso: string): Promise<number>;
+  pruneCreateJobs?(beforeIso: string): Promise<number>;
+}
+
+/**
+ * Wraps a durable {@link Store} (SQLite / Postgres) and mirrors every mutating
+ * call into the in-process `BoxRegistry` / `EventBuffer` / `BoxStatusStore` the
+ * relay handle exposes.
+ *
+ * Why this exists: the daemon's background loops (autopause, cloud-keepalive,
+ * queue) and the hub backend read those concrete instances *synchronously*, not
+ * the async `Store`. On the laptop that is fine — `MemoryStore` IS those
+ * instances. But a control box injects a durable store, and without this wrapper
+ * the handlers would write to SQLite while the instances stay empty, so
+ * cloud-keepalive would never see a box and the hub UI would show no status.
+ *
+ * The durable store stays the source of truth (it survives restarts); the
+ * in-memory instances are a within-process cache kept in lock-step by
+ * write-through + a one-time {@link hydrate} on boot. The control box runs a
+ * single hub process (SQLite single-writer, per phase 1), so no other writer can
+ * make the mirror stale. Reads are pure delegation to the durable store.
+ */
+export class WriteThroughStore implements Store {
+  private readonly inner: StoreWithStatuses;
+  private readonly registry: BoxRegistry;
+  private readonly events: EventBuffer;
+  private readonly statusStore: BoxStatusStore;
+
+  constructor(inner: Store, parts: WriteThroughParts) {
+    this.inner = inner;
+    this.registry = parts.registry;
+    this.events = parts.events;
+    this.statusStore = parts.statusStore;
+  }
+
+  /**
+   * Load the durable store's boxes + statuses into the in-memory instances, once
+   * at boot, so the loops start against a populated registry after a restart.
+   * Events are a ring buffer (ephemeral) and are not hydrated.
+   */
+  async hydrate(): Promise<void> {
+    for (const reg of await this.inner.listBoxes()) this.registry.register(reg);
+    if (this.inner.listStatuses) {
+      for (const { boxId, status } of await this.inner.listStatuses()) {
+        const reg = this.registry.get(boxId);
+        await this.statusStore.set(boxId, reg?.name ?? boxId, reg?.projectIndex, status);
+      }
+    }
+  }
+
+  migrate(): Promise<void> {
+    return this.inner.migrate?.() ?? Promise.resolve();
+  }
+
+  // --- boxes ---
+
+  async registerBox(reg: BoxRegistration): Promise<void> {
+    await this.inner.registerBox(reg);
+    this.registry.register(reg);
+  }
+
+  getBox(boxId: string): Promise<BoxRegistration | undefined> {
+    return this.inner.getBox(boxId);
+  }
+
+  authenticateBox(token: string): Promise<BoxRegistration | null> {
+    return this.inner.authenticateBox(token);
+  }
+
+  listBoxes(): Promise<BoxRegistration[]> {
+    return this.inner.listBoxes();
+  }
+
+  async forgetBox(boxId: string): Promise<boolean> {
+    const existed = await this.inner.forgetBox(boxId);
+    this.registry.forget(boxId);
+    return existed;
+  }
+
+  countBoxes(): Promise<number> {
+    return this.inner.countBoxes();
+  }
+
+  // --- events ---
+
+  async appendEvent(input: Omit<RelayEvent, 'id' | 'receivedAt'>): Promise<RelayEvent> {
+    const ev = await this.inner.appendEvent(input);
+    // The mirror ring keeps its own id sequence; the loops only read box/type/ts,
+    // never cross-reference the durable id, so the divergence is harmless.
+    this.events.append(input);
+    return ev;
+  }
+
+  listEvents(since: number, boxId?: string): Promise<RelayEvent[]> {
+    return this.inner.listEvents(since, boxId);
+  }
+
+  countEvents(): Promise<number> {
+    return this.inner.countEvents();
+  }
+
+  // --- status ---
+
+  async setStatus(
+    boxId: string,
+    name: string,
+    projectIndex: number | undefined,
+    status: BoxStatusSnapshot,
+  ): Promise<void> {
+    await this.inner.setStatus(boxId, name, projectIndex, status);
+    await this.statusStore.set(boxId, name, projectIndex, status);
+  }
+
+  getStatus(boxId: string): Promise<BoxStatusSnapshot | undefined> {
+    return this.inner.getStatus(boxId);
+  }
+
+  async deleteStatus(boxId: string): Promise<void> {
+    await this.inner.deleteStatus(boxId);
+    this.statusStore.delete(boxId);
+  }
+
+  /** Off-interface bulk read (postgres-source.ts) — forwarded for parity. */
+  listStatuses(): Promise<Array<{ boxId: string; status: BoxStatusSnapshot }>> {
+    return this.inner.listStatuses?.() ?? Promise.resolve([]);
+  }
+
+  // --- prompt mailbox (pure delegation; no in-memory mirror the loops read) ---
+
+  createPrompt(row: PromptRow): Promise<void> {
+    return this.inner.createPrompt(row);
+  }
+
+  getPrompt(promptId: string): Promise<PromptRow | null> {
+    return this.inner.getPrompt(promptId);
+  }
+
+  answerPrompt(promptId: string, answer: 'y' | 'n', cancelled?: boolean): Promise<boolean> {
+    return this.inner.answerPrompt(promptId, answer, cancelled);
+  }
+
+  listPendingPrompts(boxId: string): Promise<PromptRow[]> {
+    return this.inner.listPendingPrompts(boxId);
+  }
+
+  setPromptResult(promptId: string, result: GitRpcResult): Promise<void> {
+    return this.inner.setPromptResult(promptId, result);
+  }
+
+  // --- box-create job queue (pure delegation) ---
+
+  enqueueCreateJob(job: CreateJobRow): Promise<void> {
+    if (!this.inner.enqueueCreateJob) return Promise.resolve();
+    return this.inner.enqueueCreateJob(job);
+  }
+
+  getCreateJob(id: string): Promise<CreateJobRow | null> {
+    return this.inner.getCreateJob?.(id) ?? Promise.resolve(null);
+  }
+
+  claimNextCreateJob(workerId: string): Promise<CreateJobRow | null> {
+    return this.inner.claimNextCreateJob?.(workerId) ?? Promise.resolve(null);
+  }
+
+  completeCreateJob(
+    id: string,
+    status: 'done' | 'failed',
+    result: { boxId?: string; error?: string },
+  ): Promise<void> {
+    if (!this.inner.completeCreateJob) return Promise.resolve();
+    return this.inner.completeCreateJob(id, status, result);
+  }
+
+  // --- retention (forwarded; blocker B) ---
+
+  prunePrompts(beforeIso: string): Promise<number> {
+    return this.inner.prunePrompts?.(beforeIso) ?? Promise.resolve(0);
+  }
+
+  pruneCreateJobs(beforeIso: string): Promise<number> {
+    return this.inner.pruneCreateJobs?.(beforeIso) ?? Promise.resolve(0);
+  }
+}

--- a/packages/relay/test/remote-boxes.test.ts
+++ b/packages/relay/test/remote-boxes.test.ts
@@ -1,0 +1,84 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { handleRemoteBoxesRequest } from '../src/remote-boxes.js';
+import { SqliteStore } from '../src/store/sqlite-store.js';
+
+const ADMIN = 'admin-secret';
+const open: SqliteStore[] = [];
+function store(): SqliteStore {
+  const s = new SqliteStore({ path: ':memory:' });
+  open.push(s);
+  return s;
+}
+afterAll(async () => {
+  await Promise.all(open.map((s) => s.close()));
+});
+
+function req(over: Partial<Parameters<typeof handleRemoteBoxesRequest>[0]>) {
+  return { method: 'GET', path: '/remote/boxes', bearer: ADMIN, bodyText: '', ...over };
+}
+
+describe('handleRemoteBoxesRequest', () => {
+  it('returns null for non-remote paths (router falls through)', async () => {
+    const res = await handleRemoteBoxesRequest(req({ path: '/events' }), { store: store(), adminToken: ADMIN });
+    expect(res).toBeNull();
+  });
+
+  it('fail-closes 503 when the admin token is unset', async () => {
+    const res = await handleRemoteBoxesRequest(req({ bearer: '' }), { store: store(), adminToken: '' });
+    expect(res?.status).toBe(503);
+  });
+
+  it('401s a wrong bearer', async () => {
+    const res = await handleRemoteBoxesRequest(req({ bearer: 'nope' }), { store: store(), adminToken: ADMIN });
+    expect(res?.status).toBe(401);
+  });
+
+  it('400s a malformed enqueue body', async () => {
+    const res = await handleRemoteBoxesRequest(
+      req({ method: 'POST', bodyText: JSON.stringify({ provider: 'e2b' }) }),
+      { store: store(), adminToken: ADMIN },
+    );
+    expect(res?.status).toBe(400);
+  });
+
+  it('enqueues (202) and round-trips via GET /remote/boxes/:id', async () => {
+    const s = store();
+    const enq = await handleRemoteBoxesRequest(
+      req({ method: 'POST', bodyText: JSON.stringify({ repoUrl: 'https://x/r.git', provider: 'e2b', branch: 'main' }) }),
+      { store: s, adminToken: ADMIN },
+    );
+    expect(enq?.status).toBe(202);
+    const jobId = (enq?.body as { jobId: string }).jobId;
+    expect(jobId).toBeTruthy();
+
+    const get = await handleRemoteBoxesRequest(req({ path: `/remote/boxes/${jobId}` }), { store: s, adminToken: ADMIN });
+    expect(get?.status).toBe(200);
+    expect((get?.body as { request: { provider: string } }).request.provider).toBe('e2b');
+    expect((get?.body as { status: string }).status).toBe('queued');
+  });
+
+  it('404s an unknown job id', async () => {
+    const res = await handleRemoteBoxesRequest(req({ path: '/remote/boxes/missing' }), { store: store(), adminToken: ADMIN });
+    expect(res?.status).toBe(404);
+  });
+
+  it('rejects a provider outside the allowlist', async () => {
+    const res = await handleRemoteBoxesRequest(
+      req({ method: 'POST', bodyText: JSON.stringify({ repoUrl: 'https://x/r.git', provider: 'hetzner' }) }),
+      { store: store(), adminToken: ADMIN, createProviders: ['e2b', 'vercel'] },
+    );
+    expect(res?.status).toBe(400);
+  });
+
+  it('501s when the store has no create-job queue', async () => {
+    // A store without the optional queue methods (e.g. a federated RemoteStore).
+    const bare = { enqueueCreateJob: undefined } as unknown as Parameters<
+      typeof handleRemoteBoxesRequest
+    >[1]['store'];
+    const res = await handleRemoteBoxesRequest(
+      req({ method: 'POST', bodyText: JSON.stringify({ repoUrl: 'https://x/r.git', provider: 'e2b' }) }),
+      { store: bare, adminToken: ADMIN },
+    );
+    expect(res?.status).toBe(501);
+  });
+});

--- a/packages/relay/test/retention.test.ts
+++ b/packages/relay/test/retention.test.ts
@@ -1,0 +1,97 @@
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import { startRetentionLoop } from '../src/retention.js';
+import { SqliteStore } from '../src/store/sqlite-store.js';
+import type { CreateJobRow, PromptRow } from '../src/store/store.js';
+
+const open: SqliteStore[] = [];
+function store(): SqliteStore {
+  const s = new SqliteStore({ path: ':memory:' });
+  open.push(s);
+  return s;
+}
+afterAll(async () => {
+  await Promise.all(open.map((s) => s.close()));
+});
+
+function prompt(id: string, over: Partial<PromptRow>): PromptRow {
+  return {
+    id,
+    boxId: 'b1',
+    ev: { id, kind: 'confirm', message: 'push?', context: { command: 'git push' } },
+    method: 'git.lease-token',
+    params: {},
+    status: 'pending',
+    createdAt: new Date().toISOString(),
+    ...over,
+  };
+}
+function job(id: string, over: Partial<CreateJobRow>): CreateJobRow {
+  return {
+    id,
+    status: 'queued',
+    request: { repoUrl: 'https://example.com/r.git', provider: 'e2b' },
+    createdAt: new Date().toISOString(),
+    ...over,
+  };
+}
+
+const OLD = '2000-01-01T00:00:00.000Z';
+const CUTOFF = '2020-01-01T00:00:00.000Z';
+
+describe('SqliteStore.prunePrompts', () => {
+  it('removes answered + expired rows older than the cutoff, keeps live ones', async () => {
+    const s = store();
+    await s.createPrompt(prompt('answered-old', { status: 'answered', createdAt: OLD }));
+    await s.createPrompt(prompt('answered-new', { status: 'answered' })); // now
+    await s.createPrompt(prompt('expired-old', { expiresAt: OLD })); // pending but long expired
+    await s.createPrompt(prompt('pending-live', {})); // pending, no expiry
+
+    expect(await s.prunePrompts(CUTOFF)).toBe(2);
+    expect(await s.getPrompt('answered-old')).toBeNull();
+    expect(await s.getPrompt('expired-old')).toBeNull();
+    expect((await s.getPrompt('answered-new'))?.id).toBe('answered-new');
+    expect((await s.getPrompt('pending-live'))?.id).toBe('pending-live');
+  });
+});
+
+describe('SqliteStore.pruneCreateJobs', () => {
+  it('removes finished jobs older than the cutoff, keeps running/queued', async () => {
+    const s = store();
+    await s.enqueueCreateJob(job('done-old', { status: 'done', finishedAt: OLD }));
+    await s.enqueueCreateJob(job('failed-old', { status: 'failed', finishedAt: OLD }));
+    await s.enqueueCreateJob(job('done-new', { status: 'done', finishedAt: new Date().toISOString() }));
+    await s.enqueueCreateJob(job('queued', {}));
+
+    expect(await s.pruneCreateJobs(CUTOFF)).toBe(2);
+    expect(await s.getCreateJob('done-old')).toBeNull();
+    expect(await s.getCreateJob('failed-old')).toBeNull();
+    expect((await s.getCreateJob('done-new'))?.id).toBe('done-new');
+    expect((await s.getCreateJob('queued'))?.id).toBe('queued');
+  });
+});
+
+describe('startRetentionLoop', () => {
+  it('is a no-op when the store has no prune methods', async () => {
+    const bare = {} as unknown as Parameters<typeof startRetentionLoop>[0]['store'];
+    const handle = startRetentionLoop({ store: bare, log: () => {} });
+    await handle.stop(); // must not throw
+  });
+
+  it('sweeps on tick using now - retentionMs as the cutoff', async () => {
+    const s = store();
+    await s.createPrompt(prompt('old', { status: 'answered', createdAt: OLD }));
+    await s.enqueueCreateJob(job('old', { status: 'done', finishedAt: OLD }));
+    const lines: string[] = [];
+    const handle = startRetentionLoop({
+      store: s,
+      log: (l) => lines.push(l),
+      intervalMs: 5,
+      retentionMs: 1000,
+      now: () => Date.parse('2020-06-01T00:00:00.000Z'),
+    });
+    await vi.waitFor(() => expect(lines.some((l) => l.includes('pruned'))).toBe(true));
+    await handle.stop();
+    expect(await s.getPrompt('old')).toBeNull();
+    expect(await s.getCreateJob('old')).toBeNull();
+  });
+});

--- a/packages/relay/test/write-through-store.test.ts
+++ b/packages/relay/test/write-through-store.test.ts
@@ -1,0 +1,100 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { BoxRegistry, EventBuffer } from '../src/registry.js';
+import { BoxStatusStore } from '../src/status-store.js';
+import { SqliteStore } from '../src/store/sqlite-store.js';
+import { WriteThroughStore } from '../src/store/write-through-store.js';
+import { makeBox, runStoreConformance } from './store-conformance-suite.js';
+
+// BoxStatusStore.set persists status.json under $HOME/.agentbox/boxes — point it
+// at a throwaway dir so the suite doesn't touch the real home.
+const home = mkdtempSync(join(tmpdir(), 'agentbox-wt-home-'));
+beforeAll(() => {
+  process.env.HOME = home;
+});
+afterAll(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+// A WriteThroughStore over a fresh in-memory SQLite store must be behaviorally
+// identical to the durable store it wraps — reads delegate straight through.
+const open: SqliteStore[] = [];
+runStoreConformance('WriteThroughStore(SqliteStore)', () => {
+  const inner = new SqliteStore({ path: ':memory:' });
+  open.push(inner);
+  const store = new WriteThroughStore(inner, {
+    registry: new BoxRegistry(),
+    events: new EventBuffer(),
+    statusStore: new BoxStatusStore(),
+  });
+  return Promise.resolve(store);
+});
+afterAll(async () => {
+  await Promise.all(open.map((s) => s.close()));
+});
+
+describe('WriteThroughStore mirroring', () => {
+  function fresh(): { store: WriteThroughStore; registry: BoxRegistry; statusStore: BoxStatusStore } {
+    const registry = new BoxRegistry();
+    const statusStore = new BoxStatusStore();
+    const store = new WriteThroughStore(new SqliteStore({ path: ':memory:' }), {
+      registry,
+      events: new EventBuffer(),
+      statusStore,
+    });
+    return { store, registry, statusStore };
+  }
+
+  const status = { schema: 1, boxId: 'b1', claude: { state: 'idle' } };
+
+  it('mirrors registerBox + setStatus into the in-memory instances the loops read', async () => {
+    const { store, registry, statusStore } = fresh();
+    await store.registerBox(makeBox('b1', 'tok-1', { name: 'box-one' }));
+    await store.setStatus('b1', 'box-one', 1, status);
+
+    // The daemon loops + hub backend read these synchronously — they must be populated.
+    expect(registry.get('b1')?.token).toBe('tok-1');
+    expect(registry.list().map((r) => r.boxId)).toEqual(['b1']);
+    expect(statusStore.get('b1')).toEqual(status);
+  });
+
+  it('mirrors forgetBox + deleteStatus removals', async () => {
+    const { store, registry, statusStore } = fresh();
+    await store.registerBox(makeBox('b1', 'tok-1'));
+    await store.setStatus('b1', 'b1', undefined, status);
+    expect(await store.forgetBox('b1')).toBe(true);
+    await store.deleteStatus('b1');
+    expect(registry.get('b1')).toBeUndefined();
+    expect(statusStore.get('b1')).toBeUndefined();
+  });
+
+  it('hydrate() re-populates the in-memory instances from a restarted store', async () => {
+    // Seed a durable store, then simulate a relay restart: a brand-new
+    // WriteThroughStore over the same DB with EMPTY in-memory instances.
+    const dir = mkdtempSync(join(tmpdir(), 'agentbox-wt-'));
+    try {
+      const path = join(dir, 'store.db');
+      const seed = new SqliteStore({ path });
+      await seed.registerBox(makeBox('b1', 'tok-1', { name: 'persisted' }));
+      await seed.setStatus('b1', 'persisted', 2, status);
+      await seed.close();
+
+      const registry = new BoxRegistry();
+      const statusStore = new BoxStatusStore();
+      const restarted = new WriteThroughStore(new SqliteStore({ path }), {
+        registry,
+        events: new EventBuffer(),
+        statusStore,
+      });
+      // Before hydration the mirror is empty (the loops would see nothing).
+      expect(registry.list()).toEqual([]);
+      await restarted.hydrate();
+      expect(registry.get('b1')?.name).toBe('persisted');
+      expect(statusStore.get('b1')).toEqual(status);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -588,6 +588,15 @@ export function createCloudProvider(
       const inboundOpt = req.providerOptions?.['inbound'];
       const inbound =
         typeof inboundOpt === 'string' && inboundOpt.trim() !== '' ? inboundOpt.trim() : undefined;
+      // Extra firewall source CIDRs for a control-plane-topology box: the control
+      // box locks a box it creates to its OWN egress IP, so the admin's PC egress
+      // CIDR is added here to keep direct PC→box SSH working (phase 4). Only
+      // honored when a control plane is configured (control-plane topology).
+      const extraCidrsOpt = req.providerOptions?.['extraInboundCidrs'];
+      const extraInboundCidrs =
+        req.controlPlaneUrl && Array.isArray(extraCidrsOpt)
+          ? extraCidrsOpt.filter((c): c is string => typeof c === 'string' && c.trim() !== '')
+          : undefined;
       // Cloud resource grouping (DigitalOcean's `--do-project` / `box.digitaloceanProject`).
       const projectOpt = req.providerOptions?.['project'];
       const project =
@@ -700,6 +709,7 @@ export function createCloudProvider(
           project,
           host,
           inbound,
+          ...(extraInboundCidrs && extraInboundCidrs.length > 0 ? { extraInboundCidrs } : {}),
           sandboxClass,
           timeoutMs,
           exposePorts: exposeServicePorts,

--- a/packages/sandbox-hetzner/src/backend.ts
+++ b/packages/sandbox-hetzner/src/backend.ts
@@ -371,6 +371,15 @@ export const hetznerBackend: CloudBackend = {
           ? normalizeSourceCidr(egressOverride)
           : `${await detectEgressIp({ onLog })}/32`;
     const sources = resolveInboundSources(inboundPolicy, hostEgress);
+    // Control-plane-topology creates: the control box locks the box to its own
+    // egress IP; add the admin-supplied PC egress CIDR(s) so direct PC→box SSH
+    // still works. Skipped when `open` (already 0.0.0.0/0). Deduped.
+    if (inboundPolicy.mode !== 'open' && req.extraInboundCidrs && req.extraInboundCidrs.length > 0) {
+      for (const cidr of req.extraInboundCidrs) {
+        const normalized = normalizeSourceCidr(cidr);
+        if (!sources.includes(normalized)) sources.push(normalized);
+      }
+    }
     progress(`firewall inbound: ${describeInbound(inboundPolicy)} -> ${sources.join(', ')}`);
 
     // 3. Mint per-box SSH key into a temp dir keyed by a fresh uuid; we

--- a/packages/sandbox-hetzner/src/control-plane-deploy.ts
+++ b/packages/sandbox-hetzner/src/control-plane-deploy.ts
@@ -13,7 +13,7 @@
  * Secrets ride scp (per-deploy key), never cloud-init user-data (cloud metadata).
  */
 
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { readFile, mkdir, rm, writeFile } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { makeHetznerClient, type HetznerServer } from './client.js';
@@ -49,6 +49,40 @@ export interface ControlPlaneHetznerDeployResult {
 }
 
 const REMOTE_APP_DIR = '/opt/agentbox/apps/hub';
+// Host bind-mounted into the app container at /root/.agentbox: store.db, auth.db,
+// custody/, boxes/<id>/ssh, secrets.env (provider creds), logs. Persists the hub
+// across `compose up` / VPS reboots.
+const REMOTE_DATA_DIR = '/opt/agentbox/hub-data';
+
+// Provider credentials the resident worker needs to provision cloud boxes. Only
+// these keys are copied from the host `~/.agentbox/secrets.env` — never the whole
+// file (it may hold unrelated secrets).
+const PROVIDER_SECRET_KEYS = [
+  'HCLOUD_TOKEN',
+  'E2B_API_KEY',
+  'DAYTONA_API_KEY',
+  'DAYTONA_JWT_TOKEN',
+  'DAYTONA_ORG_ID',
+];
+
+/** Extract just the provider-credential lines from the host `~/.agentbox/secrets.env`. */
+async function collectProviderSecrets(): Promise<string> {
+  let body = '';
+  try {
+    body = await readFile(join(homedir(), '.agentbox', 'secrets.env'), 'utf8');
+  } catch {
+    return '';
+  }
+  const out: string[] = [];
+  for (const line of body.split(/\r?\n/)) {
+    const stripped = line.startsWith('export ') ? line.slice('export '.length) : line;
+    const eq = stripped.indexOf('=');
+    if (eq <= 0) continue;
+    const key = stripped.slice(0, eq).trim();
+    if (PROVIDER_SECRET_KEYS.includes(key)) out.push(`${key}=${stripped.slice(eq + 1)}`);
+  }
+  return out.length > 0 ? out.join('\n') + '\n' : '';
+}
 
 function caddyfile(domain: string): string {
   // Caddy auto-provisions a Let's Encrypt cert for the site address and reverse-
@@ -167,6 +201,20 @@ export async function deployControlPlaneToHetzner(
     throw new Error('repo clone did not complete on the VPS (cloud-init failed)');
   }
 
+  // The full-hub compose keys the deploy adds on top of the App/auth env:
+  //  - the persistent data dir (bind-mounted at /root/.agentbox),
+  //  - the public URL a hub-created box registers against (control-plane topology),
+  //  - the admin PC egress CIDR (== this deploying machine) added to a hetzner
+  //    box's firewall so the PC can still SSH direct (phase 4).
+  const hubEnvExtra =
+    `AGENTBOX_HUB_DATA_DIR=${REMOTE_DATA_DIR}\n` +
+    `AGENTBOX_HUB_PUBLIC_URL=${url}\n` +
+    `AGENTBOX_HUB_ADMIN_CIDR=${hostCidr}\n`;
+  const providerSecrets = await collectProviderSecrets();
+  if (!providerSecrets) {
+    log('warning: no provider credentials found in ~/.agentbox/secrets.env — the worker can only create boxes for providers whose creds you push later');
+  }
+
   // Stage the secret env + Caddy config locally, then scp them up.
   const staging = join(tmpdir(), `agentbox-cp-deploy-${stamp}`);
   await mkdir(staging, { recursive: true });
@@ -174,13 +222,20 @@ export async function deployControlPlaneToHetzner(
     const envLocal = join(staging, 'control-plane.env');
     const caddyLocal = join(staging, 'Caddyfile');
     const composeLocal = join(staging, 'docker-compose.caddy.yml');
-    await writeFile(envLocal, opts.envContent, { mode: 0o600 });
+    const secretsLocal = join(staging, 'secrets.env');
+    await writeFile(envLocal, opts.envContent + hubEnvExtra, { mode: 0o600 });
     await writeFile(caddyLocal, caddyfile(domain));
     await writeFile(composeLocal, CADDY_COMPOSE);
-    log('uploading env + Caddy config…');
+    await writeFile(secretsLocal, providerSecrets, { mode: 0o600 });
+    log('creating the persistent data dir on the VPS…');
+    await sshExec(target, `mkdir -p ${REMOTE_DATA_DIR} && chmod 700 ${REMOTE_DATA_DIR}`);
+    log('uploading env + provider secrets + Caddy config…');
     await scpUpload(target, envLocal, `${REMOTE_APP_DIR}/.env`);
     await scpUpload(target, caddyLocal, `${REMOTE_APP_DIR}/Caddyfile`);
     await scpUpload(target, composeLocal, `${REMOTE_APP_DIR}/docker-compose.caddy.yml`);
+    // Provider creds live in the data volume (read as ~/.agentbox/secrets.env),
+    // NOT in the compose env — so they're never in `docker inspect`/compose logs.
+    await scpUpload(target, secretsLocal, `${REMOTE_DATA_DIR}/secrets.env`);
   } finally {
     await rm(staging, { recursive: true, force: true });
   }


### PR DESCRIPTION
Phase 3 of docs/control-box-plan.md, implemented in box cbx-phase3.

- Backlog blockers addressed: write-through durable store (daemon loops + hub backend see SQLite/Postgres state; MemoryStore path byte-identical) and prompt/create-job retention sweep.
- Full-hub Dockerfile (standalone server.ts + git/ssh) and app+Caddy compose on SQLite with persistent ~/.agentbox volume (Postgres dropped from the control-box deploy).
- Resident in-process create worker (AGENTBOX_HUB_WORKER=on): seeds agent creds from custody (AGENT_SYNC_SPECS), registers boxes on the hub, mirrors per-box SSH keys into custody boxes/<id>/ssh/.
- Dual-IP firewall (extraInboundCidrs) so PC keeps direct SSH to VPS-created hetzner boxes.
- Shared /remote/boxes dispatcher mounted in both routers; agentbox create --via-hub enqueues + polls job progress.
- agentbox control-plane deploy hetzner [--ref] reuses existing App creds (no manifest re-run).
- In-box smoke: image build, hetzner-profile boot, auth login, custody round-trip, enqueue → worker → mock create done, restart persistence. Live hetzner verify is PENDING-HOST (checklist in the plan doc).

https://claude.ai/code/session_01QnaMFuHVZUdTq5VzxiSg2L

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large cross-cutting change to deploy topology, durable store mirroring, firewall rules, and remote box creation/auth paths; mistakes could leave hubs misconfigured, boxes unreachable, or create jobs stuck.
> 
> **Overview**
> Phase 3 turns the **Hetzner control plane** into a **control box**: the VPS runs the full standalone hub (`server.ts` + SQLite + persistent `~/.agentbox`), not the Postgres/`next start` plane. Postgres is dropped from hub compose; the image builds `build:standalone`, adds `git`/`openssh`, and starts the bundled server.
> 
> **Relay / store:** A **`WriteThroughStore`** mirrors durable writes into in-memory registry/status so daemon loops and the hub UI see SQLite state after restart; **`startRetentionLoop`** prunes old prompts and finished create jobs. **`/remote/boxes`** is extracted to a shared dispatcher mounted on both the Vercel handler and **`server.ts`** (admin bearer only).
> 
> **Hub worker:** With **`AGENTBOX_HUB_WORKER=on`**, an in-process worker drains the create queue (lease → clone → `provider.create`), seeds agent creds from custody, registers boxes on the hub, and mirrors hetzner/DO SSH keys into custody. Hetzner deploy scps filtered provider secrets into the data volume, sets public URL + admin PC egress CIDR, and uses **`AGENTBOX_HUB_PROFILE=hetzner`** (fixes setup auth block). **`extraInboundCidrs`** keeps direct PC SSH to hub-created hetzner boxes.
> 
> **CLI:** **`agentbox create --via-hub`** enqueues and polls jobs via new **`hub-enqueue`** helpers; **`agentbox control-plane deploy hetzner [--ref --repo]`** redeploys reusing existing App creds. **`makeControlPlaneCreateBox`** moves to **`@agentbox/relay`** for shared use by CLI worker and hub.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f987fa88940bf81b84c59e820dfe013bf414cc33. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->