### PR TITLE
feat(hub): reverse-adoption + CLI on /api/v1 (consolidation Phase 1+2 subset)

### DIFF
--- a/apps/cli/src/commands/control-plane.ts
+++ b/apps/cli/src/commands/control-plane.ts
@@ -47,7 +47,7 @@ import {
   planPush,
   type UploadItem,
 } from '../control-plane/custody-client.js';
-import { ControlPlaneAdminClient } from '../control-plane/admin-client.js';
+import { HubApiClient, HubApiError, type HubLifecycleAction } from '../control-plane/hub-api-client.js';
 import { loadControlPlaneEnv } from '../control-plane/env-file.js';
 import { AGENT_SYNC_SPECS } from '@agentbox/sandbox-core';
 import { handleLifecycleError } from './_errors.js';
@@ -595,6 +595,19 @@ export async function resolveHubApiTarget(
 }
 
 /**
+ * Build a {@link HubApiClient} for the configured hub from {@link resolveHubApiTarget}
+ * (URL + `/api/v1` key), or null (with an actionable error unless `quiet`) when
+ * unconfigured. The client-facing counterpart to `new ControlPlaneAdminClient`.
+ */
+export async function resolveHubApiClient(
+  urlFlag: string | undefined,
+  opts: { quiet?: boolean } = {},
+): Promise<HubApiClient | null> {
+  const target = await resolveHubApiTarget(urlFlag, opts);
+  return target ? new HubApiClient(target) : null;
+}
+
+/**
  * Slug a project into a custody `projects/<slug>` key: `owner__repo`, else the
  * dir name.
  *
@@ -911,33 +924,27 @@ const custodyCmd = new Command('custody')
 // --- control-plane box registry (the PC's admin view of the control box) ---
 
 const boxesListSub = new Command('list')
-  .description('List boxes registered on the control box')
+  .description('List boxes on the control box (via its /api/v1)')
   .option('--url <url>', 'override the control-plane URL (default: relay.controlPlaneUrl)')
   .option('--json', 'print raw JSON')
   .action(async (opts: { url?: string; json?: boolean }) => {
     try {
-      const target = await resolveCustodyTarget(opts.url);
-      if (!target) {
+      const client = await resolveHubApiClient(opts.url);
+      if (!client) {
         process.exitCode = 1;
         return;
       }
-      const client = new ControlPlaneAdminClient(target);
-      const [boxes, statuses] = await Promise.all([client.listBoxes(), client.store.listStatuses()]);
+      const boxes = await client.listBoxes();
       if (opts.json) {
-        process.stdout.write(`${JSON.stringify({ boxes, statuses }, null, 2)}\n`);
+        process.stdout.write(`${JSON.stringify({ boxes }, null, 2)}\n`);
         return;
       }
       if (boxes.length === 0) {
-        log.info('No boxes registered on the control box.');
+        log.info('No boxes on the control box.');
         return;
       }
-      const statusBy = new Map(statuses.map((s) => [s.boxId, s.status]));
       for (const b of boxes) {
-        const st = statusBy.get(b.boxId);
-        const state = st && typeof st === 'object' && 'state' in st ? String((st as { state?: unknown }).state) : '-';
-        process.stdout.write(
-          `${b.boxId}  ${b.name}  ${b.kind ?? 'docker'}${b.backend ? `/${b.backend}` : ''}  ${state}\n`,
-        );
+        process.stdout.write(`${b.id}  ${b.name ?? b.task}  ${b.provider}  ${b.state ?? b.status}\n`);
       }
     } catch (err) {
       handleLifecycleError(err);
@@ -945,38 +952,65 @@ const boxesListSub = new Command('list')
   });
 
 const boxesRmSub = new Command('rm')
-  .description('Reap a box from the control box (registration + status + SSH-key custody; NOT the cloud resource)')
+  .description('Destroy a box via the control box (tears down the cloud resource AND reaps its registration/custody)')
   .argument('<boxId>', 'the box id as shown by `control-plane boxes list`')
   .option('--url <url>', 'override the control-plane URL (default: relay.controlPlaneUrl)')
   .action(async (boxId: string, opts: { url?: string }) => {
     try {
-      const target = await resolveCustodyTarget(opts.url);
-      if (!target) {
+      const client = await resolveHubApiClient(opts.url);
+      if (!client) {
         process.exitCode = 1;
         return;
       }
-      const client = new ControlPlaneAdminClient(target);
-      const res = await client.reapBox(boxId);
-      if (!res.removed && res.custodyRemoved === 0) {
+      // Reverse-adoption on the control box means this drives a REAL destroy even
+      // for a box created on the PC (registration-only) — not just a state reap.
+      await client.destroy(boxId);
+      log.success(`Destroyed '${boxId}' (cloud resource + control-box state).`);
+    } catch (err) {
+      if (err instanceof HubApiError && err.code === 'not_found') {
         log.info(`No box '${boxId}' on the control box.`);
         return;
       }
-      log.success(
-        `Reaped '${boxId}': registration ${res.removed ? 'removed' : 'absent'}, ` +
-          `${String(res.custodyRemoved)} custody file(s) removed. ` +
-          `(The cloud resource, if any, is untouched — destroy it from the hub or its provider.)`,
-      );
-    } catch (err) {
       handleLifecycleError(err);
     }
   });
 
+/** A `control-plane boxes <action>` lifecycle subcommand over the hub `/api/v1`. */
+function boxesLifecycleSub(action: HubLifecycleAction, verb: string, past: string): Command {
+  return new Command(action)
+    .description(`${verb} a box on the control box (via its /api/v1)`)
+    .argument('<boxId>', 'the box id as shown by `control-plane boxes list`')
+    .option('--url <url>', 'override the control-plane URL (default: relay.controlPlaneUrl)')
+    .action(async (boxId: string, opts: { url?: string }) => {
+      try {
+        const client = await resolveHubApiClient(opts.url);
+        if (!client) {
+          process.exitCode = 1;
+          return;
+        }
+        await client.lifecycle(boxId, action);
+        log.success(`${past} '${boxId}'.`);
+      } catch (err) {
+        if (err instanceof HubApiError && err.code === 'not_found') {
+          log.info(`No box '${boxId}' on the control box.`);
+          process.exitCode = 1;
+          return;
+        }
+        handleLifecycleError(err);
+      }
+    });
+}
+
 const boxesCmd = new Command('boxes')
-  .description('List + reap boxes registered on the control box')
+  .description('List + drive boxes on the control box over its public /api/v1')
   .addCommand(boxesListSub)
+  .addCommand(boxesLifecycleSub('start', 'Start', 'Started'))
+  .addCommand(boxesLifecycleSub('stop', 'Stop', 'Stopped'))
+  .addCommand(boxesLifecycleSub('pause', 'Pause', 'Paused'))
+  .addCommand(boxesLifecycleSub('resume', 'Resume', 'Resumed'))
   .addCommand(boxesRmSub);
 
-// --- control-plane approvals (answerable from the PC) ---
+// --- control-plane approvals (answerable from the PC over /api/v1) ---
 
 const promptsListSub = new Command('list')
   .description('List pending host-action approvals across control-box boxes')
