### PR TITLE
fix(hetzner): retry firewall creation on transient 5xx + stop setup spinner on failure

### DIFF
--- a/apps/cli/src/commands/control-plane.ts
+++ b/apps/cli/src/commands/control-plane.ts
@@ -186,9 +186,9 @@ const setupSub = new Command('setup')
           await writeFile(ENV_PATH, envBody + hetznerAuthBody(hubAuth), { mode: 0o600 });
           await chmod(ENV_PATH, 0o600);
         }
+        const ds = spinner();
+        ds.start(`deploying the control plane to ${target}`);
         try {
-          const ds = spinner();
-          ds.start(`deploying the control plane to ${target}`);
           const onLog = (line: string): void => ds.message(line);
           const repo = opts.repo ?? DEFAULT_DEPLOY_REPO;
           const ref = opts.ref ?? DEFAULT_DEPLOY_REF;
@@ -205,6 +205,9 @@ const setupSub = new Command('setup')
           }
           ds.stop(`deployed: ${deployedUrl}`);
         } catch (e) {
+          // Stop the spinner (code 1) before printing — otherwise it keeps
+          // animating its last "creating the firewall…" frame under the error.
+          ds.stop(`deploy to ${target} failed`, 1);
           log.warn(`deploy to ${target} failed: ${e instanceof Error ? e.message : String(e)}`);
           printManualDeploy();
         }

--- a/packages/sandbox-hetzner/src/control-plane-deploy.ts
+++ b/packages/sandbox-hetzner/src/control-plane-deploy.ts
@@ -155,8 +155,12 @@ export async function deployControlPlaneToHetzner(
   const hostCidr = normalizeSourceCidr(await detectEgressIp());
 
   log('creating the control-plane firewall (:22 host-only, :80/:443 open)…');
+  // retryOnAmbiguous: true — a firewall is free and per-deploy-uniquely named,
+  // so a retry after a hidden success leaves at most a harmless orphan; unlike
+  // the server create below (billable), a transient 502/504/429 must not abort
+  // the deploy on its very first step.
   const firewall = await withHetznerRetry(
-    { method: 'createFirewall', retryOnAmbiguous: false, attemptTimeoutMs: 60_000 },
+    { method: 'createFirewall', retryOnAmbiguous: true, attemptTimeoutMs: 60_000 },
     () =>
       client.createFirewall({
         name,

--- a/packages/sandbox-hetzner/src/firewall.ts
+++ b/packages/sandbox-hetzner/src/firewall.ts
@@ -89,8 +89,12 @@ export async function createPerBoxFirewall(
   client: HetznerClient,
   opts: CreateFirewallOptions,
 ): Promise<HetznerFirewall> {
+  // retryOnAmbiguous: true — unlike a server/image create (billable, a hidden
+  // success on retry duplicates a paid resource), a firewall is free and a
+  // duplicate is a harmless, easily-reaped orphan. A transient 502/504/429 here
+  // should not abort the whole box create.
   return withHetznerRetry(
-    { method: 'createFirewall', retryOnAmbiguous: false, attemptTimeoutMs: 60_000 },
+    { method: 'createFirewall', retryOnAmbiguous: true, attemptTimeoutMs: 60_000 },
     () =>
       client.createFirewall({
         name: opts.name,

--- a/packages/sandbox-hetzner/test/firewall.test.ts
+++ b/packages/sandbox-hetzner/test/firewall.test.ts
@@ -1,5 +1,29 @@
 import { describe, expect, it } from 'vitest';
-import { firewallNeedsSync, normalizeSourceCidr, sshOnlyInboundRule } from '../src/firewall.js';
+import {
+  createPerBoxFirewall,
+  firewallNeedsSync,
+  normalizeSourceCidr,
+  sshOnlyInboundRule,
+} from '../src/firewall.js';
+import { HetznerApiError, type HetznerClient, type HetznerFirewall } from '../src/client.js';
+
+describe('createPerBoxFirewall retries transient 5xx', () => {
+  it('retries a 502 Bad Gateway and returns the firewall (does not abort the create)', async () => {
+    let calls = 0;
+    const fw: HetznerFirewall = { id: 7, name: 'box-fw', rules: [], applied_to: [] };
+    const client = {
+      createFirewall: async () => {
+        calls += 1;
+        if (calls === 1) throw new HetznerApiError(502, 'http_502', 'bad gateway');
+        return fw;
+      },
+    } as unknown as HetznerClient;
+
+    const result = await createPerBoxFirewall(client, { name: 'box-fw', sources: ['1.2.3.4/32'] });
+    expect(result.id).toBe(7);
+    expect(calls).toBe(2);
+  });
+});
 
 describe('firewallNeedsSync', () => {
   it('no sync when the allowed source already matches the current egress', () => {


### PR DESCRIPTION
A transient Hetzner 502 during firewall creation aborted 'control-plane setup' on its first step (createFirewall was retryOnAmbiguous: false). Firewalls are free + per-op-uniquely-named, so a transient-gateway retry is safe — flipped both createFirewall sites to true (setFirewallRules/deleteFirewall already were). Also fixed the setup deploy spinner dangling after failure. Regression test added; hetzner suite + typecheck + lint green.

Reported live: setup → 'deploy to hetzner failed: hetzner 502 http_502: Bad Gateway'.

https://claude.ai/code/session_01QnaMFuHVZUdTq5VzxiSg2L

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted retry-policy and CLI UX fixes for Hetzner firewall creation and setup deploy errors; no auth or data-path changes.
> 
> **Overview**
> Hetzner **`createFirewall`** calls now use **`retryOnAmbiguous: true`** in control-plane deploy and per-box provisioning, so transient gateway errors (502/504/429) are retried instead of failing setup on the first step. Billable **`createServer`** / **`createImage`** paths stay **`retryOnAmbiguous: false`** to avoid duplicate paid resources; firewalls are treated as safe to retry (free, uniquely named, orphan-tolerant).
> 
> **`control-plane setup`** starts the deploy spinner before the try block and calls **`ds.stop(..., 1)`** in the catch path so the spinner does not keep animating under the failure message.
> 
> A regression test asserts **`createPerBoxFirewall`** retries a 502 and succeeds on the second attempt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1881d81ab5230fb505ccfefd2625592262323e07. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->