### PR TITLE
fix(hub): control-box container listens on 8787 (CLI relay convention)

### DIFF
--- a/apps/hub/Dockerfile
+++ b/apps/hub/Dockerfile
@@ -35,7 +35,7 @@ ENV AGENTBOX_CLI_ENTRY=/repo/apps/cli/dist/index.js
 # externals (next, react, pg, better-auth, the cloud SDKs) resolve from the
 # workspace node_modules present here. Not size-optimized; fine for a VPS.
 COPY --from=build /repo .
-EXPOSE 3000
+EXPOSE 8787
 # server.ts self-migrates auth (ensureAuthReady) + the store on boot, so there is
 # no separate migrate step. It anchors its own cwd from required-server-files.json.
 CMD ["node", "apps/hub/dist-standalone/apps/hub/server.js"]

--- a/apps/hub/docker-compose.yml
+++ b/apps/hub/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       # store (no POSTGRES_URL), and the resident create worker.
       AGENTBOX_HUB_PROFILE: hetzner
       AGENTBOX_HUB_HOST: 0.0.0.0
-      AGENTBOX_HUB_PORT: '3000'
+      AGENTBOX_HUB_PORT: '8787'
       AGENTBOX_HUB_WORKER: ${AGENTBOX_HUB_WORKER:-on}
       HOME: /root
       # Secrets (from the compose env-file / shell). Login is secret-gated: with
@@ -45,4 +45,4 @@ services:
       # lost on every image rebuild).
       - ${AGENTBOX_HUB_PROJECTS_DIR:-/opt/agentbox-projects}:/root/projects
     ports:
-      - '8787:3000'
+      - '8787:8787'

--- a/packages/sandbox-hetzner/src/control-plane-deploy.ts
+++ b/packages/sandbox-hetzner/src/control-plane-deploy.ts
@@ -86,8 +86,8 @@ async function collectProviderSecrets(): Promise<string> {
 
 function caddyfile(domain: string): string {
   // Caddy auto-provisions a Let's Encrypt cert for the site address and reverse-
-  // proxies to the Next app on the compose network (the app listens on :3000).
-  return `${domain} {\n\treverse_proxy app:3000\n}\n`;
+  // proxies to the Next app on the compose network (the app listens on :8787).
+  return `${domain} {\n\treverse_proxy app:8787\n}\n`;
 }
 
 const CADDY_COMPOSE = `services:


### PR DESCRIPTION
Sixth live finding: in-container CLI workers (web-UI creates) forked a second relay on 8787 because the hub listened on 3000 — the parallel daemon owned the new box, invisible to the hub store. Container now runs on 8787 end to end (compose, Caddy upstream, EXPOSE). hetzner package tests + typecheck green.

https://claude.ai/code/session_01QnaMFuHVZUdTq5VzxiSg2L

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production networking for Hetzner/compose deploys; misconfiguration could break HTTPS or box registration until images are redeployed.
> 
> **Overview**
> Aligns the self-hosted **control-box** hub with the **8787** relay port used by `agentbox hub` and the CLI, instead of listening on **3000** inside the container while exposing **8787** on the host.
> 
> **Docker / compose:** `AGENTBOX_HUB_PORT` and `EXPOSE` are **8787**, and host mapping is **`8787:8787`** (no longer **`8787:3000`**).
> 
> **Hetzner deploy:** Generated Caddy config now reverse-proxies to **`app:8787`** so HTTPS traffic reaches the app on the same port.
> 
> This avoids in-container CLI workers from starting a **second** relay on **8787** because the hub was bound to **3000**, which left new boxes owned by that parallel daemon and invisible to the hub store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d27c679783c29f46a924328871025e3769b946e1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->