### PR TITLE
feat(hub): remote-docker host-alias REST endpoints (/api/v1/hosts)

### DIFF
--- a/apps/hub/app/(dashboard)/api/v1/hosts/[alias]/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/hosts/[alias]/route.ts
@@ -1,0 +1,28 @@
+// DELETE /api/v1/hosts/:alias — forget a remote-docker host alias (drops it from
+// the registry + baked-image record, clears the global default if it pointed
+// here). Local record only — the remote machine/containers are untouched. Returns
+// the box names created against the alias (now unreachable) so the caller can warn.
+import { backendOrNull } from '../../lib/backend';
+import { fail, ok } from '../../lib/envelope';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function DELETE(
+  _req: Request,
+  ctx: { params: Promise<{ alias: string }> },
+): Promise<Response> {
+  const { alias } = await ctx.params;
+  const backend = backendOrNull();
+  if (!backend) return fail('backend_unavailable', 'hub backend unavailable (run the hub server)');
+
+  // The backend remove is idempotent; answer a genuinely-unknown alias with 404.
+  const hosts = await backend.listRemoteDockerHosts();
+  if (!hosts.some((h) => h.alias === alias)) {
+    return fail('not_found', `unknown host alias ${alias}`);
+  }
+
+  const res = await backend.removeRemoteDockerHost(alias);
+  if (!res.ok) return fail('conflict', res.error);
+  return ok({ ok: true, boxesAffected: res.boxesAffected });
+}

--- a/apps/hub/app/(dashboard)/api/v1/hosts/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/hosts/route.ts
@@ -1,0 +1,42 @@
+// GET /api/v1/hosts — the registered remote-docker host aliases (alias -> SSH
+// connection, with baked/default state). POST /api/v1/hosts — register a new
+// alias: validates + probes the host (ssh + docker) before saving. No image bake
+// (that would block for minutes; the image builds on first create, or via
+// POST /providers/remote-docker/prepare). Mutations need the in-process backend.
+import { backendOrNull } from '../lib/backend';
+import { fail, ok } from '../lib/envelope';
+import { parseHostUpsert } from '../lib/validate';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(): Promise<Response> {
+  const backend = backendOrNull();
+  if (!backend) return fail('backend_unavailable', 'hub backend unavailable (run the hub server)');
+  return ok({ hosts: await backend.listRemoteDockerHosts() });
+}
+
+export async function POST(req: Request): Promise<Response> {
+  const backend = backendOrNull();
+  if (!backend) return fail('backend_unavailable', 'hub backend unavailable (run the hub server)');
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return fail('invalid_request', 'body must be valid JSON');
+  }
+  const parsed = parseHostUpsert(body);
+  if (!parsed.ok) return fail('invalid_request', parsed.message, parsed.details);
+
+  const res = await backend.addRemoteDockerHost(parsed.value.alias, parsed.value.ssh, {
+    default: parsed.value.default,
+  });
+  if (!res.ok) {
+    // "already exists" is a conflict; an unreachable host / missing docker is a
+    // client-input problem → 400.
+    if (/already exists/i.test(res.error)) return fail('conflict', res.error);
+    return fail('invalid_request', res.error);
+  }
+  return ok({ ok: true }, 201);
+}

--- a/apps/hub/app/(dashboard)/api/v1/lib/openapi.ts
+++ b/apps/hub/app/(dashboard)/api/v1/lib/openapi.ts
@@ -30,6 +30,7 @@ export function buildOpenApi(): Record<string, unknown> {
       { name: 'Box services', description: "A box's agentbox.yaml service/task/port status." },
       { name: 'Projects', description: 'Register folders as projects and list their branches.' },
       { name: 'Providers', description: 'Sandbox providers: status, credentials, base-image bake.' },
+      { name: 'Hosts', description: 'Remote-docker host aliases (name -> SSH connection).' },
       { name: 'Approvals', description: 'Pending host-action approvals.' },
       { name: 'Jobs', description: 'Async create/bake job status and log streams.' },
     ],
