### PR TITLE
feat(web): dynamic branded OG images for docs + home

### DIFF
--- a/apps/web/app/docs-og/[...slug]/route.tsx
+++ b/apps/web/app/docs-og/[...slug]/route.tsx
@@ -1,0 +1,110 @@
+import { ImageResponse } from 'next/og';
+import { notFound } from 'next/navigation';
+import { source } from '@/lib/source';
+import { OG, boxMark, loadOgFonts } from '@/lib/og';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ slug: string[] }> },
+) {
+  const { slug } = await params;
+  // slug ends in the synthetic "image.png" segment (see generateStaticParams).
+  const page = source.getPage(slug.slice(0, -1));
+  if (!page) notFound();
+
+  const fonts = await loadOgFonts();
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          width: '100%',
+          height: '100%',
+          padding: '80px',
+          backgroundColor: OG.paper,
+          fontFamily: 'IBM Plex Sans',
+          borderBottom: `20px solid ${OG.accent}`,
+        }}
+      >
+        <div
+          style={{
+            fontSize: 82,
+            fontWeight: 600,
+            color: OG.ink,
+            lineHeight: 1.1,
+            letterSpacing: '-0.02em',
+          }}
+        >
+          {page.data.title}
+        </div>
+        {page.data.description ? (
+          <div
+            style={{
+              fontSize: 40,
+              fontWeight: 400,
+              color: OG.muted,
+              marginTop: 28,
+              lineHeight: 1.35,
+            }}
+          >
+            {page.data.description}
+          </div>
+        ) : null}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 20,
+            marginTop: 'auto',
+            paddingTop: 36,
+            borderTop: `2px solid ${OG.line}`,
+          }}
+        >
+          {boxMark(OG.ink, 60)}
+          <div
+            style={{
+              fontFamily: 'IBM Plex Mono',
+              fontWeight: 600,
+              fontSize: 40,
+              color: OG.ink,
+            }}
+          >
+            agentbox
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'flex-end',
+              marginLeft: 'auto',
+            }}
+          >
+            <div style={{ fontSize: 26, color: OG.ink }}>
+              One command teleport for agents, in parallel.
+            </div>
+            <div
+              style={{
+                fontFamily: 'IBM Plex Mono',
+                fontSize: 22,
+                color: OG.accent,
+                marginTop: 6,
+              }}
+            >
+              agent-box.sh/docs
+            </div>
+          </div>
+        </div>
+      </div>
+    ),
+    { width: 1200, height: 630, fonts: fonts.length ? fonts : undefined },
+  );
+}
+
+export function generateStaticParams() {
+  return source.generateParams().map((param) => ({
+    ...param,
+    slug: [...param.slug, 'image.png'],
+  }));
+}

