### PR TITLE
fix(relay): admin gate accepts the admin bearer from non-loopback callers

### DIFF
--- a/packages/relay/src/admin-gate.ts
+++ b/packages/relay/src/admin-gate.ts
@@ -1,0 +1,29 @@
+import { timingSafeEqual } from 'node:crypto';
+
+/** Constant-time string compare (length leak only, like the HTTP handlers accept). */
+export function timingSafeEqualStr(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'utf8');
+  const bb = Buffer.from(b, 'utf8');
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+/**
+ * Whether an `/admin/*` request may proceed on the full relay/hub.
+ *
+ * Loopback callers are the host CLI/tray — always allowed (unchanged laptop
+ * behavior). A non-loopback caller is allowed only when it presents the
+ * configured admin bearer: the control box is network-reachable behind Caddy,
+ * and its own resident worker + the PC (phase 4) reach `/admin/*` through the
+ * public URL. Fail-closed: with no admin token configured the gate stays
+ * loopback-only, so a laptop relay (which never sets one) exposes nothing new.
+ */
+export function adminGateAllows(
+  isLoopback: boolean,
+  bearer: string | undefined,
+  adminToken: string,
+): boolean {
+  if (isLoopback) return true;
+  if (adminToken.length === 0) return false;
+  return Boolean(bearer) && timingSafeEqualStr(bearer ?? '', adminToken);
+}

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -61,6 +61,7 @@ import { GitHubAppLeaser, loadGitHubAppConfig, type GitHubAppConfig } from './gi
 import { leaseTokenResult } from './lease.js';
 import { gateApproval, type GateDeps, type PromptMode } from './permission.js';
 import { resolveWorktree } from './worktree.js';
+import { adminGateAllows } from './admin-gate.js';
 import { handleCustodyRequest } from './custody/routes.js';
 import { handleRemoteBoxesRequest, isRemoteBoxesPath } from './remote-boxes.js';
 import type { CustodyStore } from './custody/store.js';
@@ -540,17 +541,21 @@ export function createRelayServer(opts: RelayServerOptions): RelayServerHandle {
       }
     }
 
-    // Admin endpoints are reachable from loopback only. The relay binds to
-    // 0.0.0.0 so containers can reach /events and /rpc via host.docker.internal,
-    // but admin operations (register-box, forget-box, list events, etc.) are
-    // for the host CLI and must not be exposed to boxes. Any other `/remote/*`
-    // is a hosted-plane surface not served by this relay.
+    // Admin endpoints are reachable from loopback, or — on a relay with an
+    // admin token configured (the control box) — with that bearer. The relay
+    // binds to 0.0.0.0 so containers can reach /events and /rpc via
+    // host.docker.internal, but admin operations (register-box, forget-box,
+    // list events, etc.) are for the host CLI / an authenticated admin and must
+    // not be exposed to boxes. A laptop relay sets no admin token, so its gate
+    // stays loopback-only. Any other `/remote/*` is a hosted-plane surface not
+    // served by this relay.
     if (url.pathname.startsWith('/admin/') || url.pathname.startsWith('/remote/')) {
       if (url.pathname.startsWith('/remote/')) {
         send(res, 404, { error: 'not found', route });
         return;
       }
-      if (!isLoopbackAddress(req.socket.remoteAddress)) {
+      const loopback = isLoopbackAddress(req.socket.remoteAddress);
+      if (!adminGateAllows(loopback, bearerToken(req), custodyAdminToken)) {
         send(res, 403, { error: 'admin endpoints are loopback-only' });
         return;
       }

--- a/packages/relay/test/admin-gate.test.ts
+++ b/packages/relay/test/admin-gate.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { adminGateAllows } from '../src/admin-gate.js';
+
+describe('adminGateAllows', () => {
+  it('always allows loopback callers (laptop CLI/tray, unchanged)', () => {
+    expect(adminGateAllows(true, undefined, '')).toBe(true);
+    expect(adminGateAllows(true, 'anything', 'tok')).toBe(true);
+  });
+
+  it('rejects non-loopback when no admin token is configured (laptop relay)', () => {
+    expect(adminGateAllows(false, undefined, '')).toBe(false);
+    expect(adminGateAllows(false, 'guess', '')).toBe(false);
+  });
+
+  it('allows non-loopback only with the matching admin bearer (control box)', () => {
+    expect(adminGateAllows(false, 'secret-token', 'secret-token')).toBe(true);
+    expect(adminGateAllows(false, 'wrong', 'secret-token')).toBe(false);
+    expect(adminGateAllows(false, undefined, 'secret-token')).toBe(false);
+    expect(adminGateAllows(false, '', 'secret-token')).toBe(false);
+  });
+
+  it('is not prefix-tolerant', () => {
+    expect(adminGateAllows(false, 'secret-token-longer', 'secret-token')).toBe(false);
+    expect(adminGateAllows(false, 'secret-toke', 'secret-token')).toBe(false);
+  });
+});


### PR DESCRIPTION
Second live phase-3 finding: the resident worker's register-box call 403'd (loopback-only gate) leaving hub-created boxes unregistered ('unknown box token' on push). Gate now allows a timing-safe admin-bearer match from non-loopback, matching the plane handler's posture; fail-closed with no token configured. Unit tests added; relay suite + typecheck + lint green.

https://claude.ai/code/session_01QnaMFuHVZUdTq5VzxiSg2L

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands who can call admin routes when an admin token is configured; behavior is fail-closed without a token and uses timing-safe bearer comparison, but misconfiguration or token leakage would expose register-box and related admin APIs.
> 
> **Overview**
> **`/admin/*` is no longer loopback-only when the relay has an admin token configured.** Non-loopback callers (e.g. the control box resident worker hitting `register-box` through the public URL behind Caddy) can proceed if they present a matching `Authorization: Bearer` token; comparison uses a new `adminGateAllows` helper with timing-safe equality.
> 
> **Laptop relays stay unchanged:** with no admin token, the gate remains loopback-only. Loopback callers are still always allowed.
> 
> Adds `packages/relay/src/admin-gate.ts` and wires it in `server.ts` in place of the prior `isLoopbackAddress` check for general admin routes (custody/remote boxes paths were already bearer-gated separately).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4adbea1cc55a9aaf22d1ada0347b52daa483612. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->