### PR TITLE
fix(hub): control-box image carries the CLI + persistent projects volume

### DIFF
--- a/apps/hub/Dockerfile
+++ b/apps/hub/Dockerfile
@@ -16,6 +16,10 @@ RUN pnpm install --frozen-lockfile
 # spawnable standalone hub (next build + esbuild-bundled server.ts + chunks).
 RUN pnpm turbo run build --filter=@agentbox/hub
 RUN pnpm --filter @agentbox/hub build:standalone
+# The agentbox CLI too: the hub's queue (web-UI creates, queued agent runs) and
+# the host-app launchers spawn `node $AGENTBOX_CLI_ENTRY …` — without a built
+# CLI the control box can list boxes but never create one from the UI.
+RUN pnpm turbo run build --filter=@madarco/agentbox
 
 FROM node:22-slim AS runtime
 WORKDIR /repo
@@ -25,6 +29,8 @@ RUN corepack enable
 RUN apt-get update && apt-get install -y --no-install-recommends git openssh-client ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 ENV NODE_ENV=production
+# Queue worker + host-app spawns re-exec the CLI from this entry.
+ENV AGENTBOX_CLI_ENTRY=/repo/apps/cli/dist/index.js
 # The whole built monorepo: the standalone bundle ships no node_modules, so its
 # externals (next, react, pg, better-auth, the cloud SDKs) resolve from the
 # workspace node_modules present here. Not size-optimized; fine for a VPS.

--- a/apps/hub/docker-compose.yml
+++ b/apps/hub/docker-compose.yml
@@ -40,5 +40,9 @@ services:
       # secrets.env (provider creds), logs. A HOST path so the deploy can scp
       # provider secrets in before `compose up`.
       - ${AGENTBOX_HUB_DATA_DIR:-./hub-data}:/root/.agentbox
+      # Persistent project clones (the full-host hub keeps real checkouts so
+      # the web UI can create boxes from them; container-local paths would be
+      # lost on every image rebuild).
+      - ${AGENTBOX_HUB_PROJECTS_DIR:-/opt/agentbox-projects}:/root/projects
     ports:
       - '8787:3000'


### PR DESCRIPTION
Fifth live finding (final verify): web-UI create on the control box failed — the image had no built CLI and no AGENTBOX_CLI_ENTRY for the queue worker, and the only 'projects' were the worker's deleted temp clones. Image now builds apps/cli + sets the entry; compose mounts a persistent /root/projects volume for real checkouts. Typecheck green; live re-verify follows.

https://claude.ai/code/session_01QnaMFuHVZUdTq5VzxiSg2L

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and volume-mount changes for self-hosted hub deployment; no application auth or business-logic changes in this diff.
> 
> **Overview**
> Fixes **web-UI box creation on the control-box Docker image**, which could list boxes but could not actually create them because the image never built the agentbox CLI and did not expose where workers should re-exec it.
> 
> The **hub Dockerfile** now runs `pnpm turbo run build --filter=@madarco/agentbox` and sets **`AGENTBOX_CLI_ENTRY=/repo/apps/cli/dist/index.js`** so the resident create queue and host-app launchers can spawn `node $AGENTBOX_CLI_ENTRY …` as intended.
> 
> **docker-compose** adds a host-mounted volume (**`AGENTBOX_HUB_PROJECTS_DIR`**, default `/opt/agentbox-projects`) at **`/root/projects`** so project checkouts used for UI-driven creates persist across image rebuilds instead of living only in ephemeral worker temp dirs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 768a92f79ca2b12e6ad75c921a5e17b75598f23c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->