@@ -984,23 +1018,25 @@ const promptsListSub = new Command('list')
   .option('--json', 'print raw JSON')
   .action(async (opts: { url?: string; json?: boolean }) => {
     try {
-      const target = await resolveCustodyTarget(opts.url);
-      if (!target) {
+      const client = await resolveHubApiClient(opts.url);
+      if (!client) {
         process.exitCode = 1;
         return;
       }
-      const client = new ControlPlaneAdminClient(target);
-      const pending = await client.pendingPrompts();
+      // One call returns every pending approval (vs the admin wire's N per-box
+      // fetches); cross-ref the box list once for human-readable names.
+      const [approvals, boxes] = await Promise.all([client.listApprovals(), client.listBoxes().catch(() => [])]);
       if (opts.json) {
-        process.stdout.write(`${JSON.stringify(pending, null, 2)}\n`);
+        process.stdout.write(`${JSON.stringify(approvals, null, 2)}\n`);
         return;
       }
-      if (pending.length === 0) {
+      if (approvals.length === 0) {
         log.info('No pending approvals.');
         return;
       }
-      for (const p of pending) {
-        process.stdout.write(`${p.prompt.id}  [${p.boxName}]  ${p.prompt.message}\n`);
+      const nameBy = new Map(boxes.map((b) => [b.id, b.name ?? b.task]));
+      for (const a of approvals) {
+        process.stdout.write(`${a.id}  [${nameBy.get(a.boxId) ?? a.boxId}]  ${a.message}\n`);
       }
     } catch (err) {
       handleLifecycleError(err);
@@ -1019,19 +1055,19 @@ const promptsAnswerSub = new Command('answer')
         process.exitCode = 1;
         return;
       }
-      const target = await resolveCustodyTarget(opts.url);
-      if (!target) {
+      const client = await resolveHubApiClient(opts.url);
+      if (!client) {
         process.exitCode = 1;
         return;
       }
-      const client = new ControlPlaneAdminClient(target);
-      const ok = await client.answerPrompt(id, answer);
-      if (ok) log.success(`Answered ${id} → ${answer}.`);
-      else {
+      await client.answerApproval(id, answer);
+      log.success(`Answered ${id} → ${answer}.`);
+    } catch (err) {
+      if (err instanceof HubApiError && err.code === 'not_found') {
         log.info(`No pending approval with id ${id} (already answered or expired?).`);
         process.exitCode = 1;
+        return;
       }
-    } catch (err) {
       handleLifecycleError(err);
     }
   });

--- a/apps/cli/src/control-plane/hub-adopt.ts
+++ b/apps/cli/src/control-plane/hub-adopt.ts
@@ -19,17 +19,15 @@
  * is unit-testable with fake clients + a temp HOME, mirroring `hub-pull.ts`.
  */
 import { execa } from 'execa';
-import type { BoxRecord, GitWorktreeRecord, SshTargetRecord } from '@agentbox/core';
-import { boxSshDirForProvider, readState } from '@agentbox/sandbox-core';
+import type { BoxRecord } from '@agentbox/core';
+import { readState } from '@agentbox/sandbox-core';
 import { generateRelayToken, recordBox } from '@agentbox/sandbox-docker';
 import { allocateProjectIndex } from '@agentbox/sandbox-core';
+import { registrationToBoxRecord } from '@agentbox/relay';
 import type { CustodyClient } from './custody-client.js';
 import type { ControlPlaneAdminClient } from './admin-client.js';
 import { downloadBoxSshKeys } from './hub-pull.js';
 import { matchRegistration } from './match-ref.js';
-
-/** Box user on every cloud provider's image (the agent never runs as root). */
-const BOX_SSH_USER = 'vscode';
 
 export interface HubAdoptArgs {
   admin: ControlPlaneAdminClient;
@@ -145,7 +143,6 @@ export async function adoptHubBox(args: HubAdoptArgs): Promise<HubAdoptResult> {
   const reg = matchRegistration(registrations, args.ref);
   if (!reg) throw new HubBoxNotFoundError(args.ref);
 
-  const provider = reg.backend ?? 'docker';
   const sandboxId = reg.sandboxId ?? reg.boxId;
 
   const state = await readState();
@@ -166,64 +163,17 @@ export async function adoptHubBox(args: HubAdoptArgs): Promise<HubAdoptResult> {
     existing?.projectIndex ??
     (projectRoot ? allocateProjectIndex(state, projectRoot) : undefined);
 
-  const branch = reg.worktrees?.[0]?.branch ?? `agentbox/${reg.name}`;
-  const sanctionedBranch = reg.worktrees?.[0]?.sanctionedBranch ?? branch;
-
-  // Point git worktree bookkeeping at the LOCAL clone. The registration's
-  // hostMainRepo is the control box's temp create-time checkout (deleted after
-  // create), so carrying it over would make host-side git RPCs run against a
-  // path that doesn't exist here.
-  const gitWorktrees: GitWorktreeRecord[] | undefined = projectRoot
-    ? [
-        {
-          kind: 'root',
-          branch,
-          sanctionedBranch,
-          containerPath: '/workspace',
-          hostMainRepo: projectRoot,
-          gitWorktreePath: '',
-          relPathFromWorkspace: '',
-        },
-      ]
-    : undefined;
-
-  const record: BoxRecord = {
-    id: existing?.id ?? reg.boxId,
-    name: reg.name,
-    displayName: existing?.displayName,
-    provider,
-    container: `cloud:${sandboxId}`,
-    image: reg.image ?? existing?.image ?? '',
-    workspacePath: projectRoot ?? existing?.workspacePath ?? '/workspace',
+  // One source of truth for registration → record reconstruction, shared with
+  // the control box's own `hydrateRegisteredBox` (@agentbox/relay). The PC-only
+  // concerns — which local project the box maps to, its per-project index, and
+  // the SSH-key download below — stay here.
+  const record: BoxRecord = registrationToBoxRecord(reg, {
+    controlPlaneUrl: args.controlPlaneUrl,
+    existing,
     projectRoot,
     projectIndex,
-    // Tokens are regenerated only for a fresh adoption; a re-adopt keeps the
-    // box's live tokens (they're already injected in the running box).
-    relayToken: existing?.relayToken ?? reg.token ?? generateRelayToken(),
-    lastAgent: normalizeAgent(reg.agent) ?? existing?.lastAgent,
-    gitWorktrees,
-    createdAt: reg.createdAt ?? existing?.createdAt ?? new Date().toISOString(),
-    ssh: buildSshTarget(provider, sandboxId, reg.publicHost) ?? existing?.ssh,
-    cloud: {
-      ...existing?.cloud,
-      backend: provider,
-      sandboxId,
-      image: reg.image ?? existing?.cloud?.image,
-      webPort: reg.webPort ?? existing?.cloud?.webPort,
-      publicHost: reg.publicHost ?? existing?.cloud?.publicHost,
-      bridgeToken: reg.bridgeToken ?? existing?.cloud?.bridgeToken ?? generateRelayToken(),
-      relayPreviewUrl: reg.previewUrl ?? existing?.cloud?.relayPreviewUrl,
-      relayPreviewToken: reg.previewToken ?? existing?.cloud?.relayPreviewToken,
-      workspaceBranch: branch,
-      sanctionedBranch,
-      lastState: existing?.cloud?.lastState ?? 'running',
-      topology: 'control-plane',
-      controlPlaneUrl: args.controlPlaneUrl,
-      // A hub-created box clones in-box from a leased URL — it shares no fork
-      // base with this PC, so the session-start live resync must skip it.
-      hostSeeded: undefined,
-    },
-  };
+    freshToken: generateRelayToken,
+  });
 
   // Key material: only providers that mint a keypair (hetzner/DO) have any.
   // Detected by what's actually in custody rather than by provider name, so a
@@ -254,33 +204,4 @@ export async function adoptHubBox(args: HubAdoptArgs): Promise<HubAdoptResult> {
 
   await recordBox(record);
   return { record, sshFiles, projectRoot, refreshed: existing !== undefined, sshKeysMissing };
-}
-
-/** Narrow a registration's free-form agent string to the record's union. */
-function normalizeAgent(agent: string | undefined): BoxRecord['lastAgent'] {
-  return agent === 'claude' || agent === 'codex' || agent === 'opencode' ? agent : undefined;
-}
-
-/**
- * The box's SSH target, or undefined when the registration carries no host.
- *
- * `identityFile` is set only when the provider actually has a per-box key dir:
- * a provider that reports a `publicHost` but mints no keypair would otherwise
- * get `"/id_ed25519"` — an absolute path at the filesystem root — written into
- * the record and into the generated `~/.agentbox/ssh/config`. Omitting it leaves
- * ssh to its normal key resolution (agent / default identities) instead of
- * pointing at a file that cannot exist.
- */
-function buildSshTarget(
-  provider: string,
-  sandboxId: string,
-  publicHost: string | undefined,
-): SshTargetRecord | undefined {
-  if (!publicHost) return undefined;
-  const dir = boxSshDirForProvider(provider, sandboxId);
-  return {
-    host: publicHost,
-    user: BOX_SSH_USER,
-    ...(dir ? { identityFile: `${dir}/id_ed25519` } : {}),
-  };
 }

--- a/apps/cli/src/control-plane/hub-api-client.ts
+++ b/apps/cli/src/control-plane/hub-api-client.ts
@@ -1,0 +1,166 @@
+/**
+ * The PC's client for a hub's public REST API (`/api/v1`) — the SAME surface the
+ * tray and web UI speak. Its only local⇄remote difference is the base URL + token
+ * (a control box's `AGENTBOX_HUB_API_KEY`, or a local hub's token), so a command
+ * built on this client works against either by swapping the target.
+ *
+ * Distinct from {@link ControlPlaneAdminClient}, which speaks the INTERNAL relay
+ * wire (`/admin/*` + `/remote/*`) — the box↔hub + credential plane that is not a
+ * client API. Client-facing box operations (list, lifecycle, git, approvals)
+ * belong here; custody / registration / RPC-lease stay on the admin client.
+ */
+
+/** A hub box as the `/api/v1` list/get returns it (the UI view + raw host fields). */
+export interface HubApiBox {
+  id: string;
+  name?: string;
+  provider: string;
+  /** Raw provider runtime state; absent on synthetic in-flight `job:` boxes. */
+  state?: 'running' | 'paused' | 'stopped' | 'missing' | 'destroyed';
+  /** Normalized lifecycle status (running | paused | stopped | creating | error). */
+  status: string;
+  branch: string;
+  task: string;
+  projectRoot?: string;
+  projectIndex?: number;
+}
+
+/** A create-job's status as `/api/v1/jobs/:id` returns it. */
+export interface HubApiJob {
+  id: string;
+  status: 'queued' | 'running' | 'done' | 'failed' | string;
+  boxId?: string;
+  login?: {
+    required?: boolean;
+    phase?: string;
+    url?: string;
+    error?: string;
+    lastError?: string;
+  };
+}
+
+/** A pending host-action approval as `/api/v1/approvals` returns it. */
+export interface HubApiApproval {
+  id: string;
+  boxId: string;
+  message: string;
+  detail?: string;
+  command?: string;
+  cwd?: string;
+  argv?: string[];
+  defaultAnswer: 'y' | 'n';
+  createdAt: number;
+}
+
+/** Result of a box git/service op (mirrors the backend `BoxOpResult`). */
+export interface HubApiOpResult {
+  ok: boolean;
+  stdout?: string;
+  stderr?: string;
+  error?: string;
+}
+
+export type HubLifecycleAction = 'start' | 'pause' | 'resume' | 'stop' | 'destroy';
+export type HubGitOp = 'checkout' | 'branch' | 'pull' | 'push' | 'push-host';
+
+export interface HubApiTarget {
+  url: string;
+  apiKey: string;
+  fetchImpl?: typeof fetch;
+}
+
+/** An error carrying the `/api/v1` envelope's code + HTTP status. */
+export class HubApiError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = 'HubApiError';
+  }
+}
+
+interface ApiErrorBody {
+  error?: { code?: string; message?: string; details?: unknown };
+}
+
+export class HubApiClient {
+  private readonly base: string;
+  private readonly token: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(target: HubApiTarget) {
+    this.base = target.url.replace(/\/+$/, '');
+    this.token = target.apiKey;
+    this.fetchImpl = target.fetchImpl ?? fetch;
+  }
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const res = await this.fetchImpl(`${this.base}/api/v1${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+    if (res.status === 204) return undefined as T;
+    const text = await res.text();
+    let parsed: unknown;
+    try {
+      parsed = text.length > 0 ? JSON.parse(text) : {};
+    } catch {
+      throw new HubApiError(`unexpected non-JSON response (${res.status})`, 'internal', res.status);
+    }
+    if (!res.ok) {
+      const err = (parsed as ApiErrorBody).error;
+      throw new HubApiError(
+        err?.message ?? `request failed: ${res.status}`,
+        err?.code ?? 'internal',
+        res.status,
+      );
+    }
+    return parsed as T;
+  }
+
+  /** All boxes the hub knows (its own + registered). Topology-agnostic read. */
+  async listBoxes(): Promise<HubApiBox[]> {
+    return (await this.request<{ boxes: HubApiBox[] }>('GET', '/boxes')).boxes;
+  }
+
+  /** One box by id (throws HubApiError 'not_found' when absent). */
+  getBox(id: string): Promise<HubApiBox> {
+    return this.request<HubApiBox>('GET', `/boxes/${encodeURIComponent(id)}`);
+  }
+
+  /** Lifecycle action on a box. Reverse-adoption lets the hub drive registered-only boxes. */
+  async lifecycle(id: string, action: HubLifecycleAction): Promise<void> {
+    await this.request<{ ok: true }>('POST', `/boxes/${encodeURIComponent(id)}/${action}`);
+  }
+
+  /** Real destroy: tears down the cloud resource AND reaps the hub's registration/custody. */
+  destroy(id: string): Promise<void> {
+    return this.lifecycle(id, 'destroy');
+  }
+
+  /** A git op against the box's branch. */
+  git(id: string, op: HubGitOp, body: Record<string, unknown> = {}): Promise<HubApiOpResult> {
+    return this.request<HubApiOpResult>('POST', `/boxes/${encodeURIComponent(id)}/git/${op}`, body);
+  }
+
+  /** Create-job status (poll until done/failed). */
+  getJob(id: string): Promise<HubApiJob> {
+    return this.request<HubApiJob>('GET', `/jobs/${encodeURIComponent(id)}`);
+  }
+
+  /** Pending host-action approvals across every box. */
+  async listApprovals(): Promise<HubApiApproval[]> {
+    return (await this.request<{ approvals: HubApiApproval[] }>('GET', '/approvals')).approvals;
+  }
+
+  /** Answer a pending approval by id. */
+  async answerApproval(id: string, answer: 'y' | 'n'): Promise<void> {
+    await this.request<{ ok: true }>('POST', `/approvals/${encodeURIComponent(id)}/answer`, { answer });
+  }
+}

--- a/apps/cli/test/hub-api-client.test.ts
+++ b/apps/cli/test/hub-api-client.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { HubApiClient, HubApiError } from '../src/control-plane/hub-api-client.js';
+
+interface Call {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body?: unknown;
+}
+
+/** A fetch stub that records calls and replies from a per-path table. */
+function stub(
+  replies: Record<string, { status: number; body?: unknown }>,
+): { fetchImpl: typeof fetch; calls: Call[] } {
+  const calls: Call[] = [];
+  const fetchImpl = (async (url: string | URL, init?: RequestInit) => {
+    const u = String(url);
+    const method = init?.method ?? 'GET';
+    calls.push({
+      url: u,
+      method,
+      headers: (init?.headers as Record<string, string>) ?? {},
+      body: init?.body ? JSON.parse(init.body as string) : undefined,
+    });
+    const key = `${method} ${new URL(u).pathname}`;
+    const reply = replies[key] ?? { status: 404, body: { error: { code: 'not_found', message: 'no route' } } };
+    return new Response(reply.body === undefined ? null : JSON.stringify(reply.body), {
+      status: reply.status,
+    });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+const target = (fetchImpl: typeof fetch) => ({ url: 'https://hub.example/', apiKey: 'KEY', fetchImpl });
+
+describe('HubApiClient', () => {
+  it('lists boxes and unwraps the envelope', async () => {
+    const { fetchImpl, calls } = stub({
+      'GET /api/v1/boxes': { status: 200, body: { boxes: [{ id: 'b1', provider: 'e2b', status: 'running', branch: 'x', task: 't' }] } },
+    });
+    const boxes = await new HubApiClient(target(fetchImpl)).listBoxes();
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0]!.id).toBe('b1');
+    // Bearer auth + the /api/v1 base URL (trailing slash on the target trimmed).
+    expect(calls[0]!.url).toBe('https://hub.example/api/v1/boxes');
+    expect(calls[0]!.headers.Authorization).toBe('Bearer KEY');
+  });
+
+  it('posts a lifecycle action to the right path', async () => {
+    const { fetchImpl, calls } = stub({ 'POST /api/v1/boxes/b1/pause': { status: 200, body: { ok: true } } });
+    await new HubApiClient(target(fetchImpl)).lifecycle('b1', 'pause');
+    expect(calls[0]!.method).toBe('POST');
+    expect(calls[0]!.url).toBe('https://hub.example/api/v1/boxes/b1/pause');
+  });
+
+  it('destroy maps to the destroy lifecycle action', async () => {
+    const { fetchImpl, calls } = stub({ 'POST /api/v1/boxes/b1/destroy': { status: 200, body: { ok: true } } });
+    await new HubApiClient(target(fetchImpl)).destroy('b1');
+    expect(calls[0]!.url).toBe('https://hub.example/api/v1/boxes/b1/destroy');
+  });
+
+  it('answers an approval with the answer body', async () => {
+    const { fetchImpl, calls } = stub({ 'POST /api/v1/approvals/p1/answer': { status: 200, body: { ok: true } } });
+    await new HubApiClient(target(fetchImpl)).answerApproval('p1', 'y');
+    expect(calls[0]!.body).toEqual({ answer: 'y' });
+  });
+
+  it('throws a typed HubApiError carrying the envelope code + status', async () => {
+    const { fetchImpl } = stub({
+      'POST /api/v1/boxes/gone/pause': { status: 404, body: { error: { code: 'not_found', message: 'box not found: gone' } } },
+    });
+    const client = new HubApiClient(target(fetchImpl));
+    await expect(client.lifecycle('gone', 'pause')).rejects.toMatchObject({
+      name: 'HubApiError',
+      code: 'not_found',
+      status: 404,
+    });
+    await expect(client.lifecycle('gone', 'pause')).rejects.toBeInstanceOf(HubApiError);
+  });
+
+  it('treats 204 as a successful empty response', async () => {
+    const { fetchImpl } = stub({ 'POST /api/v1/boxes/b1/stop': { status: 204 } });
+    await expect(new HubApiClient(target(fetchImpl)).lifecycle('b1', 'stop')).resolves.toBeUndefined();
+  });
+});

--- a/apps/hub/lib/hub-backend.ts
+++ b/apps/hub/lib/hub-backend.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process';
 import { readFileSync } from 'node:fs';
-import { readdir, stat } from 'node:fs/promises';
+import { chmod, mkdir, readdir, stat, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
@@ -30,8 +30,10 @@ import {
   isValidBoxStatus,
   loadQueue,
   readJob,
+  registrationToBoxRecord,
   writeQueueLoginCode,
   type BoxRegistration,
+  type CustodyStore,
   type PendingApproval,
   type QueueAgentKind,
   type QueueJob,
@@ -50,8 +52,10 @@ import {
   boxRestartService,
   boxRestartServices,
   boxServicesStatusRaw,
+  boxSshDirForProvider,
   readPreparedStateRaw,
   readState,
+  recordBox,
   secretsEnvPath,
   setBoxDisplayName,
   syncAgentboxSshConfig,
@@ -64,6 +68,7 @@ import {
 } from '@agentbox/sandbox-cloud';
 import {
   ensureBoxBrowserShowingApp,
+  generateRelayToken,
   listBoxes,
   mintHostInitiatedToken,
   type ListedBox,
@@ -848,10 +853,111 @@ async function verifyFromBranch(repo: string, ref: string): Promise<{ ok: true }
   return ok ? { ok: true } : { ok: false, error: `unknown base ref "${ref}" (not found in the project repo)` };
 }
 
-async function runLifecycle(id: string, op: (box: BoxRecord, provider: Provider) => Promise<void>): Promise<ActionResult> {
+/** Reverse-adoption seam: reconstruct + persist a local record from a Store registration. */
+type HydrateFn = (id: string) => Promise<BoxRecord | null>;
+
+/**
+ * Materialize a box's per-box SSH key from the control box's local custody into
+ * the on-disk ssh dir the provider exec/git path reads. Best-effort: SDK
+ * providers (e2b/vercel/daytona) mint no keypair (`boxSshDirForProvider` → null),
+ * and a PC-created VPS box whose PC never pushed its key simply has none in
+ * custody — lifecycle + destroy still work (cloud API), only git/exec over SSH
+ * needs it.
+ */
+async function materializeBoxSshFromCustody(
+  custody: CustodyStore | null | undefined,
+  provider: string,
+  sandboxId: string,
+): Promise<void> {
+  if (!custody) return;
+  const dir = boxSshDirForProvider(provider, sandboxId);
+  if (!dir) return;
+  const entries = await custody.list(`boxes/${sandboxId}/ssh`).catch(() => []);
+  if (entries.length === 0) return;
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+  for (const e of entries) {
+    const found = await custody.get(e.path).catch(() => null);
+    if (!found) continue;
+    const out = path.join(dir, path.basename(e.path));
+    await writeFile(out, found.data, { mode: 0o600 });
+    await chmod(out, 0o600);
+  }
+}
+
+/**
+ * Reverse-adopt a box the control box holds only as a Store registration (created
+ * on a PC / another host, never locally): rebuild a drivable `BoxRecord` via the
+ * shared `registrationToBoxRecord` — the mirror of the PC's `hub adopt` — pull its
+ * SSH key from local custody, and persist it to `state.json`. Returns null when
+ * there is no registration or the provider can't be resolved (unknown kind /
+ * missing creds), so the caller reports "not found" or falls back to a state-only
+ * reap exactly as before. Idempotent: once recorded, a second call finds it in
+ * local state and never reaches here.
+ */
+async function hydrateRegisteredBox(handle: RelayServerHandle, id: string): Promise<BoxRecord | null> {
+  const reg = await handle.store.getBox(id).catch(() => undefined);
+  if (!reg) return null;
+  const record = registrationToBoxRecord(reg, {
+    // The control box IS the control plane; persist its own public URL so the
+    // record's topology matches a worker-created box's.
+    controlPlaneUrl: process.env.AGENTBOX_HUB_PUBLIC_URL ?? '',
+    freshToken: generateRelayToken,
+  });
+  // Only adopt a box we can actually drive: resolving the provider loads its
+  // module + credentials, so a missing-cred / unknown-provider box returns null
+  // rather than leaving behind a local record we can't act on.
   try {
-    const { boxes } = await readState();
-    const box = boxes.find((b) => b.id === id);
+    await providerForBox(record);
+  } catch {
+    return null;
+  }
+  await materializeBoxSshFromCustody(handle.custody, record.provider ?? 'docker', reg.sandboxId ?? id).catch(
+    () => {},
+  );
+  await recordBox(record);
+  return record;
+}
+
+/**
+ * Reap a box's control-box Store state — registration, status snapshot, and
+ * SSH-key custody subtree. Idempotent; returns whether a registration existed.
+ * Used both after a real destroy (clear the now-dead registration) and as the
+ * fallback when the cloud resource can't be driven (state cleanup only).
+ */
+async function reapStoreState(handle: RelayServerHandle, id: string): Promise<boolean> {
+  const reg = await handle.store.getBox(id).catch(() => undefined);
+  const existed = await handle.store.forgetBox(id).catch(() => false);
+  await handle.store.deleteStatus(id).catch(() => {});
+  if (handle.custody) {
+    const key = reg?.sandboxId ?? id;
+    const entries = await handle.custody.list(`boxes/${key}`).catch(() => []);
+    for (const e of entries) await handle.custody.delete(e.path).catch(() => false);
+  }
+  return existed || reg !== undefined;
+}
+
+/**
+ * Resolve a box id to its local `BoxRecord`, falling back to reverse-adoption:
+ * a box the control box knows only from its Store registration (created on a PC
+ * / another host) has no local `state.json` record, so `readState()` misses it.
+ * `hydrate` reconstructs + persists that record on demand (see
+ * `hydrateRegisteredBox`), after which every provider-driven path (lifecycle,
+ * git, real destroy) finds it in state and Just Works.
+ */
+async function findOrHydrateBox(id: string, hydrate?: HydrateFn): Promise<BoxRecord | null> {
+  const { boxes } = await readState();
+  const local = boxes.find((b) => b.id === id);
+  if (local) return local;
+  return hydrate ? await hydrate(id) : null;
+}
+
+async function runLifecycle(
+  id: string,
+  op: (box: BoxRecord, provider: Provider) => Promise<void>,
+  hydrate?: HydrateFn,
+): Promise<ActionResult> {
+  try {
+    const box = await findOrHydrateBox(id, hydrate);
     if (!box) return { ok: false, error: `box ${id} not found` };
     const provider = await providerForBox(box);
     await op(box, provider);
@@ -881,9 +987,11 @@ async function hubWriteSshConfig(box: BoxRecord, provider: Provider): Promise<vo
 }
 
 /** Resolve a box id to its record + provider, or null when the box is gone. */
-async function resolveBoxProvider(id: string): Promise<{ box: BoxRecord; provider: Provider } | null> {
-  const { boxes } = await readState();
-  const box = boxes.find((b) => b.id === id);
+async function resolveBoxProvider(
+  id: string,
+  hydrate?: HydrateFn,
+): Promise<{ box: BoxRecord; provider: Provider } | null> {
+  const box = await findOrHydrateBox(id, hydrate);
   if (!box) return null;
   return { box, provider: await providerForBox(box) };
 }
@@ -908,9 +1016,13 @@ function hubGitDeps(boxId: string): BoxGitDeps {
 }
 
 /** Run a box-git helper and map its exec result to a BoxOpResult. */
-async function gitOp(id: string, fn: (box: BoxRecord, provider: Provider) => Promise<ExecResult>): Promise<BoxOpResult> {
+async function gitOp(
+  id: string,
+  fn: (box: BoxRecord, provider: Provider) => Promise<ExecResult>,
+  hydrate?: HydrateFn,
+): Promise<BoxOpResult> {
   try {
-    const rp = await resolveBoxProvider(id);
+    const rp = await resolveBoxProvider(id, hydrate);
     if (!rp) return { ok: false, error: `box ${id} not found` };
     const r = await fn(rp.box, rp.provider);
     if (r.exitCode !== 0) {
@@ -1047,6 +1159,10 @@ async function probeOpenTargets(): Promise<OpenTargetsReport | null> {
 }
 
 export function createHubBackend(handle: RelayServerHandle): HubBackend {
+  // Reverse-adoption: drive a box the control box knows only from its Store
+  // registration (PC-created / independent) by reconstructing its local record on
+  // demand. Threaded into every provider-driven path below.
+  const hydrate: HydrateFn = (bid) => hydrateRegisteredBox(handle, bid);
   return {
     // authMode is layered on by source.ts (an env-derived concern), so the host
     // backend produces everything else.
@@ -1120,15 +1236,15 @@ export function createHubBackend(handle: RelayServerHandle): HubBackend {
         else await provider.start(box);
         // Refresh the box's SSH-config alias now it's back online (IP may have changed).
         await hubWriteSshConfig(box, provider);
-      }),
-    pause: (id) => runLifecycle(id, (box, provider) => provider.pause(box)),
+      }, hydrate),
+    pause: (id) => runLifecycle(id, (box, provider) => provider.pause(box), hydrate),
     resume: (id) =>
       runLifecycle(id, async (box, provider) => {
         await provider.resume(box);
         // Refresh the box's SSH-config alias now it's back online (IP may have changed).
         await hubWriteSshConfig(box, provider);
-      }),
-    stop: (id) => runLifecycle(id, (box, provider) => provider.stop(box)),
+      }, hydrate),
+    stop: (id) => runLifecycle(id, (box, provider) => provider.stop(box), hydrate),
     screen: (id) =>
       runLifecycle(id, async (box, provider) => {
         // The open-VNC prep step: mirror `agentbox screen` so the viewer shows
@@ -1143,7 +1259,7 @@ export function createHubBackend(handle: RelayServerHandle): HubBackend {
             console.warn(`[hub] screen ${box.name}: in-box browser failed: ${br.reason}`);
           }
         }
-      }),
+      }, hydrate),
     async destroy(id): Promise<ActionResult> {
       // A synthetic `job:` box is a failed create with no real container — "destroy"
       // it by clearing its queue manifest (what the tray/UI Dismiss action hits).
@@ -1162,28 +1278,22 @@ export function createHubBackend(handle: RelayServerHandle): HubBackend {
           return { ok: false, error: errMsg(err) };
         }
       }
+      // `hydrate` reverse-adopts a registration-only box (PC-created / worker-
+      // created whose temp clone was cleaned) so `provider.destroy` tears down the
+      // REAL cloud resource — not just a state reap. Then reap the now-dead Store
+      // registration + custody regardless (idempotent; also cleans up a
+      // locally-created box's lingering registration).
       const local = await runLifecycle(id, async (box, provider) => {
         await provider.destroy(box);
         // Drop the destroyed box's `~/.agentbox/ssh/config` block (regenerate from state).
         await syncAgentboxSshConfig().catch(() => {});
-      });
-      if (local.ok) return local;
-      // Not in host state — on the control box a worker-created box lives only in
-      // the Store (its temp seed clone was deleted after create), so there is no
-      // BoxRecord to drive `provider.destroy`. Reap its control-box state instead
-      // (registration + status + SSH-key custody). The cloud resource, if any,
-      // stays a backlog follow-up (needs the sandboxId + provider creds + a
-      // reconstructed record).
-      const reg = await handle.store.getBox(id);
-      if (!reg) return local;
-      await handle.store.forgetBox(id);
-      await handle.store.deleteStatus(id);
-      if (handle.custody) {
-        const key = reg.sandboxId ?? id;
-        const entries = await handle.custody.list(`boxes/${key}`).catch(() => []);
-        for (const e of entries) await handle.custody.delete(e.path).catch(() => false);
-      }
-      return { ok: true };
+      }, hydrate);
+      const reaped = await reapStoreState(handle, id);
+      if (local.ok) return { ok: true };
+      // Real destroy couldn't run (no creds / provider unresolvable). If a
+      // registration was reaped, the box is gone from the control box's view —
+      // report success; otherwise surface the original "not found"/error.
+      return reaped ? { ok: true } : local;
     },
     async rename(id, displayName): Promise<ActionResult> {
       // Pure state mutation — no provider round-trip. Empty/blank clears the label.
@@ -1409,17 +1519,17 @@ export function createHubBackend(handle: RelayServerHandle): HubBackend {
     },
 
     // ── box git operations (delegate to the shared, provider-agnostic helpers) ──
-    gitCheckout: (id, branch) => gitOp(id, (box, provider) => boxGitCheckout(provider, box, branch)),
+    gitCheckout: (id, branch) => gitOp(id, (box, provider) => boxGitCheckout(provider, box, branch), hydrate),
     gitNewBranch: (id, input) =>
-      gitOp(id, (box, provider) => boxGitNewBranch(provider, box, input.name, input.from)),
+      gitOp(id, (box, provider) => boxGitNewBranch(provider, box, input.name, input.from), hydrate),
     gitPush: (id, input = {}) =>
-      gitOp(id, (box, provider) => boxGitPush(provider, box, input, hubGitDeps(id))),
+      gitOp(id, (box, provider) => boxGitPush(provider, box, input, hubGitDeps(id)), hydrate),
     gitPull: (id, input = {}) =>
-      gitOp(id, (box, provider) => boxGitPull(provider, box, input, hubGitDeps(id))),
-    gitPushHost: (id, input = {}) => gitOp(id, (box, provider) => boxGitPushHost(provider, box, input)),
+      gitOp(id, (box, provider) => boxGitPull(provider, box, input, hubGitDeps(id)), hydrate),
+    gitPushHost: (id, input = {}) => gitOp(id, (box, provider) => boxGitPushHost(provider, box, input), hydrate),
     async getGit(id): Promise<GitInfo> {
       try {
-        const rp = await resolveBoxProvider(id);
+        const rp = await resolveBoxProvider(id, hydrate);
         if (!rp) return { ok: false, error: `box ${id} not found` };
         const r = await rp.provider.exec(rp.box, ['git', 'status', '--porcelain=v2', '--branch'], {
           cwd: BOX_WORKSPACE,
@@ -1433,7 +1543,7 @@ export function createHubBackend(handle: RelayServerHandle): HubBackend {
 
     // ── box service control ──
     async getServices(id): Promise<ServicesResult> {
-      const rp = await resolveBoxProvider(id).catch(() => null);
+      const rp = await resolveBoxProvider(id, hydrate).catch(() => null);
       if (!rp) return { source: 'unavailable', services: [], tasks: [], ports: [], error: `box ${id} not found` };
       const live = await liveServices(rp.provider, rp.box);
       if (live) return mapLiveServices(live);
@@ -1443,7 +1553,7 @@ export function createHubBackend(handle: RelayServerHandle): HubBackend {
     },
     async restartService(id, name): Promise<BoxOpResult> {
       try {
-        const rp = await resolveBoxProvider(id);
+        const rp = await resolveBoxProvider(id, hydrate);
         if (!rp) return { ok: false, error: `box ${id} not found` };
         if (name) {
           const r = await boxRestartService(rp.provider, rp.box, name);

--- a/apps/web/content/docs/deployed-hub.mdx
+++ b/apps/web/content/docs/deployed-hub.mdx
@@ -137,17 +137,23 @@ Re-pushes are hash-skipped: an unchanged working tree uploads nothing. When the 
 
 ## Manage control-box boxes from your laptop
 
-## Manage control-box boxes from your laptop
+These commands speak the control box's public REST API (`/api/v1`) — the same surface the web UI and
+the macOS tray use — over its hub API key (minted at `setup`/`deploy`). Local docker boxes are never
+here; they stay on your laptop.
 
 ```bash
-agentbox relay status                          # shows the configured control box + reachability
-agentbox control-plane boxes list              # boxes on the control box (from either side)
-agentbox control-plane prompts list            # pending host-action approvals
-agentbox control-plane prompts answer <id> y   # answer one (also answerable in the web UI)
-agentbox control-plane boxes rm <box>          # reap its control-box state (registration + status + SSH-key custody)
+agentbox relay status                              # shows the configured control box + reachability
+agentbox control-plane boxes list                  # boxes on the control box (from either side)
+agentbox control-plane boxes start|stop|pause|resume <box>   # drive one remotely (laptop can be off)
+agentbox control-plane boxes rm <box>              # destroy it (cloud resource + control-box state)
+agentbox control-plane prompts list                # pending host-action approvals
+agentbox control-plane prompts answer <id> y       # answer one (also answerable in the web UI)
 ```
 
-`boxes rm` reaps the control box's *state* only; the actual cloud sandbox is destroyed from the web UI or its provider.
+`boxes rm` now performs a **real destroy** — it tears down the cloud sandbox and reaps the control
+box's state (registration, status, SSH-key custody) — including for boxes you created on this PC and
+registered against the control box. The control box drives them by reconstructing their record from
+its registry on demand (reverse-adoption), so no local record on the control box is required.
 
 ## Credentials and secrets
 

--- a/docs/control-box-plan.md
+++ b/docs/control-box-plan.md
@@ -1134,6 +1134,18 @@ apps/cli/dist/index.js <cmd> --url http://127.0.0.1:8799`). The walk (all 8 gree
 
 Findings and follow-ups discovered while implementing, kept out of the phase they were found in.
 
+- **(2026-07-24) Reverse-adoption shipped — the control box now DRIVES + DESTROYS registered-only
+  boxes.** Previously a box the control box knew only from its Store registration (PC-created /
+  independent) rendered as `running` but couldn't be driven: lifecycle/git 404'd and `boxes rm` reaped
+  state only, leaving the cloud resource. Now the hub backend reconstructs a drivable `BoxRecord` from
+  the registration on demand (`hydrateRegisteredBox`, the shared `registrationToBoxRecord` mirror of
+  `hub adopt`) so `/api/v1` lifecycle, git, services, and **real destroy** (cloud teardown + reap) work
+  on them. The CLI's `control-plane boxes` group (list, new start/stop/pause/resume, real `rm`) and
+  `prompts` now speak `/api/v1` via the shared `HubApiClient`. Remaining consolidation (CLI `ls -g` +
+  `create --via-hub` onto `/api/v1`, main-command dispatch) tracked in
+  [`hub-api-consolidation-plan.md`](./hub-api-consolidation-plan.md). VPS git/exec on a PC-created box
+  still needs the box's SSH key pushed to custody (local-adoption follow-up).
+
 - **(phase 3) A hub-created box is control-plane topology but host-seeded (local clone).** The
   resident worker sets `controlPlaneUrl` (so the box registers on the control box) yet hands
   `provider.create` a locally-cloned workspace rather than `inBoxClone`. That mix is untested against

--- a/docs/hub-api-consolidation-plan.md
+++ b/docs/hub-api-consolidation-plan.md
@@ -9,7 +9,10 @@
 > deployed hub, incl. the earlier per-command remote-support audit in its appendix),
 > [`local-adoption-plan.md`](./local-adoption-plan.md) (PC as thin client), [`host-relay.md`](./host-relay.md)
 > (the relay core), and the public API reference [`apps/web/content/docs/api.mdx`](../apps/web/content/docs/api.mdx).
-> Status: **analysis + design (not yet implemented)**. Maintain status live per project convention.
+> Status: **P0 shipped** (headless `/api/v1` key, PR #245); **Phase 1 (reverse-adoption) + Phase 2
+> clean subset (CLI `HubApiClient`, `control-plane boxes`/`prompts` on `/api/v1`) shipped**; `ls -g`
+> + `create --via-hub` + main-command dispatch deferred (see the phased plan below). Maintain status
+> live per project convention.
 
 ## Context
 
@@ -183,18 +186,43 @@ intentional divergences above (git auth, gate, worker) branch on the profile.
   (`randomBytes(32).hex`), recorded in `~/.agentbox/control-plane/control-plane.env`, and injected into
   the container via `docker-compose.yml`. CLI seam `resolveHubApiTarget()` added (not yet wired).
   Unblocks CLI **and** tray remotely.
-- **Phase 1 — Remote-write path for `/api/v1`.** Make `POST /api/v1/boxes`, lifecycle, git, services,
-  approvals work on the control box for boxes the hub owns by routing writes through the resident
-  worker / `RemoteStore` instead of 503 (`api/v1/lib/backend.ts` + the boxes/git/approvals routes).
-  Add reverse-adoption so a remote hub can drive PC-registered boxes. Converge the two approval
-  mailboxes on one, surfaced at `/api/v1/approvals`.
-- **Phase 2 — CLI onto one client.** Add a shared `HubApiClient` (base URL = local `~/.agentbox/hub/token`
-  target **or** remote `relay.controlPlaneUrl` + key, via a `resolveCustodyTarget`-style resolver).
-  Move box list/create/job/lifecycle/destroy/approvals off `admin-client`/`hub-enqueue`/`hub-list`
-  onto `/api/v1`. Keep `custody-client`, `plane-register`, `ensure-repo-installed`, `/rpc` lease on
-  the admin wire (Internal). At the create/routing choke points, when a remote hub is configured,
-  **cloud boxes register + lease + report to the remote hub by default** (the remote relay), so the
-  laptop relay isn't needed and the laptop can be off — only local docker stays on the laptop hub.
+- **Phase 1 — Reverse-adoption (server). DONE.** Reframed after exploration: on the **Hetzner control
+  box** `/api/v1` writes never 503 (the custom server sets the in-process backend), and the daemon runs
+  block-mode so `/api/v1/approvals` and `/admin/prompts` are already one mailbox — the 503 + two-mailbox
+  gaps are **Vercel-serverless-only** (a frozen profile). The real residual was **reverse-adoption**:
+  a box the control box knew only from its Store registration (PC-created / independent) rendered as
+  `running` but 404'd on lifecycle/git and only *reaped* on destroy. Fixed by extracting the
+  registration→`BoxRecord` mapper into `@agentbox/relay` (`registrationToBoxRecord`, shared with the
+  PC's `hub adopt`) and adding `hydrateRegisteredBox` to the hub backend: on a local-state miss it
+  reconstructs + persists a drivable record from the registration + local custody SSH keys, so
+  `/api/v1` lifecycle, git, services, and **real destroy** (cloud teardown, then reap) work on
+  registered-only boxes. Lifecycle + destroy use cloud **API creds** (no SSH) → all providers; git/exec
+  over SSH needs the box's key in custody (hub-created VPS boxes have it; PC-created VPS boxes are the
+  documented local-adoption follow-up). The Vercel-serverless remote-write/poll path stays deferred
+  (frozen profile).
+- **Phase 2 — CLI onto one client. PARTIAL (shipped the clean subset).** Added the shared
+  `HubApiClient` (`apps/cli/src/control-plane/hub-api-client.ts`) — the URL-swappable `/api/v1` client,
+  the same surface the tray + web speak — resolved via `resolveHubApiClient` over the P0
+  `resolveHubApiTarget` (remote URL + `AGENTBOX_HUB_API_KEY`). Migrated the **`control-plane boxes`**
+  group onto it: `boxes list`, new `boxes start|stop|pause|resume`, and a real `boxes rm` (POST
+  `/api/v1/boxes/:id/destroy` → cloud teardown + reap, not the old reap-only `DELETE /remote/boxes`),
+  plus **`control-plane prompts` list/answer** onto `/api/v1/approvals`. Reverse-adoption (Phase 1)
+  makes these drive every box on the control box, including PC-registered ones.
+  - **Deferred (not like-for-like — real API work, own phase):**
+    - **`ls -g` (`fetchHubListing`)** stays on `/admin/store`: the `/api/v1/boxes` `Box` view drops the
+      raw `sandboxId`/`originUrl`/`publicHost`/`image` the local↔hub merge + adoption dedup need.
+      Migrating means enriching the `Box` shape first (additive on the hub) then reworking `mergeHubBoxes`.
+    - **`create --via-hub`** stays on `/remote/boxes`: it sends a **`repoUrl`** and the resident worker
+      leases + clones into the SQLite `create_jobs` queue, whereas `/api/v1/boxes` create takes a
+      **`projectId`** of a hub-known project and enqueues on the local file queue — different inputs and
+      different queues/workers. Unifying needs `/api/v1/boxes` to accept a repoUrl create routed to the
+      worker queue.
+    - **Main-command dispatch** (`agentbox start|stop|git <box>` routing to the remote hub) left on the
+      local path — it's load-bearing for local docker; the `control-plane boxes` subcommands provide the
+      remote-drive path in the meantime.
+    - The remote-relay default (cloud boxes register/lease/report to the remote hub so the laptop can be
+      off) is already the control-plane topology; making it the default at the create/routing choke
+      points is future work.
 - **Phase 3 — Tray remote.** Make `HubClient.baseURL` configurable + add a remote-key source
   (`../agentbox-tray/Sources/AgentBox/Source/HubClient.swift:6`, SSE cookie in `SSEClient.swift`). The
   `BoxSource`/`HubAPIBoxSource` seam already anticipates a hosted source — no UI change. Local

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -34,6 +34,12 @@ export type {
   RelayEvent,
   SetNoticeBody,
 } from './types.js';
+export {
+  registrationToBoxRecord,
+  normalizeRegistrationAgent,
+  buildSshTarget,
+  type RegistrationToRecordOptions,
+} from './registration-to-record.js';
 export { HostActionQueue } from './host-action-queue.js';
 export { CloudBoxPoller, CloudBoxPollers, type CloudBoxPollerDeps } from './cloud-poller.js';
 export { BoxRegistry, EventBuffer } from './registry.js';

--- a/packages/relay/src/registration-to-record.ts
+++ b/packages/relay/src/registration-to-record.ts
@@ -1,0 +1,150 @@
+/**
+ * Rebuild a drivable `BoxRecord` from a control-box `BoxRegistration`.
+ *
+ * The single source of truth for "registration → record" reconstruction, used by
+ * BOTH sides of the control-plane topology:
+ *   - the PC's `agentbox hub adopt` (materializes the record into the PC's
+ *     `state.json` so direct PC↔box commands resolve the box), and
+ *   - the control box's own hub backend (`hydrateRegisteredBox`), which drives a
+ *     box it knows only from its Store registration — created on a PC / another
+ *     host — so `/api/v1` lifecycle, git, and REAL destroy work on it, not just a
+ *     state reap.
+ *
+ * Everything needed rides on the registration (the adoption material added by the
+ * plane-register enrichment): provider, sandbox id, public VM host, image, web
+ * port, agent, branch, origin URL, bridge/preview tokens. Host-specific concerns
+ * stay with the caller: which LOCAL project the box maps to (PC only — the
+ * control box has no local clone), SSH-key material (downloaded from custody over
+ * HTTP on the PC, read from the local FS store on the control box), and the token
+ * generator used for the relay/bridge fallbacks.
+ *
+ * Kept pure (no fs, no network) so both callers layer their own IO around it.
+ */
+import type { BoxRecord, GitWorktreeRecord, SshTargetRecord } from '@agentbox/core';
+import { boxSshDirForProvider } from '@agentbox/sandbox-core';
+import type { BoxRegistration } from './types.js';
+
+/** Box user on every cloud provider's image (the agent never runs as root). */
+const BOX_SSH_USER = 'vscode';
+
+export interface RegistrationToRecordOptions {
+  /** The control-plane base URL, persisted on the record's cloud fields. */
+  controlPlaneUrl: string;
+  /**
+   * A local record for the same box, when re-adopting: its id/project linkage
+   * and live tokens are preserved so status paths stay stable and a refresh
+   * never re-mints tokens already injected in the running box.
+   */
+  existing?: BoxRecord;
+  /**
+   * Absolute host path of the LOCAL checkout the box maps to. Set only when a
+   * clone is present (the PC path); on the control box there is none, so git
+   * worktree bookkeeping is left off (the registration's `hostMainRepo` is the
+   * control box's create-time temp clone, deleted after create — carrying it
+   * over would point host-side git RPCs at a path that doesn't exist).
+   */
+  projectRoot?: string;
+  /** 1-based per-project box index, when the caller resolved one. */
+  projectIndex?: number;
+  /** Fallback token generator for the relay/bridge tokens (e.g. `generateRelayToken`). */
+  freshToken: () => string;
+}
+
+/** Narrow a registration's free-form agent string to the record's union. */
+export function normalizeRegistrationAgent(agent: string | undefined): BoxRecord['lastAgent'] {
+  return agent === 'claude' || agent === 'codex' || agent === 'opencode' ? agent : undefined;
+}
+
+/**
+ * The box's SSH target, or undefined when the registration carries no host.
+ *
+ * `identityFile` is set only when the provider actually mints a per-box key dir:
+ * a provider that reports a `publicHost` but no keypair would otherwise get a
+ * bogus absolute `"/id_ed25519"` written into the record. Omitting it leaves ssh
+ * to its normal key resolution.
+ */
+export function buildSshTarget(
+  provider: string,
+  sandboxId: string,
+  publicHost: string | undefined,
+): SshTargetRecord | undefined {
+  if (!publicHost) return undefined;
+  const dir = boxSshDirForProvider(provider, sandboxId);
+  return {
+    host: publicHost,
+    user: BOX_SSH_USER,
+    ...(dir ? { identityFile: `${dir}/id_ed25519` } : {}),
+  };
+}
+
+/**
+ * Map a `BoxRegistration` (+ caller-supplied host context) to a `BoxRecord`.
+ * Pure: it neither reads SSH keys nor writes state — the caller does that around
+ * it. Idempotent-friendly: pass `existing` to preserve local identity on refresh.
+ */
+export function registrationToBoxRecord(
+  reg: BoxRegistration,
+  opts: RegistrationToRecordOptions,
+): BoxRecord {
+  const provider = reg.backend ?? 'docker';
+  const sandboxId = reg.sandboxId ?? reg.boxId;
+  const { existing, projectRoot, projectIndex, controlPlaneUrl, freshToken } = opts;
+
+  const branch = reg.worktrees?.[0]?.branch ?? `agentbox/${reg.name}`;
+  const sanctionedBranch = reg.worktrees?.[0]?.sanctionedBranch ?? branch;
+
+  // Git worktree bookkeeping points at the LOCAL clone (PC only). On the control
+  // box `projectRoot` is undefined → no worktrees, which is correct: cloud
+  // lifecycle/destroy need none, and host-side git RPCs would have no repo here.
+  const gitWorktrees: GitWorktreeRecord[] | undefined = projectRoot
+    ? [
+        {
+          kind: 'root',
+          branch,
+          sanctionedBranch,
+          containerPath: '/workspace',
+          hostMainRepo: projectRoot,
+          gitWorktreePath: '',
+          relPathFromWorkspace: '',
+        },
+      ]
+    : undefined;
+
+  return {
+    id: existing?.id ?? reg.boxId,
+    name: reg.name,
+    displayName: existing?.displayName,
+    provider,
+    container: `cloud:${sandboxId}`,
+    image: reg.image ?? existing?.image ?? '',
+    workspacePath: projectRoot ?? existing?.workspacePath ?? '/workspace',
+    projectRoot,
+    projectIndex,
+    // Tokens are regenerated only for a fresh adoption; a re-adopt keeps the
+    // box's live tokens (already injected in the running box).
+    relayToken: existing?.relayToken ?? reg.token ?? freshToken(),
+    lastAgent: normalizeRegistrationAgent(reg.agent) ?? existing?.lastAgent,
+    gitWorktrees,
+    createdAt: reg.createdAt ?? existing?.createdAt ?? new Date().toISOString(),
+    ssh: buildSshTarget(provider, sandboxId, reg.publicHost) ?? existing?.ssh,
+    cloud: {
+      ...existing?.cloud,
+      backend: provider,
+      sandboxId,
+      image: reg.image ?? existing?.cloud?.image,
+      webPort: reg.webPort ?? existing?.cloud?.webPort,
+      publicHost: reg.publicHost ?? existing?.cloud?.publicHost,
+      bridgeToken: reg.bridgeToken ?? existing?.cloud?.bridgeToken ?? freshToken(),
+      relayPreviewUrl: reg.previewUrl ?? existing?.cloud?.relayPreviewUrl,
+      relayPreviewToken: reg.previewToken ?? existing?.cloud?.relayPreviewToken,
+      workspaceBranch: branch,
+      sanctionedBranch,
+      lastState: existing?.cloud?.lastState ?? 'running',
+      topology: 'control-plane',
+      controlPlaneUrl,
+      // A hub-created box clones in-box from a leased URL — it shares no fork
+      // base with a PC, so the session-start live resync must skip it.
+      hostSeeded: undefined,
+    },
+  };
+}

--- a/packages/relay/test/registration-to-record.test.ts
+++ b/packages/relay/test/registration-to-record.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { registrationToBoxRecord } from '../src/registration-to-record.js';
+import type { BoxRegistration } from '../src/types.js';
+
+// A stable, non-random token so assertions are deterministic.
+const TOKEN = 'tok-fixed';
+const freshToken = (): string => TOKEN;
+
+function reg(overrides: Partial<BoxRegistration> = {}): BoxRegistration {
+  return {
+    boxId: 'box-1',
+    token: 'reg-token',
+    name: 'brave-otter',
+    registeredAt: '2026-07-01T00:00:00.000Z',
+    kind: 'cloud',
+    backend: 'e2b',
+    sandboxId: 'sbx-abc',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    agent: 'claude',
+    image: 'tmpl-xyz',
+    webPort: 8080,
+    originUrl: 'git@github.com:o/r.git',
+    worktrees: [{ containerPath: '/workspace', hostMainRepo: '/tmp/clone', branch: 'agentbox/brave-otter' }],
+    ...overrides,
+  };
+}
+
+describe('registrationToBoxRecord', () => {
+  it('rebuilds a drivable cloud record from an SDK-provider registration', () => {
+    const rec = registrationToBoxRecord(reg(), { controlPlaneUrl: 'https://hub.example', freshToken });
+    expect(rec.id).toBe('box-1');
+    expect(rec.name).toBe('brave-otter');
+    expect(rec.provider).toBe('e2b');
+    expect(rec.container).toBe('cloud:sbx-abc');
+    expect(rec.image).toBe('tmpl-xyz');
+    expect(rec.lastAgent).toBe('claude');
+    expect(rec.cloud?.backend).toBe('e2b');
+    expect(rec.cloud?.sandboxId).toBe('sbx-abc');
+    expect(rec.cloud?.webPort).toBe(8080);
+    expect(rec.cloud?.topology).toBe('control-plane');
+    expect(rec.cloud?.controlPlaneUrl).toBe('https://hub.example');
+    // No local clone → no worktree bookkeeping (the registration's hostMainRepo
+    // is the control box's create-time temp clone, deleted after create).
+    expect(rec.gitWorktrees).toBeUndefined();
+    // SDK providers mint no per-box key → no ssh target (no bogus identityFile).
+    expect(rec.ssh).toBeUndefined();
+    // The relay token rides the registration; bridge token falls back to freshToken.
+    expect(rec.relayToken).toBe('reg-token');
+    expect(rec.cloud?.bridgeToken).toBe(TOKEN);
+  });
+
+  it('sets an ssh target with identityFile for a VPS provider with a publicHost', () => {
+    const rec = registrationToBoxRecord(
+      reg({ backend: 'hetzner', sandboxId: '12345', publicHost: '10.0.0.1' }),
+      { controlPlaneUrl: 'https://hub.example', freshToken },
+    );
+    expect(rec.ssh?.host).toBe('10.0.0.1');
+    expect(rec.ssh?.user).toBe('vscode');
+    expect(rec.ssh?.identityFile).toMatch(/12345\/ssh\/id_ed25519$/);
+  });
+
+  it('builds local git worktree bookkeeping when a projectRoot is supplied (PC adopt)', () => {
+    const rec = registrationToBoxRecord(reg(), {
+      controlPlaneUrl: 'https://hub.example',
+      projectRoot: '/home/me/proj',
+      projectIndex: 3,
+      freshToken,
+    });
+    expect(rec.projectRoot).toBe('/home/me/proj');
+    expect(rec.projectIndex).toBe(3);
+    expect(rec.workspacePath).toBe('/home/me/proj');
+    expect(rec.gitWorktrees?.[0]).toMatchObject({
+      kind: 'root',
+      hostMainRepo: '/home/me/proj',
+      containerPath: '/workspace',
+      branch: 'agentbox/brave-otter',
+    });
+  });
+
+  it('preserves existing local identity + tokens on re-adopt', () => {
+    const existing = registrationToBoxRecord(reg(), {
+      controlPlaneUrl: 'https://hub.example',
+      freshToken: () => 'first-bridge',
+    });
+    const refreshed = registrationToBoxRecord(reg({ image: 'tmpl-new' }), {
+      controlPlaneUrl: 'https://hub.example',
+      existing,
+      freshToken: () => 'second-bridge',
+    });
+    // Live tokens are kept (already injected in the running box); only new fields update.
+    expect(refreshed.id).toBe(existing.id);
+    expect(refreshed.cloud?.bridgeToken).toBe(existing.cloud?.bridgeToken);
+    expect(refreshed.image).toBe('tmpl-new');
+  });
+
+  it('falls back to agentbox/<name> branch and freshToken when the registration is sparse', () => {
+    const rec = registrationToBoxRecord(
+      { boxId: 'b2', token: '', name: 'lone-wolf', registeredAt: '2026-07-01T00:00:00.000Z' },
+      { controlPlaneUrl: '', freshToken },
+    );
+    expect(rec.provider).toBe('docker');
+    expect(rec.cloud?.workspaceBranch).toBe('agentbox/lone-wolf');
+    // No registration bridgeToken → freshToken fallback.
+    expect(rec.cloud?.bridgeToken).toBe(TOKEN);
+    expect(rec.lastAgent).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Second step of the [hub-API consolidation](../blob/feat/local-adoption/docs/hub-api-consolidation-plan.md) (after P0's headless `/api/v1` key, #245). Two complementary pieces so the CLI drives boxes on a deployed control box through the **same `/api/v1` REST API the tray + web use**, and so those endpoints work for **every** box.

### D — Reverse-adoption (server)
A box the control box knew only from its Store registration (PC-created / independent, registered against the control box) rendered as `running` but couldn't be driven — lifecycle/git 404'd and `boxes rm` only *reaped* state, leaving the cloud resource alive.

- Extracted the registration→`BoxRecord` mapper into `@agentbox/relay` (`registrationToBoxRecord`, the shared source of truth with the PC's `hub adopt`).
- Added `hydrateRegisteredBox` to the hub backend: on a local-state miss it reconstructs + persists a drivable record from the registration + local custody SSH keys, threaded into `resolveBoxProvider`/`runLifecycle`/`gitOp`/`destroy`.
- `destroy` now runs the **real** `provider.destroy` (cloud teardown) **and** reaps the Store registration + custody; reap-only stays as the fallback when creds are missing.
- Lifecycle + destroy use cloud **API creds** (no SSH) → all providers. Git/exec over SSH needs the box's key in custody (hub-created VPS boxes have it; PC-created VPS boxes are a documented local-adoption follow-up).

### A/B/C — CLI on `/api/v1`
- New `HubApiClient` — the URL-swappable `/api/v1` client (same surface as the tray/web), resolved via the P0 `resolveHubApiTarget` (remote URL + `AGENTBOX_HUB_API_KEY`).
- `control-plane boxes` now speaks `/api/v1`: `list`, **new** `start|stop|pause|resume`, and a **real** `rm` (destroy the cloud resource + reap, not the old reap-only `DELETE /remote/boxes`). `control-plane prompts` list/answer → `/api/v1/approvals`.

### Deferred (not like-for-like — documented in the consolidation plan)
- `ls -g` (`fetchHubListing`) stays on `/admin/store` — the `/api/v1/boxes` `Box` view drops the raw `sandboxId`/`originUrl` the local↔hub merge needs.
- `create --via-hub` stays on `/remote/boxes` — it uses a `repoUrl`+lease+clone model on a different queue than `/api/v1/boxes` (`projectId`+local path).
- Routing the main `agentbox start/stop/git` dispatch to the remote hub (load-bearing local path).

## Verification
- Unit: `registrationToBoxRecord` (5) + `HubApiClient` (6); existing `hub-adopt` (16, now via the shared mapper) green.
- Full `pnpm typecheck` + `pnpm lint` + relay (370) + cli (894) suites green.
- Live smoke (control box + reverse-adoption drive/destroy): see PR comments.

Docs updated: `hub-api-consolidation-plan.md`, `control-box-plan.md`, `deployed-hub.mdx`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes destroy semantics (cloud teardown, not reap-only) and on-demand hydration for remote box operations; mistakes could tear down live sandboxes or leave partial state, though fallbacks and tests mitigate this.
> 
> **Overview**
> **Reverse-adoption** lets a control box drive boxes it only knows from Store registration (e.g. PC-created): on a local `state.json` miss, `hydrateRegisteredBox` rebuilds a `BoxRecord` via shared **`registrationToBoxRecord`** (`@agentbox/relay`), materializes SSH keys from custody, and threads hydration through lifecycle, git, services, and **destroy** (real `provider.destroy` plus store/custody reap, with reap-only fallback when creds are missing).
> 
> **CLI consolidation:** new **`HubApiClient`** + **`resolveHubApiClient`** replace `ControlPlaneAdminClient` for **`control-plane boxes`** (list, new start/stop/pause/resume, **`rm` → real destroy**) and **`control-plane prompts`** (single `/api/v1/approvals` list/answer). PC **`hub adopt`** now uses the same mapper instead of duplicated logic.
> 
> Docs/plan status updated (`hub-api-consolidation-plan`, `deployed-hub.mdx`, `control-box-plan`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0734c90bbc764cd4518cccd731440fe882a4f93. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->