### PR TITLE
docs(control-box): expand the local-adoption gap backlog entry

### DIFF
--- a/docs/control-box-plan.md
+++ b/docs/control-box-plan.md
@@ -1224,12 +1224,39 @@ Findings and follow-ups discovered while implementing, kept out of the phase the
   verify, but the **hetzner base snapshot and any other provider bakes still ship the broken
   lease push** until their next `agentbox prepare`. Re-prepare hetzner before relying on leased
   pushes from hetzner boxes (tracked for the phase-4 hetzner-provider verify).
-- **(phase 4) `hub pull` downloads keys but doesn't fully adopt the box.** It writes the SSH key
-  material to `~/.agentbox/boxes/<sandboxId>/ssh/`, but not a local `state.json` `BoxRecord`, so
-  `agentbox attach <name>` can't yet resolve a hub-created box by name (it also needs the box's VPS
-  IP, which the `BoxRegistration` doesn't carry). Full adoption = enrich the registration (public
-  IP/host) + write a local record + rewrite `hostMainRepo` if the PC clones the repo (the deferred
-  half of the `hostMainRepo` item). Until then, adopt manually with the pulled key.
+- **(phase 4) Local-adoption gap — a control-box-created box is not operable from the PC by name.**
+  This is the single biggest asymmetry between the two creation origins, so the full detail:
+  - **Root cause.** A box created by the control box (web-UI create or `--via-hub`) lives in the
+    control box's Store; the PC never writes a local `state.json` `BoxRecord` for it. `hub pull`
+    downloads only the SSH-key material to `~/.agentbox/boxes/<sandboxId>/ssh/` — no record.
+  - **`agentbox ls` / `list` does not show it.** `list.ts` reads local state via
+    `listBoxes()` (`@agentbox/sandbox-docker`) and has only `--global` (all local *projects*) — no
+    control-plane source. So a hub-created box is invisible to `agentbox ls` even with `--global`.
+    The only PC-side view is the explicit `agentbox control-plane boxes list` (queries the control
+    box Store over HTTPS).
+  - **All the direct PC↔box commands miss too, not just attach.** `attach`, `cp`, `download`, `url`,
+    and `screen` each resolve the target from local state (`resolveBoxOrExit` → `readState`) and then
+    call the provider directly — none are proxied through the control box. With no local record,
+    `agentbox <cmd> <name>` can't resolve a hub-created box at all.
+  - **Reachability, by provider** (what adoption must also satisfy, beyond the record):
+    - **hetzner / DigitalOcean (SSH):** need the per-box key (via `hub pull`) **and the box's VPS
+      IP/host**, which the `BoxRegistration` does not carry today. The dual-IP firewall already
+      admits the PC's egress, so once the record + IP exist, direct SSH works.
+    - **e2b / vercel (SDK):** no per-box key — reached via the provider SDK + your API key (which the
+      PC has if the provider is configured). `url` is a **public HTTPS domain** shown in the web UI,
+      so it already works from anywhere; `attach`/`cp`/`download` still need a local record to know
+      the provider + sandbox id.
+    - **daytona:** SDK + bridge; same record requirement.
+  - **The fix.** Make `hub pull` (or a dedicated `agentbox hub adopt <box>`) write a local
+    `state.json` `BoxRecord` reconstructed from the control box's registration — provider, sandbox
+    id, VPS public IP/host, key path, origin/branch — so the box shows in `agentbox ls` and resolves
+    for `attach`/`cp`/`download`/`url`/`screen` exactly like a PC-created box. This needs the
+    registration **enriched** first (add public IP/host — `sandboxId` is already there), and it folds
+    in the deferred `hostMainRepo`-rewrite-on-PC-clone half of the `hostMainRepo` guard item, and it
+    unblocks cloud-resource teardown from the PC (the reap item below). Until then, the control box's
+    **web UI** is where a hub-created box is fully operable; from the PC you can `control-plane boxes
+    list` to see it, `hub pull` the key, and open the public preview `url` (e2b/vercel), but not
+    drive it by name.
 - **(phase 4) Cloud-resource teardown of a worker-created box from the hub.** `control-plane boxes
   rm` / the hub Destroy button reap control-box *state* only; the actual sandbox is left running
   because the control box has no full `BoxRecord` to drive `provider.destroy`. Persist enough on the


### PR DESCRIPTION
Expands the phase-4 local-adoption backlog item with the full detail from the Q&A: `agentbox ls` invisibility, all five direct PC->box commands (not just attach), per-provider reachability, and the fix shape (hub pull/adopt writes a local BoxRecord; registration needs public IP/host).

https://claude.ai/code/session_01QnaMFuHVZUdTq5VzxiSg2L

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown documentation update only; no runtime or API behavior changes.
> 
> **Overview**
> **Expands the phase-4 backlog item** on the **local-adoption gap** so it documents the full asymmetry between PC-created and control-box-created boxes, replacing the shorter `hub pull` / attach-only note.
> 
> The new text spells out why hub-created boxes lack a local `state.json` `BoxRecord`, why **`agentbox ls`** only reads local state (not the control plane), and that **`attach`**, **`cp`**, **`download`**, **`url`**, and **`screen`** all resolve via `resolveBoxOrExit` → local state with no hub proxy. It adds **per-provider reachability** (SSH providers need IP/host on registration; SDK providers need a record for most commands except public preview URLs). The proposed fix is **`hub pull` / `hub adopt`** writing a reconstructed `BoxRecord` after enriching registration with public IP/host, tying in deferred `hostMainRepo` rewrite and PC-side cloud teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a06c58714a000d4e12f17baca244210a727da09. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->