### PR TITLE
feat(hub): run background -i cloud jobs fully on the control box

### DIFF
--- a/apps/cli/src/commands/_cloud-agent-via-hub.ts
+++ b/apps/cli/src/commands/_cloud-agent-via-hub.ts
@@ -83,3 +83,53 @@ export async function createCloudBoxViaHubAndAdopt(
   });
   return res.record;
 }
+
+export interface AgentJobViaHubArgs extends CloudAgentViaHubArgs {
+  /** The seed prompt — its presence tells the worker to START the agent in-box. */
+  prompt: string;
+  /** Fully-processed agent args (post-`--`, incl. skip-permissions). */
+  agentArgs?: string[];
+}
+
+export interface AgentJobViaHubResult {
+  /** The created box id, when the box was provisioned (even if the agent then failed). */
+  boxId?: string;
+  /** Set when the job failed — a create failure, or the agent failing to start. */
+  error?: string;
+}
+
+/**
+ * Enqueue a background `-i` run on the control box: the resident worker creates
+ * the box AND starts the agent detached with the seed prompt, so the whole run
+ * lives on the VPS (laptop off). Polls to a terminal state and returns the box
+ * id + any error — no adopt/attach (it runs on the hub). Returns `null` when the
+ * control box isn't fully configured (no admin token / no git origin), so the
+ * caller can fall back to the local queue.
+ */
+export async function enqueueAgentJobViaHub(
+  args: AgentJobViaHubArgs,
+): Promise<AgentJobViaHubResult | null> {
+  const { providerName, projectRoot, agent, name, fromBranch, prompt, agentArgs, urlFlag, onStatus } =
+    args;
+  const target = await resolveCustodyTarget(urlFlag, { quiet: true });
+  if (!target) return null;
+  const repoUrl = await readGitOriginUrl(projectRoot).catch(() => undefined);
+  if (!repoUrl) return null;
+
+  const jobId = await enqueueCreateViaHub(target, {
+    repoUrl,
+    provider: providerName,
+    branch: fromBranch?.trim() || undefined,
+    name: name?.trim() || undefined,
+    agent,
+    prompt,
+    agentArgs,
+  });
+  onStatus?.(`enqueued on the control plane (job ${jobId})`);
+  const job = await pollHubJob(target, jobId, {
+    onStatus: (j) => onStatus?.(`job ${jobId}: ${j.status}`),
+  });
+  // A failed job with a boxId means the box was created but the agent didn't
+  // start (e.g. creds rejected) — surface the error but keep the box id.
+  return { boxId: job.result?.boxId, error: job.status === 'done' ? undefined : job.result?.error };
+}

--- a/apps/cli/src/commands/_cloud-agent-via-hub.ts
+++ b/apps/cli/src/commands/_cloud-agent-via-hub.ts
@@ -1,19 +1,19 @@
 /**
- * Foreground cloud-agent routing through the control box.
+ * Cloud-agent routing through the control box.
  *
  * `agentbox claude|codex|opencode` on a cloud provider, with a control box
  * configured (and `cloud.viaHub` on), builds the box ON the control box instead
  * of on this machine — so it lives in the same place as `agentbox create` boxes.
- * The resident hub worker clones the repo VPS-side and provisions the box, then
- * this PC ADOPTS it (writes local state + downloads its SSH keys) so the normal
- * attach path can launch the agent and drop you into the session.
+ * The resident hub worker clones the repo VPS-side and provisions the box.
  *
- * The worker creates the box "cold": it never starts the agent (it drops any
- * prompt and keeps `agent` only as a registration hint). That is fine for the
- * FOREGROUND path — the caller attaches right after, and `cloudAgentAttach`
- * starts the agent on a cold box. It is why background `-i` does NOT route here:
- * a queued run needs the agent started detached with a seed prompt, which the
- * worker can't do yet, so `-i` stays on the local queue.
+ * Two shapes:
+ *   - **Foreground** (`createCloudBoxViaHubAndAdopt`): the worker creates the box
+ *     "cold" (no agent), then this PC ADOPTS it (local state + SSH keys) so the
+ *     normal attach path launches the agent and drops you into the session.
+ *   - **Background `-i`** (`enqueueAgentJobViaHub`): the worker creates the box AND
+ *     starts the agent detached with the seed prompt (it seeds the agent login
+ *     from custody first), so the whole run lives on the VPS — laptop off from
+ *     submit on. No adopt/attach here; it's fire-and-forget.
  */
 import type { BoxRecord } from '@agentbox/sandbox-docker';
 import { readGitOriginUrl } from '@agentbox/sandbox-cloud';

--- a/apps/cli/src/commands/_cloud-attach.ts
+++ b/apps/cli/src/commands/_cloud-attach.ts
@@ -1,12 +1,22 @@
-import { spawn } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { log, spinner } from '@clack/prompts';
 import { DEFAULT_RELAY_PORT } from '@agentbox/sandbox-docker';
+import {
+  buildCloudAttachInnerCommand,
+  startDetachedCloudAgent,
+  startDetachedSession,
+  verifyDetachedSession,
+} from '@agentbox/sandbox-cloud';
 import type { BoxRecord, Provider } from '@agentbox/core';
 import type { AttachOpenIn } from '@agentbox/config';
 import { agentResumeArgs } from '../agent-sessions.js';
+
+// Re-exported so existing importers (dashboard, unit tests) keep their paths; the
+// implementations now live in @agentbox/sandbox-cloud so the hub worker can share
+// them without importing apps/cli.
+export { buildCloudAttachInnerCommand, verifyDetachedSession };
 import { withFirewallRepair } from '../lib/firewall-repair.js';
 import { providerForBox } from '../provider/registry.js';
 import { runWrappedAttach } from '../wrapped-pty/index.js';
@@ -78,84 +88,6 @@ export interface CloudAgentAttachArgs {
    * SSH token) can't affect it.
    */
   openIn?: AttachOpenIn;