@@ -356,6 +357,45 @@ export function buildOpenApi(): Record<string, unknown> {
             '400': errorResponse,
             '401': errorResponse,
             '409': errorResponse,
+            '503': errorResponse,
+          },
+        },
+      },
+      '/hosts': {
+        get: {
+          tags: ['Hosts'],
+          summary: 'List remote-docker host aliases',
+          description: 'Each with its SSH connection and baked/default state.',
+          responses: {
+            '200': { description: 'Hosts', content: { 'application/json': { schema: { type: 'object', properties: { hosts: { type: 'array', items: { type: 'object', properties: { alias: { type: 'string' }, ssh: { type: 'string' }, baked: { type: 'boolean' }, bakedImageRef: { type: 'string' }, default: { type: 'boolean' } }, required: ['alias', 'ssh', 'baked', 'default'] } } }, required: ['hosts'] } } } },
+            '401': errorResponse,
+            '503': errorResponse,
+          },
+        },
+        post: {
+          tags: ['Hosts'],
+          summary: 'Register a remote-docker host alias',
+          description: 'Probes the host (ssh + docker) before saving. Does not bake the image (builds on first create). `default` also pins box.remoteDockerHost.',
+          requestBody: { required: true, content: { 'application/json': { schema: { type: 'object', properties: { alias: { type: 'string' }, ssh: { type: 'string', description: 'an ~/.ssh/config alias or [user@]host[:port]' }, default: { type: 'boolean' } }, required: ['alias', 'ssh'] } } } },
+          responses: {
+            '201': { description: 'Registered', content: { 'application/json': { schema: { type: 'object', properties: { ok: { const: true } }, required: ['ok'] } } } },
+            '400': errorResponse,
+            '401': errorResponse,
+            '409': errorResponse,
+            '503': errorResponse,
+          },
+        },
+      },
+      '/hosts/{alias}': {
+        delete: {
+          tags: ['Hosts'],
+          summary: 'Forget a remote-docker host alias',
+          description: 'Drops the alias + baked-image record + default. Local record only. Returns boxes created against it (now unreachable).',
+          parameters: [{ name: 'alias', in: 'path', required: true, schema: { type: 'string' } }],
+          responses: {
+            '200': { description: 'Removed', content: { 'application/json': { schema: { type: 'object', properties: { ok: { const: true }, boxesAffected: { type: 'array', items: { type: 'string' } } }, required: ['ok', 'boxesAffected'] } } } },
+            '401': errorResponse,
+            '404': errorResponse,
             '503': errorResponse,
           },
         },

--- a/apps/hub/app/(dashboard)/api/v1/lib/validate.ts
+++ b/apps/hub/app/(dashboard)/api/v1/lib/validate.ts
@@ -147,6 +147,34 @@ export function parseProviderPrepare(
   };
 }
 
+// ── remote-docker host aliases ──
+// Mirrors isValidAlias in @agentbox/sandbox-remote-docker; replicated (not imported)
+// to keep that package out of the Next bundle, like PROVIDERS/AGENTS above.
+const HOST_ALIAS_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+export function isValidHostAlias(v: string): boolean {
+  return HOST_ALIAS_RE.test(v);
+}
+
+export function parseHostUpsert(
+  body: unknown,
+): Parsed<{ alias: string; ssh: string; default?: boolean }> {
+  if (!isObject(body)) return { ok: false, message: 'body must be a JSON object' };
+  const { alias, ssh, default: dflt } = body;
+  if (typeof alias !== 'string' || !isValidHostAlias(alias)) {
+    return {
+      ok: false,
+      message: 'alias must be a plain name (letters, digits, ., _, -; no @, :, /)',
+    };
+  }
+  if (typeof ssh !== 'string' || ssh.trim().length === 0) {
+    return { ok: false, message: 'ssh is required (an ~/.ssh/config alias or [user@]host[:port])' };
+  }
+  const db = optionalBool(dflt, 'default');
+  if (!db.ok) return db;
+  return { ok: true, value: { alias, ssh: ssh.trim(), default: db.value } };
+}
+
 // ── git operations ──
 export const GIT_OPS = ['checkout', 'branch', 'pull', 'push', 'push-host'] as const;
 export type GitOp = (typeof GIT_OPS)[number];