--- a/apps/web/app/docs/[[...slug]]/page.tsx
+++ b/apps/web/app/docs/[[...slug]]/page.tsx
@@ -70,6 +70,12 @@ export async function generateMetadata(props: {
   const title = page.data.title;
   const description = page.data.description;
 
+  // Per-page dynamic OG image, served by app/docs-og/[...slug]/route.tsx. The
+  // URL mirrors the shape produced by that route's generateStaticParams (the
+  // page slug plus a synthetic "image.png" segment). metadataBase resolves it
+  // to an absolute URL for the tags.
+  const ogUrl = `/docs-og/${[...(params.slug ?? []), 'image.png'].join('/')}`;
+
   // Re-specify siteName + image: Next shallowly merges the `openGraph`/`twitter`
   // keys, so a page-level object replaces the root defaults rather than deep-
   // merging into them.
@@ -83,13 +89,13 @@ export async function generateMetadata(props: {
       url: `${SITE.url}${page.url}`,
       title,
       description,
-      images: [SITE.ogImage],
+      images: [{ url: ogUrl, width: 1200, height: 630, alt: title }],
     },
     twitter: {
       card: 'summary_large_image',
       title,
       description,
-      images: [SITE.ogImage.url],
+      images: [ogUrl],
       creator: SITE.twitterCreator,
     },
   };

--- a/apps/web/app/home-og/route.tsx
+++ b/apps/web/app/home-og/route.tsx
@@ -1,0 +1,284 @@
+import { ImageResponse } from 'next/og';
+import { OG, boxMark, cubeMark, loadOgFonts, localPng, simpleIcon } from '@/lib/og';
+
+// A themed recreation of the home-page hero (macOS menu-bar tray + terminal),
+// so a shared link to agent-box.sh matches the site instead of the README png.
+// Served at /home-og/image.png; public/home.html's OG meta tags point here.
+
+// Content is fixed, so prerender the image at build time and serve it cached.
+export const dynamic = 'force-static';
+
+const mono = 'IBM Plex Mono';
+const sans = 'IBM Plex Sans';
+
+function FolderIcon({ color }: { color: string }) {
+  return (
+    <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2">
+      <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+    </svg>
+  );
+}
+
+function GlobeIcon({ color }: { color: string }) {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2">
+      <circle cx="12" cy="12" r="9" />
+      <path d="M3 12h18M12 3c2.5 3 2.5 15 0 18M12 3c-2.5 3-2.5 15 0 18" />
+    </svg>
+  );
+}
+
+function BoxRow({ name, sub }: { name: string; sub: string }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '9px 16px' }}>
+      <div style={{ display: 'flex', width: 11, height: 11, borderRadius: 11, backgroundColor: OG.accent }} />
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <div style={{ fontFamily: sans, fontWeight: 600, fontSize: 21, color: OG.ink }}>{name}</div>
+        <div style={{ fontFamily: mono, fontSize: 15, color: OG.muted, marginTop: 2 }}>{sub}</div>
+      </div>
+      <div style={{ marginLeft: 'auto', fontFamily: mono, fontSize: 22, color: OG.faint }}>›</div>
+    </div>
+  );
+}
+
+function FolderRow({ name }: { name: string }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '7px 16px' }}>
+      <FolderIcon color={OG.faint} />
+      <div style={{ fontFamily: sans, fontSize: 18, color: OG.muted }}>{name}</div>
+    </div>
+  );
+}
+
+function MenuRow({ label }: { label: string }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 11, padding: '8px 16px' }}>
+      <GlobeIcon color={OG.muted} />
+      <div style={{ fontFamily: sans, fontSize: 19, color: OG.ink }}>{label}</div>
+    </div>
+  );
+}
+
+const TERM_LINES: { text: string; color: string }[] = [
+  { text: '$ agentbox vercel codex', color: OG.accent },
+  { text: '• provisioning box on vercel…', color: OG.termFaint },
+  { text: '✓ box 2 ready · codex', color: OG.accent },
+  { text: '', color: OG.termText },
+  { text: '$ agentbox codex attach 2', color: OG.accent },
+  { text: '> reattaching to running box', color: OG.termFaint },
+  { text: '✓ resumed codex on box 2', color: OG.accent },
+];
+
+// Small labelled icon+text used in the bottom logos strip.
+function LogoItem({ icon, label }: { icon: React.ReactNode; label: string }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+      {icon}
+      <div style={{ fontFamily: sans, fontSize: 22, color: OG.ink }}>{label}</div>
+    </div>
+  );
+}
+
+function iconImg(src: string | null, size = 24): React.ReactNode {
+  if (!src) return <div style={{ display: 'flex', width: size, height: size }} />;
+  return <img src={src} width={size} height={size} style={{ objectFit: 'contain' }} />;
+}
+
+export async function GET() {
+  const [fonts, docker, vercel, hetzner, digitalocean, claude, codex, opencode] =
+    await Promise.all([
+      loadOgFonts(),
+      simpleIcon('docker'),
+      simpleIcon('vercel'),
+      simpleIcon('hetzner'),
+      simpleIcon('digitalocean'),
+      localPng('assets/agent-claude.png'),
+      localPng('assets/agent-codex.png'),
+      localPng('assets/agent-opencode.png'),
+    ]);
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          width: '100%',
+          height: '100%',
+          padding: '46px 64px 30px',
+          backgroundColor: OG.paper,
+          fontFamily: sans,
+          borderBottom: `20px solid ${OG.accent}`,
+        }}
+      >
+      <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', flex: 1, gap: 40 }}>
+        {/* Left: wordmark + headline + lede + install chip */}
+        <div style={{ display: 'flex', flexDirection: 'column', width: 470 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 22 }}>
+            {boxMark(OG.ink, 38)}
+            <div style={{ fontFamily: mono, fontWeight: 600, fontSize: 29, color: OG.ink }}>agentbox</div>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', fontSize: 52, fontWeight: 600, color: OG.ink, lineHeight: 1.08, letterSpacing: '-0.02em' }}>
+            <div style={{ display: 'flex' }}>One command teleport</div>
+            <div style={{ display: 'flex', color: OG.faint }}>for agents, in parallel.</div>
+          </div>
+          <div style={{ fontSize: 23, color: OG.muted, marginTop: 20, lineHeight: 1.4 }}>
+            Isolated, checkpointed VMs — local or in the cloud.
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              alignSelf: 'flex-start',
+              marginTop: 24,
+              padding: '12px 18px',
+              backgroundColor: OG.panel,
+              border: `1px solid ${OG.line}`,
+              borderRadius: 10,
+              fontFamily: mono,
+              fontSize: 21,
+            }}
+          >
+            <span style={{ color: OG.accent }}>npx&nbsp;</span>
+            <span style={{ color: OG.ink }}>@madarco/agentbox claude</span>
+          </div>
+        </div>
+
+        {/* Right: the desktop scene — menu bar + tray dropdown + terminal */}
+        <div
+          style={{
+            position: 'relative',
+            display: 'flex',
+            width: 560,
+            height: 406,
+            backgroundColor: OG.paper,
+            border: `1px solid ${OG.line}`,
+            borderRadius: 16,
+            overflow: 'hidden',
+          }}
+        >
+          {/* menu bar */}
+          <div
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              height: 44,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'flex-end',
+              gap: 14,
+              padding: '0 16px',
+              backgroundColor: '#eeeeea',
+              borderBottom: `1px solid ${OG.line}`,
+            }}
+          >
+            <div style={{ display: 'flex', padding: 4, borderRadius: 6, backgroundColor: '#dcdcd6' }}>{boxMark(OG.ink, 20)}</div>
+            <div style={{ fontFamily: mono, fontSize: 15, color: OG.muted }}>Thu Jul 9  9:41 AM</div>
+          </div>
+
+          {/* terminal window */}
+          <div
+            style={{
+              position: 'absolute',
+              left: 22,
+              bottom: 22,
+              width: 322,
+              display: 'flex',
+              flexDirection: 'column',
+              backgroundColor: OG.term,
+              borderRadius: 12,
+              overflow: 'hidden',
+              boxShadow: '0 18px 40px -12px rgba(0,0,0,0.45)',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 7, padding: '10px 12px', backgroundColor: '#15171b' }}>
+              <div style={{ display: 'flex', width: 11, height: 11, borderRadius: 11, backgroundColor: '#ff5f57' }} />
+              <div style={{ display: 'flex', width: 11, height: 11, borderRadius: 11, backgroundColor: '#febc2e' }} />
+              <div style={{ display: 'flex', width: 11, height: 11, borderRadius: 11, backgroundColor: '#28c840' }} />
+              <div style={{ fontFamily: mono, fontSize: 14, color: OG.termFaint, marginLeft: 8 }}>agentbox — zsh</div>
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', padding: '14px 16px', gap: 6 }}>
+              {TERM_LINES.map((l, i) => (
+                <div key={i} style={{ display: 'flex', fontFamily: mono, fontSize: 15, color: l.color, height: 19 }}>
+                  {l.text}
+                </div>
+              ))}
+              <div style={{ display: 'flex', fontFamily: mono, fontSize: 15, marginTop: 2 }}>
+                <span style={{ color: '#6ea8fe' }}>user@box-2:~/workspace$</span>
+                <span style={{ color: OG.accent }}>&nbsp;▏</span>
+              </div>
+            </div>
+          </div>
+
+          {/* tray dropdown */}
+          <div
+            style={{
+              position: 'absolute',
+              right: 18,
+              top: 30,
+              width: 288,
+              display: 'flex',
+              flexDirection: 'column',
+              backgroundColor: OG.panel,
+              border: `1px solid ${OG.line}`,
+              borderRadius: 14,
+              paddingTop: 6,
+              paddingBottom: 6,
+              boxShadow: '0 22px 50px -14px rgba(0,0,0,0.28)',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', padding: '10px 16px 12px' }}>
+              <div style={{ fontFamily: sans, fontWeight: 600, fontSize: 23, color: OG.ink }}>AgentBox</div>
+              <div
+                style={{
+                  marginLeft: 'auto',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 6,
+                  padding: '6px 12px',
+                  backgroundColor: OG.accent,
+                  borderRadius: 8,
+                  color: '#ffffff',
+                  fontFamily: sans,
+                  fontWeight: 600,
+                  fontSize: 16,
+                }}
+              >
+                + New Box
+              </div>
+            </div>
+            <div style={{ display: 'flex', height: 1, backgroundColor: OG.line, margin: '0 12px' }} />
+            <FolderRow name="storefront-web" />
+            <BoxRow name="payment-retries" sub="codex · vercel" />
+            <FolderRow name="docs-site" />
+            <BoxRow name="search-filters" sub="claude · vercel" />
+            <div style={{ display: 'flex', height: 1, backgroundColor: OG.line, margin: '6px 12px' }} />
+            <MenuRow label="Open Hub" />
+          </div>
+        </div>
+      </div>
+
+        {/* Logos strip: clouds + agents (mirrors the home "works with" row) */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 14, marginTop: 26, paddingTop: 22, borderTop: `1px solid ${OG.line}` }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 26 }}>
+            <div style={{ fontFamily: mono, fontSize: 18, color: OG.faint, width: 84 }}>clouds</div>
+            <LogoItem icon={iconImg(docker)} label="Docker" />
+            <LogoItem icon={iconImg(vercel)} label="Vercel" />
+            <LogoItem icon={iconImg(hetzner)} label="Hetzner" />
+            <LogoItem icon={iconImg(digitalocean)} label="DigitalOcean" />
+            <LogoItem icon={cubeMark(OG.ink, 22)} label="Daytona" />
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 26 }}>
+            <div style={{ fontFamily: mono, fontSize: 18, color: OG.faint, width: 84 }}>agents</div>
+            <LogoItem icon={iconImg(claude)} label="Claude Code" />
+            <LogoItem icon={iconImg(codex)} label="Codex" />
+            <LogoItem icon={iconImg(opencode)} label="OpenCode" />
+          </div>
+        </div>
+      </div>
+    ),
+    { width: 1200, height: 630, fonts: fonts.length ? fonts : undefined },
+  );
+}

