### PR TITLE
feat(remote-docker): host-alias registry, install-wizard setup, bake-on-add

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Uses `portless` to give box web apps the same URL from inside the box and on the
 - `agentbox daytona login` — interactive Daytona API key setup, saved to `~/.agentbox/secrets.env`
 - `agentbox e2b login` — interactive E2B API key setup, saved to `~/.agentbox/secrets.env`
 - `agentbox digitalocean login` — interactive DigitalOcean Personal Access Token setup, saved to `~/.agentbox/secrets.env`
-- `agentbox remote-docker check <host>` — run boxes on a machine you already own, over SSH. No login and no token: it connects as you, using your own `~/.ssh/config`. Then `agentbox docker:<host> claude`.
+- `agentbox remote-docker doctor <host>` — run boxes on a machine you already own, over SSH. No login and no token: it connects as you, using your own `~/.ssh/config`. Then `agentbox docker:<host> claude`.
 - `agentbox prepare [--provider daytona|hetzner|vercel|e2b|digitalocean|docker:<host>]` — build the image and initial snapshot (e2b builds from a Dockerfile via `Template.build()`)
 - `agentbox hetzner claude`, `agentbox hetzner codex`, `agentbox hetzner create`, etc.
 

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -9,6 +9,20 @@ Entries are generated from the commit history with `/release-notes` and then
 hand-reviewed — they describe what changed for someone using the `agentbox`
 CLI, not the raw commits.
 
+## [Unreleased]
+
+### Changed
+
+- Reworked the `remote-docker` provider around named **host aliases**. Register a
+  host with `agentbox remote-docker add <alias> <[user@]host[:port]>`; boxes are
+  created against the alias (`agentbox docker:<alias> …`), and `agentbox
+  remote-docker update <alias> <new-ssh>` retargets existing boxes after an IP
+  change. `doctor`/`list`/`remove` work on aliases, and a raw connection string is
+  no longer accepted where an alias is expected. `add` now bakes the box image on the
+  host by default (`--no-bake` to skip), and `agentbox install` → Remote Docker prompts
+  for the alias + SSH connection. (Subcommands were also renamed from the old
+  `check`/`use`/`hosts` to `doctor`/`add`/`list`.)
+
 ## [0.26.1] - 2026-07-15
 
 ### Fixed

--- a/apps/cli/src/commands/create.ts
+++ b/apps/cli/src/commands/create.ts
@@ -298,16 +298,17 @@ export const createCommand = new Command('create')
     }
     const checkpointRef = resolveCheckpointRef(
       opts,
-      resolveDefaultCheckpoint(
-        cfg.effective,
-        providerName,
-      ),
+      resolveDefaultCheckpoint(cfg.effective, providerName),
     );
     if (opts.location && providerName !== 'hetzner' && providerName !== 'digitalocean') {
-      log.warn(`--location applies to hetzner/digitalocean only; ignored for provider ${providerName}`);
+      log.warn(
+        `--location applies to hetzner/digitalocean only; ignored for provider ${providerName}`,
+      );
     }
     if (opts.inbound && providerName !== 'hetzner' && providerName !== 'digitalocean') {
-      log.warn(`--inbound applies to hetzner/digitalocean only; ignored for provider ${providerName}`);
+      log.warn(
+        `--inbound applies to hetzner/digitalocean only; ignored for provider ${providerName}`,
+      );
     }
     if (opts.remoteHost && providerName !== 'remote-docker') {
       log.warn(`--remote-host applies to remote-docker only; ignored for provider ${providerName}`);
@@ -315,10 +316,7 @@ export const createCommand = new Command('create')
     // Box image: same precedence pattern as --size. `--image` wins; otherwise
     // the cascaded box.image / box.image<Provider> (written by `agentbox
     // prepare --provider X`).
-    const imageDefault = resolveBoxImage(
-      cfg.effective,
-      providerName,
-    );
+    const imageDefault = resolveBoxImage(cfg.effective, providerName);
     const effectiveImage = opts.image && opts.image.length > 0 ? opts.image : imageDefault;
 
     // Cloud providers that use the Daytona public-URL path don't need
@@ -394,10 +392,7 @@ export const createCommand = new Command('create')
     // runtime; if the local install no longer matches, the wizard offers to
     // rebuild before creating. Docker self-heals via `ensureImage`, so its
     // baseStatus is always `fresh` and the wizard is a no-op here.
-    const baseStatus = await evaluateBaseFreshness(
-      providerName,
-      cfg.effective.box.claudeInstall,
-    );
+    const baseStatus = await evaluateBaseFreshness(providerName, cfg.effective.box.claudeInstall);
     const wiz = await maybeRunSetupWizard({
       workspace: opts.workspace,
       yes: !!opts.yes,
@@ -571,7 +566,7 @@ export const createCommand = new Command('create')
           ]
         : [
             `  agentbox shell ${result.record.name}`,
-            `  agentbox claude attach ${result.record.name}`,
+            `  agentbox attach ${result.record.name}`,
             `  agentbox url ${result.record.name}`,
           ];
       log.message(

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -65,6 +65,7 @@ import {
 } from './install-app.js';
 import { isNewer } from '../lib/semver-lite.js';
 import { runPrepare } from './prepare.js';
+import { interactiveRegisterHost } from '@agentbox/sandbox-remote-docker';
 
 /** Marker on the line after the frontmatter of every skill we ship. Its
  *  presence in an existing target means we wrote it and may overwrite freely. */
@@ -495,21 +496,17 @@ async function maybeSetDefaultProvider(name: ProviderName, autoYes: boolean): Pr
         initialValue: true,
       });
   if (!wantDefault) {
-    log.info(
-      `left the default as ${cfg.effective.box.provider} — start a ${name} box with \`agentbox ${name} claude\`, ` +
-        `or set it later with \`agentbox config set box.provider ${name} --global\``,
-    );
+    log.info(`kept ${cfg.effective.box.provider} as the default for new boxes`);
     return false;
   }
 
   try {
-    const r = await setConfigValue('global', 'box.provider', name, process.cwd(), { raw: true });
-    log.info(`box.provider = ${name}   (wrote ${r.path})`);
+    await setConfigValue('global', 'box.provider', name, process.cwd(), { raw: true });
+    log.info(`${label} is now the default for new boxes`);
     return true;
   } catch (err) {
     log.warn(
-      `could not write box.provider: ${err instanceof Error ? err.message : String(err)} — ` +
-        `set it with \`agentbox config set box.provider ${name} --global\``,
+      `could not set ${label} as the default: ${err instanceof Error ? err.message : String(err)}`,
     );
     return false;
   }
@@ -524,7 +521,7 @@ function tutorialBody(provider: ProviderName, isDefault: boolean): string {
     `  ${startCmd}                       # for claude, codex, opencode\n` +
     `   -> Setup wizard? -> Yes          # install dependencies and setup agentbox.yaml\n` +
     `   -> Ctrl+a d                      # to detach from the box and leave claude running\n` +
-    `  agentbox claude attach 1          # resume it later\n` +
+    `  agentbox attach                   # resume it later\n` +
     `  agentbox install                  # to set up another provider`
   );
 }
@@ -607,12 +604,30 @@ export async function runInstallWizard(opts: RunInstallWizardOptions = {}): Prom
     }
   }
 
+  // 3b) remote-docker has no credential — its "setup" is registering a host
+  // (alias + SSH connection). Do it here so the bake step below (which targets
+  // `box.remoteDockerHost`) has something to bake against.
+  let remoteDockerHostReady = true;
+  if (providerName === 'remote-docker') {
+    const alias = await interactiveRegisterHost();
+    if (!alias) {
+      remoteDockerHostReady = false;
+      log.info(
+        'no host registered — add one later with `agentbox remote-docker add <alias> <ssh>`',
+      );
+    }
+  }
+
   // 4) Optional remote/build prepare.
   const prepareMsg =
     providerName === 'docker'
       ? 'Build the box image now? (~1GB, a few minutes)'