--- a/apps/hub/lib/boxes/backend-types.ts
+++ b/apps/hub/lib/boxes/backend-types.ts
@@ -240,4 +240,34 @@ export interface HubBackend {
   // <id> --in <app>` (which owns all the SSH-alias / deep-link / terminal-spawn
   // logic). Refuses when openTargets() would report unsupported.
   openIn(id: string, app: OpenInApp): Promise<ActionResult>;
+
+  // ── remote-docker host aliases (~/.agentbox/remote-docker-hosts.json) ──
+  // List the registered remote-docker host aliases with their baked/default state.
+  listRemoteDockerHosts(): Promise<RemoteDockerHostView[]>;
+  // Register an alias -> SSH connection: validates + probes the host (ssh + docker)
+  // before saving. Does NOT bake the image (would block for minutes). `default`
+  // also pins it as box.remoteDockerHost (global).
+  addRemoteDockerHost(
+    alias: string,
+    ssh: string,
+    opts?: { default?: boolean },
+  ): Promise<ActionResult>;
+  // Forget an alias: drops it from the registry + baked-image record, clears the
+  // global default if it pointed here. Returns the box names created against the
+  // alias (now unreachable) so the caller can warn. Local record only.
+  removeRemoteDockerHost(
+    alias: string,
+  ): Promise<{ ok: true; boxesAffected: string[] } | { ok: false; error: string }>;
+}
+
+// One remote-docker host alias, as surfaced by the hub API.
+export interface RemoteDockerHostView {
+  alias: string;
+  /** The SSH connection string the alias resolves to. */
+  ssh: string;
+  /** Whether the box image is baked on this host (from the prepared-state record). */
+  baked: boolean;
+  bakedImageRef?: string;
+  /** Whether this alias is the configured default (box.remoteDockerHost). */
+  default: boolean;
 }

--- a/apps/hub/lib/hub-backend.ts
+++ b/apps/hub/lib/hub-backend.ts
@@ -14,7 +14,9 @@ import {
   providerMeta,
   registerProject,
   resolveDefaultCheckpoint,
+  setConfigValue,
   unregisterProject,
+  unsetConfigValue,
   type ProviderKind,
 } from '@agentbox/config';
 import { normalizeLastAgent, type BoxRecord, type ExecResult, type Provider } from '@agentbox/core';
@@ -76,6 +78,7 @@ import type {
   OpenInApp,
   OpenTargets,
   OpenTargetsReport,
+  RemoteDockerHostView,
   ServicesResult,
 } from './boxes/backend-types';
 import { hubProfile } from './auth-config';
@@ -1262,6 +1265,75 @@ export function createHubBackend(handle: RelayServerHandle): HubBackend {
         // rather than execFile's generic "Command failed: node …".
         const e = err as { stderr?: string; stdout?: string; message?: string };
         return { ok: false, error: cleanCliError(e) };
+      }
+    },
+
+    // ── remote-docker host aliases ──
+    async listRemoteDockerHosts(): Promise<RemoteDockerHostView[]> {
+      const rd = await import('@agentbox/sandbox-remote-docker');
+      const prepared = rd.readPreparedState();
+      const cfg = await loadEffectiveConfig(os.homedir());
+      const dflt = (cfg.effective.box.remoteDockerHost || '').trim();
+      return rd.listHostAliases().map(({ alias, entry }) => {
+        const baked = prepared?.hosts[alias];
+        return {
+          alias,
+          ssh: entry.ssh,
+          baked: Boolean(baked),
+          ...(baked ? { bakedImageRef: baked.imageRef } : {}),
+          default: alias === dflt,
+        };
+      });
+    },
+    async addRemoteDockerHost(alias, ssh, opts): Promise<ActionResult> {
+      try {
+        const rd = await import('@agentbox/sandbox-remote-docker');
+        const trimmedSsh = ssh.trim();
+        if (!rd.isValidAlias(alias)) {
+          return {
+            ok: false,
+            error: `invalid host alias "${alias}" — use a plain name (letters, digits, ., _, -; no @, :, /)`,
+          };
+        }
+        if (!trimmedSsh) return { ok: false, error: 'SSH connection is required' };
+        if (rd.getHostAlias(alias)) {
+          return { ok: false, error: `host alias "${alias}" already exists` };
+        }
+        // Probe before saving so an unreachable host / missing docker is rejected.
+        const probe = await rd.probeRemoteEngine(trimmedSsh);
+        if (!probe.ok) return { ok: false, error: probe.error ?? `${trimmedSsh}: remote engine unusable` };
+        rd.upsertHostAlias(alias, trimmedSsh);
+        if (opts?.default) {
+          await setConfigValue('global', 'box.remoteDockerHost', alias, os.homedir(), { raw: true });
+        }
+        return { ok: true };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    },
+    async removeRemoteDockerHost(alias) {
+      try {
+        const rd = await import('@agentbox/sandbox-remote-docker');
+        rd.removeHostAlias(alias);
+        rd.removePreparedHost(alias);
+        // Clear the global default if it pointed at this alias.
+        const cfg = await loadEffectiveConfig(os.homedir());
+        if (cfg.layers.global.values.box?.remoteDockerHost === alias) {
+          await unsetConfigValue('global', 'box.remoteDockerHost', os.homedir());
+        }
+        // Boxes whose sandbox id was baked against this alias are now unreachable.
+        const { boxes } = await readState();
+        const boxesAffected = boxes
+          .filter(
+            (b) =>
+              b.provider === 'remote-docker' &&
+              typeof b.cloud?.sandboxId === 'string' &&
+              b.cloud.sandboxId.startsWith(`${alias}/`),
+          )
+          .map((b) => b.name);
+        return { ok: true, boxesAffected };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
       }
     },
   };

