### PR TITLE
fix(ctl): lease-and-push must run the real git, not the PATH shim

### DIFF
--- a/packages/ctl/src/commands/git.ts
+++ b/packages/ctl/src/commands/git.ts
@@ -199,11 +199,14 @@ async function leaseAndPush(opts: CommonOptions, extra: string[]): Promise<numbe
     return 1;
   }
   const originalUrl = await captureGit(['remote', 'get-url', remote], cwd);
-  await runLocalGit(['remote', 'set-url', remote, remoteUrl], cwd);
+  // Real git, not the PATH shim: the shim intercepts `push` and refuses the
+  // positional remote/branch, and a baked box always has the shim first on
+  // PATH — spawning bare `git push` here would die (or loop) inside it.
+  await runRealGit(['remote', 'set-url', remote, remoteUrl], cwd);
   try {
-    return await runLocalGit(['push', remote, branch, ...extra], cwd);
+    return await runRealGit(['push', remote, branch, ...extra], cwd);
   } finally {
-    if (originalUrl) await runLocalGit(['remote', 'set-url', remote, originalUrl], cwd);
+    if (originalUrl) await runRealGit(['remote', 'set-url', remote, originalUrl], cwd);
   }
 }
 


### PR DESCRIPTION
Fourth live phase-3 finding: leased pushes from baked boxes hit the git shim's positional-remote refusal. leaseAndPush now uses the direct-mode runRealGit helper. ctl suite + typecheck green; live re-verification (with a re-baked e2b template) follows on the control box.

https://claude.ai/code/session_01QnaMFuHVZUdTq5VzxiSg2L

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to the lease-token push path in ctl, aligning it with an existing direct-mode pattern; no auth or relay contract changes beyond fixing broken pushes on shim-first PATH.
> 
> **Overview**
> **Control-plane leased pushes** (`AGENTBOX_GIT_LEASE=1`) were failing on baked boxes because `leaseAndPush` invoked `git` via `runLocalGit`, which resolves the PATH shim ahead of `/usr/bin/git`. That shim rejects `git push` with positional remote and branch, so the leased-token push path could error or recurse instead of hitting the network.
> 
> `leaseAndPush` now uses **`runRealGit`** for temporarily swapping the remote URL, pushing, and restoring the original URL—the same bypass already used for direct-mode push/fetch. A short comment documents why the shim must be avoided on baked images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea5e9b8399115600bfb06bcd451826c43d8bdc1d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->