### PR TITLE
fix(create): reject --via-hub for remote-docker with a clear message

### DIFF
--- a/apps/cli/src/commands/create.ts
+++ b/apps/cli/src/commands/create.ts
@@ -186,6 +186,15 @@ async function runCreateViaHub(
     cmdLog.close();
     process.exit(1);
   }
+  if (providerName === 'remote-docker') {
+    // remote-docker authenticates as *you* through your own ~/.ssh/config + agent
+    // (no stored credential the control box could custody), and the SSH
+    // ControlMaster runs from the creating machine. The VPS has no access to your
+    // SSH identity, so it can't reach your remote host — run it from this machine.
+    log.error('--via-hub cannot run a remote-docker box: it connects to your remote host over your own ~/.ssh/config, which the control box has no access to. Run `agentbox docker:<host> …` from this machine instead.');
+    cmdLog.close();
+    process.exit(1);
+  }
   const repoUrl = originUrl(projectRoot);
   if (!repoUrl) {
     log.error('--via-hub needs a git `origin` remote (the hub worker clones it VPS-side). None found in this project.');


### PR DESCRIPTION
remote-docker connects to your remote host over your own ~/.ssh/config — the control box can't custody that, so a --via-hub remote-docker create fails confusingly on the VPS. The guard only blocked local docker; now it rejects remote-docker upfront and points at the local `agentbox docker:<host>` path. typecheck + lint green.

https://claude.ai/code/session_01QnaMFuHVZUdTq5VzxiSg2L

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an early validation branch with a user-facing error; no changes to hub provisioning or remote-docker create when run locally.
> 
> **Overview**
> **`agentbox create --via-hub`** now fails fast when the provider is **`remote-docker`**, not only for local **`docker`**.
> 
> The new check runs in **`runCreateViaHub`** before hub enqueue. It explains that remote-docker relies on the creator’s **`~/.ssh/config`** and SSH agent (no credential the control box can hold), so the hub worker cannot reach the remote Docker host. The error tells users to create from their machine with **`agentbox docker:<host> …`** instead of **`--via-hub`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e327dcc3cba87c6f769150d512b428f2089d853. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->