--- a/packages/sandbox-remote-docker/src/index.ts
+++ b/packages/sandbox-remote-docker/src/index.ts
@@ -111,3 +111,13 @@ export { remoteDockerBackend, BACKEND_NAME, listOnHost } from './backend.js';
 export { probeRemoteEngine } from './remote-docker.js';
 export { parseRemoteTarget, parseSandboxId } from './target.js';
 export { interactiveRegisterHost } from './host-setup.js';
+export {
+  isValidAlias,
+  readHostsRegistry,
+  getHostAlias,
+  listHostAliases,
+  upsertHostAlias,
+  removeHostAlias,
+  type RemoteHostEntry,
+} from './hosts-registry.js';
+export { readPreparedState, removePreparedHost } from './prepared-state.js';


### PR DESCRIPTION
## Hub REST endpoints for remote-docker host aliases (`/api/v1/hosts`)

Backs a new **Remote Docker Hosts** section in the tray Settings (that Swift change ships separately in `agentbox-tray`). Adds host management to the hub API, mirroring the existing providers routes.

- **`GET /api/v1/hosts`** — list aliases with `ssh`, `baked`, `default`.
- **`POST /api/v1/hosts`** `{alias, ssh, default?}` — validate + **probe** (ssh + docker) + register. 201 on success; 409 on a duplicate alias; 400 on an unreachable host (surfaces the probe error) or invalid alias. **No image bake** (would block the request minutes; the image builds on first create).
- **`DELETE /api/v1/hosts/:alias`** — forget the alias + baked-image record, clear the global default if it pointed here, and return `boxesAffected` (boxes created against it, now unreachable). Local record only — the remote machine is untouched.

Implementation follows the hub's conventions: thin routes delegate to new `HubBackend` methods (implemented in `hub-backend.ts` where `@agentbox/*` imports live), hand-rolled `parseHostUpsert` validation (alias regex replicated locally to keep the package out of the Next bundle), hand-added OpenAPI paths + a `Hosts` tag, and auth is free via `proxy.ts`. Also exports the registry helpers from `@agentbox/sandbox-remote-docker`.

### Verification
Built the standalone hub, restarted it, and curl'd every path against the live Hetzner host (`root@178.104.43.192`): GET lists, POST 201 (probes), 409 dup, 400 bad-ssh (with the probe message) + invalid alias, DELETE 200 with `boxesAffected`, 404 unknown, 401 no-auth. Lint + typecheck + tests green.

Stacks on the earlier remote-docker alias work (already on `nightly`).

https://claude.ai/code/session_014Lp4fP5ZaqLzrd3LXksmkU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> POST performs live SSH/Docker probes and mutates global config and on-disk host registry; DELETE can leave existing remote-docker boxes unreachable while only updating local metadata.
> 
> **Overview**
> Adds **Hub REST management** for remote-docker **host aliases** at `/api/v1/hosts`, following the same thin-route → `HubBackend` pattern as providers.
> 
> **`GET /api/v1/hosts`** returns registered aliases with `ssh`, baked-image state, and whether each is the global default (`box.remoteDockerHost`). **`POST /api/v1/hosts`** accepts `{ alias, ssh, default? }`, validates the alias (regex mirrored in `parseHostUpsert` to avoid bundling the sandbox package into Next), **probes SSH + Docker** before persisting, optionally sets the global default, and returns **201** (duplicate alias → **409**, bad probe/alias → **400**). Registration does **not** bake the image.
> 
> **`DELETE /api/v1/hosts/:alias`** forgets the alias locally (registry, prepared-state, default config if needed), returns **`boxesAffected`** for remote-docker boxes whose sandbox id used that alias, and returns **404** for unknown aliases. Remote machines are untouched.
> 
> `hub-backend.ts` implements the new `HubBackend` methods via dynamic `@agentbox/sandbox-remote-docker` imports; OpenAPI gains a **Hosts** tag and paths; the package **re-exports** registry/prepared-state helpers used by the backend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e19f2419cb76587de38a150ae90871e0bc68643. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->