--- a/apps/web/content/docs/remote-docker.mdx
+++ b/apps/web/content/docs/remote-docker.mdx
@@ -1,6 +1,6 @@
 ---
 title: Remote Docker
-description: Run your agents on a machine you already own — the workstation under the desk, a team server — over SSH
+description: Run your agents on a machine you already own, using Docker over SSH
 ---
 
 Run boxes on a machine you already own instead of your laptop or a cloud: the workstation under the desk, a spare Mac, a team server. AgentBox SSHes in and drives **that machine's Docker engine**, so the box gets its CPU, its RAM and its disk while your laptop stays cool and its fans stay quiet. No account, no API token, no bill — if `ssh <host> docker version` works from your terminal, you can run boxes there.

--- a/apps/web/lib/og.tsx
+++ b/apps/web/lib/og.tsx
@@ -1,0 +1,139 @@
+import type { ReactElement } from 'react';
+
+// Home-page theme tokens (public/home.html :root) so OG images match the site.
+export const OG = {
+  paper: '#f6f6f3',
+  panel: '#ffffff',
+  ink: '#16181c',
+  muted: '#7b818b',
+  faint: '#a4a9b0',
+  line: '#e3e3dd',
+  accent: '#128a4f',
+  accentSoft: '#eaf4ee',
+  term: '#0e1218',
+  termText: '#c8ccd3',
+  termFaint: '#7c828c',
+} as const;
+
+// IBM Plex (the site's typefaces) as raw TTF for satori — Google Fonts serves
+// woff2, which satori can't parse; the IBM/plex repo ships complete TTFs.
+const PLEX = 'https://cdn.jsdelivr.net/gh/IBM/plex@v6.4.0';
+const FONT_URLS = {
+  sans400: `${PLEX}/IBM-Plex-Sans/fonts/complete/ttf/IBMPlexSans-Regular.ttf`,
+  sans600: `${PLEX}/IBM-Plex-Sans/fonts/complete/ttf/IBMPlexSans-SemiBold.ttf`,
+  mono400: `${PLEX}/IBM-Plex-Mono/fonts/complete/ttf/IBMPlexMono-Regular.ttf`,
+  mono600: `${PLEX}/IBM-Plex-Mono/fonts/complete/ttf/IBMPlexMono-SemiBold.ttf`,
+} as const;
+
+export interface OgFont {
+  name: string;
+  data: ArrayBuffer;
+  weight: 400 | 600;
+  style: 'normal';
+}
+
+async function fetchFont(url: string): Promise<ArrayBuffer | null> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    return await res.arrayBuffer();
+  } catch {
+    return null;
+  }
+}
+
+// Fetch once per server process; satori tolerates missing fonts (falls back to
+// a built-in sans) so a flaky CDN degrades gracefully rather than failing build.
+let fontsPromise: Promise<OgFont[]> | null = null;
+export function loadOgFonts(): Promise<OgFont[]> {
+  fontsPromise ??= (async () => {
+    const [sans400, sans600, mono400, mono600] = await Promise.all([
+      fetchFont(FONT_URLS.sans400),
+      fetchFont(FONT_URLS.sans600),
+      fetchFont(FONT_URLS.mono400),
+      fetchFont(FONT_URLS.mono600),
+    ]);
+    const fonts: OgFont[] = [];
+    if (sans400)
+      fonts.push({ name: 'IBM Plex Sans', data: sans400, weight: 400, style: 'normal' });
+    if (sans600)
+      fonts.push({ name: 'IBM Plex Sans', data: sans600, weight: 600, style: 'normal' });
+    if (mono400)
+      fonts.push({ name: 'IBM Plex Mono', data: mono400, weight: 400, style: 'normal' });
+    if (mono600)
+      fonts.push({ name: 'IBM Plex Mono', data: mono600, weight: 600, style: 'normal' });
+    return fonts;
+  })();
+  return fontsPromise;
+}
+
+// Brand icons as data URIs so satori can inline them (it can't reliably fetch
+// remote images at render time). SVGs come from Simple Icons tinted to ink;
+// agent glyphs are the local PNGs the home page uses. Memoized per process.
+const iconCache = new Map<string, Promise<string | null>>();
+
+export function simpleIcon(slug: string): Promise<string | null> {
+  const key = `si:${slug}`;
+  if (!iconCache.has(key)) {
+    iconCache.set(
+      key,
+      (async () => {
+        try {
+          const res = await fetch(`https://cdn.simpleicons.org/${slug}/16181c`);
+          if (!res.ok) return null;
+          const svg = await res.text();
+          return `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`;
+        } catch {
+          return null;
+        }
+      })(),
+    );
+  }
+  return iconCache.get(key)!;
+}
+
+export function localPng(relPathFromPublic: string): Promise<string | null> {
+  const key = `png:${relPathFromPublic}`;
+  if (!iconCache.has(key)) {
+    iconCache.set(
+      key,
+      (async () => {
+        try {
+          const { readFile } = await import('node:fs/promises');
+          const { join } = await import('node:path');
+          const buf = await readFile(join(process.cwd(), 'public', relPathFromPublic));
+          return `data:image/png;base64,${buf.toString('base64')}`;
+        } catch {
+          return null;
+        }
+      })(),
+    );
+  }
+  return iconCache.get(key)!;
+}
+
+// A simple 3D cube (Daytona has no Simple Icon; mirrors home.html's #i-cube).
+export function cubeMark(color: string, size = 22): ReactElement {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="1.8" strokeLinejoin="round">
+      <path d="M12 2 21 7v10l-9 5-9-5V7z" />
+      <path d="M12 12 21 7M12 12v10M12 12 3 7" />
+    </svg>
+  );
+}
+
+// The AgentBox box mark (public/logo.svg), tintable to sit on light or dark.
+export function boxMark(color: string, size = 60): ReactElement {
+  return (
+    <svg width={size} height={size} viewBox="0 0 385 382" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M325 16H59C35.804 16 17 34.804 17 58V324C17 347.196 35.804 366 59 366H325C348.196 366 367 347.196 367 324V58C367 34.804 348.196 16 325 16Z"
+        fill="none"
+        stroke={color}
+        strokeWidth="31"
+      />
+      <path d="M255 191H129V317H255V191Z" stroke={color} strokeWidth="10" />
+      <path d="M236 210H148V298H236V210Z" fill={color} />
+    </svg>
+  );
+}

