### PR TITLE
fix(cloud): retry a dropped detached start, and keep its stderr

### DIFF
--- a/packages/sandbox-cloud/src/detached-agent.ts
+++ b/packages/sandbox-cloud/src/detached-agent.ts
@@ -118,7 +118,7 @@ export async function verifyDetachedSession(
 ): Promise<void> {
   const windowMs = opts.windowMs ?? 10_000;
   const pollMs = opts.pollMs ?? 2_000;
-  const q = `'${sessionName.replace(/'/g, `'\\''`)}'`;
+  const q = tmuxTarget(sessionName);
   // One round-trip per tick: bail (exit 7) if the session is gone, else echo the
   // pane so we can sniff for an auth dead-end.
   const probe = `tmux has-session -t ${q} 2>/dev/null || exit 7; tmux capture-pane -p -t ${q} 2>/dev/null`;
@@ -169,8 +169,14 @@ function runDetached(
     child.stderr?.on('data', (c: Buffer) => {
       stderr += c.toString('utf8');
     });
-    child.on('error', (err) => resolve({ exitCode: 1, stderr: stderr + String(err.message ?? err) }));
-    child.on('exit', (code) => resolve({ exitCode: code ?? 0, stderr }));
+    child.on('error', (err) =>
+      resolve({ exitCode: 1, stderr: stderr + String(err.message ?? err) }),
+    );
+    // `close`, NOT `exit`: `exit` fires the moment the process dies, while the
+    // piped stderr may still be buffered — a fast failure (ssh giving up in
+    // under a second) then reports an EMPTY stderr and the caller throws a bare
+    // exit code with no cause. `close` waits for the stdio streams to drain.
+    child.on('close', (code) => resolve({ exitCode: code ?? 0, stderr }));
   });
 }
 
@@ -193,6 +199,51 @@ export interface StartDetachedCloudAgentArgs {
   resolveResumeArgs?: (box: BoxRecord) => Promise<string[] | null>;
   /** Settle-window tuning for the post-start session verification (test hook). */
   verify?: { windowMs?: number; pollMs?: number };
+  /** Retry tuning for the session pre-start itself (test hook). */
+  startRetry?: { attempts?: number; backoffMs?: number };
+}
+
+/**
+ * ssh's exit code for its OWN failures (connection dropped, host key, an auth
+ * token the gateway refuses) — the remote command never ran. Daytona's SSH
+ * gateway takes the ephemeral token as the *username* and simply hangs up on one
+ * it does not recognise, which is exactly what a token minted a second after
+ * sandbox create can look like: `Connection closed by remote host` → 255. The
+ * box is then fully healthy with no agent in it, so it is worth retrying: each
+ * attempt goes through `buildAttach` → `attachArgv` again and therefore mints a
+ * FRESH token.
+ */
+const SSH_TRANSPORT_EXIT = 255;
+const DEFAULT_START_ATTEMPTS = 3;
+const DEFAULT_START_BACKOFF_MS = 2_000;
+
+/** Single-quote a session name for the remote `bash -lc` probe. */
+function tmuxTarget(sessionName: string): string {
+  return `'${sessionName.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Did the session get created after all? A transport failure usually means the
+ * command never ran, but a mid-flight disconnect can drop the connection *after*
+ * tmux created the session — and a blind retry would then fail forever on tmux's
+ * duplicate-session error. Checked over `exec` (the SDK path), which is
+ * independent of the ssh transport that just failed.
+ */
+async function tmuxSessionExists(
+  provider: Provider,
+  box: BoxRecord,
+  sessionName: string,
+): Promise<boolean> {
+  try {
+    const r = await provider.exec(
+      box,
+      ['bash', '-lc', `tmux has-session -t ${tmuxTarget(sessionName)} 2>/dev/null`],
+      { user: 'vscode' },
+    );
+    return r.exitCode === 0;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -201,7 +252,9 @@ export interface StartDetachedCloudAgentArgs {
  * on an auth error). Provider-parameterized so the hub worker can call it against
  * the `Provider` it already holds. Returns the possibly-started box record.
  */
-export async function startDetachedCloudAgent(args: StartDetachedCloudAgentArgs): Promise<BoxRecord> {
+export async function startDetachedCloudAgent(
+  args: StartDetachedCloudAgentArgs,
+): Promise<BoxRecord> {
   const { provider, binary, sessionName } = args;
   let box = args.box;
   const state = await provider.probeState(box);
@@ -217,12 +270,26 @@ export async function startDetachedCloudAgent(args: StartDetachedCloudAgentArgs)
     if (resume) extraArgs = resume;
   }
   const command = buildCloudAttachInnerCommand(binary, extraArgs);
-  const { exitCode, stderr } = await startDetachedSession(provider, box, sessionName, command);
-  if (exitCode !== 0) {
+  const attempts = Math.max(1, args.startRetry?.attempts ?? DEFAULT_START_ATTEMPTS);
+  const backoffMs = args.startRetry?.backoffMs ?? DEFAULT_START_BACKOFF_MS;
+  for (let attempt = 1; ; attempt++) {
+    const { exitCode, stderr } = await startDetachedSession(provider, box, sessionName, command);
+    if (exitCode === 0) break;
+    if (await tmuxSessionExists(provider, box, sessionName)) break;
+    if (exitCode === SSH_TRANSPORT_EXIT && attempt < attempts) {
+      await sleep(backoffMs * attempt);
+      continue;
+    }
     const detail = stderr.trim().slice(0, 500);
     throw new Error(
-      `failed to start the ${binary} session in box ${box.name} (exit ${String(exitCode)})` +
-        (detail ? `: ${detail}` : ''),
+      `failed to start the ${binary} session in box ${box.name} (exit ${String(exitCode)}` +
+        (attempt > 1 ? `, ${String(attempt)} attempts` : '') +
+        ')' +
+        (detail
+          ? `: ${detail}`
+          : exitCode === SSH_TRANSPORT_EXIT
+            ? ': the ssh transport failed before the command ran (connection closed or the attach token was rejected)'
+            : ''),
     );
   }
   await verifyDetachedSession(provider, box, sessionName, binary, args.verify);

--- a/packages/sandbox-cloud/test/detached-agent.test.ts
+++ b/packages/sandbox-cloud/test/detached-agent.test.ts
@@ -6,14 +6,27 @@ import { startDetachedCloudAgent } from '../src/detached-agent.js';
 // auth-rejection markers, so it resolves.
 const HEALTHY: ExecResult = { exitCode: 0, stdout: 'Working on it...', stderr: '' };
 
+// The bare `tmux has-session` probe the retry path uses to decide whether a
+// transport failure still left a session behind. Distinguished from the verify
+// probe, which also captures the pane.
+const isSessionExistsProbe = (argv: string[]): boolean =>
+  argv.some((a) => a.includes('has-session') && !a.includes('capture-pane'));
+
 interface FakeOpts {
   state?: 'running' | 'paused' | 'stopped' | 'missing';
   exec?: (argv: string[]) => ExecResult;
   onBuildAttach?: (opts: unknown) => void;
+  /** argv runDetached spawns, per attempt (1-indexed); defaults to `true`. */
+  argvForAttempt?: (attempt: number) => string[];
 }
 
-function fakeProvider(opts: FakeOpts = {}): { provider: Provider; started: () => number } {
+function fakeProvider(opts: FakeOpts = {}): {
+  provider: Provider;
+  started: () => number;
+  attempts: () => number;
+} {
   let starts = 0;
+  let attempts = 0;
   const provider = {
     name: 'e2b',
     probeState: () => Promise.resolve(opts.state ?? 'running'),
@@ -25,11 +38,17 @@ function fakeProvider(opts: FakeOpts = {}): { provider: Provider; started: () =>
     // touching a sandbox. The verify step below drives the mocked exec.
     buildAttach: (_box: BoxRecord, _kind: string, o: unknown) => {
       opts.onBuildAttach?.(o);
-      return Promise.resolve({ argv: ['true'], env: undefined });
+      attempts++;
+      return Promise.resolve({ argv: opts.argvForAttempt?.(attempts) ?? ['true'], env: undefined });
     },
-    exec: (_box: BoxRecord, argv: string[]) => Promise.resolve((opts.exec ?? (() => HEALTHY))(argv)),
+    exec: (_box: BoxRecord, argv: string[]) =>
+      Promise.resolve(
+        opts.exec?.(argv) ??
+          // No session yet unless a test says otherwise; the verify probe is healthy.
+          (isSessionExistsProbe(argv) ? { exitCode: 1, stdout: '', stderr: '' } : HEALTHY),
+      ),
   } as unknown as Provider;
-  return { provider, started: () => starts };
+  return { provider, started: () => starts, attempts: () => attempts };
 }
 
 const box = { name: 'kanban', cloud: { sandboxId: 'sbx-1' } } as BoxRecord;
@@ -71,15 +90,103 @@ describe('startDetachedCloudAgent', () => {
   it('throws when the sandbox is missing', async () => {
     const { provider } = fakeProvider({ state: 'missing' });
     await expect(
-      startDetachedCloudAgent({ provider, box, binary: 'claude', sessionName: 'claude', extraArgs: ['x'] }),
+      startDetachedCloudAgent({
+        provider,
+        box,
+        binary: 'claude',
+        sessionName: 'claude',
+        extraArgs: ['x'],
+      }),
     ).rejects.toThrow(/missing/);
   });
 
   it('propagates a verify failure when the session did not stay up (exit 7)', async () => {
     const { provider } = fakeProvider({ exec: () => ({ exitCode: 7, stdout: '', stderr: '' }) });
     await expect(
-      startDetachedCloudAgent({ provider, box, binary: 'claude', sessionName: 'claude', extraArgs: ['x'] }),
+      startDetachedCloudAgent({
+        provider,
+        box,
+        binary: 'claude',
+        sessionName: 'claude',
+        extraArgs: ['x'],
+      }),
     ).rejects.toThrow(/exited immediately after launch/);
+  });
+
+  it('surfaces the stderr of a fast-failing start (drains the pipe before resolving)', async () => {
+    // Regression: resolving on `exit` instead of `close` raced the buffered
+    // stderr, so a sub-second ssh failure reported a bare exit code with no cause.
+    const { provider } = fakeProvider({
+      argvForAttempt: () => ['bash', '-c', 'echo "closed by remote host" >&2; exit 255'],
+    });
+    await expect(
+      startDetachedCloudAgent({
+        provider,
+        box,
+        binary: 'claude',
+        sessionName: 'claude',
+        extraArgs: ['x'],
+        startRetry: { attempts: 1 },
+      }),
+    ).rejects.toThrow(/closed by remote host/);
+  });
+
+  it('retries a 255 transport failure with a freshly built attach spec', async () => {
+    // Daytona's SSH gateway hangs up on an attach token it does not recognise
+    // yet — each retry re-runs buildAttach, minting a new one.
+    const { provider, attempts } = fakeProvider({
+      argvForAttempt: (n) => (n < 3 ? ['bash', '-c', 'exit 255'] : ['true']),
+    });
+    await expect(
+      startDetachedCloudAgent({
+        provider,
+        box,
+        binary: 'claude',
+        sessionName: 'claude',
+        extraArgs: ['x'],
+        verify: { windowMs: 0 },
+        startRetry: { attempts: 3, backoffMs: 0 },
+      }),
+    ).resolves.toBeDefined();
+    expect(attempts()).toBe(3);
+  });
+
+  it('does not retry a non-transport failure', async () => {
+    const { provider, attempts } = fakeProvider({
+      argvForAttempt: () => ['bash', '-c', 'echo "duplicate session" >&2; exit 1'],
+    });
+    await expect(
+      startDetachedCloudAgent({
+        provider,
+        box,
+        binary: 'claude',
+        sessionName: 'claude',
+        extraArgs: ['x'],
+        startRetry: { attempts: 3, backoffMs: 0 },
+      }),
+    ).rejects.toThrow(/duplicate session/);
+    expect(attempts()).toBe(1);
+  });
+
+  it('accepts a session the failed transport left behind instead of retrying', async () => {
+    const { provider, attempts } = fakeProvider({
+      argvForAttempt: () => ['bash', '-c', 'exit 255'],
+      // The disconnect happened after tmux created the session; a blind retry
+      // would fail forever on tmux's duplicate-session error.
+      exec: () => HEALTHY,
+    });
+    await expect(
+      startDetachedCloudAgent({
+        provider,
+        box,
+        binary: 'claude',
+        sessionName: 'claude',
+        extraArgs: ['x'],
+        verify: { windowMs: 0 },
+        startRetry: { attempts: 3, backoffMs: 0 },
+      }),
+    ).resolves.toBeDefined();
+    expect(attempts()).toBe(1);
   });
 
   it('resolves resume args only when extraArgs is empty', async () => {


### PR DESCRIPTION
## What happened

A `--provider daytona` create from the tray on a Mac mini failed with:

```
17:58:20.005Z box created: b450c495f
17:58:21.222Z starting detached claude-code session
17:58:23.387Z FAIL: Error: failed to start the claude session in box test-daytona (exit 255)
```

The box was fully healthy — `agentbox-ctl daemon`, the web server, VNC all running — with no agent tmux session in it. And the error carried no cause.

## Two bugs

**1. The stderr was thrown away.** `runDetached` resolved on the child's `exit` event, which fires the moment the process dies while the piped stderr may still be buffered. ssh gave up in under a second, so the capture was empty and the caller threw a bare exit code. Now resolves on `close`, which waits for the stdio streams to drain.

**2. One shot at the ssh.** Verified against the gateway directly: `ssh.app.daytona.io` authenticates with method `none`, takes the ephemeral attach token as the *username*, and simply hangs up on one it doesn't recognise — `Connection closed by remote host` → exit 255. That is exactly the observed signature, one second after sandbox create. There was no retry anywhere on the path, so a gateway that hasn't propagated the fresh token yet costs you the whole agent.

Now a 255 (ssh's exit code for its own failures, i.e. the remote command never ran) is retried up to 3 times with backoff. Each attempt goes through `buildAttach` → `attachArgv` again and therefore mints a **fresh** token.

Guards on the retry:
- a non-transport exit still fails on the first attempt (no pointless re-runs)
- before retrying, the session is probed over `exec` — the SDK path, independent of the transport that just failed. A mid-flight disconnect that dropped the connection *after* tmux created the session is accepted as success, rather than retried into tmux's duplicate-session error forever.
- when a 255 does surface with no stderr at all, the message now says the transport failed before the command ran.

## Testing

`packages/sandbox-cloud/test/detached-agent.test.ts` — 4 new cases, 9 passing: stderr survives a sub-second failure, 255 retries with a rebuilt attach spec, non-255 doesn't retry, and a left-behind session is accepted. Full `sandbox-cloud` suite (159) green, `pnpm typecheck` clean.

Not live-verified against daytona yet — the reproducing host runs the published npm build, so it needs this nightly first.

https://claude.ai/code/session_01WM35PAMmswyzcxmAbMXaPp

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provisioning-time detached agent startup used by CLI and hub workers; retry logic could mask rare non-255 failures if misclassified, but guards limit retries to SSH transport exit 255 and session-existence checks.
> 
> **Overview**
> Fixes flaky **detached cloud agent** starts right after sandbox create, especially when Daytona's SSH gateway rejects a not-yet-propagated attach token (**exit 255**).
> 
> **`runDetached`** now resolves on the child's **`close`** event instead of **`exit`**, so piped **stderr** is drained before reporting failure—fast SSH hangups no longer surface as a bare exit code.
> 
> **`startDetachedCloudAgent`** retries up to **3** times (with backoff, tunable via **`startRetry`**) when the detached start returns **255** and no tmux session exists yet; each attempt re-runs **`buildAttach`** to mint a fresh token. If a transport failure still left a session behind, it **accepts success** via an **`exec`** **`tmux has-session`** probe instead of retrying into a duplicate-session error. Errors now include attempt count and a clearer message when stderr is empty on **255**.
> 
> Session-name quoting for tmux probes is centralized in **`tmuxTarget`**. Tests cover stderr capture, **255** retry, no retry on other failures, and the left-behind-session path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e62a336aab75a0738312d45747ebd691ad524a9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->