### PR TITLE
feat(hub): create boxes on remote-docker hosts from the UI

### DIFF
--- a/apps/hub/app/(dashboard)/api/v1/lib/validate.ts
+++ b/apps/hub/app/(dashboard)/api/v1/lib/validate.ts
@@ -38,8 +38,21 @@ export function parseCreateBox(body: unknown): Parsed<CreateBoxInput> {
   if (typeof agent !== 'string' || !(AGENTS as readonly string[]).includes(agent)) {
     return { ok: false, message: `agent must be one of ${AGENTS.join(', ')}`, details: { got: agent } };
   }
-  if (provider !== undefined && (typeof provider !== 'string' || !(PROVIDERS as readonly string[]).includes(provider))) {
-    return { ok: false, message: `provider must be one of ${PROVIDERS.join(', ')}`, details: { got: provider } };
+  // A host-qualified `docker:<alias>` / `remote-docker:<alias>` spec picks a
+  // registered remote-docker host (alias rule mirrors the hosts registry). The
+  // backend validates the alias exists; here we only gate the shape.
+  const isHostSpec =
+    typeof provider === 'string' && /^(?:docker|remote-docker):[A-Za-z0-9][A-Za-z0-9._-]*$/.test(provider);
+  if (
+    provider !== undefined &&
+    !isHostSpec &&
+    (typeof provider !== 'string' || !(PROVIDERS as readonly string[]).includes(provider))
+  ) {
+    return {
+      ok: false,
+      message: `provider must be one of ${PROVIDERS.join(', ')} (or a docker:<host> spec)`,
+      details: { got: provider },
+    };
   }
   if (name !== undefined && typeof name !== 'string') return { ok: false, message: 'name must be a string' };
   if (prompt !== undefined && typeof prompt !== 'string') return { ok: false, message: 'prompt must be a string' };

--- a/apps/hub/app/(dashboard)/api/v1/providers/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/providers/route.ts
@@ -15,10 +15,16 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request): Promise<Response> {
-  const wantsFreshness = new URL(req.url).searchParams.get('freshness') === '1';
+  const params = new URL(req.url).searchParams;
+  const wantsFreshness = params.get('freshness') === '1';
+  // `?hosts=expand` (create pickers only) lists each registered remote-docker host
+  // as its own `docker:<alias>` provider option. Settings never passes it.
+  const wantsHosts = params.get('hosts') === 'expand';
   const backend = backendOrNull();
-  if (wantsFreshness && backend) {
-    return ok({ providers: await backend.providersWithFreshness() });
+  if ((wantsFreshness || wantsHosts) && backend) {
+    return ok({
+      providers: await backend.providersWithFreshness({ expandRemoteDockerHosts: wantsHosts }),
+    });
   }
   const { providers } = await readState();
   return ok({ providers });

--- a/apps/hub/app/(dashboard)/boxes/components/create-box-modal.tsx
+++ b/apps/hub/app/(dashboard)/boxes/components/create-box-modal.tsx
@@ -74,11 +74,16 @@ function CreateBoxModal({
 }) {
   const router = useRouter();
   const { state } = useStore();
-  const providers = state.providers.length ? state.providers : DOCKER_ONLY;
+  // The create picker's provider list is fetched (with remote-docker hosts expanded
+  // into `docker:<alias>` options); until it lands we render the store list so the
+  // form paints instantly. See the effect below.
+  const [fetchedProviders, setFetchedProviders] = useState<ProviderOption[] | null>(null);
+  const providers = fetchedProviders ?? (state.providers.length ? state.providers : DOCKER_ONLY);
   const [pending, startTransition] = useTransition();
   const [projectId, setProjectId] = useState(project?.id ?? projects[0]?.id ?? '');
   const [agent, setAgent] = useState<Agent>('claude');
-  const [provider, setProvider] = useState<CreateBoxInput['provider']>('docker');
+  // May hold a bare provider id or a `docker:<alias>` remote-docker host spec.
+  const [provider, setProvider] = useState<string>('docker');
   const [name, setName] = useState('');
   const [prompt, setPrompt] = useState('');
   const [fromBranch, setFromBranch] = useState('');
@@ -106,12 +111,18 @@ function CreateBoxModal({
     let cancelled = false;
     void (async () => {
       try {
-        const res = await fetch('/api/v1/providers?freshness=1', { credentials: 'same-origin' });
+        // `hosts=expand` lists each remote-docker host as a `docker:<alias>` option;
+        // `freshness=1` carries base-image staleness for the two-phase bake logic.
+        const res = await fetch('/api/v1/providers?freshness=1&hosts=expand', {
+          credentials: 'same-origin',
+        });
         if (!res.ok) return;
         const j = (await res.json()) as { providers?: ProviderOption[] };
         if (cancelled) return;
+        const list = j.providers ?? [];
+        setFetchedProviders(list);
         const map: Record<string, Pick<ProviderOption, 'baseStatus' | 'baseStaleReason' | 'jobId'>> = {};
-        for (const p of j.providers ?? []) {
+        for (const p of list) {
           map[p.id] = { baseStatus: p.baseStatus, baseStaleReason: p.baseStaleReason, jobId: p.jobId };
         }
         setFreshness(map);
@@ -301,7 +312,7 @@ function CreateBoxModal({
               </Field>
             ) : null}
             <Field label="Provider">
-              <Select value={provider} onChange={(e) => setProvider(e.target.value as CreateBoxInput['provider'])}>
+              <Select value={provider} onChange={(e) => setProvider(e.target.value)}>
                 {providers.map((p) => (
                   <option key={p.id} value={p.id} disabled={!p.configured} title={p.reason}>
                     {p.label}

--- a/apps/hub/lib/boxes/backend-types.ts
+++ b/apps/hub/lib/boxes/backend-types.ts
@@ -1,4 +1,3 @@
-import type { ProviderKind } from '@agentbox/config';
 import type { HubState, ProviderOption } from './types';
 
 // Result of a lifecycle server action.
@@ -88,9 +87,11 @@ export interface CreateBoxInput {
   projectId: string;
   // 'none' = just create the box (like `agentbox create`), don't start an agent.
   agent: 'claude' | 'codex' | 'opencode' | 'none';
-  // Sandbox provider to create on. Defaults to 'docker'. The backend rejects a
-  // provider that isn't configured (baked) on this host.
-  provider?: ProviderKind;
+  // Sandbox provider to create on. Defaults to 'docker'. A bare provider name
+  // (ProviderKind) OR a host-qualified `docker:<alias>` / `remote-docker:<alias>`
+  // spec targeting a registered remote-docker host. The backend rejects a provider
+  // that isn't configured (baked) on this host, or an unknown host alias.
+  provider?: string;
   name?: string;
   prompt?: string;
   // Base ref the box's per-box branch forks from (branch / tag / SHA), instead
@@ -180,7 +181,9 @@ export interface HubBackend {
   // `baseStaleReason`). Off the getData() hot path — computing it loads provider
   // code + hashes the runtime build context (memoized with a short TTL). Backs
   // GET /api/v1/providers?freshness=1 so the default endpoint stays fast.
-  providersWithFreshness(): Promise<ProviderOption[]>;
+  // `expandRemoteDockerHosts` (create pickers only) replaces the single
+  // remote-docker entry with one `docker:<alias>` option per registered host.
+  providersWithFreshness(opts?: { expandRemoteDockerHosts?: boolean }): Promise<ProviderOption[]>;
   // Enqueue a background create job for a registered project; returns the jobId.
   create(input: CreateBoxInput): Promise<CreateBoxResult>;
   // Persist a provider's credentials (validated against the cloud, then written

--- a/apps/hub/lib/hub-backend.ts
+++ b/apps/hub/lib/hub-backend.ts
@@ -361,8 +361,26 @@ function mapJobToBox(job: QueueJob, status: BoxStatus): Box {
  * offline (no cloud SDK), so it's cheap to compute on every getData(). A prepared
  * marker implies a prior `<provider> login`, so it's a sufficient readiness proxy.
  */
+// remote-docker keeps no single base image — it's a set of SSH host aliases in
+// `~/.agentbox/remote-docker-hosts.json`, each baked (or lazily built) on its own.
+// A direct sync read (mirrors readPreparedStateRaw/readSecretsKeys) keeps the hot
+// `listProviders` path off the remote-docker package's dynamic import.
+function remoteDockerHostCount(): number {
+  try {
+    const raw = JSON.parse(
+      readFileSync(path.join(os.homedir(), '.agentbox', 'remote-docker-hosts.json'), 'utf8'),
+    ) as { hosts?: Record<string, unknown> };
+    return raw.hosts && typeof raw.hosts === 'object' ? Object.keys(raw.hosts).length : 0;
+  } catch {
+    return 0;
+  }
+}
+
 function isProviderConfigured(id: ProviderKind): boolean {
   if (id === 'docker') return true;
+  // remote-docker is usable as soon as one host alias is registered (the image
+  // builds lazily on first create); it never writes a top-level `base` marker.
+  if (id === 'remote-docker') return remoteDockerHostCount() > 0;
   const raw = readPreparedStateRaw(id);
   return !!(raw && typeof raw === 'object' && (raw as { base?: unknown }).base);
 }
@@ -467,9 +485,12 @@ function listProviders(jobs: QueueJob[]): ProviderOption[] {
     );
     let reason: string | undefined;
     if (!configured) {
-      reason = hasCredentials
-        ? 'Credentials set — bake the base image to finish setup.'
-        : 'Not set up — add credentials, then bake the base image.';
+      reason =
+        id === 'remote-docker'
+          ? 'Add a host in Settings to run boxes on your own machine over SSH.'
+          : hasCredentials
+            ? 'Credentials set — bake the base image to finish setup.'
+            : 'Not set up — add credentials, then bake the base image.';
     }
     return { id, label, configured, hasCredentials, jobId: bake?.id, reason };
   });
@@ -553,6 +574,48 @@ async function listProvidersWithFreshness(base: ProviderOption[]): Promise<Provi
       };
     }),
   );
+}
+
+/** The registered remote-docker host aliases as create/settings-facing views. */
+async function loadRemoteDockerHostViews(): Promise<RemoteDockerHostView[]> {
+  const rd = await import('@agentbox/sandbox-remote-docker');
+  const prepared = rd.readPreparedState();
+  const cfg = await loadEffectiveConfig(os.homedir());
+  const dflt = (cfg.effective.box.remoteDockerHost || '').trim();
+  return rd.listHostAliases().map(({ alias, entry }) => {
+    const baked = prepared?.hosts[alias];
+    return {
+      alias,
+      ssh: entry.ssh,
+      baked: Boolean(baked),
+      ...(baked ? { bakedImageRef: baked.imageRef } : {}),
+      default: alias === dflt,
+    };
+  });
+}
+
+/**
+ * For the create pickers only: replace the single `remote-docker` provider entry
+ * with one `docker:<alias>` option per registered host, so a user can create a box
+ * on a specific machine. Keeps the single entry (guiding to Settings) when there
+ * are no hosts. Settings never asks for this — it renders one Remote Docker row and
+ * nests the hosts itself.
+ */
+async function expandRemoteDockerHosts(base: ProviderOption[]): Promise<ProviderOption[]> {
+  const idx = base.findIndex((p) => p.id === 'remote-docker');
+  if (idx < 0) return base;
+  const hosts = await loadRemoteDockerHostViews();
+  if (hosts.length === 0) return base;
+  const perHost: ProviderOption[] = hosts.map((h) => ({
+    id: `docker:${h.alias}`,
+    label: `docker:${h.alias}`,
+    configured: true,
+    hasCredentials: true,
+    reason: h.baked
+      ? undefined
+      : 'Image builds on first create — bake it in Settings for a faster start.',
+  }));
+  return [...base.slice(0, idx), ...perHost, ...base.slice(idx + 1)];
 }
 
 function currentUser(): User {
@@ -911,8 +974,9 @@ export function createHubBackend(handle: RelayServerHandle): HubBackend {
         providers: listProviders(jobs),
       };
     },
-    async providersWithFreshness(): Promise<ProviderOption[]> {
-      return listProvidersWithFreshness(listProviders(await loadQueue()));
+    async providersWithFreshness(opts): Promise<ProviderOption[]> {
+      const fresh = await listProvidersWithFreshness(listProviders(await loadQueue()));
+      return opts?.expandRemoteDockerHosts ? expandRemoteDockerHosts(fresh) : fresh;
     },
     start: (id) =>
       runLifecycle(id, async (box, provider) => {
@@ -1012,10 +1076,22 @@ export function createHubBackend(handle: RelayServerHandle): HubBackend {
         if (!workspace) return { ok: false, error: `unknown project ${input.projectId}` };
         // Provider gate (defense-in-depth: a client could bypass the disabled UI
         // option). Default docker; reject unknown kinds and unconfigured providers.
-        const provider = input.provider ?? 'docker';
-        if (!isProviderKind(provider)) return { ok: false, error: `unknown provider ${provider}` };
-        if (!isProviderConfigured(provider)) {
-          return { ok: false, error: `provider ${provider} is not set up on this host` };
+        const provider = (input.provider ?? 'docker').trim();
+        // A host-qualified `docker:<alias>` / `remote-docker:<alias>` spec targets a
+        // registered remote-docker host — validate the alias (the worker parses the
+        // spec out of providerName). Bare names take the configured-provider gate.
+        const hostSpec = provider.match(/^(?:docker|remote-docker):(.+)$/);
+        if (hostSpec) {
+          const alias = hostSpec[1];
+          const rd = await import('@agentbox/sandbox-remote-docker');
+          if (!rd.getHostAlias(alias)) {
+            return { ok: false, error: `unknown remote-docker host '${alias}' — add it in Settings` };
+          }
+        } else {
+          if (!isProviderKind(provider)) return { ok: false, error: `unknown provider ${provider}` };
+          if (!isProviderConfigured(provider)) {
+            return { ok: false, error: `provider ${provider} is not set up on this host` };
+          }
         }
         const noAgent = input.agent === 'none';
         // For a no-agent box `agent` is inert (the worker ignores it when noAgent);
@@ -1270,20 +1346,7 @@ export function createHubBackend(handle: RelayServerHandle): HubBackend {
 
     // ── remote-docker host aliases ──
     async listRemoteDockerHosts(): Promise<RemoteDockerHostView[]> {
-      const rd = await import('@agentbox/sandbox-remote-docker');
-      const prepared = rd.readPreparedState();
-      const cfg = await loadEffectiveConfig(os.homedir());
-      const dflt = (cfg.effective.box.remoteDockerHost || '').trim();
-      return rd.listHostAliases().map(({ alias, entry }) => {
-        const baked = prepared?.hosts[alias];
-        return {
-          alias,
-          ssh: entry.ssh,
-          baked: Boolean(baked),
-          ...(baked ? { bakedImageRef: baked.imageRef } : {}),
-          default: alias === dflt,
-        };
-      });
+      return loadRemoteDockerHostViews();
     },
     async addRemoteDockerHost(alias, ssh, opts): Promise<ActionResult> {
       try {

--- a/apps/hub/lib/hub-backend.ts
+++ b/apps/hub/lib/hub-backend.ts
@@ -607,8 +607,9 @@ async function expandRemoteDockerHosts(base: ProviderOption[]): Promise<Provider
   const hosts = await loadRemoteDockerHostViews();
   if (hosts.length === 0) return base;
   const perHost: ProviderOption[] = hosts.map((h) => ({
+    // id stays the `docker:<alias>` create spec; the label reads like "Docker (local)".
     id: `docker:${h.alias}`,
-    label: `docker:${h.alias}`,
+    label: `Docker (${h.alias})`,
     configured: true,
     hasCredentials: true,
     reason: h.baked

--- a/apps/web/content/docs/remote-docker.mdx
+++ b/apps/web/content/docs/remote-docker.mdx
@@ -62,6 +62,8 @@ agentbox docker:gpu-rig claude      # the GPU machine
 agentbox docker:mac-mini claude     # the Mac in the closet
 ```
 
+The [hub](/docs/hub) web UI and the macOS tray also list each registered host as a `docker:<alias>` option in their create-box provider pickers, so you can start a box on a specific machine without the terminal.
+
 Everything else is the same as any other box: `list`, `shell`, `logs`, `url`, `checkpoint`, `pause`, `destroy`.
 
 ## How it works

--- a/apps/web/content/docs/remote-docker.mdx
+++ b/apps/web/content/docs/remote-docker.mdx
@@ -62,7 +62,7 @@ agentbox docker:gpu-rig claude      # the GPU machine
 agentbox docker:mac-mini claude     # the Mac in the closet
 ```
 
-The [hub](/docs/hub) web UI and the macOS tray also list each registered host as a `docker:<alias>` option in their create-box provider pickers, so you can start a box on a specific machine without the terminal.
+The [hub](/docs/hub) web UI and the macOS tray also list each registered host as a **Docker (&lt;alias&gt;)** option in their create-box provider pickers, so you can start a box on a specific machine without the terminal.
 
 Everything else is the same as any other box: `list`, `shell`, `logs`, `url`, `checkpoint`, `pause`, `destroy`.
 


### PR DESCRIPTION
## What

You can register/bake/remove remote-docker hosts from the hub Web + tray Settings, but you couldn't **create a box on one** — the provider picker showed a single disabled "Remote Docker — not configured" entry. This adds it to both create pickers:

- Each registered host appears as a selectable **`docker:<alias>`** option.
- Remote Docker reads as **ready** (not "not configured") once ≥1 host exists.

The create/queue pipeline already handled a `docker:<alias>` spec end-to-end (the hub emits it for per-host bakes). This opens the hub's create **front-door**, computed once server-side so both clients just render:

- `isProviderConfigured('remote-docker')` → true when ≥1 host is registered (sync read of the hosts registry), and a remote-docker-specific "add a host in Settings" reason.
- `GET /api/v1/providers?hosts=expand` replaces the single remote-docker entry with one `docker:<alias>` option per host. **Create pickers only** — plain `/api/v1/providers` (Settings) is unchanged (single Remote Docker row, hosts nested).
- `parseCreateBox` accepts a `docker:<alias>` / `remote-docker:<alias>` spec (shape-validated); `backend.create` validates the alias exists (`getHostAlias`) and passes the spec to the worker, which already parses it.
- `CreateBoxInput.provider` widened to `string`.
- Web create modal adopts the expanded list (`?freshness=1&hosts=expand`).

Tray change (fetch `?hosts=expand` on the create path only) ships separately to `agentbox-tray` `main`.

## Verification (live, against Hetzner host `mybox` → root@178.104.43.192)

- `?hosts=expand` → `docker:mybox` (configured); plain + `?freshness=1` still return a single `remote-docker` row (Settings unaffected).
- Create-gate: bad shape `docker:bad!alias` → 400 (validator); unknown alias `docker:doesnotexist` → "unknown remote-docker host".
- **End-to-end:** created a box on `docker:mybox` via the hub → job `done`, container `agentbox-rd-web-smoke` `Up` on the remote host; destroyed → gone.
- Browser: the create modal's Provider dropdown lists `docker:mybox` enabled.
- `pnpm --filter @agentbox/hub typecheck` + eslint clean.

https://claude.ai/code/session_014Lp4fP5ZaqLzrd3LXksmkU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes box creation provider validation and enqueue semantics for host-qualified specs; mistakes could allow creates on wrong hosts or reject valid aliases, but alias checks mirror existing CLI/worker behavior.
> 
> **Overview**
> The hub **create-box** flow can target a specific **remote-docker** machine instead of showing a single disabled Remote Docker row.
> 
> **Provider API:** `GET /api/v1/providers?hosts=expand` (create pickers only; Settings unchanged) asks the in-process backend to replace the lone `remote-docker` entry with one **`docker:<alias>`** option per registered host. `providersWithFreshness` accepts `{ expandRemoteDockerHosts }`; the create modal loads **`?freshness=1&hosts=expand`** and uses that list for the provider dropdown.
> 
> **Readiness:** `remote-docker` is **configured** when at least one host exists in `~/.agentbox/remote-docker-hosts.json` (sync count, no lazy import on the hot path), with a Settings-oriented reason when no hosts are registered.
> 
> **Create path:** `CreateBoxInput.provider` is a **`string`** (bare `ProviderKind` or `docker:<alias>` / `remote-docker:<alias>`). `parseCreateBox` shape-validates host specs; **`backend.create`** checks the alias via `getHostAlias` and enqueues the spec for the existing worker. Host list loading is shared via **`loadRemoteDockerHostViews`**.
> 
> Docs note that hub and tray create pickers list **`docker:<alias>`** options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6bbdcb95bfa5a020def27c0591937830cced17b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->