--- a/apps/web/public/home.html
+++ b/apps/web/public/home.html
@@ -13,16 +13,16 @@
 <meta property="og:url" content="https://agent-box.sh/" />
 <meta property="og:title" content="AgentBox — Teleport for agents" />
 <meta property="og:description" content="AgentBox teleports your project into an isolated VM — local or in the cloud — and runs Claude Code, Codex, or OpenCode inside it. Checkpointed, parallel, on hardware you control." />
-<meta property="og:image" content="https://agent-box.sh/public/cover.jpg" />
-<meta property="og:image:width" content="1586" />
-<meta property="og:image:height" content="992" />
+<meta property="og:image" content="https://agent-box.sh/home-og" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
 <meta property="og:image:alt" content="AgentBox — one command teleport for coding agents" />
 
 <!-- Twitter card -->
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="AgentBox — Teleport for agents" />
 <meta name="twitter:description" content="AgentBox teleports your project into an isolated VM — local or in the cloud — and runs Claude Code, Codex, or OpenCode inside it. Checkpointed, parallel, on hardware you control." />
-<meta name="twitter:image" content="https://agent-box.sh/public/cover.jpg" />
+<meta name="twitter:image" content="https://agent-box.sh/home-og" />
 <meta name="twitter:creator" content="@madarco" />
 
 <link rel="icon" type="image/svg+xml" href="/public/logo.svg" />


