### PR TITLE
fix(hub): worker fetches git-LFS over the authed HTTPS endpoint

### DIFF
--- a/apps/cli/src/commands/control-plane.ts
+++ b/apps/cli/src/commands/control-plane.ts
@@ -29,7 +29,7 @@ import {
 } from '@agentbox/relay';
 import { randomBytes } from 'node:crypto';
 import { providerForCreate } from '../provider/registry.js';
-import { makeControlPlaneCreateBox } from '../control-plane/create-box.js';
+import { makeControlPlaneCreateBox, cloneRepoWithLfs } from '../control-plane/create-box.js';
 import { runGitHubAppManifestFlow } from '../control-plane/github-app-manifest.js';
 import { deployControlPlaneToVercel } from '../control-plane/deploy-vercel.js';
 import { runHetznerDeploy } from '../control-plane/deploy-hetzner.js';
@@ -408,15 +408,24 @@ const addSub = new Command('add')
   });
 
 /** Run `git <args>`, rejecting on a non-zero exit. */
-function runGit(args: string[]): Promise<void> {
+function runGit(args: string[], env?: Record<string, string>, timeoutMs?: number): Promise<void> {
   return new Promise((resolve, reject) => {
-    const child = spawn('git', args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    const child = spawn('git', args, {
+      stdio: ['ignore', 'ignore', 'pipe'],
+      env: env ? { ...process.env, ...env } : process.env,
+    });
+    const timer = timeoutMs ? setTimeout(() => child.kill('SIGKILL'), timeoutMs) : undefined;
     let err = '';
     child.stderr.on('data', (c: Buffer) => (err += c.toString('utf8')));
-    child.on('error', reject);
-    child.on('close', (code) =>
-      code === 0 ? resolve() : reject(new Error(`git ${args[0]} failed (${String(code)}): ${err.trim()}`)),
-    );
+    child.on('error', (e) => {
+      if (timer) clearTimeout(timer);
+      reject(e);
+    });
+    child.on('close', (code) => {
+      if (timer) clearTimeout(timer);
+      if (code === 0) resolve();
+      else reject(new Error(`git ${args[0]} failed (${String(code)}): ${err.trim()}`));
+    });
   });
 }
 
@@ -455,11 +464,8 @@ const workerSub = new Command('worker')
           const { token } = await leaser.leaseRepoToken(owner, repo);
           return toAuthedHttpsUrl(repoUrl, token);
         },
-        cloneRepo: async (authedUrl, repoUrl, dest, branch) => {
-          await runGit(branch ? ['clone', '--branch', branch, authedUrl, dest] : ['clone', authedUrl, dest]);
-          // Scrub the leased token: leave the box pointing at the bare origin.
-          await runGit(['-C', dest, 'remote', 'set-url', 'origin', repoUrl]);
-        },
+        cloneRepo: (authedUrl, repoUrl, dest, branch) =>
+          cloneRepoWithLfs(runGit, authedUrl, repoUrl, dest, branch, (line) => log.info(line)),
         createBox: async ({ workspacePath, name, provider, agent, onLog }) => {
           const p = await providerForCreate({ flag: provider, config: cfg.effective });
           const created = await p.create({

--- a/apps/cli/src/control-plane/create-box.ts
+++ b/apps/cli/src/control-plane/create-box.ts
@@ -4,4 +4,4 @@
  * worker` command and the resident hub worker can build a `CreateBoxFn` from it
  * (an app can't import another app). Re-exported here for the CLI's callers.
  */
-export { makeControlPlaneCreateBox, type CreateBoxDeps } from '@agentbox/relay';
+export { makeControlPlaneCreateBox, cloneRepoWithLfs, type CreateBoxDeps } from '@agentbox/relay';

--- a/apps/hub/lib/hub-worker.ts
+++ b/apps/hub/lib/hub-worker.ts
@@ -17,6 +17,7 @@ import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
 import { isProviderKind, loadEffectiveConfig, type ProviderKind } from '@agentbox/config';
 import {
+  cloneRepoWithLfs,
   drainCreateJobs,
   FsCustodyStore,
   GitHubAppLeaser,
@@ -51,8 +52,16 @@ const IMPORTERS: Record<ProviderKind, () => Promise<{ providerModule: ProviderMo
   'remote-docker': () => import('@agentbox/sandbox-remote-docker'),
 };
 
-async function runGit(args: string[]): Promise<void> {
-  await execFileAsync('git', args, { maxBuffer: 64 * 1024 * 1024 });
+async function runGit(
+  args: string[],
+  env?: Record<string, string>,
+  timeoutMs?: number,
+): Promise<void> {
+  await execFileAsync('git', args, {
+    maxBuffer: 64 * 1024 * 1024,
+    env: env ? { ...process.env, ...env } : process.env,
+    ...(timeoutMs ? { timeout: timeoutMs } : {}),
+  });
 }
 
 /**
@@ -200,10 +209,8 @@ export function makeHubCreateBox(opts: HubWorkerOptions): CreateBoxFn {
       const { token } = await leaser.leaseRepoToken(owner, repo);
       return toAuthedHttpsUrl(repoUrl, token);
     },
-    cloneRepo: async (authedUrl, repoUrl, dest, branch) => {
-      await runGit(branch ? ['clone', '--branch', branch, authedUrl, dest] : ['clone', authedUrl, dest]);
-      await runGit(['-C', dest, 'remote', 'set-url', 'origin', repoUrl]);
-    },
+    cloneRepo: (authedUrl, repoUrl, dest, branch) =>
+      cloneRepoWithLfs(runGit, authedUrl, repoUrl, dest, branch, log),
     createBox: async ({ workspacePath, name, provider, agent, prompt, agentArgs, onLog }) => {
       if (!isProviderKind(provider)) throw new Error(`unknown provider ${provider}`);
       const mod = (await IMPORTERS[provider]()).providerModule;

--- a/packages/relay/src/control-plane.ts
+++ b/packages/relay/src/control-plane.ts
@@ -30,8 +30,10 @@ export {
   drainOneCreateJob,
   drainCreateJobs,
   makeControlPlaneCreateBox,
+  cloneRepoWithLfs,
   type CreateBoxFn,
   type CreateBoxDeps,
+  type CloneRepoRunGit,
 } from './create-worker.js';
 export { type CreateJobRequest, type CreateJobRow } from './store/store.js';
 export { toAuthedHttpsUrl, parseGitRemote, repoSlugFromRemote } from './git-pat.js';

--- a/packages/relay/src/create-worker.ts
+++ b/packages/relay/src/create-worker.ts
@@ -71,6 +71,66 @@ export interface CreateBoxDeps {
   log?: (line: string) => void;
 }
 
+/** Runs `git <args>` with optional extra env + timeout; rejects on non-zero. */
+export type CloneRepoRunGit = (
+  args: string[],
+  env?: Record<string, string>,
+  timeoutMs?: number,
+) => Promise<void>;
+
+/** The GitHub/GitLab-convention LFS API endpoint for a clone URL: `<repo>.git/info/lfs`. */
+function lfsEndpointFor(cloneUrl: string): string {
+  return `${cloneUrl.replace(/\.git$/, '')}.git/info/lfs`;
+}
+
+/**
+ * Clone `authedUrl` into `dest` robustly against **git-LFS**. A worker (control
+ * box / laptop) clones with a leased token, and LFS reuses that token over HTTPS
+ * (the standard CI path — verified). But the worker's git environment can resolve
+ * an *SSH* LFS batch endpoint — e.g. a `git@github.com: insteadOf` rewrite (the
+ * git-identity seeding configures such rewrites) makes git-lfs try SSH — and then
+ * it hard-fails the create at the smudge step (`ssh_askpass ... Host key
+ * verification failed`). To make the LFS fetch deterministic over HTTPS:
+ *  1. clone with `GIT_LFS_SKIP_SMUDGE=1` — the checkout comes down with LFS
+ *     **pointer files**, so the clone can't fail on LFS transport at all;
+ *  2. `git lfs pull` with `lfs.url` FORCED to the authed HTTPS endpoint — the
+ *     embedded `x-access-token:<token>@` userinfo both authenticates the fetch
+ *     AND dodges an `https://github.com/ → ssh` insteadOf rewrite (that prefix no
+ *     longer matches once the userinfo is present), so the real bytes come down
+ *     over HTTPS. Best-effort + non-interactive + timed: a token that genuinely
+ *     can't read LFS is left as pointers with a log line, not a failed create;
+ *  3. scrub the leased token from `origin` (leave the box on the bare repo URL).
+ *
+ * Shared by both worker impls (`apps/hub` resident worker, `apps/cli control-plane
+ * worker`) via an injected git-runner so it stays runtime-agnostic.
+ */
+export async function cloneRepoWithLfs(
+  runGit: CloneRepoRunGit,
+  authedUrl: string,
+  repoUrl: string,
+  dest: string,
+  branch?: string,
+  log: (line: string) => void = () => {},
+): Promise<void> {
+  await runGit(branch ? ['clone', '--branch', branch, authedUrl, dest] : ['clone', authedUrl, dest], {
+    GIT_LFS_SKIP_SMUDGE: '1',
+  });
+  // Fetch the real LFS bytes over the forced HTTPS endpoint (best-effort). A repo
+  // with no LFS makes this a fast no-op. `-c lfs.url` overrides remote/insteadOf
+  // resolution; the token is passed on the argv (ephemeral), never written to the
+  // box's config — origin is scrubbed to the bare URL below regardless.
+  try {
+    await runGit(
+      ['-C', dest, '-c', `lfs.url=${lfsEndpointFor(authedUrl)}`, 'lfs', 'pull'],
+      { GIT_TERMINAL_PROMPT: '0', GIT_SSH_COMMAND: 'ssh -o BatchMode=yes -o StrictHostKeyChecking=no' },
+      120_000,
+    );
+  } catch (err) {
+    log(`git-lfs objects left as pointers (fetch failed): ${err instanceof Error ? err.message : String(err)}`);
+  }
+  await runGit(['-C', dest, 'remote', 'set-url', 'origin', repoUrl]);
+}
+
 /**
  * Build a {@link CreateBoxFn} from injected side-effecting steps: lease a push
  * token, clone the repo locally, provision the box from that checkout, clean up.

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -63,8 +63,10 @@ export {
   drainOneCreateJob,
   drainCreateJobs,
   makeControlPlaneCreateBox,
+  cloneRepoWithLfs,
   type CreateBoxFn,
   type CreateBoxDeps,
+  type CloneRepoRunGit,
 } from './create-worker.js';
 export { type CreateJobRequest, type CreateJobRow } from './store/store.js';
 export { toAuthedHttpsUrl, parseGitRemote, repoSlugFromRemote } from './git-pat.js';

--- a/packages/relay/test/create-worker.test.ts
+++ b/packages/relay/test/create-worker.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { drainCreateJobs, drainOneCreateJob } from '../src/create-worker.js';
+import { cloneRepoWithLfs, drainCreateJobs, drainOneCreateJob } from '../src/create-worker.js';
 import { handleRelayRequest, type ControlPlaneDeps } from '../src/core/handler.js';
 import { MemoryStore } from '../src/store/memory-store.js';
 import type { CreateJobRequest } from '../src/store/store.js';
@@ -110,5 +110,58 @@ describe('box-create flow', () => {
   it('drains nothing when the queue is empty', async () => {
     const store = new MemoryStore();
     expect(await drainOneCreateJob(store, () => Promise.resolve({ boxId: 'x' }), 'w1')).toBeNull();
+  });
+});
+
+describe('cloneRepoWithLfs', () => {
+  interface Call {
+    args: string[];
+    env?: Record<string, string>;
+  }
+
+  it('clones with LFS smudge skipped, fetches LFS over forced HTTPS, then scrubs the token', async () => {
+    const calls: Call[] = [];
+    const runGit = (args: string[], env?: Record<string, string>): Promise<void> => {
+      calls.push({ args, env });
+      return Promise.resolve();
+    };
+    await cloneRepoWithLfs(runGit, 'https://x-access-token:tok@github.com/o/r.git', 'https://github.com/o/r.git', '/tmp/d', 'main');
+    // 1) clone --branch with GIT_LFS_SKIP_SMUDGE so an LFS repo never hard-fails.
+    expect(calls[0]!.args).toEqual([
+      'clone',
+      '--branch',
+      'main',
+      'https://x-access-token:tok@github.com/o/r.git',
+      '/tmp/d',
+    ]);
+    expect(calls[0]!.env?.GIT_LFS_SKIP_SMUDGE).toBe('1');
+    // 2) `lfs pull` with lfs.url FORCED to the authed HTTPS endpoint (the embedded
+    //    token authenticates + dodges any insteadOf SSH rewrite).
+    expect(calls[1]!.args).toEqual([
+      '-C',
+      '/tmp/d',
+      '-c',
+      'lfs.url=https://x-access-token:tok@github.com/o/r.git/info/lfs',
+      'lfs',
+      'pull',
+    ]);
+    // 3) scrub the leased token → bare origin.
+    expect(calls[2]!.args).toEqual(['-C', '/tmp/d', 'remote', 'set-url', 'origin', 'https://github.com/o/r.git']);
+  });
+
+  it('still scrubs the token when the LFS pull fails (pointers left in place)', async () => {
+    const calls: Call[] = [];
+    const logs: string[] = [];
+    const runGit = (args: string[]): Promise<void> => {
+      calls.push({ args });
+      // Fail only the LFS pull (e.g. the control box can't auth the LFS transport).
+      if (args.includes('lfs')) return Promise.reject(new Error('smudge error: ssh_askpass'));
+      return Promise.resolve();
+    };
+    await cloneRepoWithLfs(runGit, 'authed', 'bare', '/tmp/d', undefined, (l) => logs.push(l));
+    // clone (no --branch), lfs pull (failed), set-url still ran.
+    expect(calls[0]!.args).toEqual(['clone', 'authed', '/tmp/d']);
+    expect(calls[2]!.args).toEqual(['-C', '/tmp/d', 'remote', 'set-url', 'origin', 'bare']);
+    expect(logs.join('\n')).toMatch(/pointers/i);
   });
 });


### PR DESCRIPTION
Fixes hub-created boxes hard-failing at the workspace-clone step for **git-LFS repos**.

## Root cause
The create worker clones with a leased token, and LFS *does* reuse that token over HTTPS (the standard CI path — verified: a plain `git clone https://x-access-token:<token>@github.com/o/r.git` pulls the 512 KB `sample.bin` as real bytes). But the control box's git can carry an `insteadOf` rewrite that pushes `https://github.com/` → SSH, so git-lfs resolved an **SSH batch endpoint** and failed with `ssh_askpass: … Host key verification failed`.

## Fix
Shared `cloneRepoWithLfs` (relay), used by both the hub resident worker and the laptop `control-plane worker`:
1. clone with `GIT_LFS_SKIP_SMUDGE=1` so the clone can never fail on LFS transport (checkout has pointer files);
2. `git lfs pull` with **`lfs.url` forced to the authed HTTPS endpoint** — the embedded `x-access-token:<token>@` userinfo authenticates the fetch *and* dodges the `insteadOf` rewrite (the prefix no longer matches `https://github.com/`), so the real bytes come down over HTTPS. Best-effort, non-interactive, timed — a token that genuinely can't read LFS falls back to pointers with a log line rather than failing the create;
3. scrub the leased token from `origin`.

## Verification
- Empirically validated locally: `GIT_LFS_SKIP_SMUDGE=1` clone → 131-byte pointer; then the forced-HTTPS `lfs pull` → 524288 real bytes.
- Unit: `cloneRepoWithLfs` (skip-smudge clone → forced-HTTPS pull → token scrub; pull-fails-but-still-scrubs). `pnpm typecheck` + `lint` + relay tests green.

This unblocks the `-i`-on-hub / `create --via-hub` smokes against LFS repos (e.g. the `agentbox-test-repo` fixture).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the provisioning clone path for all hub and laptop create workers; behavior is mostly additive (best-effort LFS) but misconfiguration could leave LFS pointers in new boxes without failing the job.
> 
> **Overview**
> Fixes **hub/laptop create workers** hard-failing when cloning **git-LFS** repos, often because `url.insteadOf` rewrites push LFS to SSH and smudge dies on host-key/`ssh_askpass`.
> 
> Adds shared **`cloneRepoWithLfs`** in `@agentbox/relay`: clone with **`GIT_LFS_SKIP_SMUDGE=1`**, then a **best-effort** `git lfs pull` with **`lfs.url`** forced to the leased **HTTPS** endpoint (token in URL, 120s cap, non-interactive SSH env). LFS fetch failure logs and leaves pointers instead of failing the job. **`origin` is still scrubbed** to the bare repo URL afterward.
> 
> The **CLI `control-plane worker`** and **hub resident worker** delegate cloning to this helper; their local **`runGit`** helpers now accept optional **env** and **timeout** so the LFS pull can be bounded. Unit tests cover the clone → LFS pull → scrub sequence and token scrub when LFS pull fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4be6592560de46531a187419a4d6465b0b85a0fe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->