-      : `Create the ${providerName} base snapshot now? (a few minutes, uses cloud time)`;
-  const wantPrepare = opts.yes ? true : await confirm({ message: prepareMsg, initialValue: true });
+      : providerName === 'remote-docker'
+        ? 'Bake the box image on the host now? (a few minutes; pulled from GHCR or built there)'
+        : `Create the ${providerName} base snapshot now? (a few minutes, uses cloud time)`;
+  const wantPrepare =
+    remoteDockerHostReady &&
+    (opts.yes ? true : await confirm({ message: prepareMsg, initialValue: true }));
   if (wantPrepare) {
     try {
       await runPrepare(providerName, {
@@ -625,6 +640,8 @@ export async function runInstallWizard(opts: RunInstallWizardOptions = {}): Prom
         `prepare failed: ${err instanceof Error ? err.message : String(err)} — you can rerun \`agentbox prepare --provider ${providerName}\` later`,
       );
     }
+  } else if (providerName === 'remote-docker') {
+    log.info('skipped — the box image builds on the host on first create');
   } else {
     log.info(
       `skipped — the ${providerName} base will build lazily on first \`agentbox ${providerName === 'docker' ? '' : providerName + ' '}create\``,
@@ -667,15 +684,14 @@ export async function runInstallWizard(opts: RunInstallWizardOptions = {}): Prom
       dryRun: opts.dryRun,
       quiet: true,
     });
-    if (codexRes.ran) {
+    // Only announce a real change — an already-enabled plugin is a silent no-op.
+    if (codexRes.ran && codexRes.enableStatus !== 'user-enabled') {
       log.info(
         codexRes.enableStatus === 'added'
           ? 'Codex plugin: installed and enabled by default'
-          : codexRes.enableStatus === 'user-enabled'
-            ? 'Codex plugin: already enabled'
-            : codexRes.enableStatus === 'user-disabled'
-              ? 'Codex plugin: installed (left disabled per your config)'
-              : 'Codex plugin: installed (could not edit ~/.codex/config.toml)',
+          : codexRes.enableStatus === 'user-disabled'
+            ? 'Codex plugin: installed (left disabled per your config)'
+            : 'Codex plugin: installed (could not edit ~/.codex/config.toml)',
       );
     }
   } catch (err) {
@@ -713,11 +729,8 @@ export async function runInstallWizard(opts: RunInstallWizardOptions = {}): Prom
     let action: 'install' | 'update' | 'none' = 'install';
     if (trayInstalled()) action = behind ? 'update' : 'none';
 
-    if (action === 'none') {
-      log.info(
-        `Menu-bar app: already installed${installedVersion ? ` (${installedVersion})` : ''}`,
-      );
-    } else {
+    // Already installed and up to date → silent no-op (only prompt to install/update).
+    if (action !== 'none') {
       const message =
         action === 'update'
           ? `Update the AgentBox menu-bar app (${installedVersion ?? '?'} → ${latestVersion ?? '?'})?`

--- a/apps/cli/src/help.ts
+++ b/apps/cli/src/help.ts
@@ -252,11 +252,11 @@ const COMPACT_EXAMPLE = [
   'Example:',
   '  agentbox claude                  # launch Claude, one box per task/branch',
   '  agentbox hetzner|e2b|… codex     # launch with other agents or providers',
-  '  ! agentbox fork hetzner|e2b|…    # teleport the current session from the chat',
+  '  > ! agentbox fork hetzner|e2b|…    # teleport the current session from the chat',
   '',
   '  agentbox attach 1                # detach with Ctrl+a d, then re-attach',
   '',
-  '  # Then ask your agent to push/pr or do it from your pc:',
+  '  # Ask your agent to push/pr from the box, or do it from your pc:',
   '  agentbox git push 1              # push to remote',
   '  agentbox git push 1 --host-only  # move back the branch to your pc',
   '  agentbox git pr create 1 -f      # create a PR from the box',
@@ -275,7 +275,7 @@ const COMPACT_MORE = [
   '    connect|download|services|inbound, drive|queue, config, …',
 ];
 
-const COMPACT_FOOTER = ['Run `agentbox <command> --help` for command options.'];
+const COMPACT_FOOTER = ['Run `agentbox help` for the full list of commands.'];
 
 export function buildCompactHelp(program: Command): string {
   const byName = new Map(program.commands.map((c) => [c.name(), c] as const));
@@ -292,7 +292,7 @@ export function buildCompactHelp(program: Command): string {
   const allTerms = COMPACT_HELP.flatMap((g) => g.rows.map(rowTerm));
   const pad = Math.max(0, ...allTerms.map((t) => t.length)) + 3;
 
-  const lines: string[] = ['Commands:'];
+  const lines: string[] = [...COMPACT_EXAMPLE, '', 'Commands:'];
   for (const g of COMPACT_HELP) {
     lines.push('', `  ${g.title}`);
     for (const row of g.rows) {
@@ -301,6 +301,6 @@ export function buildCompactHelp(program: Command): string {
       lines.push(`    ${rowTerm(row).padEnd(pad)}${description}`);
     }
   }
-  lines.push('', ...COMPACT_MORE, '', ...COMPACT_EXAMPLE, '', ...COMPACT_FOOTER);
+  lines.push('', ...COMPACT_MORE, '', ...COMPACT_FOOTER);
   return lines.join('\n');
 }

--- a/apps/cli/src/lib/doctor-checks.ts
+++ b/apps/cli/src/lib/doctor-checks.ts
@@ -11,7 +11,13 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { execa } from 'execa';
 import { loadEffectiveConfig, type ProviderKind } from '@agentbox/config';
-import { errSummary, firstLine, type CheckResult, type CheckStatus } from '@agentbox/sandbox-core';
+import {
+  errSummary,
+  firstLine,
+  statusBadge,
+  type CheckResult,
+  type CheckStatus,
+} from '@agentbox/sandbox-core';
 import { ALL_CONNECTORS, type IntegrationConnector } from '@agentbox/integrations';
 import { getRuntimeProviderNames, loadProviderModule } from '../provider/loaders.js';
 import { evaluateBaseFreshness } from '../checkpoint-lookup.js';
@@ -490,13 +496,6 @@ export function formatCompact(groups: CheckGroup[]): string {
 
 function pad(s: string, width: number): string {
   return s.length >= width ? s : s + ' '.repeat(width - s.length);
-}
-
-function statusBadge(s: CheckStatus): string {
-  if (s === 'ok') return '[ ok ]';
-  if (s === 'info') return '[info]';
-  if (s === 'warn') return '[warn]';
-  return '[FAIL]';
 }
 
 /** Multi-line grouped report used by `agentbox doctor`. */

--- a/apps/cli/test/help.test.ts
+++ b/apps/cli/test/help.test.ts
@@ -231,8 +231,9 @@ describe('compact --help (default view)', () => {
     expect(help).toMatch(/^\s+destroy\|rm\s/m);
     expect(help).toContain('Example:');
     expect(help).toContain('agentbox git push');
-    expect(help).toContain('Run `agentbox <command> --help`');
+    expect(help).toContain('Run `agentbox help` for the full list of commands.');
     expect(help).toContain('`agentbox help`');
+    expect(help.indexOf('Example:')).toBeLessThan(help.indexOf('Commands:'));
     expect(help).toContain('drive|queue');
     expect(help).toContain('connect|download|services|inbound');
   });

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -17,7 +17,7 @@ A provider can be **host-qualified**: `agentbox docker:<host> claude` runs the b
 
 ## Create & run
 
-`create` makes a box but launches no agent. `claude`, `codex`, and `opencode` create (or reuse) a box *and* launch that agent in a detachable tmux session — they mirror `create`'s entire flag surface, so you can swap the verb without relearning flags. `fork` teleports the agent session you're running on the host right now into a fresh box.
+`create` makes a box but launches no agent. `claude`, `codex`, and `opencode` create (or reuse) a box _and_ launch that agent in a detachable tmux session — they mirror `create`'s entire flag surface, so you can swap the verb without relearning flags. `fork` teleports the agent session you're running on the host right now into a fresh box.
 
 ```bash
 # Create a box, no agent
@@ -29,7 +29,7 @@ agentbox codex
 agentbox opencode
 ```
 
-The agent-agnostic `agentbox attach [box]` reattaches to whichever agent session is running in the box (it prompts when more than one is live). It never auto-starts: when nothing is running it prints a warning and exits non-zero. Each agent command also exposes its own `attach` / `start` / `login` subcommands: per-agent `attach` reattaches *and* starts a session if none is running (never re-syncs config), `start` (re)starts a session in an existing box (rsyncs host config unless `--no-sync-config`), and `login` runs that agent's auth flow. In a terminal, `login` prints the approval URL and prompts you for the code itself — the agent's own sign-in TUI never takes over your terminal, so it behaves the same in every emulator. Pass `--interactive` to hand the terminal to that TUI instead (needed for login methods the guided prompt can't drive). With no TTY (or `--headless`), `claude login` prints the OAuth approval URL — including a greppable `AGENTBOX_LOGIN_URL=` marker — and you finish with `agentbox claude login --code <CODE>`, so an orchestrating agent can drive the sign-in. See [first-run auth](/docs/run-an-agent#first-run-auth).
+The agent-agnostic `agentbox attach [box]` reattaches to whichever agent session is running in the box (it prompts when more than one is live). It never auto-starts: when nothing is running it prints a warning and exits non-zero. Each agent command also exposes its own `attach` / `start` / `login` subcommands: per-agent `attach` reattaches _and_ starts a session if none is running (never re-syncs config), `start` (re)starts a session in an existing box (rsyncs host config unless `--no-sync-config`), and `login` runs that agent's auth flow. In a terminal, `login` prints the approval URL and prompts you for the code itself — the agent's own sign-in TUI never takes over your terminal, so it behaves the same in every emulator. Pass `--interactive` to hand the terminal to that TUI instead (needed for login methods the guided prompt can't drive). With no TTY (or `--headless`), `claude login` prints the OAuth approval URL — including a greppable `AGENTBOX_LOGIN_URL=` marker — and you finish with `agentbox claude login --code <CODE>`, so an orchestrating agent can drive the sign-in. See [first-run auth](/docs/run-an-agent#first-run-auth).
 
 ```bash
 # Create a box and drop into a shell once it's ready
@@ -59,9 +59,16 @@ Shared create/agent flags include `-n, --name`, `-w, --workspace <path>`, `--pro
 
 Agent-specific: `--attach-in <split|window|tab|same>`, `-d, --no-attach`, `-i, --initial-prompt <text>` (background queue), and for `claude` only `-c, --continue`, `--resume <id>`, `--plan <path>`, and `--dangerously-skip-permissions` (on by default in boxes). `fork` adds `--agent`, `--session <id>`, `--attach-in` (default `tab`), and a positional `[provider]` (`agentbox fork hetzner` is shorthand for `--provider hetzner`). When `--agent`/`--session` are omitted, `fork` autodetects the launching agent and current session from its env vars (Claude via `CLAUDECODE` / `CLAUDE_CODE_SESSION_ID`, Codex via `CODEX_THREAD_ID`), so a bare `agentbox fork` forks whichever agent you ran it from.
 
-<Callout type="warn" title="HEADS UP">`-i` / `--initial-prompt` is AgentBox's background-queue prompt, not the agent's own `-p` print mode. To run the agent headless, pass it after `--` (e.g. `agentbox claude -- -p "..."`). Note also that `-i` means `--inline` on the `attach`/`start` subcommands.</Callout>
+<Callout type="warn" title="HEADS UP">
+  `-i` / `--initial-prompt` is AgentBox's background-queue prompt, not the agent's own `-p` print
+  mode. To run the agent headless, pass it after `--` (e.g. `agentbox claude -- -p "..."`). Note
+  also that `-i` means `--inline` on the `attach`/`start` subcommands.
+</Callout>
 
-<Figure src="/screenshots/claude-tui.png" caption="agentbox claude creates the box and drops you into a detachable Claude Code session." />
+<Figure
+  src="/screenshots/claude-tui.png"
+  caption="agentbox claude creates the box and drops you into a detachable Claude Code session."
+/>
 
 These commands tee progress to `~/.agentbox/logs/<command>.log`; `~/.agentbox/logs/latest.log` always points at the most recent run.
 
@@ -110,10 +117,16 @@ Add `--print` to `url`, `screen`, or `code` to print the URL instead of opening 
 
 A one-shot command after `--` is run under the box's login shell. A single quoted argument is treated as a shell snippet (so `&&`, pipes, redirections, and `$VAR` are interpreted by the box); multiple tokens are passed through verbatim as a literal argv (like `docker exec`), so quoting and format strings such as `curl -w '%{http_code}'` reach the command intact — no double-parsing.
 
-<Callout title="TIP">`agentbox screen` needs VNC, which is on by default — boxes created with `--no-vnc` can't use it.</Callout>
+<Callout title="TIP">
+  `agentbox screen` needs VNC, which is on by default — boxes created with `--no-vnc` can't use it.
+</Callout>
 
 {/* SCREENSHOT /screenshots/dashboard.png — REPRO: drive the TUI via the PTY harness — pnpm drive start --cols 96 --rows 19 --cwd <project> -- agentbox dashboard <box> ; pnpm drive screen <id> ; strip the pnpm/tsx wrapper lines ; render via /tmp/gen-term.js and screenshot headlessly. */}
-<Figure src="/screenshots/dashboard.png" caption="agentbox dashboard — the box list plus the actions for the selected box." />
+
+<Figure
+  src="/screenshots/dashboard.png"
+  caption="agentbox dashboard — the box list plus the actions for the selected box."
+/>
 
 See [Access your box](/docs/access-your-box), [Web apps & tunnels](/docs/web-apps-and-tunnels), and [Browser & screen](/docs/browser-and-screen).
 
@@ -146,17 +159,20 @@ agentbox wait 1
 
 `list` (alias `ls`) lists boxes in the current project; `-g` spans all projects. `status` shows live service/task state from the in-box `agentbox-ctl` daemon, and `status --inspect` adds detailed box info (volumes, limits, paths). `status --set-name <name>` (and `--clear-name`) **renames** a box — it sets a cosmetic display label shown in `list`, the hub, and the tray. The label is display-only: the container, git branch, and web/VNC URL keep the box's original name, and you can still address the box by either name. Works for every provider and any box state. `top` is a live resource monitor, `logs` tails a service log, and `wait` blocks until autostart units are ready.
 
-| Command | Useful flags |
-| --- | --- |
-| `list` / `ls` | `-j, --json`, `-g, --global`, `--watch`, `--live`, `--cmux` |
-| `status` | `-j, --json`, `--inspect`, `--set-name <name>`, `--clear-name` |
-| `top` | `--once`, `-j, --json`, `--interval <s>`, `--live` |
-| `logs` | `-n, --tail <n>`, `-f, --follow`, `--daemon` |
-| `wait` | `--timeout <ms>`, `--units <names...>`, `-j, --json` |
+| Command       | Useful flags                                                   |
+| ------------- | -------------------------------------------------------------- |
+| `list` / `ls` | `-j, --json`, `-g, --global`, `--watch`, `--live`, `--cmux`    |
+| `status`      | `-j, --json`, `--inspect`, `--set-name <name>`, `--clear-name` |
+| `top`         | `--once`, `-j, --json`, `--interval <s>`, `--live`             |
+| `logs`        | `-n, --tail <n>`, `-f, --follow`, `--daemon`                   |
+| `wait`        | `--timeout <ms>`, `--units <names...>`, `-j, --json`           |
 
 The `agent` group is a scripting surface for the agent's live state: `agent state`, `agent wait-for <state>`, and `agent get-plan-question`, all with `--json`. It also unifies **approvals** an orchestrator answers on a box's behalf: `agent approvals [box]` lists everything the box is blocked on — relay host-action confirms (git push, cp, gh PR writes, checkpoint) **and** the agent's in-TUI prompts (plan approval, question, tool permission) — each with an id, and `agent approve <id>` (with `--option`/`--deny`) answers that exact one. The id is a safety token: a prompt that changed since you listed it is refused, not mis-answered. Pair it with `agentbox drive` (snapshot the screen / send keystrokes) to drive one agent from another — see [Orchestration & queue boxes](/docs/background-and-parallel).
 
-<Callout title="TIP">Most inspect commands take `-j/--json` for scripting; `top` and `list` also offer `--live` to probe real cloud state (slower) instead of last-known host state.</Callout>
+<Callout title="TIP">
+  Most inspect commands take `-j/--json` for scripting; `top` and `list` also offer `--live` to
+  probe real cloud state (slower) instead of last-known host state.
+</Callout>
 
 See [Services & tasks](/docs/services-and-tasks) and [Background & parallel](/docs/background-and-parallel).
 
@@ -189,7 +205,10 @@ agentbox connect 1 --add-key @phone.pub   # authorize a device's key; print the 
 
 `recover` re-establishes a box's **host-side** connectivity without power-cycling it — for after a host reboot, a relay restart, or a fresh CLI process on another machine. It ensures the host relay is up and re-registers every box with it, re-opens the host transport (the Hetzner SSH tunnel + port forwards), re-registers the Portless aliases, relaunches the in-box daemons, and brings back the agent the box was last running (`claude`/`codex`/`opencode` — resuming its session, or starting fresh), then attaches. With no argument it recovers the current project's box; `--all` recovers every box in state (and skips the attach); `--no-attach` restores without attaching. `agentbox recover --provider <cloud> --adopt [id|name]` first rebuilds local state for a running sandbox that this host has no record of (e.g. one created on another machine), minting fresh relay tokens from what the box exposes. For Hetzner, adoption needs the box's per-host SSH key — a box created on a different host can't be controlled and `recover` says so.
 
-<Callout title="TIP">Prefer `pause`/`unpause` to switch between boxes — it frees CPU and RAM while frozen and resumes instantly on docker. Use `stop` when you want the box off but kept.</Callout>
+<Callout title="TIP">
+  Prefer `pause`/`unpause` to switch between boxes — it frees CPU and RAM while frozen and resumes
+  instantly on docker. Use `stop` when you want the box off but kept.
+</Callout>
 
 `inbound`/`connect` (Hetzner/DigitalOcean) let you drive a box from a phone with the laptop off. `agentbox inbound <box> open|lock|<cidr…>` sets the per-box firewall's inbound policy (`--show` prints it); `agentbox connect <box>` prints the SSH connection bundle, `--add-key <pubkey>` authorizes another device's key (the box's own key stays on the host), and `--export-key` prints the box key for a mobile client, and `--dangerously-git-credentials` copies a git credential into an already-running box so it pushes on its own (the post-create equivalent of `create --dangerously-with-credentials`; restart the agent afterward). See [remote access](/docs/access-your-box#use-a-box-with-your-laptop-offline) and [sync & git](/docs/sync-and-git#independent-boxes--dangerously-with-credentials).
 
@@ -239,7 +258,11 @@ Useful flags: `download` takes `--dry-run`, `--no-respect-gitignore`, `--include
 
 `git branch <box> <name>` forks a fresh `agentbox/<name>` branch (an `agentbox/` prefix is added when missing) from the box's current HEAD — or from `--from <ref>` — and switches the box onto it, handy for reusing a box on a new task. `services <box>` lists the [services](/docs/services-and-tasks) from the box's `agentbox.yaml` with their live state (running / ready / crashed / …); `services restart <box> [name]` restarts one service, or all of them when no name is given. All of these operations are also available on the [hub](/docs/hub) box-detail page and the [REST API](/docs/api).
 
-<Callout title="TIP">`agentbox git push` runs through the host relay — your git/SSH credentials stay on your machine. The box requests the push; the host performs it (and prompts for approval per the relay's host-action gate).</Callout>
+<Callout title="TIP">
+  `agentbox git push` runs through the host relay — your git/SSH credentials stay on your machine.
+  The box requests the push; the host performs it (and prompts for approval per the relay's
+  host-action gate).
+</Callout>
 
 See [Sync & git](/docs/sync-and-git) and [Environment](/docs/environment).
 
@@ -273,7 +296,11 @@ agentbox claude --snapshot warm
 
 Checkpoints are per-project and provider-aware. `set-default --provider <name>` pins for one provider; otherwise it sets the cross-provider fallback. Docker stacks `docker commit` layers; cloud providers use native snapshots.
 
-<Callout type="warn" title="HEADS UP">`--merged` (flatten layers) is docker-only — cloud snapshots are always flattened. On vercel, creating a checkpoint stops and reboots the box; pass `-y` to skip the confirmation. Cloud snapshots can't be used by docker boxes, so pin them with `--provider`.</Callout>
+<Callout type="warn" title="HEADS UP">
+  `--merged` (flatten layers) is docker-only — cloud snapshots are always flattened. On vercel,
+  creating a checkpoint stops and reboots the box; pass `-y` to skip the confirmation. Cloud
+  snapshots can't be used by docker boxes, so pin them with `--provider`.
+</Callout>
 
 See [Checkpoints & pausing](/docs/checkpoints-and-pausing).
 
@@ -347,9 +374,11 @@ agentbox hetzner login --status   # show what's configured (masked)
 agentbox hetzner firewall show <box>
 agentbox hetzner firewall sync <box>
 agentbox daytona resync             # re-sync the credential volume
-agentbox remote-docker check <host> # can this machine host boxes? (ssh + docker)
-agentbox remote-docker use <host>   # set the default engine
-agentbox remote-docker hosts        # engines you've baked the box image on
+agentbox remote-docker add <alias> <ssh>    # register a host alias (name -> ssh connection)
+agentbox remote-docker update <alias> <ssh> # re-point an alias; existing boxes follow
+agentbox remote-docker list                 # your host aliases (alias: ls)
+agentbox remote-docker doctor [alias]       # can this host host boxes? (ssh + docker)
+agentbox remote-docker remove <alias>       # forget an alias (+ default + bake record; alias: rm)
 ```
 
 `docker` is the default and is pure sugar (no login). Each cloud provider has a `login` subcommand (run by default); hetzner adds `firewall`, daytona adds `resync`. `remote-docker` has **no login at all** — it connects as you, over your own `~/.ssh/config` — and offers `check` / `use` / `hosts` instead. E2B is the only cloud whose `prepare` builds the base image **directly from a Dockerfile** via the SDK's `Template.build()` — the others bake a one-time snapshot.
@@ -396,9 +425,9 @@ agentbox self-update --dry-run
 
 `prune` cleans up orphan state records; `--all` also removes orphan docker resources, and `--provider <cloud>` lists untracked cloud sandboxes and offers to delete them. `queue` manages background `-i` jobs. `relay` manages the host relay (`status`, `stop`, `start`, `restart`). `app` controls the macOS menu-bar app (`status`, `start`, `stop`, `restart`) — install it first with `agentbox install app`. `app log` collects the app's diagnostics for a bug report: it reads the app's macOS unified-log entries (`--last <window>`, `-f` to stream live, `--crashes` for just the crash reports) and lists its crash reports from `~/Library/Logs/DiagnosticReports`; `--open` reveals that folder in Finder, and `--out <file>` writes a single self-contained bundle (versions, log, newest crash report) to attach. The app keeps no log file of its own — these are macOS-native surfaces.
 
-`self-update` updates the CLI, then refreshes everything that depends on it: the host skill files, the relay, and the menu-bar app (reinstalled only when the published build's checksum differs from the installed one — a matching build is left running). The box image is **checked, not deleted**: it is content-addressed by a hash of its build context, so an update that changes none of those files leaves it in place and costs nothing. When the context *has* changed, the image rebuilds on the next create, `agentbox doctor` flags it as `base freshness: stale`, and the hub/menu-bar app show a **stale — re-bake** pill; `agentbox prepare --provider docker` re-bakes it up front. If you update the package yourself (`npm update -g @madarco/agentbox`), the next interactive command notices the version change and offers the same refresh with a one-line prompt. Independently, at most once per day, an interactive command kicks off a small background check of the npm registry and prints "a newer agentbox is available — run `agentbox self-update`" when one is; normal CLI calls never hit the network outside that daily probe. Disable the check and the nudge with `agentbox config set update.check false` (see [configuration](/docs/configuration)).
+`self-update` updates the CLI, then refreshes everything that depends on it: the host skill files, the relay, and the menu-bar app (reinstalled only when the published build's checksum differs from the installed one — a matching build is left running). The box image is **checked, not deleted**: it is content-addressed by a hash of its build context, so an update that changes none of those files leaves it in place and costs nothing. When the context _has_ changed, the image rebuilds on the next create, `agentbox doctor` flags it as `base freshness: stale`, and the hub/menu-bar app show a **stale — re-bake** pill; `agentbox prepare --provider docker` re-bakes it up front. If you update the package yourself (`npm update -g @madarco/agentbox`), the next interactive command notices the version change and offers the same refresh with a one-line prompt. Independently, at most once per day, an interactive command kicks off a small background check of the npm registry and prints "a newer agentbox is available — run `agentbox self-update`" when one is; normal CLI calls never hit the network outside that daily probe. Disable the check and the nudge with `agentbox config set update.check false` (see [configuration](/docs/configuration)).
 
-The **menu-bar app is versioned and released separately from the CLI**, so an app release does not bump the CLI (and vice versa). Both channels watch for it: the same daily probe compares the published app build against the installed one and, when only the app is behind, the next interactive command offers to install it — answering "no" remembers that build, so you are asked once, not on every command. The app checks for itself too: **Check for Updates…** reports the CLI *and* the app, and offers `agentbox install app` when only the app is stale (a full `self-update` would needlessly bounce the relay). You can always update it directly with `agentbox install app`, which reinstalls the latest published build regardless of what is installed.
+The **menu-bar app is versioned and released separately from the CLI**, so an app release does not bump the CLI (and vice versa). Both channels watch for it: the same daily probe compares the published app build against the installed one and, when only the app is behind, the next interactive command offers to install it — answering "no" remembers that build, so you are asked once, not on every command. The app checks for itself too: **Check for Updates…** reports the CLI _and_ the app, and offers `agentbox install app` when only the app is stale (a full `self-update` would needlessly bounce the relay). You can always update it directly with `agentbox install app`, which reinstalls the latest published build regardless of what is installed.
 
 `hub` runs the **AgentBox hub** — the host relay plus a local Web UI (dashboard, box detail, live approvals) at `https://agentbox.localhost` (registered by [Portless](https://portless.sh); it falls back to `http://127.0.0.1:8787` when Portless isn't in play), gated by a per-machine token. Start it with the command rather than by typing the URL: `agentbox hub` opens the page with the token, which the hub then remembers in a cookie. It's a superset of the relay on the same port: `agentbox hub` takes over from a bare relay, and normal box commands reuse it. Needs Node ≥ 22.5.
 

--- a/apps/web/content/docs/remote-docker.mdx
+++ b/apps/web/content/docs/remote-docker.mdx
@@ -6,38 +6,43 @@ description: Run your agents on a machine you already own — the workstation un
 Run boxes on a machine you already own instead of your laptop or a cloud: the workstation under the desk, a spare Mac, a team server. AgentBox SSHes in and drives **that machine's Docker engine**, so the box gets its CPU, its RAM and its disk while your laptop stays cool and its fans stay quiet. No account, no API token, no bill — if `ssh <host> docker version` works from your terminal, you can run boxes there.
 
 ```bash
-agentbox docker:buildbox claude
+agentbox remote-docker add buildbox marco@10.0.0.9   # register the host once
+agentbox docker:buildbox claude                      # then run boxes on it
 ```
 
-The `docker:<host>` prefix is the whole interface: "docker, but over there". Pick Remote Docker when you have a machine with real resources and want the local-Docker experience on it — a fast Dockerfile-based image, `docker commit` checkpoints, instant `docker pause`, and full [Docker-in-Docker](/docs/docker-in-docker). Comparing options? See [local-docker](/docs/local-docker), [hetzner](/docs/hetzner), [daytona](/docs/daytona), [vercel](/docs/vercel), and [e2b](/docs/e2b).
+You register a machine under a short **alias**, then address it as `docker:<alias>`: "docker, but over there". Pick Remote Docker when you have a machine with real resources and want the local-Docker experience on it — a fast Dockerfile-based image, `docker commit` checkpoints, instant `docker pause`, and full [Docker-in-Docker](/docs/docker-in-docker). Comparing options? See [local-docker](/docs/local-docker), [hetzner](/docs/hetzner), [daytona](/docs/daytona), [vercel](/docs/vercel), and [e2b](/docs/e2b).
 
 ## Set up
 
-There is no login step, because there is no credential. The provider connects **as you**, using your own `~/.ssh/config`, your agent and your `known_hosts`. It mints no keys for the connection and reads no tokens.
+There is no login step, because there is no credential. The provider connects **as you**, using your own `~/.ssh/config`, your agent and your `known_hosts`. It mints no keys for the connection and reads no tokens. You need one thing on the remote machine: Docker, on the login-shell `PATH` of the user you SSH in as.
 
-You need one thing on the remote machine: Docker, on the login-shell `PATH` of the user you SSH in as.
+The install wizard walks you through it — `agentbox install`, pick **Remote Docker**, and it prompts for the alias name and SSH connection, then offers to bake the image. Or do it directly:
 
-```bash
-agentbox remote-docker check buildbox
-```
-
-That probes the destination end to end — SSH reachable, `docker` found, daemon answering — and prints the engine's version and architecture. Then set it as your default (or skip this and name the host per command):
+Register the host under an alias. The second argument is the SSH connection — an `~/.ssh/config` alias or `[user@]host[:port]`:
 
 ```bash
-agentbox remote-docker use buildbox            # writes box.remoteDockerHost for this project
-agentbox remote-docker use buildbox --global   # ...or for every project
+agentbox remote-docker add buildbox marco@10.0.0.9      # alias `buildbox` → marco@10.0.0.9
+agentbox remote-docker add mini dev@10.0.0.9:2222       # a custom port works too
 ```
 
-Optionally bake the box image ahead of time, so your first `create` isn't waiting on it:
+`add` probes the connection end to end — SSH reachable, `docker` found, daemon answering — then **bakes the box image on the host** so your first `create` is instant (pass `--no-bake` to skip; it builds lazily on first create). Pass `--default` (or `--global`) to also make it the default host, so you can drop the `docker:<alias>` prefix. Check a host any time with:
 
 ```bash
-agentbox prepare --provider docker:buildbox
+agentbox remote-docker doctor buildbox
 ```
+
+Boxes are created against the **alias**, not the raw address — so when the machine's IP changes, one command retargets every box you created on it:
+
+```bash
+agentbox remote-docker update buildbox marco@10.0.0.42  # existing boxes follow
+```
+
+To re-bake later (e.g. after an AgentBox upgrade), run `agentbox prepare --provider docker:buildbox`.
 
 This isn't a required step, unlike the cloud providers' `prepare`. A remote engine can build from a Dockerfile, so `create` ensures the image itself if it's missing — `prepare` just does the slow part when you're not watching.
 
 <Callout title="NOTE">
-A `<host>` is any SSH destination OpenSSH accepts: an `~/.ssh/config` alias (`buildbox`), or `[user@]host[:port]` (`dev@10.0.0.9:2222`). Aliases are the good path — keys, ports, `ProxyJump` and usernames all keep working, because AgentBox hands the destination to `ssh` untouched.
+Every host must be a registered alias — `docker:<alias>` (and `--remote-host <alias>` / `box.remoteDockerHost`) reject a raw connection string with "register it first". The alias is what gets baked into each box's id, which is why `update` can move a box to a new address without recreating it. The SSH connection you register can itself be an `~/.ssh/config` alias, so keys, ports and `ProxyJump` keep working — AgentBox hands it to `ssh` untouched.
 </Callout>
 
 ## Use it
@@ -103,9 +108,11 @@ A checkpoint lives on **the engine that made it**. Boot a box on a different mac
 ## Commands
 
 ```bash
-agentbox remote-docker check [host]   # is this machine usable? (ssh + docker)
-agentbox remote-docker use <host>     # set the default destination
-agentbox remote-docker hosts          # machines you've baked the box image on
+agentbox remote-docker add <alias> <ssh>     # register a host + bake its image (--no-bake, --default)
+agentbox remote-docker update <alias> <ssh>  # re-point an alias (existing boxes follow)
+agentbox remote-docker list                  # your host aliases (alias: ls)
+agentbox remote-docker doctor [alias]        # is this host usable? (ssh + docker)
+agentbox remote-docker remove <alias>        # forget an alias (+ default + bake record; alias: rm)
 agentbox prepare --provider docker:<host>
 agentbox prune --provider remote-docker   # reap containers with no local record
 ```

--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -935,7 +935,9 @@ a real machine — and forces the box init to uid 0.
 **No credential.** There is nothing in `secrets.env`: the provider authenticates
 as the user, through their own `~/.ssh/config`, agent and `known_hosts`. Its
 `providerModule` deliberately omits `ensureCredentials` / `readCredStatus`, so the
-CLI and hub show no login row. `agentbox remote-docker check|use|hosts` replace it.
+CLI and hub show no login row. A named host-alias registry
+(`~/.agentbox/remote-docker-hosts.json`) driven by `agentbox remote-docker
+add|update|list|doctor|remove` replaces it.
 
 **Known limits.** Published ports are fixed at `docker run` (same constraint as
 Vercel): a service added to `agentbox.yaml` after create is reachable through the

--- a/docs/remote-docker-backlog.md
+++ b/docs/remote-docker-backlog.md
@@ -19,7 +19,7 @@ file tracks what is done, what was verified, and what is left.
 | VNC + web preview | published on the engine's loopback, forwarded, portless alias |
 | `prune` | `backend.list()` sweeps every engine named by a box record or the config default |
 | Doctor | ssh reachable / docker present / image baked |
-| CLI | `agentbox remote-docker check | use | hosts` (no login — there is no credential) |
+| CLI | `agentbox remote-docker add | update | list | doctor | remove` — a named host-alias registry (no login — there is no credential) |
 
 ## Verified end-to-end
 
@@ -34,13 +34,38 @@ Against a real SSH-reached engine (2026-07-12):
 - `pause` / `unpause` — `docker pause` / `unpause`.
 - `destroy` — no container and no volume left behind.
 
+### First real macOS/OrbStack remote (2026-07-15)
+
+A live run from a laptop against a **mac mini** (`docker:macmini`, OrbStack engine)
+surfaced three host-side bugs, all fixed — none reproduce on the nested/loopback
+path the earlier verify used, which is why they slipped through:
+
+1. **ControlMaster socket path too long.** The per-box ssh dir
+   (`~/.agentbox/remote-docker/boxes/<sanitized-box-id>/ssh/control.sock`) plus ssh's
+   17-char temp suffix overflows the ~104-byte `sun_path` limit on macOS, because
+   remote-docker's box-id embeds the SSH destination + project + hash. Fixed by
+   hanging the ControlMaster socket off a short, flat `~/.agentbox/cm/<hash>.sock`
+   (`controlSockPath` in `sandbox-core/src/ssh-tunnel.ts`); keys/known_hosts stay in
+   the deep per-box dir. VPS providers never hit this — their box-ids are short ints.
+2. **Attach ran the remote command in a non-login shell.** `buildRemoteDockerAttach`
+   built a bare `docker exec …` string; ssh runs it in the remote user's *non-login*
+   shell, where `docker` (Docker Desktop `/usr/local/bin`, OrbStack `~/.orbstack/bin`)
+   isn't on PATH → `command not found: docker`, so the tmux session was never created.
+   Fixed by wrapping in `loginShell()` like every other remote invocation.
+3. **Credential seed relied on in-box passwordless sudo.** The ephemeral credential
+   extract ran `sudo -u vscode …`, but the shared docker box image doesn't grant
+   vscode sudo (the e2b/vercel/hetzner *snapshots* do), so it failed with "user vscode
+   is not allowed to execute … as vscode" and the box came up unauthenticated. Fixed
+   by running the extract via `backend.exec`'s `user` option instead of an in-shell
+   sudo (`sandbox-cloud/src/sync/agent-credentials.ts`) — benefits all non-volume
+   backends. Verified: fresh box seeds all three agents and `claude -p` returns a live
+   answer in-box.
+
 ## Backlog
 
-- **Live-verify against a non-nested remote.** All of the above was verified against
-  an engine that is itself an AgentBox box (loopback ssh). The nested path is the
-  *harder* one (it needs the uid-0 workaround), but a plain Linux server and a
-  macOS/OrbStack remote should both get a real run. `scripts/linux-dev-vm.sh up`
-  spins an Ubuntu VM with docker for exactly this.
+- **Live-verify against a non-nested Linux remote.** A macOS/OrbStack remote now has a
+  real run (above); a plain Linux server should get one too. `scripts/linux-dev-vm.sh
+  up` spins an Ubuntu VM with docker for exactly this.
 - **`agentbox recover --adopt`** for a remote-docker box created on another host —
   needs the per-box key, like hetzner.
 - **Ports are fixed at create.** A service added to `agentbox.yaml` afterwards is
@@ -54,7 +79,7 @@ Against a real SSH-reached engine (2026-07-12):
   `~/.claude`, so it needs thought.
 - **`box.remoteDockerHost` in the install wizard.** The provider shows up in the
   picker but has no wizard step to set its default host (there is no credential to
-  prompt for); `agentbox remote-docker use <host>` covers it for now.
+  prompt for); `agentbox remote-docker add <alias> <ssh>` covers it for now.
 
 ## Adjacent bug found while building this (not remote-docker's)
 

--- a/docs/remote-docker-plan.md
+++ b/docs/remote-docker-plan.md
@@ -55,7 +55,7 @@ Then, from the repo (or any project):
 
 ```bash
 ssh agentbox-linux-vm docker version                      # must work first — nothing else will
-agentbox remote-docker check agentbox-linux-vm            # ssh + docker + arch
+agentbox remote-docker doctor agentbox-linux-vm          # ssh + docker + arch
 
 agentbox prepare --provider docker:agentbox-linux-vm      # expect an amd64 GHCR PULL, not a build
 agentbox create -y -n rd-vm --provider docker:agentbox-linux-vm &
@@ -108,14 +108,14 @@ The least-tested surface and the one with the most specific design behind it. An
 Mac you can `ssh` into with Docker Desktop / OrbStack / Colima:
 
 ```bash
-agentbox remote-docker check my-mac
+agentbox remote-docker doctor my-mac
 agentbox docker:my-mac create -y -n rd-mac
 ```
 
 The whole point of running `docker` inside `bash -lc` on the remote is that
 OrbStack lives in `~/.orbstack/bin`, which is *not* on the non-login PATH — which
 is also precisely why `DOCKER_HOST=ssh://` was rejected (it runs `docker system
-dial-stdio` on the remote without a login shell). If `remote-docker check` passes
+dial-stdio` on the remote without a login shell). If `remote-docker doctor` passes
 but a create fails with "command not found", that assumption broke.
 
 ## Test 4 — a second engine at once
@@ -164,4 +164,4 @@ host-side has to remember which is which.
 
 4. **Install-wizard step for `box.remoteDockerHost`.** The provider appears in the
    picker but has no wizard step (there is no credential to prompt for);
-   `agentbox remote-docker use <host>` covers it for now.
+   `agentbox remote-docker add <host>` covers it for now.

--- a/packages/sandbox-cloud/src/sync/agent-credentials.ts
+++ b/packages/sandbox-cloud/src/sync/agent-credentials.ts
@@ -58,6 +58,14 @@ import { createCloudSyncTransport } from './sync-transport.js';
 export type CloudAgentKind = 'claude' | 'codex' | 'opencode';
 
 /**
+ * The unprivileged user every cloud box runs its agent as. All the box images /
+ * snapshots bake `/home/vscode`, so credentials must land owned by this user.
+ * Passed to `backend.exec({ user })` so the extract runs as vscode without an
+ * in-box `sudo` (which the docker image doesn't grant — see `seedCredentialsOne`).
+ */
+const CLOUD_BOX_USER = 'vscode';
+
+/**
  * Single per-org volume that holds all three agents' credentials. Mounted
  * three times via `subpath` so each agent's tokens get their own dir without
  * the volumes-API churn of registering three separate volumes.
@@ -431,17 +439,23 @@ async function seedCredentialsOne(
           );
         })()
       : // Ephemeral FS: extract straight into the box-baked `~/.agentbox-creds/
-        // <agent>/` dir. `sudo -u vscode` ensures the on-disk file ends up
-        // vscode-owned regardless of which user `backend.exec` runs as
-        // (e2b: vscode, vercel: vscode, hetzner: vscode via ssh — sudo
-        // works on all three because vscode has passwordless sudo). The
+        // <agent>/` dir, running the extract AS the box user via `backend.exec`'s
+        // `user` option — NOT an in-shell `sudo -u vscode`. Every non-volume
+        // backend resolves `user: vscode` through its own mechanism (docker `-u`,
+        // ssh-as-vscode, vercel/e2b SDK), so the files land vscode-owned WITHOUT
+        // relying on an in-box passwordless-sudo policy. That distinction matters:
+        // the shared docker image (remote-docker) does NOT grant vscode sudo, so
+        // an in-shell `sudo -u vscode` fails there ("user vscode is not allowed to
+        // execute … as vscode"), leaving the box credential-less. The
         // `--no-same-permissions --no-same-owner -m` flags mirror what
         // vercel/hetzner did in their old custom pushers.
         `set -e; ` +
-        `sudo -u vscode mkdir -p ${spec.credentialsMountPath}; ` +
-        `sudo -u vscode tar -xzf ${remoteTar} -C ${spec.credentialsMountPath} --no-same-permissions --no-same-owner -m; ` +
+        `mkdir -p ${spec.credentialsMountPath}; ` +
+        `tar -xzf ${remoteTar} -C ${spec.credentialsMountPath} --no-same-permissions --no-same-owner -m; ` +
         `rm -f ${remoteTar}`;
-    const extract = await backend.exec(handle, extractCmd);
+    const extract = hasVolume
+      ? await backend.exec(handle, extractCmd)
+      : await backend.exec(handle, extractCmd, { user: CLOUD_BOX_USER });
     if (extract.exitCode !== 0) {
       const msg =
         `${spec.kind}: credentials extract failed (exit ${String(extract.exitCode)}); ` +

--- a/packages/sandbox-cloud/test/agent-credentials.test.ts
+++ b/packages/sandbox-cloud/test/agent-credentials.test.ts
@@ -19,6 +19,7 @@ import {
 
 interface ExecCall {
   cmd: string;
+  user?: string;
 }
 
 interface UploadCall {
@@ -61,8 +62,8 @@ function makeMockBackend(opts: {
     async state(): Promise<CloudState> {
       return 'running';
     },
-    async exec(_h, cmd: string): Promise<CloudExecResult> {
-      execCalls.push({ cmd });
+    async exec(_h, cmd: string, opts?: { user?: string }): Promise<CloudExecResult> {
+      execCalls.push({ cmd, ...(opts?.user !== undefined ? { user: opts.user } : {}) });
       const m = /^test -f (.+\/\.agentbox-seeded-at)$/.exec(cmd);
       if (m) {
         return existing.has(m[1]!)
@@ -198,6 +199,31 @@ describe('seedAgentVolumesIfFresh (credentials-only)', () => {
       ),
     ).toBe(true);
     expect(uploadCalls.some((c) => c.remotePath.includes('opencode'))).toBe(false);
+
+    await rm(codexDir, { recursive: true, force: true });
+  });
+
+  it('extracts as the box user via exec `user` (no in-shell sudo) on a non-volume backend', async () => {
+    // remote-docker regression: the box docker image doesn't grant vscode
+    // passwordless sudo, so the ephemeral extract must run AS vscode via
+    // backend.exec's `user` option — NOT an in-shell `sudo -u vscode`, which
+    // fails with "user vscode is not allowed to execute … as vscode" and leaves
+    // the box credential-less.
+    const codexDir = join(fakeHome, '.codex');
+    await mkdir(codexDir, { recursive: true });
+    await writeFile(join(codexDir, 'auth.json'), '{"token":"redacted"}\n');
+
+    const { backend, execCalls } = makeMockBackend({});
+    // No volume primitive → the ephemeral upload+extract path.
+    delete (backend as { ensureVolume?: unknown }).ensureVolume;
+    await seedAgentVolumesIfFresh(backend, { sandboxId: 's' }, { agents: ['codex'] });
+
+    const extractCall = execCalls.find(
+      (c) => c.cmd.includes('tar -xzf') && c.cmd.includes('/home/vscode/.agentbox-creds/codex'),
+    );
+    expect(extractCall).toBeDefined();
+    expect(extractCall!.user).toBe('vscode');
+    expect(extractCall!.cmd).not.toContain('sudo');
 
     await rm(codexDir, { recursive: true, force: true });
   });

--- a/packages/sandbox-core/src/doctor.ts
+++ b/packages/sandbox-core/src/doctor.ts
@@ -83,6 +83,18 @@ export interface ProviderModule {
   doctorChecks: () => Promise<CheckResult[]>;
 }
 
+/**
+ * The `[ ok ]` / `[warn]` / `[FAIL]` / `[info]` badge prefix used by
+ * `agentbox doctor`'s detailed report and the `remote-docker doctor` subcommand.
+ * Colorless by design — same width per status so labels line up.
+ */
+export function statusBadge(s: CheckStatus): string {
+  if (s === 'ok') return '[ ok ]';
+  if (s === 'info') return '[info]';
+  if (s === 'warn') return '[warn]';
+  return '[FAIL]';
+}
+
 /** First line of a multi-line string (for compact error summaries). */
 export function firstLine(s: string): string {
   const i = s.indexOf('\n');

--- a/packages/sandbox-core/src/index.ts
+++ b/packages/sandbox-core/src/index.ts
@@ -54,6 +54,7 @@ export {
 } from './ssh-exec.js';
 export {
   SshTunnelManager,
+  controlSockPath,
   defaultBoxSshDir,
   pickFreePort,
   type PortForward,
@@ -93,6 +94,7 @@ export {
 export {
   errSummary,
   firstLine,
+  statusBadge,
   type CheckResult,
   type CheckStatus,
   type CredSetResult,

--- a/packages/sandbox-core/src/ssh-tunnel.ts
+++ b/packages/sandbox-core/src/ssh-tunnel.ts
@@ -11,7 +11,12 @@
  *   ~/.agentbox/[<namespace>/]boxes/<box-id>/ssh/
  *     id_ed25519        per-box private key (VPS providers only; 0600)
  *     known_hosts       per-box host-key pinning (VPS providers only)
- *     control.sock      ssh ControlMaster socket (created at runtime, removed by `-O exit`)
+ *   ~/.agentbox/cm/<hash>.sock
+ *                       ssh ControlMaster socket (created at runtime, removed by
+ *                       `-O exit`). Lives in a short, flat dir — NOT under the deep
+ *                       per-box dir — because a Unix socket path is capped at ~104
+ *                       bytes and remote-docker's box-id-derived path overflows it.
+ *                       See `controlSockPath`.
  *
  * `namespace` exists because provider sandbox-ids are only unique *within* a
  * provider — a DigitalOcean droplet id and a Hetzner server id can collide as
@@ -33,6 +38,7 @@
  * idempotent on the SSH side.
  */
 
+import { createHash } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { mkdir, rm } from 'node:fs/promises';
 import { createServer } from 'node:net';
@@ -41,6 +47,21 @@ import { join, resolve } from 'node:path';
 import { execa } from 'execa';
 
 const HOST = '127.0.0.1';
+
+/**
+ * ControlMaster socket path. It must be SHORT: a Unix domain socket path is
+ * capped at ~104 bytes (`sun_path`) on macOS / ~108 on Linux, and ssh appends
+ * its own `.XXXXXXXXXXXXXXXX` temp suffix (17 bytes) while creating the master.
+ * The per-box ssh dir (`~/.agentbox/[ns/]boxes/<sanitized-box-id>/ssh/`) blows
+ * past that for remote-docker, whose box-id embeds the SSH destination
+ * (`macmini_agentbox-<project>-<hash>`). So we hang the socket off a short,
+ * flat `~/.agentbox/cm/<hash>.sock` keyed by the full box ssh dir, while
+ * known_hosts / keys stay in the deep per-box dir.
+ */
+export function controlSockPath(boxSshDir: string): string {
+  const hash = createHash('sha1').update(boxSshDir).digest('hex').slice(0, 12);
+  return resolve(homedir(), '.agentbox', 'cm', `${hash}.sock`);
+}
 
 export interface SshTunnelOpenOptions {
   boxId: string;
@@ -92,7 +113,8 @@ export class SshTunnelManager {
   async open(opts: SshTunnelOpenOptions): Promise<void> {
     const boxSshDir = opts.boxSshDir ?? defaultBoxSshDir(opts.boxId, this.namespace);
     await mkdir(boxSshDir, { recursive: true, mode: 0o700 });
-    const controlPath = join(boxSshDir, 'control.sock');
+    const controlPath = controlSockPath(boxSshDir);
+    await mkdir(join(controlPath, '..'), { recursive: true, mode: 0o700 });
     const knownHosts = join(boxSshDir, 'known_hosts');
     const tunnel: BoxTunnel = {
       controlPath,
@@ -288,7 +310,7 @@ export class SshTunnelManager {
   registerExisting(boxId: string, opts: SshTunnelOpenOptions): void {
     const boxSshDir = opts.boxSshDir ?? defaultBoxSshDir(opts.boxId, this.namespace);
     this.boxes.set(boxId, {
-      controlPath: join(boxSshDir, 'control.sock'),
+      controlPath: controlSockPath(boxSshDir),
       vpsHost: opts.vpsHost,
       vpsUser: opts.vpsUser,
       identity: opts.identity,

--- a/packages/sandbox-digitalocean/src/ssh-tunnel.ts
+++ b/packages/sandbox-digitalocean/src/ssh-tunnel.ts
@@ -12,6 +12,7 @@ import {
   defaultBoxSshDir as coreDefaultBoxSshDir,
 } from '@agentbox/sandbox-core';
 
+export { controlSockPath } from '@agentbox/sandbox-core';
 export type { PortForward, SshTunnelOpenOptions } from '@agentbox/sandbox-core';
 
 const DIGITALOCEAN_SSH_NAMESPACE = 'digitalocean';

--- a/packages/sandbox-digitalocean/test/ssh-tunnel.test.ts
+++ b/packages/sandbox-digitalocean/test/ssh-tunnel.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { SshTunnelManager } from '../src/ssh-tunnel.js';
+import { SshTunnelManager, controlSockPath } from '../src/ssh-tunnel.js';
 
 interface ExecaCall {
   argv: string[];
@@ -63,7 +63,11 @@ beforeEach(() => {
 });
 
 let tmpRoot: string | undefined;
+let origHome: string | undefined;
 afterEach(() => {
+  if (origHome === undefined) delete process.env.HOME;
+  else process.env.HOME = origHome;
+  origHome = undefined;
   if (tmpRoot) {
     rmSync(tmpRoot, { recursive: true, force: true });
     tmpRoot = undefined;
@@ -72,6 +76,11 @@ afterEach(() => {
 
 function makeIdentity(): string {
   tmpRoot = mkdtempSync(join(tmpdir(), 'agentbox-ssh-tunnel-test-'));
+  // Point HOME at the temp root so the short ControlMaster socket
+  // (`$HOME/.agentbox/cm/<hash>.sock`) lands under it and gets cleaned up,
+  // instead of polluting the developer's real ~/.agentbox.
+  origHome = process.env.HOME;
+  process.env.HOME = tmpRoot;
   const id = join(tmpRoot, 'id_ed25519');
   writeFileSync(id, 'fake-key', { mode: 0o600 });
   return id;
@@ -83,7 +92,7 @@ describe('SshTunnelManager.forward', () => {
     const identity = makeIdentity();
     const boxSshDir = join(tmpRoot!, 'box-ssh');
     await m.open({ boxId: 'b1', vpsHost: '1.2.3.4', identity, boxSshDir });
-    aliveSockets.add(join(boxSshDir, 'control.sock'));
+    aliveSockets.add(controlSockPath(boxSshDir));
     const p1 = await m.forward('b1', 8788);
     const p2 = await m.forward('b1', 8788);
     expect(p1).toBe(p2);
@@ -97,10 +106,10 @@ describe('SshTunnelManager.forward', () => {
     const identity = makeIdentity();
     const boxSshDir = join(tmpRoot!, 'box-ssh');
     await m.open({ boxId: 'b1', vpsHost: '1.2.3.4', identity, boxSshDir });
-    aliveSockets.add(join(boxSshDir, 'control.sock'));
+    aliveSockets.add(controlSockPath(boxSshDir));
     const p1 = await m.forward('b1', 8788);
     // Master dies (e.g. host sleep/wake).
-    aliveSockets.delete(join(boxSshDir, 'control.sock'));
+    aliveSockets.delete(controlSockPath(boxSshDir));
     const p2 = await m.forward('b1', 8788);
     expect(p1).toBeTypeOf('number');
     expect(p2).toBeTypeOf('number');
@@ -116,13 +125,13 @@ describe('SshTunnelManager.refresh', () => {
     const identity = makeIdentity();
     const boxSshDir = join(tmpRoot!, 'box-ssh');
     await m.open({ boxId: 'b1', vpsHost: '1.2.3.4', identity, boxSshDir });
-    aliveSockets.add(join(boxSshDir, 'control.sock'));
+    aliveSockets.add(controlSockPath(boxSshDir));
     await m.forward('b1', 8788);
     // Simulate dead master.
-    aliveSockets.delete(join(boxSshDir, 'control.sock'));
+    aliveSockets.delete(controlSockPath(boxSshDir));
     await m.refresh({ boxId: 'b1', vpsHost: '1.2.3.4', identity, boxSshDir });
     // After refresh, forward() should re-mint.
-    aliveSockets.add(join(boxSshDir, 'control.sock'));
+    aliveSockets.add(controlSockPath(boxSshDir));
     const newPort = await m.forward('b1', 8788);
     expect(newPort).toBeTypeOf('number');
     const opens = execaCalls.filter((c) => c.argv[0] === '-fNT');

--- a/packages/sandbox-hetzner/src/ssh-tunnel.ts
+++ b/packages/sandbox-hetzner/src/ssh-tunnel.ts
@@ -9,6 +9,7 @@
  */
 export {
   SshTunnelManager,
+  controlSockPath,
   defaultBoxSshDir,
   type PortForward,
   type SshTunnelOpenOptions,

--- a/packages/sandbox-hetzner/test/ssh-tunnel.test.ts
+++ b/packages/sandbox-hetzner/test/ssh-tunnel.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { SshTunnelManager } from '../src/ssh-tunnel.js';
+import { SshTunnelManager, controlSockPath } from '../src/ssh-tunnel.js';
 
 interface ExecaCall {
   argv: string[];
@@ -63,7 +63,11 @@ beforeEach(() => {
 });
 
 let tmpRoot: string | undefined;
+let origHome: string | undefined;
 afterEach(() => {
+  if (origHome === undefined) delete process.env.HOME;
+  else process.env.HOME = origHome;
+  origHome = undefined;
   if (tmpRoot) {
     rmSync(tmpRoot, { recursive: true, force: true });
     tmpRoot = undefined;
@@ -72,6 +76,11 @@ afterEach(() => {
 
 function makeIdentity(): string {
   tmpRoot = mkdtempSync(join(tmpdir(), 'agentbox-ssh-tunnel-test-'));
+  // Point HOME at the temp root so the short ControlMaster socket
+  // (`$HOME/.agentbox/cm/<hash>.sock`) lands under it and gets cleaned up,
+  // instead of polluting the developer's real ~/.agentbox.
+  origHome = process.env.HOME;
+  process.env.HOME = tmpRoot;
   const id = join(tmpRoot, 'id_ed25519');
   writeFileSync(id, 'fake-key', { mode: 0o600 });
   return id;
@@ -83,7 +92,7 @@ describe('SshTunnelManager.forward', () => {
     const identity = makeIdentity();
     const boxSshDir = join(tmpRoot!, 'box-ssh');
     await m.open({ boxId: 'b1', vpsHost: '1.2.3.4', identity, boxSshDir });
-    aliveSockets.add(join(boxSshDir, 'control.sock'));
+    aliveSockets.add(controlSockPath(boxSshDir));
     const p1 = await m.forward('b1', 8788);
     const p2 = await m.forward('b1', 8788);
     expect(p1).toBe(p2);
@@ -97,10 +106,10 @@ describe('SshTunnelManager.forward', () => {
     const identity = makeIdentity();
     const boxSshDir = join(tmpRoot!, 'box-ssh');
     await m.open({ boxId: 'b1', vpsHost: '1.2.3.4', identity, boxSshDir });
-    aliveSockets.add(join(boxSshDir, 'control.sock'));
+    aliveSockets.add(controlSockPath(boxSshDir));
     const p1 = await m.forward('b1', 8788);
     // Master dies (e.g. host sleep/wake).
-    aliveSockets.delete(join(boxSshDir, 'control.sock'));
+    aliveSockets.delete(controlSockPath(boxSshDir));
     const p2 = await m.forward('b1', 8788);
     expect(p1).toBeTypeOf('number');
     expect(p2).toBeTypeOf('number');
@@ -116,13 +125,13 @@ describe('SshTunnelManager.refresh', () => {
     const identity = makeIdentity();
     const boxSshDir = join(tmpRoot!, 'box-ssh');
     await m.open({ boxId: 'b1', vpsHost: '1.2.3.4', identity, boxSshDir });
-    aliveSockets.add(join(boxSshDir, 'control.sock'));
+    aliveSockets.add(controlSockPath(boxSshDir));
     await m.forward('b1', 8788);
     // Simulate dead master.
-    aliveSockets.delete(join(boxSshDir, 'control.sock'));
+    aliveSockets.delete(controlSockPath(boxSshDir));
     await m.refresh({ boxId: 'b1', vpsHost: '1.2.3.4', identity, boxSshDir });
     // After refresh, forward() should re-mint.
-    aliveSockets.add(join(boxSshDir, 'control.sock'));
+    aliveSockets.add(controlSockPath(boxSshDir));
     const newPort = await m.forward('b1', 8788);
     expect(newPort).toBeTypeOf('number');
     const opens = execaCalls.filter((c) => c.argv[0] === '-fNT');

--- a/packages/sandbox-remote-docker/src/backend.ts
+++ b/packages/sandbox-remote-docker/src/backend.ts
@@ -56,6 +56,7 @@ import {
   parseSandboxId,
   type RemoteTarget,
 } from './target.js';
+import { requireHostAlias } from './hosts-registry.js';
 
 export const BACKEND_NAME = 'remote-docker';
 
@@ -271,9 +272,13 @@ export const remoteDockerBackend: CloudBackend = {
     const spec = (req.host ?? '').trim();
     if (!spec) {
       throw new Error(
-        'remote-docker: no SSH destination. Use `agentbox docker:<host> …`, `--remote-host <host>`, or set `box.remoteDockerHost`.',
+        'remote-docker: no host. Register one with `agentbox remote-docker add <alias> <[user@]host[:port]>`, then use `agentbox docker:<alias> …` / `--remote-host <alias>` / `box.remoteDockerHost`.',
       );
     }
+    // Alias-only: the box is created against a registered alias, and its sandbox
+    // id bakes that alias. `requireHostAlias` fails fast (before any remote work)
+    // if the reference isn't registered.
+    requireHostAlias(spec);
     const remote = parseRemoteTarget(spec);
     const container = containerNameFor(req.name);
     const sandboxId = makeSandboxId(remote.spec, container);

--- a/packages/sandbox-remote-docker/src/box-ssh.ts
+++ b/packages/sandbox-remote-docker/src/box-ssh.ts
@@ -29,6 +29,7 @@ import type { BoxRecord, SshTargetRecord } from '@agentbox/core';
 import { bashScript, quoteShellArg } from '@agentbox/sandbox-cloud';
 import { defaultBoxSshDir, mintSshKey } from '@agentbox/sandbox-core';
 import { CONTAINER_USER, dockerExecArgv, dockerOnRemote, ensureTunnel } from './remote-docker.js';
+import { resolveConnection } from './hosts-registry.js';
 import { parseSandboxId } from './target.js';
 import { parseDockerPort } from './backend.js';
 
@@ -94,6 +95,8 @@ export async function resolveBoxSshTarget(box: BoxRecord): Promise<SshTargetReco
     port,
     user: CONTAINER_USER,
     identityFile: key.privatePath,
-    proxyJump: remote.spec,
+    // The box id bakes an alias; ssh on THIS host can't resolve an AgentBox
+    // alias, so the ProxyJump must be the alias's real connection string.
+    proxyJump: resolveConnection(remote.spec),
   };
 }

--- a/packages/sandbox-remote-docker/src/build-attach.ts
+++ b/packages/sandbox-remote-docker/src/build-attach.ts
@@ -20,7 +20,7 @@ import {
   renderInnerCommand,
 } from '@agentbox/sandbox-cloud';
 import { sshDestination, sshOptArgs } from '@agentbox/sandbox-core';
-import { ensureTunnel } from './remote-docker.js';
+import { ensureTunnel, loginShell } from './remote-docker.js';
 import { parseSandboxId } from './target.js';
 
 const CONTAINER_USER = 'vscode';
@@ -53,7 +53,13 @@ export async function buildRemoteDockerAttach(
     '-lc',
     inner,
   ];
-  const remoteCommand = `docker ${quoteShellArgv(dockerArgv)}`;
+  // Wrap in a LOGIN shell for the same reason every other remote invocation does
+  // (see `loginShell` in ./remote-docker.ts): ssh runs this string in the remote
+  // user's NON-login shell, where `docker` is often not on PATH (Docker Desktop
+  // in /usr/local/bin, OrbStack in ~/.orbstack/bin). `bash -lc` sources the
+  // profile so `docker` resolves. The `-t` PTY flows through bash into `docker
+  // exec -it` unchanged.
+  const remoteCommand = loginShell(`docker ${quoteShellArgv(dockerArgv)}`);
 
   const argv = [
     'ssh',

--- a/packages/sandbox-remote-docker/src/cli.ts
+++ b/packages/sandbox-remote-docker/src/cli.ts
@@ -2,89 +2,306 @@
  * `agentbox remote-docker` — the provider's own commands.
  *
  * There is no `login` here, unlike every other cloud: the provider has no
- * credential of its own, it just uses your ssh. What it does need is a way to
- * answer "can AgentBox actually use that machine?" before you find out the hard
- * way in the middle of a create — hence `check`.
+ * credential of its own, it just uses your ssh. A host is registered by a short
+ * ALIAS (`add <alias> <ssh>`); boxes are created against the alias and it's the
+ * alias — not the connection string — that gets baked into a box's id, so
+ * `update <alias> <new-ssh>` retargets existing boxes after an IP change.
  */
 
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { Command } from 'commander';
 import * as p from '@clack/prompts';
-import { loadEffectiveConfig, setConfigValue } from '@agentbox/config';
+import { loadEffectiveConfig, setConfigValue, unsetConfigValue } from '@agentbox/config';
+import { statusBadge, type CheckResult } from '@agentbox/sandbox-core';
 import { probeRemoteEngine } from './remote-docker.js';
-import { readPreparedState } from './prepared-state.js';
+import { prepareRemoteDocker } from './prepare.js';
+import { readPreparedState, removePreparedHost } from './prepared-state.js';
+import {
+  assertValidAlias,
+  getHostAlias,
+  listHostAliases,
+  removeHostAlias,
+  upsertHostAlias,
+} from './hosts-registry.js';
 
 export const remoteDockerCommand = new Command('remote-docker')
   .description('Remote Docker provider — run boxes on your own machine over SSH')
   .addCommand(
-    new Command('check')
-      .description('Verify an SSH destination can host boxes (ssh reachable + docker present)')
-      .argument('[host]', 'SSH destination (default: box.remoteDockerHost)')
-      .action(async (host?: string) => {
-        const target = (host ?? (await configuredHost())).trim();
-        if (!target) {
+    new Command('add')
+      .description('Register a host alias (name → SSH connection) for `--provider docker:<alias>`')
+      .argument('<alias>', 'a short name for the host (letters, digits, `.`, `_`, `-`)')
+      .argument('<ssh>', 'the SSH connection: `~/.ssh/config` alias or `[user@]host[:port]`')
+      .option('-d, --default', 'also set it as the default host (box.remoteDockerHost) for this project')
+      .option('-g, --global', 'set it as the default host, written to global config (implies --default)')
+      .option('-n, --no-bake', 'skip baking the box image on the host (it builds lazily on first create)')
+      .action(
+        async (
+          alias: string,
+          ssh: string,
+          opts: { default?: boolean; global?: boolean; bake?: boolean },
+        ) => {
+          try {
+            assertValidAlias(alias);
+          } catch (err) {
+            p.log.error(err instanceof Error ? err.message : String(err));
+            process.exitCode = 1;
+            return;
+          }
+          if (getHostAlias(alias)) {
+            p.log.error(
+              `host alias '${alias}' already exists — change its connection with \`agentbox remote-docker update ${alias} <ssh>\``,
+            );
+            process.exitCode = 1;
+            return;
+          }
+          const s = p.spinner();
+          s.start(`probing ${ssh}`);
+          const res = await probeRemoteEngine(ssh);
+          if (!res.ok) {
+            s.stop(`${ssh}: unusable`);
+            p.log.error(res.error ?? 'remote engine unusable');
+            process.exitCode = 1;
+            return;
+          }
+          s.stop(`${ssh}: docker ${res.version} (${res.os}/${res.arch})`);
+          upsertHostAlias(alias, ssh);
+          p.log.success(`registered '${alias}' → ${ssh}`);
+
+          if (opts.default || opts.global) {
+            const scope = opts.global ? 'global' : 'project';
+            await setConfigValue(scope, 'box.remoteDockerHost', alias, process.cwd(), {
+              raw: true,
+            });
+            p.log.success(`'${alias}' is now the default remote-docker host (${scope})`);
+          } else {
+            p.log.info(
+              `use it with \`agentbox docker:${alias} claude\` (add \`--default\` to skip the prefix)`,
+            );
+          }
+
+          // Bake the box image on the host now (unless --no-bake), so the first
+          // create is instant. A GHCR pull is fast; a registry-miss build is slow.
+          // Best-effort: a failure leaves the alias registered and the image
+          // builds lazily on first create.
+          if (opts.bake !== false) {
+            const cfg = await loadEffectiveConfig(process.cwd());
+            const claudeInstall = cfg.effective.box.claudeInstall;
+            const bs = p.spinner();
+            bs.start(`baking the box image on ${alias} (first time can take a few minutes)`);
+            try {
+              await prepareRemoteDocker({
+                host: alias,
+                ...(claudeInstall ? { claudeInstall } : {}),
+                onLog: (line) => bs.message(line.slice(0, 80)),
+              });
+              bs.stop(`box image ready on ${alias}`);
+            } catch (err) {
+              bs.stop('box image bake failed');
+              p.log.warn(
+                `${err instanceof Error ? err.message : String(err)} — it will build on first create, or run \`agentbox prepare --provider docker:${alias}\``,
+              );
+            }
+          }
+
+          // With more than one host registered, the default is ambiguous — remind
+          // how to target a specific one.
+          const hostCount = listHostAliases().length;
+          if (hostCount > 1) {
+            p.log.info(
+              `you have ${String(hostCount)} remote hosts — run \`agentbox docker:${alias} claude\` to use this one`,
+            );
+          }
+        },
+      ),
+  )
+  .addCommand(
+    new Command('update')
+      .description('Change the SSH connection string for an existing host alias')
+      .argument('<alias>', 'the alias to retarget')
+      .argument('<ssh>', 'the new SSH connection: `~/.ssh/config` alias or `[user@]host[:port]`')
+      .action(async (alias: string, ssh: string) => {
+        if (!getHostAlias(alias)) {
           p.log.error(
-            'no SSH destination — pass one (`agentbox remote-docker check user@host`) or set `box.remoteDockerHost`',
+            `no such host alias '${alias}' — register it with \`agentbox remote-docker add ${alias} ${ssh}\``,
           );
           process.exitCode = 1;
           return;
         }
         const s = p.spinner();
-        s.start(`probing ${target}`);
-        const res = await probeRemoteEngine(target);
+        s.start(`probing ${ssh}`);
+        const res = await probeRemoteEngine(ssh);
         if (!res.ok) {
-          s.stop(`${target}: unusable`);
-          p.log.error(res.error);
+          s.stop(`${ssh}: unusable`);
+          p.log.error(res.error ?? 'remote engine unusable');
           process.exitCode = 1;
           return;
         }
-        s.stop(`${target}: docker ${res.version} (${res.os}/${res.arch})`);
+        s.stop(`${ssh}: docker ${res.version} (${res.os}/${res.arch})`);
+        upsertHostAlias(alias, ssh);
+        p.log.success(`updated '${alias}' → ${ssh} (existing boxes now use this connection)`);
+      }),
+  )
+  .addCommand(
+    new Command('remove')
+      .alias('rm')
+      .description('Forget a host alias: drop it, clear the default, and its baked image record')
+      .argument('<alias>', 'the alias to forget')
+      .action(async (alias: string) => {
+        // No probe: you must be able to remove a host that's now unreachable/dead.
+        const droppedAlias = removeHostAlias(alias);
 
-        const baked = readPreparedState()?.hosts[target];
-        p.log.info(
-          baked
-            ? `box image baked: ${baked.imageRef}`
-            : `box image not baked yet — the first create will do it, or run \`agentbox prepare --provider docker:${target}\``,
-        );
+        const cfg = await loadEffectiveConfig(process.cwd());
+        const clearedScopes: string[] = [];
+        for (const scope of ['project', 'global'] as const) {
+          if (cfg.layers[scope].values.box?.remoteDockerHost === alias) {
+            await unsetConfigValue(scope, 'box.remoteDockerHost', process.cwd());
+            clearedScopes.push(scope);
+          }
+        }
+        const inWorkspace = cfg.layers.workspace.values.box?.remoteDockerHost === alias;
+        const forgotBake = removePreparedHost(alias);
+
+        if (!droppedAlias && clearedScopes.length === 0 && !inWorkspace && !forgotBake) {
+          p.log.info(`'${alias}' is not a registered, configured, or baked remote-docker host`);
+          return;
+        }
+        const cleared: string[] = [];
+        if (droppedAlias) cleared.push('alias');
+        if (clearedScopes.length > 0) cleared.push(`${clearedScopes.join(' + ')} default`);
+        if (forgotBake) cleared.push('baked image record');
+        p.log.success(`removed ${alias}${cleared.length ? ` (${cleared.join(', ')})` : ''}`);
+
+        const boxes = boxesUsingAlias(alias);
+        if (boxes.length > 0) {
+          p.log.warn(
+            `${boxes.length} box(es) were created against '${alias}' and are now unreachable — ` +
+              `re-add it with \`agentbox remote-docker add ${alias} <ssh>\`: ${boxes.join(', ')}`,
+          );
+        }
+        if (inWorkspace) {
+          p.log.warn(
+            `'${alias}' is also set as box.remoteDockerHost in this project's agentbox.yaml — remove it there too`,
+          );
+        }
       }),
   )
   .addCommand(
-    new Command('use')
-      .description('Set the default SSH destination for `--provider remote-docker`')
-      .argument('<host>', 'SSH destination (~/.ssh/config alias or [user@]host[:port])')
-      .option('-g, --global', 'write to the global config instead of this project')
-      .action(async (host: string, opts: { global?: boolean }) => {
-        const res = await probeRemoteEngine(host);
-        if (!res.ok) {
-          p.log.error(res.error);
+    new Command('list')
+      .alias('ls')
+      .description('List your registered host aliases (and any baked-but-unregistered hosts)')
+      .action(async () => {
+        const aliases = listHostAliases();
+        const baked = readPreparedState()?.hosts ?? {};
+        const configured = (await configuredHost()).trim();
+
+        if (aliases.length === 0 && Object.keys(baked).length === 0) {
+          p.log.info(
+            'no host aliases yet — add one with `agentbox remote-docker add <alias> <[user@]host[:port]>`',
+          );
+          return;
+        }
+        for (const { alias, entry } of aliases) {
+          const bakedInfo = baked[alias];
+          const bakePart = bakedInfo ? `  [${bakedInfo.imageRef}]` : '  (not baked yet)';
+          const dflt = alias === configured ? '  (default)' : '';
+          p.log.info(`${alias}  →  ${entry.ssh}${bakePart}${dflt}`);
+        }
+        // Baked hosts with no matching alias — legacy ids created before the
+        // registry, or a host whose alias was removed. Surface so `list` is total.
+        for (const [host, info] of Object.entries(baked)) {
+          if (aliases.some((a) => a.alias === host)) continue;
+          p.log.info(`${host}  (unregistered)  [${info.imageRef}]`);
+        }
+      }),
+  )
+  .addCommand(
+    new Command('doctor')
+      .description('Check whether a host can run boxes (ssh reachable + docker present)')
+      .argument('[host]', 'a registered alias OR a raw `[user@]host[:port]` (default: box.remoteDockerHost)')
+      .action(async (host?: string) => {
+        const name = (host ?? (await configuredHost())).trim();
+        if (!name) {
+          p.log.error(
+            'no host — pass one (`agentbox remote-docker doctor <alias|ssh>`) or set a default with `agentbox remote-docker add`',
+          );
           process.exitCode = 1;
           return;
         }
-        await setConfigValue(
-          opts.global ? 'global' : 'project',
-          'box.remoteDockerHost',
-          host,
-          process.cwd(),
-        );
-        p.log.success(
-          `box.remoteDockerHost = ${host} (${opts.global ? 'global' : 'project'}) — docker ${res.version}`,
-        );
-      }),
-  )
-  .addCommand(
-    new Command('hosts')
-      .description('List the remote engines this machine has baked a box image on')
-      .action(() => {
-        const state = readPreparedState();
-        const hosts = Object.entries(state?.hosts ?? {});
-        if (hosts.length === 0) {
-          p.log.info('no remote engines prepared yet');
-          return;
+        // doctor is a read-only compatibility probe: run it against a registered
+        // alias OR a raw connection string, so you can vet a host BEFORE `add`ing
+        // it. Alias-only strictness belongs to create/prepare, not diagnostics.
+        const entry = getHostAlias(name);
+        const connection = entry ? entry.ssh : name;
+
+        const probe = await probeRemoteEngine(connection);
+        const rows: CheckResult[] = probe.steps.map((step) => ({
+          label: step.label,
+          status: step.ok ? 'ok' : 'fail',
+          detail: step.detail,
+          ...(step.hint ? { hint: step.hint } : {}),
+        }));
+        // Bake status is a local record — only meaningful once the engine is reachable.
+        if (probe.ok) {
+          const bakedInfo = readPreparedState()?.hosts[name];
+          rows.push(
+            bakedInfo
+              ? {
+                  label: 'box image',
+                  status: 'ok',
+                  detail: `${bakedInfo.imageRef} (${bakedInfo.cliVersion ?? '—'})`,
+                }
+              : {
+                  label: 'box image',
+                  status: 'info',
+                  detail: 'not baked yet',
+                  hint: `first create bakes it, or \`agentbox prepare --provider docker:${name}\``,
+                },
+          );
         }
-        for (const [host, info] of hosts) {
-          p.log.info(`${host}  ${info.imageRef}  (${info.cliVersion ?? '—'}, ${info.createdAt})`);
+        // A usable-but-unregistered host is fine to probe — just remind that a box
+        // can only be created against a registered alias.
+        if (!entry) {
+          rows.push({
+            label: 'alias',
+            status: 'warn',
+            detail: 'not registered',
+            hint: `register to create boxes here: \`agentbox remote-docker add <alias> ${connection}\``,
+          });
         }
+        // Render like `agentbox doctor`: one badged row per check.
+        const header = entry ? `${name} → ${entry.ssh}` : name;
+        process.stdout.write(`remote-docker: ${header}\n`);
+        for (const r of rows) {
+          const label = r.label.padEnd(10);
+          const tail = r.hint ? `  (${r.hint})` : '';
+          process.stdout.write(`  ${statusBadge(r.status)} ${label} ${r.detail}${tail}\n`);
+        }
+        // Exit non-zero only when the host is actually unusable; "not registered"
+        // is a heads-up, not a failure.
+        if (!probe.ok) process.exitCode = 1;
       }),
   );
+
+/** Box names whose sandbox id was baked against `alias` (i.e. `"<alias>/…"`). */
+function boxesUsingAlias(alias: string): string[] {
+  try {
+    const raw = JSON.parse(readFileSync(join(homedir(), '.agentbox', 'state.json'), 'utf8')) as {
+      boxes?: Array<{ name?: string; provider?: string; cloud?: { sandboxId?: string } }>;
+    };
+    return (raw.boxes ?? [])
+      .filter(
+        (b) =>
+          b.provider === 'remote-docker' &&
+          typeof b.cloud?.sandboxId === 'string' &&
+          b.cloud.sandboxId.startsWith(`${alias}/`),
+      )
+      .map((b) => b.name ?? '(unnamed)');
+  } catch {
+    return [];
+  }
+}
 
 async function configuredHost(): Promise<string> {
   const cfg = await loadEffectiveConfig(process.cwd());

--- a/packages/sandbox-remote-docker/src/host-setup.ts
+++ b/packages/sandbox-remote-docker/src/host-setup.ts
@@ -1,0 +1,90 @@
+/**
+ * Interactive host registration for the `agentbox install` wizard.
+ *
+ * remote-docker has no credential to log in with — what it needs instead is a
+ * host: an alias name + an SSH connection string. This drives that prompt flow
+ * (the interactive twin of `remote-docker add`), registers the alias, and pins it
+ * as the default host so the wizard's subsequent bake step + plain `agentbox
+ * claude` target it.
+ *
+ * Install-only on purpose: it must NOT hang off `providerModule.ensureCredentials`,
+ * which `getProvider()` runs on every create AND every box lifecycle op — a prompt
+ * there would fire constantly. The wizard calls this directly instead.
+ */
+
+import * as p from '@clack/prompts';
+import { setConfigValue } from '@agentbox/config';
+import { probeRemoteEngine } from './remote-docker.js';
+import { assertValidAlias, getHostAlias, listHostAliases, upsertHostAlias } from './hosts-registry.js';
+
+/**
+ * Prompt for an alias + SSH connection, probe it, register it, and set it as the
+ * default host (`box.remoteDockerHost`, global). Returns the alias, or `null` if
+ * there's no TTY or the user backs out. Never throws.
+ */
+export async function interactiveRegisterHost(): Promise<string | null> {
+  if (!process.stdin.isTTY) {
+    p.log.warn(
+      'remote-docker needs a host — run `agentbox remote-docker add <alias> <[user@]host[:port]>` to register one',
+    );
+    return null;
+  }
+
+  const alias = await p.text({
+    message: 'Name this remote host (a short alias)',
+    placeholder: 'buildbox',
+    validate: (value) => {
+      const v = (value ?? '').trim();
+      if (!v) return 'required';
+      try {
+        assertValidAlias(v);
+      } catch (err) {
+        return err instanceof Error ? err.message : String(err);
+      }
+      if (getHostAlias(v)) return `'${v}' is already registered`;
+      return undefined;
+    },
+  });
+  if (p.isCancel(alias)) return null;
+  const name = alias.trim();
+
+  // Prompt + probe in a loop so a bad connection can be corrected without
+  // restarting the wizard.
+  for (;;) {
+    const ssh = await p.text({
+      message: 'SSH connection (an ~/.ssh/config alias or [user@]host[:port])',
+      placeholder: 'user@host',
+      validate: (value) => ((value ?? '').trim() ? undefined : 'required'),
+    });
+    if (p.isCancel(ssh)) return null;
+    const conn = ssh.trim();
+
+    const s = p.spinner();
+    s.start(`probing ${conn}`);
+    const res = await probeRemoteEngine(conn);
+    if (!res.ok) {
+      s.stop(`${conn}: unusable`);
+      p.log.error(res.error ?? 'remote engine unusable');
+      const retry = await p.confirm({
+        message: 'Try a different SSH connection?',
+        initialValue: true,
+      });
+      if (p.isCancel(retry) || !retry) return null;
+      continue;
+    }
+    s.stop(`${conn}: docker ${res.version} (${res.os}/${res.arch})`);
+
+    upsertHostAlias(name, conn);
+    p.log.success(`registered '${name}' → ${conn}`);
+    // Machine-level default, matching how the wizard pins box.provider global.
+    await setConfigValue('global', 'box.remoteDockerHost', name, process.cwd(), { raw: true });
+    // With more than one host registered, remind how to target a specific one.
+    const hostCount = listHostAliases().length;
+    if (hostCount > 1) {
+      p.log.info(
+        `you have ${String(hostCount)} remote hosts — run \`agentbox docker:${name} claude\` to use this one`,
+      );
+    }
+    return name;
+  }
+}

--- a/packages/sandbox-remote-docker/src/hosts-registry.ts
+++ b/packages/sandbox-remote-docker/src/hosts-registry.ts
@@ -1,0 +1,149 @@
+/**
+ * `~/.agentbox/remote-docker-hosts.json` — the alias registry.
+ *
+ * A remote engine is addressed by a short **alias** (`macmini`), not by its raw
+ * SSH connection string. The alias is what gets baked into a box's sandbox id
+ * (`<alias>/<container>`); the connection string is resolved from this registry
+ * at connection time. That indirection is the whole point: `remote-docker update
+ * <alias> <new-ssh>` remints the connection and every existing box created against
+ * that alias follows it — no stale IP baked into an id.
+ *
+ * Two resolution modes:
+ *   - `resolveConnection(ref)` — LENIENT, for connection time. A registered alias
+ *     resolves to its ssh string; anything else passes through unchanged, so a box
+ *     whose id predates this registry (or names a raw/ssh-config destination) stays
+ *     reachable.
+ *   - `requireHostAlias(ref)` — STRICT, for entry points (create / prepare /
+ *     doctor). An unregistered reference throws — you must `add` it first. This is
+ *     what enforces the alias-only model for NEW boxes without stranding old ones.
+ *
+ * Shape mirrors `prepared-state.ts` (a provider-owned `Record<string,T>` JSON doc),
+ * but with its own filename and inline atomic read/write. `homedir()` is resolved
+ * at call time so tests can redirect `$HOME`.
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, resolve as pathResolve } from 'node:path';
+
+const SCHEMA = 1;
+
+export interface RemoteHostEntry {
+  /** The SSH connection string: `[user@]host[:port]` or an `~/.ssh/config` alias. */
+  ssh: string;
+  createdAt: string;
+  updatedAt?: string;
+}
+
+export interface RemoteHostsRegistry {
+  schema: number;
+  /** Keyed by alias — the user-facing name, also what a box's sandbox id bakes. */
+  hosts: Record<string, RemoteHostEntry>;
+}
+
+/** Aliases must be a plain name: no `@`/`:` (would look like a connection string),
+ * no `/` (sandbox-id separator), no whitespace. Keeps them unambiguous + id-safe. */
+const ALIAS_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+export function isValidAlias(alias: string): boolean {
+  return ALIAS_RE.test(alias);
+}
+
+export function assertValidAlias(alias: string): void {
+  if (!isValidAlias(alias)) {
+    throw new Error(
+      `invalid host alias ${JSON.stringify(alias)} — use a plain name (letters, digits, \`.\`, \`_\`, \`-\`; no \`@\`, \`:\`, \`/\` or spaces)`,
+    );
+  }
+}
+
+function registryPath(): string {
+  return pathResolve(homedir(), '.agentbox', 'remote-docker-hosts.json');
+}
+
+export function readHostsRegistry(): RemoteHostsRegistry | null {
+  const path = registryPath();
+  if (!existsSync(path)) return null;
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+  if (raw === null || typeof raw !== 'object') return null;
+  const parsed = raw as Partial<RemoteHostsRegistry>;
+  if (parsed.schema !== SCHEMA || typeof parsed.hosts !== 'object' || parsed.hosts === null) {
+    return null;
+  }
+  return { schema: SCHEMA, hosts: parsed.hosts };
+}
+
+/** Atomic write (tmp + rename), 0600 — same hygiene as `writePreparedStateRaw`. */
+export function writeHostsRegistry(reg: RemoteHostsRegistry): void {
+  const path = registryPath();
+  mkdirSync(dirname(path), { recursive: true });
+  const body = JSON.stringify({ schema: SCHEMA, hosts: reg.hosts }, null, 2) + '\n';
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, body, { mode: 0o600 });
+  renameSync(tmp, path);
+}
+
+export function getHostAlias(alias: string): RemoteHostEntry | undefined {
+  return readHostsRegistry()?.hosts[alias];
+}
+
+/** All registered aliases, sorted by name for stable `list` output. */
+export function listHostAliases(): Array<{ alias: string; entry: RemoteHostEntry }> {
+  const reg = readHostsRegistry();
+  if (!reg) return [];
+  return Object.entries(reg.hosts)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([alias, entry]) => ({ alias, entry }));
+}
+
+/**
+ * Register or re-point an alias. Preserves `createdAt` on an update and stamps
+ * `updatedAt`. Caller validates the alias name + probes the connection first.
+ */
+export function upsertHostAlias(alias: string, ssh: string): void {
+  const reg = readHostsRegistry() ?? { schema: SCHEMA, hosts: {} };
+  const existing = reg.hosts[alias];
+  const now = new Date().toISOString();
+  reg.hosts[alias] = existing
+    ? { ...existing, ssh, updatedAt: now }
+    : { ssh, createdAt: now };
+  writeHostsRegistry(reg);
+}
+
+/** Drop an alias. Returns whether it was present. */
+export function removeHostAlias(alias: string): boolean {
+  const reg = readHostsRegistry();
+  if (!reg || !(alias in reg.hosts)) return false;
+  const hosts = { ...reg.hosts };
+  delete hosts[alias];
+  writeHostsRegistry({ schema: SCHEMA, hosts });
+  return true;
+}
+
+/**
+ * Connection-time resolution (LENIENT): a registered alias → its ssh string;
+ * anything else → unchanged, so pre-registry / raw-baked box ids stay reachable.
+ */
+export function resolveConnection(ref: string): string {
+  return getHostAlias(ref)?.ssh ?? ref;
+}
+
+/**
+ * Entry-point resolution (STRICT): a registered alias → its entry; otherwise
+ * throw. This is what makes the model alias-only for anything that CREATES a
+ * reference (create / prepare / doctor) without stranding existing boxes.
+ */
+export function requireHostAlias(ref: string): RemoteHostEntry {
+  const entry = getHostAlias(ref);
+  if (!entry) {
+    throw new Error(
+      `no such remote-docker host alias ${JSON.stringify(ref)} — register it with \`agentbox remote-docker add <name> <[user@]host[:port]>\``,
+    );
+  }
+  return entry;
+}

--- a/packages/sandbox-remote-docker/src/index.ts
+++ b/packages/sandbox-remote-docker/src/index.ts
@@ -110,3 +110,4 @@ export const providerModule: ProviderModule = {
 export { remoteDockerBackend, BACKEND_NAME, listOnHost } from './backend.js';
 export { probeRemoteEngine } from './remote-docker.js';
 export { parseRemoteTarget, parseSandboxId } from './target.js';
+export { interactiveRegisterHost } from './host-setup.js';

--- a/packages/sandbox-remote-docker/src/prepare.ts
+++ b/packages/sandbox-remote-docker/src/prepare.ts
@@ -14,6 +14,7 @@ import type { PrepareOptions, PrepareResult } from '@agentbox/core';
 import { ensureRemoteImage } from './image.js';
 import { ensureTunnel } from './remote-docker.js';
 import { recordPreparedHost } from './prepared-state.js';
+import { requireHostAlias } from './hosts-registry.js';
 import { parseRemoteTarget } from './target.js';
 
 export async function prepareRemoteDocker(
@@ -23,10 +24,11 @@ export async function prepareRemoteDocker(
   const spec = (opts.host ?? '').trim();
   if (!spec) {
     throw new Error(
-      'remote-docker: prepare needs an SSH destination — `agentbox prepare --provider docker:<host>`, ' +
+      'remote-docker: prepare needs a host alias — `agentbox prepare --provider docker:<alias>`, ' +
         'or set `box.remoteDockerHost`.',
     );
   }
+  requireHostAlias(spec);
   const remote = parseRemoteTarget(spec);
   const target = await ensureTunnel(`engine:${remote.spec}`, remote);
 

--- a/packages/sandbox-remote-docker/src/prepared-state.ts
+++ b/packages/sandbox-remote-docker/src/prepared-state.ts
@@ -38,6 +38,16 @@ export function readPreparedState(): PreparedRemoteDockerState | null {
   return { schema: SCHEMA, hosts: parsed.hosts };
 }
 
+/** Drop one host from the prepared-image history. Returns whether it was present. */
+export function removePreparedHost(host: string): boolean {
+  const existing = readPreparedState();
+  if (!existing || !(host in existing.hosts)) return false;
+  const hosts = { ...existing.hosts };
+  delete hosts[host];
+  writePreparedStateRaw(PROVIDER, { schema: SCHEMA, hosts });
+  return true;
+}
+
 export function recordPreparedHost(
   host: string,
   fields: { imageRef: string; contextSha256: string },

--- a/packages/sandbox-remote-docker/src/provider-module.ts
+++ b/packages/sandbox-remote-docker/src/provider-module.ts
@@ -11,6 +11,7 @@ import { loadEffectiveConfig } from '@agentbox/config';
 import { detectPortless, portlessDoctorRow } from '@agentbox/sandbox-cloud';
 import { errSummary, type CheckResult } from '@agentbox/sandbox-core';
 import { probeRemoteEngine } from './remote-docker.js';
+import { getHostAlias } from './hosts-registry.js';
 import { readPreparedState } from './prepared-state.js';
 
 // No `readCredStatus` / `ensureCredentials` on this provider's module, and that
@@ -20,34 +21,46 @@ import { readPreparedState } from './prepared-state.js';
 export async function doctorChecks(): Promise<CheckResult[]> {
   try {
     const cfg = await loadEffectiveConfig(process.cwd());
-    const host = (cfg.effective.box.remoteDockerHost || '').trim();
-    if (!host) {
+    const alias = (cfg.effective.box.remoteDockerHost || '').trim();
+    if (!alias) {
       return [
         {
           label: 'remote engine',
           status: 'warn',
-          detail: 'no default SSH destination set',
-          hint: '`agentbox config set box.remoteDockerHost <user@host>` (or use `agentbox docker:<host> …`)',
+          detail: 'no default host alias set',
+          hint: '`agentbox remote-docker add <alias> <[user@]host[:port]>`',
+        },
+      ];
+    }
+    // box.remoteDockerHost is an alias; resolve it through the registry.
+    const entry = getHostAlias(alias);
+    if (!entry) {
+      return [
+        {
+          label: 'remote engine',
+          status: 'warn',
+          detail: `host alias '${alias}' is not registered`,
+          hint: `\`agentbox remote-docker add ${alias} <[user@]host[:port]>\``,
         },
       ];
     }
 
-    const probe = await probeRemoteEngine(host);
+    const probe = await probeRemoteEngine(entry.ssh);
     const engineRes: CheckResult = probe.ok
       ? {
           label: 'remote engine',
           status: 'ok',
-          detail: `${host} — docker ${probe.version} (${probe.os}/${probe.arch})`,
+          detail: `${alias} → ${entry.ssh} — docker ${probe.version} (${probe.os}/${probe.arch})`,
         }
       : {
           label: 'remote engine',
           status: 'fail',
-          detail: probe.error,
-          hint: `check that \`ssh ${host} true\` works and docker is installed there`,
+          detail: probe.error ?? 'unusable',
+          hint: `check that \`ssh ${entry.ssh} true\` works and docker is installed there`,
         };
 
     const prepared = readPreparedState();
-    const baked = prepared?.hosts[host];
+    const baked = prepared?.hosts[alias];
     const imageRes: CheckResult = baked
       ? {
           label: 'box image',
@@ -58,7 +71,7 @@ export async function doctorChecks(): Promise<CheckResult[]> {
           label: 'box image',
           status: 'warn',
           detail: 'not baked on this host yet',
-          hint: `\`agentbox prepare --provider docker:${host}\` (otherwise the first create bakes it)`,
+          hint: `\`agentbox prepare --provider docker:${alias}\` (otherwise the first create bakes it)`,
         };
 
     // Host Portless mints the <box>.localhost alias for the SSH-forwarded port;

--- a/packages/sandbox-remote-docker/src/remote-docker.ts
+++ b/packages/sandbox-remote-docker/src/remote-docker.ts
@@ -30,6 +30,18 @@ import {
   type SshTargetArgs,
 } from '@agentbox/sandbox-core';
 import { parseRemoteTarget, sshTargetFor, type RemoteTarget } from './target.js';
+import { resolveConnection } from './hosts-registry.js';
+
+/**
+ * A box's sandbox id bakes an ALIAS, not a raw connection string. Turn the
+ * baked target into one that dials the alias's current connection — so
+ * `remote-docker update` retargets existing boxes. Lenient: a non-alias spec
+ * (raw destination, or a pre-registry id) passes through unchanged.
+ */
+function dialTarget(target: RemoteTarget): RemoteTarget {
+  const resolved = resolveConnection(target.spec);
+  return resolved === target.spec ? target : parseRemoteTarget(resolved);
+}
 
 /** One ControlMaster per box, namespaced so ids can't collide with a VPS provider's. */
 export const tunnels = new SshTunnelManager('remote-docker');
@@ -48,33 +60,37 @@ export async function ensureTunnel(
   sandboxId: string,
   target: RemoteTarget,
 ): Promise<SshTargetArgs> {
+  // Dial the alias's current connection; keep the tunnel keyed by sandboxId.
+  const dial = dialTarget(target);
   if (!tunnels.has(sandboxId)) {
     try {
       await tunnels.open({
         boxId: sandboxId,
-        vpsHost: target.host,
-        ...(target.user !== undefined ? { vpsUser: target.user } : {}),
-        ...(target.port !== undefined ? { port: target.port } : {}),
+        vpsHost: dial.host,
+        ...(dial.user !== undefined ? { vpsUser: dial.user } : {}),
+        ...(dial.port !== undefined ? { port: dial.port } : {}),
       });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
+      const where = dial.spec === target.spec ? `"${target.spec}"` : `"${target.spec}" (${dial.spec})`;
       throw new Error(
-        `remote-docker: cannot SSH to "${target.spec}". Check that \`ssh ${target.spec} true\` works from this machine ` +
+        `remote-docker: cannot SSH to ${where}. Check that \`ssh ${dial.spec} true\` works from this machine ` +
           `(the provider uses your own ~/.ssh/config, agent and known_hosts — it mints no keys).\n${msg}`,
       );
     }
   }
   const controlPath = tunnels.controlPath(sandboxId);
-  return sshTargetFor(target, controlPath);
+  return sshTargetFor(dial, controlPath);
 }
 
 /** Re-open a dead master (host sleep/wake, network blip) and drop stale forwards. */
 export async function refreshTunnel(sandboxId: string, target: RemoteTarget): Promise<void> {
+  const dial = dialTarget(target);
   await tunnels.refresh({
     boxId: sandboxId,
-    vpsHost: target.host,
-    ...(target.user !== undefined ? { vpsUser: target.user } : {}),
-    ...(target.port !== undefined ? { port: target.port } : {}),
+    vpsHost: dial.host,
+    ...(dial.user !== undefined ? { vpsUser: dial.user } : {}),
+    ...(dial.port !== undefined ? { port: dial.port } : {}),
   });
 }
 
@@ -208,29 +224,54 @@ export function loginShell(command: string): string {
   return `bash -lc ${quoteShellArg(command)}`;
 }
 
+/** One preflight check, so `remote-docker doctor` can render a row per step. */
+export interface RemoteEngineStep {
+  label: 'ssh' | 'docker';
+  ok: boolean;
+  /** Success line or failure reason, shown after the status badge. */
+  detail: string;
+  hint?: string;
+}
+
+export interface RemoteEngineProbe {
+  /** True iff every attempted step passed. */
+  ok: boolean;
+  /** The steps that ran, in order (ssh, then docker). A failed step is last. */
+  steps: RemoteEngineStep[];
+  /** From the docker step when `ok`. */
+  version?: string;
+  arch?: string;
+  os?: string;
+  /** First failing step's detail — convenience for single-line callers. */
+  error?: string;
+}
+
 /**
  * Preflight a destination: SSH reachable, `docker` on the login-shell PATH, and
- * the daemon actually answering. Returns the engine's version + arch for the
- * doctor / `agentbox remote-docker check` output.
+ * the daemon actually answering. Returns a per-step result so `remote-docker
+ * doctor` can render one `[ ok ]`/`[FAIL]` row per check (like `agentbox
+ * doctor`); `add` and the provider's doctorChecks read the rolled-up fields.
  */
-export async function probeRemoteEngine(
-  spec: string,
-): Promise<{ ok: true; version: string; arch: string; os: string } | { ok: false; error: string }> {
+export async function probeRemoteEngine(spec: string): Promise<RemoteEngineProbe> {
   let target: SshTargetArgs;
   try {
     target = sshTargetFor(parseRemoteTarget(spec));
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    const detail = err instanceof Error ? err.message : String(err);
+    return { ok: false, steps: [{ label: 'ssh', ok: false, detail }], error: detail };
   }
   const reach = await sshExec({ ...target, options: { ConnectTimeout: '10' } }, 'true', {
     timeoutMs: 20_000,
   });
   if (reach.exitCode !== 0) {
+    const detail = `cannot SSH to ${spec}: ${reach.stderr.trim() || `exit ${String(reach.exitCode)}`}`;
     return {
       ok: false,
-      error: `cannot SSH to ${spec}: ${reach.stderr.trim() || `exit ${String(reach.exitCode)}`}`,
+      steps: [{ label: 'ssh', ok: false, detail, hint: `\`ssh ${spec} true\` must work from here` }],
+      error: detail,
     };
   }
+  const sshStep: RemoteEngineStep = { label: 'ssh', ok: true, detail: `reachable (${spec})` };
   const res = await dockerOnRemote(
     target,
     ['version', '--format', '{{.Server.Version}}|{{.Server.Arch}}|{{.Server.Os}}'],
@@ -240,14 +281,21 @@ export async function probeRemoteEngine(
   );
   if (res.exitCode !== 0) {
     const err = res.stderr.trim() || res.stdout.trim();
-    if (/command not found|not found/i.test(err)) {
-      return {
-        ok: false,
-        error: `\`docker\` is not on ${spec}'s login-shell PATH (${err}). Install Docker there, or add it to the remote user's profile.`,
-      };
-    }
-    return { ok: false, error: `docker on ${spec} is not answering: ${err}` };
+    const notFound = /command not found|not found/i.test(err);
+    const detail = notFound
+      ? `\`docker\` is not on ${spec}'s login-shell PATH (${err}). Install Docker there, or add it to the remote user's profile.`
+      : `docker on ${spec} is not answering: ${err}`;
+    return {
+      ok: false,
+      steps: [sshStep, { label: 'docker', ok: false, detail }],
+      error: detail,
+    };
   }
   const [version = '', arch = '', os = ''] = res.stdout.trim().split('|');
-  return { ok: true, version, arch, os };
+  const dockerStep: RemoteEngineStep = {
+    label: 'docker',
+    ok: true,
+    detail: `${version} (${os}/${arch})`,
+  };
+  return { ok: true, steps: [sshStep, dockerStep], version, arch, os };
 }

--- a/packages/sandbox-remote-docker/src/target.ts
+++ b/packages/sandbox-remote-docker/src/target.ts
@@ -11,14 +11,20 @@
  *                 "dev@10.0.0.9:2222/agentbox-brave-otter"
  *
  * That makes the handle self-describing and multi-host support fall out for
- * free — no host-side registry to keep in sync, and a box keeps working after
- * `box.remoteDockerHost` changes.
+ * free — no per-box registry to keep in sync.
  *
- * An SSH destination is anything OpenSSH accepts: an `~/.ssh/config` alias
- * (`buildbox`), or `[user@]host[:port]`. We deliberately do NOT parse it into
- * our own notion of identity/port beyond the `:port` suffix — the user's
- * `~/.ssh/config` is the source of truth for keys, ports and usernames, and
- * re-deriving them here would only let us contradict it.
+ * What the id bakes is a host **alias**, not a raw connection string: aliases are
+ * registered in `hosts-registry.ts` (`~/.agentbox/remote-docker-hosts.json`), and
+ * the alias→connection lookup happens at connection time (`ensureTunnel`). That
+ * indirection is deliberate — `remote-docker update <alias>` remints the
+ * connection and every existing box created against that alias follows it. The
+ * functions here stay PURE (no registry I/O): they only split/validate the
+ * destination string; resolution is a separate step at the connection chokepoints.
+ *
+ * A parsed destination is anything OpenSSH accepts once resolved: an
+ * `~/.ssh/config` alias (`buildbox`), or `[user@]host[:port]`. We deliberately do
+ * NOT parse it into our own notion of identity/port beyond the `:port` suffix —
+ * the user's `~/.ssh/config` is the source of truth for keys, ports and usernames.
  */
 
 import type { SshTargetArgs } from '@agentbox/sandbox-core';

--- a/packages/sandbox-remote-docker/test/build-attach.test.ts
+++ b/packages/sandbox-remote-docker/test/build-attach.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the tunnel so buildAttach doesn't try to open a real SSH ControlMaster.
+// `ensureTunnel` returns the ssh target the attach argv is built from; a bare
+// host with no control socket is enough to exercise the command assembly.
+vi.mock('../src/remote-docker.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../src/remote-docker.js')>('../src/remote-docker.js');
+  return {
+    ...actual,
+    ensureTunnel: vi.fn(async () => ({ host: 'macmini' })),
+  };
+});
+
+import { buildRemoteDockerAttach } from '../src/build-attach.js';
+import type { BoxRecord } from '@agentbox/core';
+
+function boxFixture(): BoxRecord {
+  return {
+    id: 'b1',
+    name: 'proj-b1',
+    provider: 'remote-docker',
+    cloud: { backend: 'remote-docker', sandboxId: 'macmini/agentbox-proj-b1' },
+  } as unknown as BoxRecord;
+}
+
+describe('buildRemoteDockerAttach', () => {
+  it('runs the docker command through a LOGIN shell so `docker` is on PATH', async () => {
+    const spec = await buildRemoteDockerAttach(boxFixture(), 'agent', {
+      sessionName: 'agent',
+      command: 'claude',
+    });
+    const remoteCommand = spec.argv.at(-1)!;
+    // The bug this guards: without `bash -lc`, ssh runs the string in the remote
+    // user's NON-login shell, where Docker Desktop / OrbStack aren't on PATH, so
+    // the attach dies with "command not found: docker".
+    expect(remoteCommand.startsWith('bash -lc ')).toBe(true);
+    expect(remoteCommand).toContain('docker exec');
+    expect(remoteCommand).toContain('agentbox-proj-b1');
+  });
+
+  it('allocates a TTY for an interactive attach but not for a detached pre-start', async () => {
+    const box = boxFixture();
+    const interactive = await buildRemoteDockerAttach(box, 'agent', { sessionName: 'agent' });
+    expect(interactive.argv).toContain('-t');
+    const remoteInteractive = interactive.argv.at(-1)!;
+    expect(remoteInteractive).toContain('docker exec -it');
+
+    const detached = await buildRemoteDockerAttach(box, 'agent', {
+      sessionName: 'agent',
+      detached: true,
+    });
+    expect(detached.argv).not.toContain('-t');
+    const remoteDetached = detached.argv.at(-1)!;
+    // detached only creates the session, so no TTY is requested of docker either.
+    expect(remoteDetached).toContain('docker exec -i ');
+  });
+});

--- a/packages/sandbox-remote-docker/test/hosts-registry.test.ts
+++ b/packages/sandbox-remote-docker/test/hosts-registry.test.ts
@@ -1,0 +1,98 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  assertValidAlias,
+  getHostAlias,
+  isValidAlias,
+  listHostAliases,
+  removeHostAlias,
+  requireHostAlias,
+  resolveConnection,
+  upsertHostAlias,
+} from '../src/hosts-registry.js';
+
+// The registry writes to `$HOME/.agentbox/remote-docker-hosts.json`. Point HOME
+// at a throwaway dir so these tests never touch the developer's real registry.
+let tmpHome: string | undefined;
+let origHome: string | undefined;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'agentbox-hosts-test-'));
+  origHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+});
+
+afterEach(() => {
+  if (origHome === undefined) delete process.env.HOME;
+  else process.env.HOME = origHome;
+  origHome = undefined;
+  if (tmpHome) {
+    rmSync(tmpHome, { recursive: true, force: true });
+    tmpHome = undefined;
+  }
+});
+
+describe('assertValidAlias', () => {
+  it('accepts plain names', () => {
+    for (const ok of ['macmini', 'build-box', 'host_1', 'a.b', 'H2']) {
+      expect(isValidAlias(ok)).toBe(true);
+      expect(() => assertValidAlias(ok)).not.toThrow();
+    }
+  });
+  it('rejects connection-string-shaped or unsafe names', () => {
+    for (const bad of ['marco@host', 'host:22', 'a/b', '', ' spaced', '-lead']) {
+      expect(isValidAlias(bad)).toBe(false);
+      expect(() => assertValidAlias(bad)).toThrow();
+    }
+  });
+});
+
+describe('upsert / get / list / remove', () => {
+  it('registers, retrieves, and lists aliases sorted', () => {
+    upsertHostAlias('zeta', 'marco@10.0.0.9');
+    upsertHostAlias('alpha', 'buildbox');
+    expect(getHostAlias('zeta')?.ssh).toBe('marco@10.0.0.9');
+    expect(listHostAliases().map((a) => a.alias)).toEqual(['alpha', 'zeta']);
+    // createdAt is stamped, updatedAt absent on first insert.
+    expect(getHostAlias('alpha')?.createdAt).toBeTruthy();
+    expect(getHostAlias('alpha')?.updatedAt).toBeUndefined();
+  });
+
+  it('update preserves createdAt and stamps updatedAt', () => {
+    upsertHostAlias('macmini', 'marco@192.168.68.57');
+    const created = getHostAlias('macmini')!.createdAt;
+    upsertHostAlias('macmini', 'marco@192.168.68.99');
+    const after = getHostAlias('macmini')!;
+    expect(after.ssh).toBe('marco@192.168.68.99');
+    expect(after.createdAt).toBe(created);
+    expect(after.updatedAt).toBeTruthy();
+  });
+
+  it('remove drops one and reports presence', () => {
+    upsertHostAlias('a', 'ha');
+    upsertHostAlias('b', 'hb');
+    expect(removeHostAlias('a')).toBe(true);
+    expect(getHostAlias('a')).toBeUndefined();
+    expect(getHostAlias('b')?.ssh).toBe('hb');
+    expect(removeHostAlias('a')).toBe(false);
+  });
+});
+
+describe('resolveConnection (lenient) vs requireHostAlias (strict)', () => {
+  it('resolveConnection maps a registered alias, passes anything else through', () => {
+    upsertHostAlias('macmini', 'marco@192.168.68.57');
+    expect(resolveConnection('macmini')).toBe('marco@192.168.68.57');
+    // Not registered → unchanged (keeps pre-registry / raw-baked ids reachable).
+    expect(resolveConnection('marco@1.2.3.4')).toBe('marco@1.2.3.4');
+    expect(resolveConnection('unknown')).toBe('unknown');
+  });
+
+  it('requireHostAlias returns the entry or throws a helpful error', () => {
+    upsertHostAlias('macmini', 'marco@192.168.68.57');
+    expect(requireHostAlias('macmini').ssh).toBe('marco@192.168.68.57');
+    expect(() => requireHostAlias('nope')).toThrow(/no such remote-docker host alias/);
+    expect(() => requireHostAlias('nope')).toThrow(/agentbox remote-docker add/);
+  });
+});

--- a/packages/sandbox-remote-docker/test/prepared-state.test.ts
+++ b/packages/sandbox-remote-docker/test/prepared-state.test.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { readPreparedState, recordPreparedHost, removePreparedHost } from '../src/prepared-state.js';
+
+// `writePreparedStateRaw` writes to `$HOME/.agentbox/remote-docker-prepared.json`.
+// Point HOME at a throwaway dir so these tests never touch the developer's real
+// prepared-state (this package has no HOME-isolating vitest setup file).
+let tmpHome: string | undefined;
+let origHome: string | undefined;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'agentbox-prepared-test-'));
+  origHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+});
+
+afterEach(() => {
+  if (origHome === undefined) delete process.env.HOME;
+  else process.env.HOME = origHome;
+  origHome = undefined;
+  if (tmpHome) {
+    rmSync(tmpHome, { recursive: true, force: true });
+    tmpHome = undefined;
+  }
+});
+
+describe('removePreparedHost', () => {
+  it('drops one host and leaves the others intact', () => {
+    recordPreparedHost('macmini', { imageRef: 'agentbox/box:aaa', contextSha256: 'aaa' });
+    recordPreparedHost('buildbox', { imageRef: 'agentbox/box:bbb', contextSha256: 'bbb' });
+
+    const removed = removePreparedHost('macmini');
+    expect(removed).toBe(true);
+
+    const state = readPreparedState();
+    expect(state?.hosts.macmini).toBeUndefined();
+    expect(state?.hosts.buildbox?.imageRef).toBe('agentbox/box:bbb');
+  });
+
+  it('returns false for a host that was never recorded', () => {
+    recordPreparedHost('buildbox', { imageRef: 'agentbox/box:bbb', contextSha256: 'bbb' });
+    expect(removePreparedHost('nope')).toBe(false);
+    // The existing host is untouched.
+    expect(readPreparedState()?.hosts.buildbox?.imageRef).toBe('agentbox/box:bbb');
+  });
+
+  it('returns false when there is no prepared-state file at all', () => {
+    expect(readPreparedState()).toBeNull();
+    expect(removePreparedHost('macmini')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Remote-docker: host-alias registry, install-wizard setup, bake-on-add

Reworks remote-docker onboarding around **named host aliases**.

### Feature
- **Alias registry** (`~/.agentbox/remote-docker-hosts.json`): `add <alias> <ssh>`, `update`, `list`, `doctor`, `remove`. A box bakes the **alias** into its sandbox id; the alias→connection lookup happens at connect time, so `update <alias> <new-ssh>` retargets every existing box after an IP change. Alias-only at create/prepare (a raw connection string is rejected there); `doctor` also accepts a raw connection so you can vet a host before registering it.
- **`add` bakes the box image** on the host by default (`--no-bake` to skip); a multi-host hint points at `agentbox docker:<alias> claude`.
- **`agentbox install` → Remote Docker** now prompts for the alias + SSH connection and offers to bake (previously a no-op selection).
- Subcommands renamed `check`→`doctor`, `use`→`add`, `hosts`→`list`; `doctor` renders an `[ ok ]`/`[FAIL]` checklist via a shared `statusBadge` in `sandbox-core`.

### Fixes (surfaced against a real macOS/OrbStack + Hetzner remote)
- SSH ControlMaster socket path overran the `sun_path` length limit → moved to a short hashed path.
- Attach ran the remote command in a **non-login shell** (`docker` not on PATH) → wrapped in `loginShell`.
- Credential-seed extract relied on in-box passwordless sudo the docker image doesn't grant → runs as the box user via `backend.exec`'s `user` option.

### Housekeeping
- Trimmed obscure install/add log lines; docs (`remote-docker.mdx`, `cli.mdx`, backlog, README) + CHANGELOG.
- Also folds in some concurrent CLI help/doc edits present in the tree.

### Verification
Typecheck (31/31), lint, and tests green (sandbox-core/cloud/hetzner/remote-docker + apps/cli 839). Live-verified end-to-end against a Hetzner Ubuntu host: `add`+bake, `--no-bake`, `doctor` (alias + raw), `update`, alias-baked sandbox id, resolution-at-connect, a full box create, and the install wizard driven through the PTY harness.

https://claude.ai/code/session_014Lp4fP5ZaqLzrd3LXksmkU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote-docker provisioning, SSH tunnel socket paths (shared across providers), and cloud credential seeding behavior; scope is broad but mostly additive with targeted fixes and tests.
> 
> **Overview**
> **Remote Docker** is now organized around **named host aliases** in `~/.agentbox/remote-docker-hosts.json`. Register with `agentbox remote-docker add <alias> <ssh>` (bakes the box image by default); use `docker:<alias>` / `update` / `list` / `doctor` / `remove`. New boxes must use a registered alias at create/prepare; existing boxes keep working because connections resolve from the alias baked into the sandbox id. Subcommands were renamed from `check`/`use`/`hosts` to `doctor`/`add`/`list`.
> 
> **`agentbox install`** for Remote Docker now walks through alias + SSH registration (and optional bake) instead of being a no-op.
> 
> **Reliability fixes** for real macOS/OrbStack remotes: SSH ControlMaster sockets move to a short `~/.agentbox/cm/<hash>.sock` path (avoids `sun_path` overflow); remote **attach** wraps `docker exec` in a login shell so `docker` is on PATH; cloud credential seeding runs extract as `vscode` via `backend.exec({ user })` instead of in-box `sudo` (fixes remote-docker boxes without passwordless sudo).
> 
> Shared **`statusBadge`** for doctor-style output, docs/README/CHANGELOG updates, and small CLI polish (compact help layout, quieter install messages, `agentbox attach` in create hints).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57eaad4ff67288b9fb1ee7777682aefe17ddfec4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->