### PR TITLE
feat(hub): per-host bake endpoint (POST /api/v1/hosts/:alias/bake)

### DIFF
--- a/apps/cli/src/commands/_run-queued-prepare.ts
+++ b/apps/cli/src/commands/_run-queued-prepare.ts
@@ -18,6 +18,7 @@ import { boxImageConfigKey, isProviderKind, loadEffectiveConfig, setConfigValue 
 import { readJob, writeJob, type QueueJob } from '@agentbox/relay';
 import { openCommandLog } from '../lib/log-file.js';
 import { getProvider, isKnownProvider } from '../provider/registry.js';
+import { parseProviderSpec } from '../provider/spec.js';
 
 export const runQueuedPrepareCommand = new Command('_run-queued-prepare')
   .description('internal: run a queued provider image-bake job (do not invoke directly)')
@@ -87,12 +88,16 @@ async function runPrepareJob(
     throw new Error(`provider '${providerName}' does not implement prepare`);
   }
 
+  // A `docker:<alias>` spec bakes that specific remote-docker host (the hub's
+  // per-host bake). parseProviderSpec pulls the host out; other providers ignore it.
+  const remoteHost = parseProviderSpec(providerName).remoteHost;
   log.write(`baking ${providerName} (force=${String(job.prepare?.force ?? false)})`);
   const result = await provider.prepare({
     hostWorkspace: cwd,
     force: job.prepare?.force,
     registry,
     claudeInstall,
+    ...(remoteHost ? { host: remoteHost } : {}),
     onLog: (line) => log.write(line),
   });
   log.write(

--- a/apps/hub/app/(dashboard)/api/v1/hosts/[alias]/bake/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/hosts/[alias]/bake/route.ts
@@ -1,0 +1,20 @@
+// POST /api/v1/hosts/:alias/bake — bake the box image on this host. Async: returns
+// a jobId; progress streams over GET /jobs/{id}/logs, exactly like a provider bake.
+// A pull from GHCR is fast; a registry-miss build streams the context and is slow.
+import { backendOrNull } from '../../../lib/backend';
+import { fail, failFromAction, ok } from '../../../lib/envelope';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  _req: Request,
+  ctx: { params: Promise<{ alias: string }> },
+): Promise<Response> {
+  const { alias } = await ctx.params;
+  const backend = backendOrNull();
+  if (!backend) return fail('backend_unavailable', 'hub backend unavailable (run the hub server)');
+  const res = await backend.bakeRemoteDockerHost(alias);
+  if (!res.ok) return failFromAction(res.error); // "no such host alias" -> 404
+  return ok({ jobId: res.jobId }, 202);
+}

--- a/apps/hub/app/(dashboard)/api/v1/lib/openapi.ts
+++ b/apps/hub/app/(dashboard)/api/v1/lib/openapi.ts
@@ -400,6 +400,20 @@ export function buildOpenApi(): Record<string, unknown> {
           },
         },
       },
+      '/hosts/{alias}/bake': {
+        post: {
+          tags: ['Hosts'],
+          summary: 'Bake the box image on a host',
+          description: 'Async — returns a job id. Progress streams over GET /jobs/{id}/logs (pull from GHCR is fast; a registry-miss build is slow).',
+          parameters: [{ name: 'alias', in: 'path', required: true, schema: { type: 'string' } }],
+          responses: {
+            '202': { description: 'Bake enqueued', content: { 'application/json': { schema: { type: 'object', properties: { jobId: { type: 'string' } }, required: ['jobId'] } } } },
+            '401': errorResponse,
+            '404': errorResponse,
+            '503': errorResponse,
+          },
+        },
+      },
       '/approvals': {
         get: {
           tags: ['Approvals'],

--- a/apps/hub/lib/boxes/backend-types.ts
+++ b/apps/hub/lib/boxes/backend-types.ts
@@ -258,6 +258,10 @@ export interface HubBackend {
   removeRemoteDockerHost(
     alias: string,
   ): Promise<{ ok: true; boxesAffected: string[] } | { ok: false; error: string }>;
+  // Enqueue a background bake of the box image on one host (async; returns the
+  // jobId — progress streams over GET /jobs/{id}/logs, like prepareProvider).
+  // Reuses an in-flight bake for the same host if one exists.
+  bakeRemoteDockerHost(alias: string): Promise<CreateBoxResult>;
 }
 
 // One remote-docker host alias, as surfaced by the hub API.

--- a/apps/hub/lib/hub-backend.ts
+++ b/apps/hub/lib/hub-backend.ts
@@ -1336,5 +1336,26 @@ export function createHubBackend(handle: RelayServerHandle): HubBackend {
         return { ok: false, error: err instanceof Error ? err.message : String(err) };
       }
     },
+    async bakeRemoteDockerHost(alias): Promise<CreateBoxResult> {
+      try {
+        const rd = await import('@agentbox/sandbox-remote-docker');
+        if (!rd.getHostAlias(alias)) return { ok: false, error: `no such host alias ${alias}` };
+        // The `docker:<alias>` spec bakes THIS host (the worker parses it out).
+        const spec = `docker:${alias}`;
+        // Reuse an in-flight bake for the same host if present.
+        const existing = (await loadQueue()).find(
+          (j) =>
+            j.kind === 'prepare' &&
+            j.providerName === spec &&
+            (j.status === 'queued' || j.status === 'running'),
+        );
+        if (existing) return { ok: true, jobId: existing.id };
+        const { job } = await enqueuePrepareJob({ providerName: spec });
+        handle.pokeQueue();
+        return { ok: true, jobId: job.id };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    },
   };
 }


### PR DESCRIPTION
Bake the box image on a specific remote-docker host from the hub — backs the per-host Bake/Re-bake button in the tray Settings.

- Queued-prepare worker parses a `docker:<alias>` providerName spec and passes the host to `provider.prepare`, so a prepare job can target one host.
- `HubBackend.bakeRemoteDockerHost` enqueues a prepare job for `docker:<alias>` (reusing an in-flight one for the same host), returns the jobId.
- `POST /api/v1/hosts/:alias/bake` route (202 + jobId) + OpenAPI entry.

Verified live: 202 + jobId, job runs to `done` baking hbox (root@178.104.43.192); unknown alias → 404. Stacks on the hosts-endpoints PR (already on nightly).

https://claude.ai/code/session_014Lp4fP5ZaqLzrd3LXksmkU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how prepare jobs target remote engines and enqueue host-specific bakes; behavior mirrors existing prepareProvider but wrong host routing could bake the wrong machine or leave hosts unprepared for create.
> 
> **Overview**
> Adds **per remote-docker host image baking** from the hub, matching the existing async provider prepare flow (202 + `jobId`, logs on `GET /jobs/{id}/logs`).
> 
> The queued-prepare worker now treats a prepare job whose `providerName` is **`docker:<alias>`** as a host-scoped bake: it uses `parseProviderSpec` and passes **`host`** into `provider.prepare`, so the build runs on that SSH alias instead of a generic remote-docker default.
> 
> **`HubBackend.bakeRemoteDockerHost`** validates the alias, enqueues a prepare job with `providerName: docker:<alias>`, reuses an in-flight queued/running job for the same spec, and pokes the relay queue. **`POST /api/v1/hosts/:alias/bake`** exposes this (unknown alias → 404); **`HubBackend`** types and OpenAPI document the new route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f992bbbeeb78cf03ab5a3c5599af6a140a9bbfb6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->