### PR TITLE
fix(cloud): plane registration carries the box worktree (lease auto-allow)

### DIFF
--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -485,6 +485,14 @@ export function createCloudProvider(
             name: box.name,
             originUrl,
             backend: backend.name,
+            worktrees: [
+              {
+                containerPath: '/workspace',
+                hostMainRepo: box.workspacePath,
+                branch: box.cloud.workspaceBranch ?? `agentbox/${box.name}`,
+                sanctionedBranch: box.cloud.workspaceBranch ?? `agentbox/${box.name}`,
+              },
+            ],
             bridgeToken: box.cloud.bridgeToken,
             previewUrl: relayPreview?.url,
             previewToken: relayPreview?.token,
@@ -1046,6 +1054,19 @@ export function createCloudProvider(
                 name,
                 originUrl,
                 backend: backend.name,
+                // hostMainRepo is the create-time seed checkout; on a hub
+                // worker it is a temp clone that gets deleted after create, so
+                // host-side git RPCs won't work against it — but the lease
+                // gate's sanctioned-branch auto-allow reads `branch` from this
+                // registration, which is what a control-plane box pushes with.
+                worktrees: [
+                  {
+                    containerPath: '/workspace',
+                    hostMainRepo: req.workspacePath,
+                    branch,
+                    sanctionedBranch: branch,
+                  },
+                ],
                 bridgeToken,
                 previewUrl: relayPreview?.url,
                 previewToken: relayPreview?.token,

--- a/packages/sandbox-cloud/src/plane-register.ts
+++ b/packages/sandbox-cloud/src/plane-register.ts
@@ -19,6 +19,19 @@ export interface RegisterBoxWithPlaneArgs {
   name: string;
   originUrl: string;
   backend: string;
+  /**
+   * Registered worktrees (containerPath/branch/sanctionedBranch). The plane's
+   * lease gate auto-allows only the box's sanctioned `agentbox/*` branch, and
+   * it reads that from the REGISTRATION (host-authoritative), never from box
+   * params — without this a control-plane box's `git push` blocks on a human
+   * approval that auto-approve should have covered.
+   */
+  worktrees?: Array<{
+    containerPath: string;
+    hostMainRepo: string;
+    branch: string;
+    sanctionedBranch?: string;
+  }>;
   bridgeToken?: string;
   previewUrl?: string;
   previewToken?: string;
@@ -53,6 +66,7 @@ export async function registerBoxWithPlane(args: RegisterBoxWithPlaneArgs): Prom
       kind: 'cloud',
       backend: args.backend,
       originUrl: args.originUrl,
+      worktrees: args.worktrees,
       bridgeToken: args.bridgeToken,
       previewUrl: args.previewUrl,
       previewToken: args.previewToken,


### PR DESCRIPTION
Third live phase-3 finding: hub-created boxes' pushes hung — the lease gate found no registered worktree, so the agentbox/* auto-allow never applied and block-mode approval waited forever. Registration now carries the /workspace worktree with the sanctioned branch at both call sites. sandbox-cloud tests + typecheck + lint green.

https://claude.ai/code/session_01QnaMFuHVZUdTq5VzxiSg2L

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches control-plane registration and git push approval behavior; mis-stated branches could change auto-approve vs prompt, but scope is limited to optional worktree payload on existing register calls.
> 
> **Overview**
> Fixes **hub-created control-plane boxes hanging on `git push`**: the plane lease gate had no registered worktree, so the sanctioned `agentbox/*` auto-allow never applied and block-mode approval waited indefinitely.
> 
> **`registerBoxWithPlane`** now accepts optional **`worktrees`** (`containerPath`, `hostMainRepo`, `branch`, `sanctionedBranch`) and sends them in the **`/admin/register-box`** body. The plane reads the sanctioned branch from **host-authoritative registration**, not box params.
> 
> Both registration paths pass a single **`/workspace`** worktree: **create** uses the minted `branch` for `branch` and `sanctionedBranch`; **re-ensure on resume** uses `box.cloud.workspaceBranch` (or `agentbox/${box.name}`). Inline comments note that on hub workers **`hostMainRepo`** may be a temp seed path (host git RPCs unreliable) while **`branch`** still drives lease auto-allow for pushes from inside the box.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff665230374fab5e1cedf8a6efe1f0e7de501c07. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->