### PR TITLE
docs(web): public guide — Run boxes from a deployed hub

### DIFF
--- a/apps/web/content/docs/deployed-hub.mdx
+++ b/apps/web/content/docs/deployed-hub.mdx
@@ -1,0 +1,118 @@
+---
+title: Run boxes from a deployed hub
+description: Deploy the hub to an always-on VPS so cloud boxes keep working — and you can spawn and manage them from a browser — with your laptop off
+---
+
+The [hub](/docs/hub) normally runs on your laptop. Deploy that same hub to an always-on VPS and it becomes a **control box**: a small server that holds the shared state your boxes need (registry, approvals, git credentials, agent logins, SSH keys) and can **create and run cloud boxes itself**. Cloud boxes keep pushing and opening PRs with your laptop off, and you can spawn new ones from the web UI on your phone.
+
+<Callout type="warn" title="Experimental">The deployed hub / control box is under active development. The `agentbox control-plane` commands are hidden from `agentbox --help` but work; expect rough edges. Local docker boxes are unaffected — this is only for cloud boxes.</Callout>
+
+It's the same `@agentbox/relay` core you already run locally — the relay daemon, the web UI, and a resident create worker — deployed to a **Hetzner VPS** on **SQLite** (no database to manage), reachable over HTTPS. Your laptop still does its own host-local work (`cp`, `download`, `checkpoint`); the control box takes over the *centralized* concerns so a sleeping laptop no longer stops your cloud boxes.
+
+<Callout type="info" title="Cloud boxes only">Only **cloud** boxes (e2b, daytona, hetzner, vercel) get the laptop-off guarantee. A local **docker** box bind-mounts your host `.git`, so it's simply offline when the laptop is — it stays on your laptop relay and is never sent to the control box.</Callout>
+
+## Deploy the control box
+
+One-time setup creates a GitHub App (the control box leases short-lived push tokens with it) and provisions the VPS. You need [`agentbox hetzner login`](/docs/hetzner) first.
+
+```bash
+agentbox control-plane setup                 # create the App, then deploy (pick Hetzner)
+```
+
+Already have the App from a previous run? Deploy (or redeploy) the control box directly:
+
+```bash
+agentbox control-plane deploy hetzner        # reuses ~/.agentbox/control-plane creds
+```
+
+This provisions a small VPS, installs the hub over Docker + Caddy, and serves it at **`https://<ip>.sslip.io`** with an automatic Let's Encrypt certificate — no DNS to configure. A persistent volume holds the hub's state (SQLite store, logins, custody, box SSH keys), so the hub and its create queue **survive a VPS reboot**. The deploy also:
+
+- copies the provider credentials the worker needs (`HCLOUD_TOKEN`, `E2B_API_KEY`, `DAYTONA_API_KEY` / `DAYTONA_ORG_ID`) from your host `~/.agentbox/secrets.env` into the VPS,
+- records **your laptop's egress IP** so a hetzner box the control box creates still allows direct SSH from you,
+- points your CLI at it (`relay.controlPlaneUrl`) and prompts for a web-UI admin email + password.
+
+When it finishes, open `https://<ip>.sslip.io`, sign in with those credentials, and you'll see the dashboard.
+
+<Callout type="info" title="Log in the agents once">
+So that boxes the control box creates are already signed in, push your agent logins to it once (details in [credentials and secrets](#credentials-and-secrets)):
+
+```bash
+agentbox control-plane credentials push
+```
+</Callout>
+
+## Create a box from the web UI
+
+In the dashboard, **Add project** (point it at a repo path on the VPS), then **Create box** → pick a provider (e.g. E2B) and agent → **Create box**. The control box's resident worker provisions the sandbox, starts the agent in a detached session, and the box appears in the dashboard with live status. This is the "spawn from your phone" path — nothing runs on your laptop.
+
+<Callout type="info" title="Authorize the repo">The App can only lease a token for repos it's installed on. If a create can't push later, authorize the repo from your laptop with `agentbox control-plane add` (or open the App's install page the dashboard links to).</Callout>
+
+## Create a box from your laptop — that runs with the laptop off
+
+To spawn a box from the CLI and have it keep working after you close your laptop, enqueue it on the control box with `--via-hub` instead of building it locally:
+
+```bash
+agentbox create --provider e2b --via-hub
+```
+
+This POSTs the job to the control box and streams its progress; the box is provisioned **VPS-side**, so it works even if the provider's credentials aren't configured on your laptop — and it keeps running once the job is enqueued. The box registers on the control box, so it shows in the web UI and its approvals are answerable from anywhere.
+
+Now the payoff — the box pushes on its own, with your laptop fully off:
+
+```bash
+# inside the box (or via a detached agent run): commit + push as usual
+agentbox-ctl git push
+```
+
+The box leases a 1-hour, single-repo token from the control box and pushes to GitHub directly. Your laptop relay is not involved, so it can be closed, asleep, or offline. Pushes to the box's own `agentbox/*` branch are auto-approved; any other branch raises an approval you answer from the web UI or CLI.
+
+## Manage control-box boxes from your laptop
+
+With a control box configured, your laptop keeps its direct SSH/SDK connections but reads the shared box registry, statuses, and approvals from the control box — so your laptop, the web UI, and your phone all see one world. [`agentbox relay status`](/docs/cli) shows the configured control box and whether it's reachable.
+
+```bash
+agentbox control-plane boxes list            # boxes on the control box (from either side)
+```
+
+**Attach to a control-box-created box.** Download its per-box SSH key first, then attach / port-forward / [copy files](/docs/access-your-box) as usual:
+
+```bash
+agentbox hub pull <box>                       # keys → ~/.agentbox/boxes/<id>/ssh/
+agentbox attach <box>
+```
+
+`hub pull` works because a hetzner box the control box creates locks its firewall to **both** the VPS and your recorded egress IP, so your laptop can reach it once it has the key.
+
+**Answer approvals** from the laptop (also answerable in the web UI / on your phone):
+
+```bash
+agentbox control-plane prompts list
+agentbox control-plane prompts answer <id> y
+```
+
+**Reap** a box's control-box state when you're done with it (registration + status + its SSH-key custody; the cloud sandbox itself is destroyed from the web UI or the provider):
+
+```bash
+agentbox control-plane boxes rm <box>
+```
+
+## Credentials and secrets
+
+Custody is the control box's copy of what a box needs to be useful — agent logins, project secrets, box SSH keys. Push from the laptop; pull back when the control box has fresher material (for example, a box refreshed an expired token):
+
+```bash
+agentbox control-plane credentials push       # host agent logins → custody (hub boxes log in)
+agentbox control-plane credentials pull        # custody → ~/.agentbox backups
+agentbox control-plane secrets push [--project]  # a project's .env → custody
+agentbox control-plane custody list [prefix]   # manifest (paths + hashes; values never leave the box)
+```
+
+Re-run `credentials push` after `agentbox claude login` refreshes a login — that's what a subsequently-created hub box signs in with. Uploads are content-hashed, so an unchanged push sends nothing.
+
+## How it stays safe
+
+- **Leased tokens** are per-repo, minimal permissions (contents + pull requests), 1-hour, and never persisted — the control box holds only the GitHub App's private key. A compromised box yields at most a 1-hour, single-repo token.
+- A GitHub installation token is repo-scoped, not branch-scoped, so the lease gate **auto-approves only `agentbox/*` branches**; any other branch needs your approval. Branch protection on protected branches is the real backstop.
+- The hub gates its admin and box-creation endpoints on a constant-time admin bearer, fail-closed, and the web UI on an email/password login — set at deploy time.
+
+See [sync and git](/docs/sync-and-git) for the laptop-relay credential model, the [hub](/docs/hub) page for the local Web UI, and the cloud providers ([e2b](/docs/e2b), [daytona](/docs/daytona), [hetzner](/docs/hetzner)) for how each box is provisioned.

--- a/apps/web/content/docs/meta.json
+++ b/apps/web/content/docs/meta.json
@@ -13,6 +13,7 @@
     "sync-and-git",
     "services-and-tasks",
     "background-and-parallel",
+    "deployed-hub",
     "docker-in-docker",
     "browser-and-screen",
     "skills",

--- a/apps/web/content/docs/run-an-agent.mdx
+++ b/apps/web/content/docs/run-an-agent.mdx
@@ -109,5 +109,6 @@ Sign in once on the host. Install a skill or sign in there, and the next box pic
 - [Access your box](/docs/access-your-box) — shell, VS Code/Cursor (`agentbox code`), the dashboard.
 - [Web apps and tunnels](/docs/web-apps-and-tunnels) — `agentbox url` for the box's dev server.
 - [Background and parallel](/docs/background-and-parallel) — `-i/--initial-prompt`, `--no-attach`, and running many boxes at once.
+- [Run boxes from a deployed hub](/docs/deployed-hub) — deploy the hub to a VPS so cloud boxes keep working, and spawn them from a browser, with your laptop off.
 - [Checkpoints and pausing](/docs/checkpoints-and-pausing) — `--snapshot`, pause/unpause.
 - [Teleport a project](/docs/teleport-a-project) — `-c/--continue`, `--resume`, and how the workspace and git reach the box.


### PR DESCRIPTION
A public Guides page on using the deployed hub / control box: one-time Hetzner deploy, create from the web UI or --via-hub, host-off push, and laptop-side management (boxes list / hub pull / prompts / custody). Linked from Run an agent. Docs site build green.

https://claude.ai/code/session_01QnaMFuHVZUdTq5VzxiSg2L

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security behavior impact.
> 
> **Overview**
> Adds a new **Guides** page, [Run boxes from a deployed hub](/docs/deployed-hub), documenting the always-on Hetzner **control box**: one-time `control-plane setup` / `deploy hetzner`, spawning boxes from the web UI or `agentbox create --via-hub`, laptop-off git push via leased tokens, and laptop-side management (`boxes list`, `hub pull`, prompts, credentials/custody). It marks the feature as experimental and scopes it to cloud providers (not local Docker).
> 
> **Navigation:** registers `deployed-hub` in `meta.json` under Guides (after background-and-parallel) and adds a **Next steps** link from [Run an agent](/docs/run-an-agent).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5daea75f8db4e8a8121991ec61dad3b2ec3f2c85. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->