### PR DESCRIPTION
## What

Replaces the single static `cover.jpg` social preview with dynamic, on-brand Open Graph images.

**Docs pages** now generate a per-page OG image (page title + description, `agentbox` lockup, and the tagline "One command teleport for agents, in parallel.") via a statically-generated `/docs-og/[...slug]` route wired into `generateMetadata`. Light "paper" theme matching the site.

**Home page** OG image is a themed recreation of the hero — the macOS menu-bar tray dropdown + terminal — plus a `clouds` / `agents` logos strip (Docker, Vercel, Hetzner, DigitalOcean, Daytona; Claude Code, Codex, OpenCode). Served from a `force-static` `/home-og` route; `home.html`'s `og:image`/`twitter:image` now point to it.

Shared theme tokens, IBM Plex font loading (TTF from the IBM/plex mirror — Google serves woff2 which satori can't parse), and brand-mark / Simple-Icons / agent data-URI helpers live in `apps/web/lib/og.tsx`.

Also tightens the `remote-docker.mdx` description line.

## Verify

- `pnpm --filter @agentbox/web build` — prerenders all per-page docs images + the static `/home-og`; TypeScript passes.
- Routes return `200 image/png` at 1200x630; served `/` and `/docs/*` HTML carry the new `og:image`/`twitter:image` tags.
- Rendered images eyeballed for branding (light theme, green accent, logos, tagline).

https://claude.ai/code/session_011AZJCp2TCjoruA6cqBkZv6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing/metadata and build-time image generation only; no auth, data, or runtime business logic changes.
> 
> **Overview**
> Replaces the shared static `cover.jpg` social preview with **on-brand Open Graph images** generated at build time via `next/og` (`ImageResponse`).
> 
> **Docs** get a per-page 1200×630 image (title, description, agentbox lockup) from a new `/docs-og/[...slug]` route; `generateMetadata` on docs pages now points Open Graph and Twitter at those URLs instead of `SITE.ogImage`.
> 
> **Home** (`public/home.html`) now references a **force-static** `/home-og` route that renders a hero-style preview (tray UI, terminal, clouds/agents logo strip). Shared styling, IBM Plex TTF loading, and icon helpers live in `lib/og.tsx`.
> 
> Also shortens the frontmatter `description` on `remote-docker.mdx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f58e98eceeb391173b448ca93534f4daad697a1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->