-}
-
-/**
- * Printed in the agent's tmux pane the instant the session's command starts,
- * BEFORE the agent binary paints its first frame. On a cold cloud sandbox the
- * agent CLI (node cold-start + a large seed prompt + TUI init) can take several
- * seconds to draw — and a tmux client that attaches during that window sees a
- * featureless blank pane (verified: tmux pushes the frame correctly once the
- * program draws, so the gap is pure program-startup latency, not a redraw bug).
- * Without this line the run looks hung and users Ctrl+C then re-attach. The
- * agent clears the screen on startup, so the line vanishes the moment real
- * output arrives. Shared by every cloud provider; e2b/vercel microVMs are the
- * slowest cold-starters so they benefit most.
- *
- * No escape sequences (plain text) on purpose: this string threads through
- * several shell-quoting layers (single-quoted `bash -lc` body, the outer
- * `shellSingle` wrap in `renderInnerCommand`, then the provider transport), and
- * plain ASCII is the one thing guaranteed to survive all of them intact.
- */
-function agentStartBanner(binary: string): string {
-  return `printf "  agentbox: starting ${binary} (first paint may take a few seconds)...\\r\\n"; `;
-}
-
-/**
- * Render the inner shell command tmux runs inside the cloud sandbox. Exported
- * so unit tests can exercise the base64 round-trip without spinning up SSH.
- *
- * Both paths run `agentStartBanner` first so the freshly-attached pane is never
- * blank during the agent's cold-start. The body is single-quoted (`bash -lc
- * '…'`) in both branches so the outer `shellSingle` wrap composes the same way;
- * `exec <binary>` still replaces the shell so the agent keeps PID 2 (Ctrl-c in
- * the agent tears the session down cleanly).
- */
-export function buildCloudAttachInnerCommand(binary: string, extraArgs?: string[]): string {
-  if (!extraArgs || extraArgs.length === 0) {
-    return `bash -lc '${agentStartBanner(binary)}exec ${binary}'`;
-  }
-  // Encode EACH arg to its own base64 token, newline-join the tokens, then
-  // base64 that whole list once more into a single opaque `blob`. The launcher
-  // decodes `blob` back to the newline-separated tokens, reads them one per
-  // line, and base64-decodes each into its own argv element before
-  // `exec <binary> "${A[@]}"`.
-  //
-  // Two layers, not one, on purpose: the earlier scheme joined the args with a
-  // single `\n` and split with `mapfile -t`, which conflated "argv separator"
-  // with "a newline INSIDE an arg". A multi-paragraph seed prompt (the `-i`
-  // queue's common case) was shredded into one positional per line, so claude/
-  // codex were launched as `claude "line1" "line2" …` — only the first line
-  // reached the agent and the surplus positionals could abort the launch, so
-  // the detached session died and `verifyDetachedSession` failed the job. Here
-  // the inner newlines live INSIDE a token's base64 payload (base64's alphabet
-  // is `[A-Za-z0-9+/=]` — no newlines), so they never act as a separator; only
-  // the outer per-token newlines split the argv.
-  const blob = Buffer.from(
-    extraArgs.map((a) => Buffer.from(a, 'utf8').toString('base64')).join('\n'),
-    'utf8',
-  ).toString('base64');
-  // The decode feeds the read loop via a **here-string**, NOT process
-  // substitution (`< <(…)`). Process substitution needs `/dev/fd/N`, and the
-  // Vercel Sandbox (Firecracker microVM, AL2023) has no `/dev/fd` — so it would
-  // fail with `/dev/fd/63: No such file or directory`, A stays empty, and the
-  // agent launches with no args (the wizard's initial setup prompt is silently
-  // dropped). A here-string is backed by a temp file, needs no `/dev/fd`, and
-  // works on every backend (docker/daytona/hetzner unaffected). `$(…)` strips
-  // the trailing newline `<<<` re-adds, so the loop yields one element per token
-  // exactly as the join produced them.
-  //
-  // **bash -lc body MUST be single-quoted, not double-quoted.** When tmux
-  // launches the session command, it goes through `/bin/sh -c <cmd>`. If we
-  // double-quote, sh's parser sees `"${A[@]}"` and expands it eagerly —
-  // before the loop ever runs — to the empty string, so claude is invoked as
-  // `claude ""` and the wizard's initial prompt is silently dropped. Single
-  // quotes are inert in sh's parser: the literal `${A[@]}` (and `$(…)`) reach
-  // bash, which runs them AFTER the outer sh layer. The outer shellSingle wrap
-  // in renderInnerCommand re-escapes any internal `'` as `'\''`; this body has
-  // no single quotes (it uses double quotes around the here-string), so it
-  // composes fine.
-  return `bash -lc '${agentStartBanner(binary)}A=(); while IFS= read -r t; do A+=("$(printf %s "$t" | base64 -d)"); done <<< "$(echo ${blob} | base64 -d)"; exec ${binary} "\${A[@]}"'`;
 }
 
 export async function cloudAgentAttach(args: CloudAgentAttachArgs): Promise<void> {
@@ -341,109 +273,12 @@ export async function cloudAgentAttach(args: CloudAgentAttachArgs): Promise<void
 }
 
 /**
- * Create + configure the agent's tmux session running `command` without
- * attaching (the `detached` buildAttach mode). Shared by the new-tab attach
- * pre-start and the background (`-i`) queue worker. Returns the session-create
- * command's exit code + stderr so the queue worker can fail the job when the
- * session was never created; the new-tab pre-start ignores the result (a real
- * launch failure surfaces on the subsequent attach).
- */
-async function startDetachedSession(
-  provider: Provider,
-  box: BoxRecord,
-  sessionName: string,
-  command: string,
-): Promise<{ exitCode: number; stderr: string }> {
-  if (!provider.buildAttach) {
-    throw new Error(`provider '${provider.name}' does not support detached sessions`);
-  }
-  const spec = await provider.buildAttach(box, 'agent', {
-    sessionName,
-    command,
-    detached: true,
-  });
-  try {
-    return await runDetached(spec.argv, spec.env);
-  } finally {
-    if (spec.cleanup) await spec.cleanup();
-  }
-}
-
-/**
- * Markers an agent prints to its TUI when its in-box credentials are rejected.
- * The seeded cloud login can be stale (it expires independently of the host
- * session — `agentbox <agent> login` refreshes it), in which case the agent
- * launches, draws, then sits on an auth error doing no work. Scraping the pane
- * for these turns that otherwise-silent dead-end into an actionable failure.
- */
-const AGENT_AUTH_FAILURE =
-  /Please run \/login|Invalid authentication credentials|API Error: 401|Invalid API key|\bUnauthorized\b/i;
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-/**
- * After a detached pre-start, confirm the agent's tmux session actually came up
- * and stayed up. `tmux new-session -d` creates the session synchronously, so a
- * session that's already gone — or vanishes within the settle window — means the
- * agent process exited immediately at launch (the single-window session dies
- * with it). This is the exact silent failure the `-i` queue path hit on cloud
- * providers: the box was created and the job reported "done", but no session was
- * ever running. We also scrape the pane for credential-rejection markers, the
- * most common cause of a session that's technically alive but doing nothing.
- * Throws an actionable error so the caller surfaces it (queue worker → failed
- * job; restore → logged) instead of masking it.
- */
-export async function verifyDetachedSession(
-  provider: Provider,
-  box: BoxRecord,
-  sessionName: string,
-  binary: string,
-  opts: { windowMs?: number; pollMs?: number } = {},
-): Promise<void> {
-  const windowMs = opts.windowMs ?? 10_000;
-  const pollMs = opts.pollMs ?? 2_000;
-  const q = `'${sessionName.replace(/'/g, `'\\''`)}'`;
-  // One round-trip per tick: bail (exit 7) if the session is gone, else echo the
-  // pane so we can sniff for an auth dead-end.
-  const probe = `tmux has-session -t ${q} 2>/dev/null || exit 7; tmux capture-pane -p -t ${q} 2>/dev/null`;
-  const deadline = Date.now() + windowMs;
-  for (;;) {
-    let pane = '';
-    try {
-      const r = await provider.exec(box, ['bash', '-lc', probe], { user: 'vscode' });
-      if (r.exitCode === 7) {
-        throw new Error(
-          `agent '${binary}' exited immediately after launch in box ${box.name} — the session did not stay up. ` +
-            `Attach to inspect: agentbox ${binary} attach ${box.name}`,
-        );
-      }
-      pane = r.stdout;
-    } catch (err) {
-      // Re-throw our own diagnosis; a transport-level probe error is NOT proof
-      // of death (don't false-fail on a flaky exec) — keep polling.
-      if (err instanceof Error && err.message.startsWith(`agent '${binary}'`)) throw err;
-    }
-    if (AGENT_AUTH_FAILURE.test(pane)) {
-      throw new Error(
-        `box ${binary} credentials were rejected — the agent launched but printed an auth error, so no work will run. ` +
-          `Refresh them with \`agentbox ${binary} login\`, then re-run.`,
-      );
-    }
-    if (Date.now() >= deadline) break;
-    await sleep(pollMs);
-  }
-}
-
-/**
- * Provision-time entry point for background (`-i`) cloud jobs: resolve the
- * provider, ensure the box is running, then pre-start a detached agent tmux
- * session seeded with `extraArgs` (the seed prompt as first positional + the
- * user's post-`--` args). Mirrors the `probeState`/`start` guard in
- * `cloudAgentAttach` so a box that came up paused still gets its session. A
- * later `agentbox <agent> attach` finds the running session via
- * `tmux has-session` and just attaches.
+ * Provision-time entry point for background (`-i`) cloud jobs: resolve the box's
+ * provider, then pre-start a detached agent tmux session seeded with `extraArgs`
+ * (the seed prompt + the user's post-`--` args), delegating the run + verify to
+ * the shared `startDetachedCloudAgent` (which the hub worker also uses). With no
+ * user args it resumes the box's recorded session instead of launching fresh —
+ * the `-i` queue path always seeds a prompt, so that no-ops.
  */
 export async function cloudAgentStartDetached(args: {
   box: BoxRecord;
@@ -452,69 +287,15 @@ export async function cloudAgentStartDetached(args: {
   extraArgs?: string[];
 }): Promise<void> {
   const provider = await providerForBox(args.box);
-  let box = args.box;
-  const state = await provider.probeState(box);
-  if (state === 'missing') {
-    throw new Error(`cloud sandbox for ${box.name} is missing; was it destroyed?`);
-  }
-  if (state !== 'running') {
-    box = await provider.start(box);
-  }
-  // With no user args, resume the box's recorded session instead of launching
-  // fresh — same as the interactive `cloudAgentAttach` path. Matters for a
-  // background `agentbox <agent> start <box> --no-attach` (and idle-resumed
-  // creates): the box already has a claude/codex session to reopen. The `-i`
-  // queue path always seeds a prompt, so extraArgs is non-empty and this no-ops.
-  let extraArgs = args.extraArgs;
-  if (
-    (!extraArgs || extraArgs.length === 0) &&
-    (args.binary === 'claude' || args.binary === 'codex')
-  ) {
-    const resume = await agentResumeArgs(provider, box, args.binary);
-    if (resume) extraArgs = resume;
-  }
-  const command = buildCloudAttachInnerCommand(args.binary, extraArgs);
-  const { exitCode, stderr } = await startDetachedSession(
+  await startDetachedCloudAgent({
     provider,
-    box,
-    args.sessionName,
-    command,
-  );
-  if (exitCode !== 0) {
-    const detail = stderr.trim().slice(0, 500);
-    throw new Error(
-      `failed to start the ${args.binary} session in box ${box.name} (exit ${String(exitCode)})` +
-        (detail ? `: ${detail}` : ''),
-    );
-  }
-  await verifyDetachedSession(provider, box, args.sessionName, args.binary);
-}
-
-/**
- * Run an attach-style argv non-interactively to completion (used for the
- * `detached` session pre-start). The remote command only creates + configures
- * the tmux session and exits, so stdout is dropped — but stderr and the exit
- * code are captured: the E2B helper's `--detached` path runs the session-create
- * command via the SDK and exits with its code, so a non-zero here is the only
- * signal that the session was never created (e.g. a transient SDK connect/exec
- * failure). Callers decide whether to surface it — the queue worker fails the
- * job, the new-tab pre-start ignores it (the subsequent attach re-creates the
- * session anyway). Resolves on exit regardless of code (never rejects).
- */
-function runDetached(
-  argv: string[],
-  env?: Record<string, string>,
-): Promise<{ exitCode: number; stderr: string }> {
-  return new Promise((resolve) => {
-    const child = spawn(argv[0]!, argv.slice(1), {
-      stdio: ['ignore', 'ignore', 'pipe'],
-      env: env ? { ...process.env, ...env } : process.env,
-    });
-    let stderr = '';
-    child.stderr?.on('data', (c: Buffer) => {
-      stderr += c.toString('utf8');
-    });
-    child.on('error', (err) => resolve({ exitCode: 1, stderr: stderr + String(err.message ?? err) }));
-    child.on('exit', (code) => resolve({ exitCode: code ?? 0, stderr }));
+    box: args.box,
+    binary: args.binary,
+    sessionName: args.sessionName,
+    extraArgs: args.extraArgs,
+    resolveResumeArgs:
+      args.binary === 'claude' || args.binary === 'codex'
+        ? (box) => agentResumeArgs(provider, box, args.binary as 'claude' | 'codex')
+        : undefined,
   });
 }

--- a/apps/cli/src/commands/_cloud-attach.ts
+++ b/apps/cli/src/commands/_cloud-attach.ts
@@ -9,7 +9,7 @@ import {
   startDetachedSession,
   verifyDetachedSession,
 } from '@agentbox/sandbox-cloud';
-import type { BoxRecord, Provider } from '@agentbox/core';
+import type { BoxRecord } from '@agentbox/core';
 import type { AttachOpenIn } from '@agentbox/config';
 import { agentResumeArgs } from '../agent-sessions.js';
 

--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -59,7 +59,7 @@ import {
 } from './_attach-in.js';
 import { cloudAgentAttach, cloudAgentStartDetached } from './_cloud-attach.js';
 import { cloudAgentCreate } from './_cloud-agent-create.js';
-import { createCloudBoxViaHubAndAdopt } from './_cloud-agent-via-hub.js';
+import { createCloudBoxViaHubAndAdopt, enqueueAgentJobViaHub } from './_cloud-agent-via-hub.js';
 import { resolveCreateRouting } from '../control-plane/route-create.js';
 import { runCarryGate, runQueuedCarryGate } from '../lib/carry-gate.js';
 import { resolveGitCredsCarry } from '../lib/git-creds-gate.js';
@@ -680,6 +680,48 @@ export const claudeCommand = new Command('claude')
         );
         cmdLog.close();
         process.exit(1);
+      }
+      // Route the background run to the control box when one is configured: the
+      // resident worker creates the box AND starts claude with the prompt, so it
+      // runs with the laptop off. Local agent creds aren't needed for the hub path
+      // (the control box seeds them from custody), so route before the local check.
+      const iRouting = await resolveCreateRouting({
+        providerName,
+        effective: cfg.effective,
+        projectRoot,
+        forceHub: opts.viaHub,
+        forceLocal: opts.local,
+        urlFlag: opts.url,
+      });
+      if (iRouting.where === 'hub') {
+        const res = await enqueueAgentJobViaHub({
+          providerName,
+          projectRoot,
+          agent: 'claude',
+          name: opts.name,
+          fromBranch: opts.fromBranch,
+          urlFlag: opts.url,
+          prompt: opts.initialPrompt,
+          agentArgs: applyClaudeSkipPermissions(claudeArgs, cfg.effective),
+          onStatus: (line) => log.step(line),
+        });
+        if (res) {
+          if (res.error) {
+            log.error(
+              `control plane run failed: ${res.error}` +
+                (res.boxId ? ` (box ${res.boxId} was created — attach with \`agentbox claude attach ${res.boxId}\`)` : ''),
+            );
+            cmdLog.close();
+            process.exit(1);
+          }
+          outro(`claude is running on the control plane: box ${res.boxId ?? '(id pending)'}`);
+          cmdLog.close();
+          return;
+        }
+        // res === null → control box not fully configured; fall through to local.
+      }
+      if (iRouting.where === 'local' && iRouting.fellBackReason) {
+        log.warn(`control box configured but ${iRouting.fellBackReason}; running this -i job locally.`);
       }
       try {
         await assertAgentCredsAvailable({

--- a/apps/cli/src/commands/codex.ts
+++ b/apps/cli/src/commands/codex.ts
@@ -64,7 +64,7 @@ import {
 } from './_attach-in.js';
 import { cloudAgentAttach, cloudAgentStartDetached } from './_cloud-attach.js';
 import { cloudAgentCreate } from './_cloud-agent-create.js';
-import { createCloudBoxViaHubAndAdopt } from './_cloud-agent-via-hub.js';
+import { createCloudBoxViaHubAndAdopt, enqueueAgentJobViaHub } from './_cloud-agent-via-hub.js';
 import { resolveCreateRouting } from '../control-plane/route-create.js';
 import { runCarryGate, runQueuedCarryGate } from '../lib/carry-gate.js';
 import { resolveGitCredsCarry } from '../lib/git-creds-gate.js';
@@ -573,6 +573,46 @@ export const codexCommand = new Command('codex')
         );
         cmdLog.close();
         process.exit(1);
+      }
+      // Route the background run to the control box when configured — the worker
+      // creates the box AND starts codex with the prompt (laptop off). Local
+      // creds aren't needed for the hub path (custody seeds them).
+      const iRouting = await resolveCreateRouting({
+        providerName,
+        effective: cfg.effective,
+        projectRoot,
+        forceHub: opts.viaHub,
+        forceLocal: opts.local,
+        urlFlag: opts.url,
+      });
+      if (iRouting.where === 'hub') {
+        const res = await enqueueAgentJobViaHub({
+          providerName,
+          projectRoot,
+          agent: 'codex',
+          name: opts.name,
+          fromBranch: opts.fromBranch,
+          urlFlag: opts.url,
+          prompt: opts.initialPrompt,
+          agentArgs: applyCodexSkipPermissions(codexArgs, cfg.effective),
+          onStatus: (line) => log.step(line),
+        });
+        if (res) {
+          if (res.error) {
+            log.error(
+              `control plane run failed: ${res.error}` +
+                (res.boxId ? ` (box ${res.boxId} was created — attach with \`agentbox codex attach ${res.boxId}\`)` : ''),
+            );
+            cmdLog.close();
+            process.exit(1);
+          }
+          outro(`codex is running on the control plane: box ${res.boxId ?? '(id pending)'}`);
+          cmdLog.close();
+          return;
+        }
+      }
+      if (iRouting.where === 'local' && iRouting.fellBackReason) {
+        log.warn(`control box configured but ${iRouting.fellBackReason}; running this -i job locally.`);
       }
       try {
         await assertAgentCredsAvailable({

--- a/apps/cli/src/commands/opencode.ts
+++ b/apps/cli/src/commands/opencode.ts
@@ -61,7 +61,7 @@ import {
 } from './_attach-in.js';
 import { cloudAgentAttach, cloudAgentStartDetached } from './_cloud-attach.js';
 import { cloudAgentCreate } from './_cloud-agent-create.js';
-import { createCloudBoxViaHubAndAdopt } from './_cloud-agent-via-hub.js';
+import { createCloudBoxViaHubAndAdopt, enqueueAgentJobViaHub } from './_cloud-agent-via-hub.js';
 import { resolveCreateRouting } from '../control-plane/route-create.js';
 import { runCarryGate, runQueuedCarryGate } from '../lib/carry-gate.js';
 import { resolveGitCredsCarry } from '../lib/git-creds-gate.js';
@@ -566,6 +566,46 @@ export const opencodeCommand = new Command('opencode')
         );
         cmdLog.close();
         process.exit(1);
+      }
+      // Route the background run to the control box when configured — the worker
+      // creates the box AND starts opencode with the prompt (laptop off). Local
+      // creds aren't needed for the hub path (custody seeds them).
+      const iRouting = await resolveCreateRouting({
+        providerName,
+        effective: cfg.effective,
+        projectRoot,
+        forceHub: opts.viaHub,
+        forceLocal: opts.local,
+        urlFlag: opts.url,
+      });
+      if (iRouting.where === 'hub') {
+        const res = await enqueueAgentJobViaHub({
+          providerName,
+          projectRoot,
+          agent: 'opencode',
+          name: opts.name,
+          fromBranch: opts.fromBranch,
+          urlFlag: opts.url,
+          prompt: opts.initialPrompt,
+          agentArgs: opencodeArgs,
+          onStatus: (line) => log.step(line),
+        });
+        if (res) {
+          if (res.error) {
+            log.error(
+              `control plane run failed: ${res.error}` +
+                (res.boxId ? ` (box ${res.boxId} was created — attach with \`agentbox opencode attach ${res.boxId}\`)` : ''),
+            );
+            cmdLog.close();
+            process.exit(1);
+          }
+          outro(`opencode is running on the control plane: box ${res.boxId ?? '(id pending)'}`);
+          cmdLog.close();
+          return;
+        }
+      }
+      if (iRouting.where === 'local' && iRouting.fellBackReason) {
+        log.warn(`control box configured but ${iRouting.fellBackReason}; running this -i job locally.`);
       }
       try {
         await assertAgentCredsAvailable({

--- a/apps/hub/lib/hub-worker.ts
+++ b/apps/hub/lib/hub-worker.ts
@@ -32,7 +32,8 @@ import {
   boxSshDirForProvider,
   projectSlugFromOriginUrl,
 } from '@agentbox/sandbox-core';
-import { applyProjectSeed } from '@agentbox/sandbox-cloud';
+import { applyProjectSeed, startDetachedCloudAgent } from '@agentbox/sandbox-cloud';
+import { resolveAgentLauncher, type AgentKind } from '@agentbox/core';
 import type { ProviderModule } from '@agentbox/sandbox-core';
 import { hydratePreparedFromCustody } from './prepared-hydrate.js';
 
@@ -203,7 +204,7 @@ export function makeHubCreateBox(opts: HubWorkerOptions): CreateBoxFn {
       await runGit(branch ? ['clone', '--branch', branch, authedUrl, dest] : ['clone', authedUrl, dest]);
       await runGit(['-C', dest, 'remote', 'set-url', 'origin', repoUrl]);
     },
-    createBox: async ({ workspacePath, name, provider, agent, onLog }) => {
+    createBox: async ({ workspacePath, name, provider, agent, prompt, agentArgs, onLog }) => {
       if (!isProviderKind(provider)) throw new Error(`unknown provider ${provider}`);
       const mod = (await IMPORTERS[provider]()).providerModule;
       if (mod.ensureCredentials) await mod.ensureCredentials();
@@ -230,6 +231,34 @@ export function makeHubCreateBox(opts: HubWorkerOptions): CreateBoxFn {
         onLog,
       });
       await mirrorBoxSshToCustody(custody, provider, created.record.cloud?.sandboxId, log);
+
+      // Background `-i`: a seed prompt means run the agent fully on the control
+      // box (create + start detached), so the laptop can be off from submit on.
+      // A cold create (create --via-hub / foreground) has no prompt — the PC
+      // attaches those. Creds were seeded above (seedHostBackupsFromCustody), so
+      // the box is logged in; a not-logged-in box surfaces as an actionable error
+      // from verifyDetachedSession, which we return so the job fails WITH the box
+      // id (box preserved for adopt/attach + re-login).
+      const boxAgent = normalizeCreateAgent(agent);
+      if (boxAgent && prompt && prompt.length > 0) {
+        const kind: AgentKind = boxAgent === 'claude' ? 'claude-code' : boxAgent;
+        const extraArgs = resolveAgentLauncher(kind).buildArgs(prompt, agentArgs ?? []);
+        log(`starting ${boxAgent} in ${created.record.name} with the seed prompt`);
+        try {
+          await startDetachedCloudAgent({
+            provider: mod.provider,
+            box: created.record,
+            binary: boxAgent,
+            sessionName: boxAgent,
+            extraArgs,
+          });
+          log(`${boxAgent} session is running in ${created.record.name}`);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          log(`agent start failed (box was created): ${msg}`);
+          return { id: created.record.id, agentStartError: msg };
+        }
+      }
       return { id: created.record.id };
     },
     fetchSeedMaterial: (repoUrl, dest) => applySeedFromCustody(custody, repoUrl, dest, log),

--- a/apps/web/content/docs/deployed-hub.mdx
+++ b/apps/web/content/docs/deployed-hub.mdx
@@ -71,11 +71,12 @@ The web-UI create needs a **repo checkout on the VPS** for the worker to build f
 Once a control box is configured, spawning a **cloud** box from the CLI builds it **on the control box by default** — so it keeps working after you close your laptop. Just run a normal cloud create:
 
 ```bash
-agentbox create --provider e2b          # built on the control box (default)
-agentbox claude --provider e2b          # foreground: built on the control box, then attached here
+agentbox create --provider e2b               # built on the control box (default)
+agentbox claude --provider e2b               # foreground: built on the control box, then attached here
+agentbox claude --provider e2b -i "fix the …"  # background: created AND run on the control box
 ```
 
-The box is provisioned **VPS-side**, so it works even if the provider's credentials aren't configured on your laptop, and it keeps running once enqueued. It registers on the control box, so it shows in the web UI and its approvals are answerable from anywhere. (`agentbox create` streams the job to completion; a foreground `agentbox claude`/`codex`/`opencode` waits for the box, then **adopts + attaches** it here so the agent starts.)
+The box is provisioned **VPS-side**, so it works even if the provider's credentials aren't configured on your laptop, and it keeps running once enqueued. It registers on the control box, so it shows in the web UI and its approvals are answerable from anywhere. (`agentbox create` streams the job to completion; a foreground `agentbox claude`/`codex`/`opencode` waits for the box, then **adopts + attaches** it here so the agent starts; a **background `-i`** run has the control box start the agent in-box with your prompt — nothing runs on, or waits for, your laptop.)
 
 You can force either side explicitly:
 
@@ -84,7 +85,7 @@ agentbox create --provider e2b --via-hub   # force the control box (even if clou
 agentbox create --provider e2b --local     # force a local build on this machine
 ```
 
-<Callout type="info" title="Which creates route to the control box">Only **cloud** creates default to the control box, and only when one is configured. Set **`cloud.viaHub=false`** (or pass `--local`) to keep building cloud boxes on your PC. Docker / remote-docker always build locally. **Background `-i` runs** (`agentbox claude -i "…"`) still build on your PC for now — the control box's worker builds boxes "cold" and doesn't yet start the agent; a missing prerequisite (no git `origin`, no admin token) also falls back to a local build with a notice.</Callout>
+<Callout type="info" title="Which creates route to the control box">Only **cloud** creates default to the control box, and only when one is configured — this covers `create`, foreground `claude`/`codex`/`opencode`, and background `-i` runs alike. Set **`cloud.viaHub=false`** (or pass `--local`) to keep building cloud boxes on your PC. Docker / remote-docker always build locally. A missing prerequisite (no git `origin`, no admin token) falls back to a local build with a notice. A background `-i` run needs the agent's login in custody (`agentbox control-plane credentials push`) so the control box can start it — if it's missing or stale, the job **fails with a clear "credentials rejected" message and the box id preserved**, so you can attach and re-login.</Callout>
 
 Now the payoff — the box pushes on its own, with your laptop fully off:
 

--- a/docs/hub-api-consolidation-plan.md
+++ b/docs/hub-api-consolidation-plan.md
@@ -14,8 +14,10 @@
 > **Phase 3 shipped** (tray follows the CLI hub config via `agentbox hub target`; `/api/events`
 > accepts the headless Bearer key; cloud box creation — `create` + foreground `claude`/`codex`/
 > `opencode` — defaults to the control box when configured, via `cloud.viaHub`, docker stays local);
-> `ls -g` + `create --via-hub` main-command dispatch + hub-worker agent-launch for background `-i`
-> deferred (see the phased plan below). Maintain status live per project convention.
+> **background `-i` on the control box shipped** (the hub worker starts the agent detached with the
+> seed prompt, so `-i` cloud runs execute fully on the control box); `ls -g` + `create --via-hub`
+> onto `/api/v1` + the main-command dispatch remain deferred (see the phased plan below). Maintain
+> status live per project convention.
 
 ## Context
 
@@ -243,10 +245,15 @@ intentional divergences above (git auth, gate, worker) branch on the profile.
     local; a missing prerequisite (no git origin / admin token) falls back to a local build with a
     notice. Routing decision centralized in `route-create.ts` (`resolveCreateRouting`) +
     `isHubRoutableProvider` (clouds minus remote-docker).
-  - **Deferred:** **background `-i`** stays on the local queue — the hub create worker builds boxes
-    "cold" (it never launches the agent or seeds the prompt), so routing `-i` there needs a new
-    worker feature (agent-launch + prompt-seed). `create --via-hub` onto `/api/v1`, `ls -g`, and the
-    main `start/stop/git <box>` dispatch remain as before.
+  - **Background `-i` on the control box. DONE (follow-up).** The hub create worker now starts the
+    agent detached with the seed prompt after it creates the box, so `agentbox claude|codex|opencode
+    -i "…"` on a cloud provider runs entirely on the control box (laptop off). The detached-start
+    orchestration moved into `@agentbox/sandbox-cloud` (`startDetachedCloudAgent`, shared with the
+    CLI's local `-i` path); `CreateJobRequest`/`CreateBoxDeps` carry `prompt`/`agentArgs`; an
+    agent-start failure fails the job **with the box id preserved** (creds re-login path). The CLI
+    `-i` branch defaults to the hub via the same `resolveCreateRouting` (`--local` opts out).
+  - **Deferred:** `create --via-hub` onto `/api/v1`, `ls -g`, and the main `start/stop/git <box>`
+    dispatch remain as before.
 - **Phase 4 — Web UI onto `/api/v1`.** Migrate `apps/hub/lib/boxes/actions.ts` server-action mutations
   to the same `/api/v1` fetches, so all three clients share one path and a remote deploy needs no
   in-process backend.

--- a/packages/relay/src/create-worker.ts
+++ b/packages/relay/src/create-worker.ts
@@ -7,7 +7,10 @@ import type { CreateJobRequest, Store } from './store/store.js';
  * host bundle). Kept injectable so the worker loop is unit-testable without a
  * live cloud, and so the heavy provider wiring lives outside the relay core.
  */
-export type CreateBoxFn = (request: CreateJobRequest, jobId: string) => Promise<{ boxId: string }>;
+export type CreateBoxFn = (
+  request: CreateJobRequest,
+  jobId: string,
+) => Promise<{ boxId: string; agentStartError?: string }>;
 
 /**
  * Side-effecting steps a {@link makeControlPlaneCreateBox} needs, all injected
@@ -25,18 +28,28 @@ export interface CreateBoxDeps {
    * the remote back to the bare `repoUrl`.
    */
   cloneRepo(authedUrl: string, repoUrl: string, dest: string, branch?: string): Promise<void>;
-  /** Provision the cloud box from the local checkout. Returns the new box id. */
+  /**
+   * Provision the cloud box from the local checkout. Returns the new box id, and
+   * `agentStartError` when the box was created but starting the agent in-box
+   * failed (a background `-i` run) — the caller fails the job WITH the box id so
+   * the box is preserved for adopt/attach.
+   */
   createBox(opts: {
     workspacePath: string;
     name: string | undefined;
     provider: string;
     /**
      * Agent the box is being created for. Registered on the control plane so a
-     * PC adopting this box knows which agent to relaunch.
+     * PC adopting this box knows which agent to relaunch. When `prompt` is set
+     * the worker also STARTS this agent detached in the box.
      */
     agent?: string;
+    /** Seed prompt for a background `-i` run — present ⇒ start the agent in-box. */
+    prompt?: string;
+    /** Fully-processed agent args (post-`--`, incl. skip-permissions). */
+    agentArgs?: string[];
     onLog?: (line: string) => void;
-  }): Promise<{ id: string }>;
+  }): Promise<{ id: string; agentStartError?: string }>;
   /** Make a per-job temp dir path. */
   tmpDir(jobId: string): string;
   /** Remove the temp checkout (best-effort). */
@@ -103,10 +116,15 @@ export function makeControlPlaneCreateBox(deps: CreateBoxDeps): CreateBoxFn {
         // registration, so an adopting PC relaunches the right agent instead of
         // guessing. Without this a hub-created box adopts with no `lastAgent`.
         agent: request.agent,
+        // A background `-i` run seeds a prompt: the worker starts the agent
+        // in-box with these. Absent ⇒ a "cold" create (create --via-hub /
+        // foreground) that the PC attaches later.
+        prompt: request.prompt,
+        agentArgs: request.agentArgs,
         onLog: deps.log,
       });
       log(`created box ${box.id}`);
-      return { boxId: box.id };
+      return { boxId: box.id, agentStartError: box.agentStartError };
     } finally {
       await deps.cleanup(dir);
     }
@@ -127,8 +145,14 @@ export async function drainOneCreateJob(
   const job = await store.claimNextCreateJob(workerId);
   if (!job) return null;
   try {
-    const { boxId } = await createBox(job.request, job.id);
-    await store.completeCreateJob(job.id, 'done', { boxId });
+    const { boxId, agentStartError } = await createBox(job.request, job.id);
+    // The box was created; if starting the agent in-box failed, fail the job but
+    // keep the box id so it's adoptable/attachable (the user re-logins + retries).
+    if (agentStartError) {
+      await store.completeCreateJob(job.id, 'failed', { boxId, error: agentStartError });
+    } else {
+      await store.completeCreateJob(job.id, 'done', { boxId });
+    }
   } catch (err) {
     await store.completeCreateJob(job.id, 'failed', {
       error: err instanceof Error ? err.message : String(err),

--- a/packages/relay/src/store/store.ts
+++ b/packages/relay/src/store/store.ts
@@ -38,10 +38,15 @@ export interface CreateJobRequest {
   branch?: string;
   /** Desired box name (default: generated). */
   name?: string;
-  /** Agent to launch (e.g. 'claude'); informational for the worker. */
+  /** Agent to launch (e.g. 'claude'). The worker starts it detached when a
+   * `prompt` is set (a background `-i` run); otherwise it's a registration hint. */
   agent?: string;
-  /** Initial prompt to queue for the agent, if any. */
+  /** Initial prompt to seed the agent with. Its presence is what makes the
+   * worker start the agent in-box (vs. a "cold" create the PC attaches later). */
   prompt?: string;
+  /** Fully-processed agent args (post-`--`, incl. skip-permissions) the CLI
+   * computed from its config, so the worker needs no CLI/config to launch. */
+  agentArgs?: string[];
 }
 
 /** A durable box-creation job (the hosted plane's create queue). */

--- a/packages/relay/test/create-worker.test.ts
+++ b/packages/relay/test/create-worker.test.ts
@@ -85,6 +85,28 @@ describe('box-create flow', () => {
     expect(job?.result?.error).toMatch(/provider exploded/);
   });
 
+  it('an agent-start failure fails the job but keeps the box id', async () => {
+    // A background `-i` run: the box was created, but starting the agent in-box
+    // failed (e.g. creds rejected). The job must fail (so it isn't masked as done)
+    // while preserving the box id, so the box is adoptable/attachable to re-login.
+    const store = new MemoryStore();
+    await store.enqueueCreateJob({
+      id: 'j2',
+      status: 'queued',
+      request: { repoUrl: 'x', provider: 'e2b', agent: 'claude', prompt: 'do a thing' },
+      createdAt: new Date().toISOString(),
+    });
+    await drainOneCreateJob(
+      store,
+      () => Promise.resolve({ boxId: 'box-created', agentStartError: 'credentials were rejected' }),
+      'w1',
+    );
+    const job = await store.getCreateJob('j2');
+    expect(job?.status).toBe('failed');
+    expect(job?.result?.boxId).toBe('box-created');
+    expect(job?.result?.error).toMatch(/credentials were rejected/);
+  });
+
   it('drains nothing when the queue is empty', async () => {
     const store = new MemoryStore();
     expect(await drainOneCreateJob(store, () => Promise.resolve({ boxId: 'x' }), 'w1')).toBeNull();

--- a/packages/sandbox-cloud/src/detached-agent.ts
+++ b/packages/sandbox-cloud/src/detached-agent.ts
@@ -191,6 +191,8 @@ export interface StartDetachedCloudAgentArgs {
    * background `-i` path never passes this — it always seeds a prompt.
    */
   resolveResumeArgs?: (box: BoxRecord) => Promise<string[] | null>;
+  /** Settle-window tuning for the post-start session verification (test hook). */
+  verify?: { windowMs?: number; pollMs?: number };
 }
 
 /**
@@ -223,6 +225,6 @@ export async function startDetachedCloudAgent(args: StartDetachedCloudAgentArgs)
         (detail ? `: ${detail}` : ''),
     );
   }
-  await verifyDetachedSession(provider, box, sessionName, binary);
+  await verifyDetachedSession(provider, box, sessionName, binary, args.verify);
   return box;
 }

--- a/packages/sandbox-cloud/src/detached-agent.ts
+++ b/packages/sandbox-cloud/src/detached-agent.ts
@@ -1,0 +1,228 @@
+/**
+ * Start an agent's tmux session inside a cloud sandbox WITHOUT attaching — the
+ * "detached" provider `buildAttach` mode — then verify it stayed up. Shared by:
+ *   - the CLI's background `-i` queue worker + new-tab pre-start
+ *     (`apps/cli/.../_cloud-attach.ts` `cloudAgentStartDetached`), and
+ *   - the deployed control box's create worker (`apps/hub/lib/hub-worker.ts`),
+ *     which runs an `-i` job entirely on the VPS.
+ *
+ * It stands only on the `Provider` interface (`buildAttach({detached:true})` +
+ * `exec`) so it lives here in `@agentbox/sandbox-cloud` — importable by the hub,
+ * which cannot import `apps/cli`. The apps/cli entry point keeps a thin wrapper
+ * that resolves the provider from the box + handles the resume-fallback.
+ */
+import { spawn } from 'node:child_process';
+import type { BoxRecord, Provider } from '@agentbox/core';
+
+/** Printed in the pane the instant the session command starts, so a freshly
+ * attached pane is never blank during the agent's cold-start (node cold-start +
+ * a large seed prompt + TUI init can take seconds). Plain ASCII on purpose — it
+ * threads through several shell-quoting layers. */
+function agentStartBanner(binary: string): string {
+  return `printf "  agentbox: starting ${binary} (first paint may take a few seconds)...\\r\\n"; `;
+}
+
+/**
+ * Render the inner shell command tmux runs inside the cloud sandbox. Exported so
+ * unit tests can exercise the base64 round-trip without spinning up SSH, and so
+ * the interactive attach path shares the exact launcher.
+ *
+ * Both paths run `agentStartBanner` first. The body is single-quoted (`bash -lc
+ * '…'`); `exec <binary>` replaces the shell so the agent keeps PID 2 (Ctrl-c in
+ * the agent tears the session down cleanly).
+ */
+export function buildCloudAttachInnerCommand(binary: string, extraArgs?: string[]): string {
+  if (!extraArgs || extraArgs.length === 0) {
+    return `bash -lc '${agentStartBanner(binary)}exec ${binary}'`;
+  }
+  // Encode EACH arg to its own base64 token, newline-join the tokens, then
+  // base64 that whole list once more into a single opaque `blob`. The launcher
+  // decodes `blob` back to the newline-separated tokens, reads them one per
+  // line, and base64-decodes each into its own argv element before
+  // `exec <binary> "${A[@]}"`.
+  //
+  // Two layers, not one, on purpose: joining args with a single `\n` and
+  // splitting with `mapfile -t` conflates "argv separator" with "a newline
+  // INSIDE an arg". A multi-paragraph seed prompt (the `-i` common case) was
+  // shredded into one positional per line. Here the inner newlines live INSIDE a
+  // token's base64 payload (alphabet `[A-Za-z0-9+/=]` — no newlines), so they
+  // never act as a separator; only the outer per-token newlines split the argv.
+  const blob = Buffer.from(
+    extraArgs.map((a) => Buffer.from(a, 'utf8').toString('base64')).join('\n'),
+    'utf8',
+  ).toString('base64');
+  // The decode feeds the read loop via a **here-string**, NOT process
+  // substitution (`< <(…)`): the Vercel Sandbox (AL2023) has no `/dev/fd`. And
+  // the `bash -lc` body MUST be single-quoted — a double-quoted `"${A[@]}"`
+  // expands eagerly under the outer `/bin/sh -c` before the loop runs, dropping
+  // the seed prompt. Single quotes are inert to sh; bash runs `${A[@]}`/`$(…)`.
+  return `bash -lc '${agentStartBanner(binary)}A=(); while IFS= read -r t; do A+=("$(printf %s "$t" | base64 -d)"); done <<< "$(echo ${blob} | base64 -d)"; exec ${binary} "\${A[@]}"'`;
+}
+
+/**
+ * Create + configure the agent's tmux session running `command` without
+ * attaching (the `detached` buildAttach mode). Returns the session-create
+ * command's exit code + stderr so callers can fail when the session was never
+ * created.
+ */
+export async function startDetachedSession(
+  provider: Provider,
+  box: BoxRecord,
+  sessionName: string,
+  command: string,
+): Promise<{ exitCode: number; stderr: string }> {
+  if (!provider.buildAttach) {
+    throw new Error(`provider '${provider.name}' does not support detached sessions`);
+  }
+  const spec = await provider.buildAttach(box, 'agent', {
+    sessionName,
+    command,
+    detached: true,
+  });
+  try {
+    return await runDetached(spec.argv, spec.env);
+  } finally {
+    if (spec.cleanup) await spec.cleanup();
+  }
+}
+
+/**
+ * Markers an agent prints to its TUI when its in-box credentials are rejected.
+ * The seeded cloud login can be stale (it expires independently — `agentbox
+ * <agent> login` refreshes it), in which case the agent launches, draws, then
+ * sits on an auth error doing no work. Scraping the pane turns that otherwise
+ * silent dead-end into an actionable failure.
+ */
+const AGENT_AUTH_FAILURE =
+  /Please run \/login|Invalid authentication credentials|API Error: 401|Invalid API key|\bUnauthorized\b/i;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * After a detached pre-start, confirm the agent's tmux session came up and
+ * stayed up. `tmux new-session -d` creates the session synchronously, so a
+ * session that's already gone — or vanishes within the settle window — means the
+ * agent process exited immediately at launch. We also scrape the pane for
+ * credential-rejection markers (the most common cause of an alive-but-idle
+ * session). Throws an actionable error so the caller surfaces it (queue worker /
+ * hub worker → failed job) instead of masking it.
+ */
+export async function verifyDetachedSession(
+  provider: Provider,
+  box: BoxRecord,
+  sessionName: string,
+  binary: string,
+  opts: { windowMs?: number; pollMs?: number } = {},
+): Promise<void> {
+  const windowMs = opts.windowMs ?? 10_000;
+  const pollMs = opts.pollMs ?? 2_000;
+  const q = `'${sessionName.replace(/'/g, `'\\''`)}'`;
+  // One round-trip per tick: bail (exit 7) if the session is gone, else echo the
+  // pane so we can sniff for an auth dead-end.
+  const probe = `tmux has-session -t ${q} 2>/dev/null || exit 7; tmux capture-pane -p -t ${q} 2>/dev/null`;
+  const deadline = Date.now() + windowMs;
+  for (;;) {
+    let pane = '';
+    try {
+      const r = await provider.exec(box, ['bash', '-lc', probe], { user: 'vscode' });
+      if (r.exitCode === 7) {
+        throw new Error(
+          `agent '${binary}' exited immediately after launch in box ${box.name} — the session did not stay up. ` +
+            `Attach to inspect: agentbox ${binary} attach ${box.name}`,
+        );
+      }
+      pane = r.stdout;
+    } catch (err) {
+      // Re-throw our own diagnosis; a transport-level probe error is NOT proof
+      // of death (don't false-fail on a flaky exec) — keep polling.
+      if (err instanceof Error && err.message.startsWith(`agent '${binary}'`)) throw err;
+    }
+    if (AGENT_AUTH_FAILURE.test(pane)) {
+      throw new Error(
+        `box ${binary} credentials were rejected — the agent launched but printed an auth error, so no work will run. ` +
+          `Refresh them with \`agentbox ${binary} login\`, then re-run.`,
+      );
+    }
+    if (Date.now() >= deadline) break;
+    await sleep(pollMs);
+  }
+}
+
+/**
+ * Run an attach-style argv non-interactively to completion (the `detached`
+ * session pre-start). The remote command only creates + configures the tmux
+ * session and exits; stdout is dropped, stderr + exit code captured. Resolves on
+ * exit regardless of code (never rejects).
+ */
+function runDetached(
+  argv: string[],
+  env?: Record<string, string>,
+): Promise<{ exitCode: number; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(argv[0]!, argv.slice(1), {
+      stdio: ['ignore', 'ignore', 'pipe'],
+      env: env ? { ...process.env, ...env } : process.env,
+    });
+    let stderr = '';
+    child.stderr?.on('data', (c: Buffer) => {
+      stderr += c.toString('utf8');
+    });
+    child.on('error', (err) => resolve({ exitCode: 1, stderr: stderr + String(err.message ?? err) }));
+    child.on('exit', (code) => resolve({ exitCode: code ?? 0, stderr }));
+  });
+}
+
+export interface StartDetachedCloudAgentArgs {
+  /** The box's provider (already resolved — the hub worker holds it directly). */
+  provider: Provider;
+  box: BoxRecord;
+  /** In-sandbox binary (`claude`/`codex`/`opencode`). */
+  binary: string;
+  /** tmux session name (usually the binary name). */
+  sessionName: string;
+  /** Seed prompt (already shaped into args) + any post-`--` user args. */
+  extraArgs?: string[];
+  /**
+   * With NO `extraArgs`, resolve the args to resume the box's recorded session
+   * instead of launching fresh. Runs AFTER the box is confirmed running (it
+   * execs in the box), so the caller doesn't have to start the box first. The
+   * background `-i` path never passes this — it always seeds a prompt.
+   */
+  resolveResumeArgs?: (box: BoxRecord) => Promise<string[] | null>;
+}
+
+/**
+ * Provision-time detached start: ensure the box is running, pre-start the agent
+ * tmux session seeded with `extraArgs`, and verify it stayed up (+ isn't sitting
+ * on an auth error). Provider-parameterized so the hub worker can call it against
+ * the `Provider` it already holds. Returns the possibly-started box record.
+ */
+export async function startDetachedCloudAgent(args: StartDetachedCloudAgentArgs): Promise<BoxRecord> {
+  const { provider, binary, sessionName } = args;
+  let box = args.box;
+  const state = await provider.probeState(box);
+  if (state === 'missing') {
+    throw new Error(`cloud sandbox for ${box.name} is missing; was it destroyed?`);
+  }
+  if (state !== 'running') {
+    box = await provider.start(box);
+  }
+  let extraArgs = args.extraArgs;
+  if ((!extraArgs || extraArgs.length === 0) && args.resolveResumeArgs) {
+    const resume = await args.resolveResumeArgs(box);
+    if (resume) extraArgs = resume;
+  }
+  const command = buildCloudAttachInnerCommand(binary, extraArgs);
+  const { exitCode, stderr } = await startDetachedSession(provider, box, sessionName, command);
+  if (exitCode !== 0) {
+    const detail = stderr.trim().slice(0, 500);
+    throw new Error(
+      `failed to start the ${binary} session in box ${box.name} (exit ${String(exitCode)})` +
+        (detail ? `: ${detail}` : ''),
+    );
+  }
+  await verifyDetachedSession(provider, box, sessionName, binary);
+  return box;
+}

--- a/packages/sandbox-cloud/src/index.ts
+++ b/packages/sandbox-cloud/src/index.ts
@@ -8,6 +8,13 @@ export {
   renderInnerCommand,
   type CreateCloudProviderOptions,
 } from './cloud-provider.js';
+export {
+  buildCloudAttachInnerCommand,
+  startDetachedCloudAgent,
+  startDetachedSession,
+  verifyDetachedSession,
+  type StartDetachedCloudAgentArgs,
+} from './detached-agent.js';
 export { kickCloudBootstrap, type KickCloudBootstrapArgs } from './bootstrap-launch.js';
 export {
   registerBoxWithPlane,

--- a/packages/sandbox-cloud/test/detached-agent.test.ts
+++ b/packages/sandbox-cloud/test/detached-agent.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { BoxRecord, ExecResult, Provider } from '@agentbox/core';
+import { startDetachedCloudAgent } from '../src/detached-agent.js';
+
+// A live, authenticated pane — verifyDetachedSession sees the session and no
+// auth-rejection markers, so it resolves.
+const HEALTHY: ExecResult = { exitCode: 0, stdout: 'Working on it...', stderr: '' };
+
+interface FakeOpts {
+  state?: 'running' | 'paused' | 'stopped' | 'missing';
+  exec?: (argv: string[]) => ExecResult;
+  onBuildAttach?: (opts: unknown) => void;
+}
+
+function fakeProvider(opts: FakeOpts = {}): { provider: Provider; started: () => number } {
+  let starts = 0;
+  const provider = {
+    name: 'e2b',
+    probeState: () => Promise.resolve(opts.state ?? 'running'),
+    start: (box: BoxRecord) => {
+      starts++;
+      return Promise.resolve(box);
+    },
+    // `true` is a real no-op binary, so runDetached spawns it → exit 0 without
+    // touching a sandbox. The verify step below drives the mocked exec.
+    buildAttach: (_box: BoxRecord, _kind: string, o: unknown) => {
+      opts.onBuildAttach?.(o);
+      return Promise.resolve({ argv: ['true'], env: undefined });
+    },
+    exec: (_box: BoxRecord, argv: string[]) => Promise.resolve((opts.exec ?? (() => HEALTHY))(argv)),
+  } as unknown as Provider;
+  return { provider, started: () => starts };
+}
+
+const box = { name: 'kanban', cloud: { sandboxId: 'sbx-1' } } as BoxRecord;
+
+describe('startDetachedCloudAgent', () => {
+  it('starts the detached session and verifies it for a running box', async () => {
+    const seen: unknown[] = [];
+    const { provider, started } = fakeProvider({ onBuildAttach: (o) => seen.push(o) });
+    await expect(
+      startDetachedCloudAgent({
+        provider,
+        box,
+        binary: 'claude',
+        sessionName: 'claude',
+        extraArgs: ['do a thing'],
+        verify: { windowMs: 0 },
+      }),
+    ).resolves.toBeDefined();
+    expect(started()).toBe(0); // already running → no start
+    // buildAttach was asked for a detached session with the seeded command.
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({ sessionName: 'claude', detached: true });
+    expect((seen[0] as { command: string }).command).toContain('exec claude');
+  });
+
+  it('starts a paused box before launching', async () => {
+    const { provider, started } = fakeProvider({ state: 'paused' });
+    await startDetachedCloudAgent({
+      provider,
+      box,
+      binary: 'codex',
+      sessionName: 'codex',
+      extraArgs: ['x'],
+      verify: { windowMs: 0 },
+    });
+    expect(started()).toBe(1);
+  });
+
+  it('throws when the sandbox is missing', async () => {
+    const { provider } = fakeProvider({ state: 'missing' });
+    await expect(
+      startDetachedCloudAgent({ provider, box, binary: 'claude', sessionName: 'claude', extraArgs: ['x'] }),
+    ).rejects.toThrow(/missing/);
+  });
+
+  it('propagates a verify failure when the session did not stay up (exit 7)', async () => {
+    const { provider } = fakeProvider({ exec: () => ({ exitCode: 7, stdout: '', stderr: '' }) });
+    await expect(
+      startDetachedCloudAgent({ provider, box, binary: 'claude', sessionName: 'claude', extraArgs: ['x'] }),
+    ).rejects.toThrow(/exited immediately after launch/);
+  });
+
+  it('resolves resume args only when extraArgs is empty', async () => {
+    const resolveResumeArgs = vi.fn().mockResolvedValue(['--resume', 'abc']);
+    const seen: unknown[] = [];
+    const { provider } = fakeProvider({ onBuildAttach: (o) => seen.push(o) });
+    await startDetachedCloudAgent({
+      provider,
+      box,
+      binary: 'claude',
+      sessionName: 'claude',
+      resolveResumeArgs,
+      verify: { windowMs: 0 },
+    });
+    expect(resolveResumeArgs).toHaveBeenCalledOnce();
+    // The resumed args reached the launcher (base64-embedded, so just assert the
+    // read-loop launcher form, not the literal flags).
+    expect((seen[0] as { command: string }).command).toContain('while IFS= read -r t');
+  });
+});


### PR DESCRIPTION
Follow-up to Phase 3 (#247), closing its deferred item: `agentbox claude|codex|opencode -i "<prompt>"` on a cloud provider now runs **entirely on the control box** (create the box + start the agent detached with the prompt), so the laptop can be off from the moment you submit.

## What changed

- **Shared the detached-start orchestration** into `@agentbox/sandbox-cloud` (`startDetachedCloudAgent` + `buildCloudAttachInnerCommand`/`startDetachedSession`/`verifyDetachedSession`), lifted from `apps/cli/_cloud-attach.ts` so the hub worker (which can't import `apps/cli`) can use it. The CLI keeps a thin `cloudAgentStartDetached` wrapper — the local `-i` queue path is unchanged.
- **Threaded the prompt through the worker:** `CreateJobRequest` gains `agentArgs`; `CreateBoxDeps`/`CreateBoxFn` carry `prompt`/`agentArgs` and an `agentStartError` return. A start failure marks the job `failed` **with the box id preserved**, so the box is adoptable/attachable to re-login (honors "don't mask -i failures as done").
- **Hub worker starts the agent:** after `provider.create`, when a prompt is present, it seeds the agent login from custody (already wired) and starts the agent detached. Cold creates (`create --via-hub`, foreground) are unaffected — no prompt, no start.
- **CLI `-i` routes to the hub by default** when a control box is configured (reusing Phase 3's `resolveCreateRouting`); `--local`/`cloud.viaHub=false` opt out, docker/remote-docker never route, missing origin/admin-token falls back to local with a notice.

## Verification
- Unit: `startDetachedCloudAgent` (running/paused/missing/verify-fail/resume) + `drainOneCreateJob` (agentStartError → failed + boxId). `pnpm typecheck` (31) + `lint` + relay (371) + CLI (900) + sandbox-cloud green (the `custody-seed` failures are the local git-signing hang, not this change — they pass in CI).
- Live smoke to follow (per the cloud-box-usable rule): on a control box with creds pushed and a **non-LFS** repo, `agentbox claude --provider e2b -i "…"` → box created on the control box + a running `claude` session doing the work (laptop off); negative check: no creds → job `failed` with a clear message + box id preserved.

No `@agentbox/sandbox-core` public-surface change; the new sandbox-cloud exports are internal orchestration, not part of the provider-SDK re-export list — no SDK republish.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hub create jobs, agent credential seeding, and detached tmux launch on the VPS; failures are surfaced explicitly but wrong routing or partial success could leave boxes without a running agent.
> 
> **Overview**
> **Background `-i` on cloud providers** (`agentbox claude|codex|opencode -i "…"`) now defaults to the **control box** when one is configured: the hub worker provisions the sandbox and starts the agent detached with the seed prompt, so the run continues with the laptop off. Foreground hub creates stay **cold** (adopt + attach locally); only a non-empty prompt triggers in-box agent start.
> 
> Detached-start logic moves into **`@agentbox/sandbox-cloud`** (`startDetachedCloudAgent`, `buildCloudAttachInnerCommand`, session verify). The CLI keeps thin wrappers/re-exports; the hub worker calls the same path without importing `apps/cli`.
> 
> **Create job plumbing** gains `prompt` / `agentArgs` on `CreateJobRequest` and `agentStartError` on the create worker result. If the box is created but the agent fails to start (e.g. custody creds rejected), the job is marked **failed** with the **box id preserved** for attach/re-login.
> 
> **CLI** adds `enqueueAgentJobViaHub` and routes the `-i` branch through `resolveCreateRouting` before the local queue (with `--local` / fallback when hub prerequisites are missing). Docs and the hub consolidation plan are updated to reflect shipped behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50ea87dc4011c5a5b5f6f3f64895222023c20f8c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->