### PR TITLE
fix(hub): system and seed routes 500 in the standalone build

### DIFF
--- a/apps/hub/app/(dashboard)/api/v1/system/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/system/route.ts
@@ -4,19 +4,13 @@
 // fingerprint and freshness, and the box-image build-context manifest (what skills
 // / agents / config are baked in). Read-only.
 //
-// Reuses the same freshness the settings page reads (backend.providersWithFreshness)
-// rather than recomputing it, and reads prepared-state + the deploy record directly
-// — the hub IS the host that holds them. @agentbox/sandbox-core is externalized
-// (next.config serverExternalPackages), so importing it in a nodejs route is safe.
-import { readFile } from 'node:fs/promises';
-import {
-  DOCKER_CONTEXT_FILE_MAP,
-  controlPlaneDeployPath,
-  readPreparedStateRaw,
-  shortFingerprint,
-  type ControlPlaneDeployRecord,
-  type PreparedBaseSnapshot,
-} from '@agentbox/sandbox-core';
+// Freshness comes from the in-process host backend (backend.providersWithFreshness).
+// The prepared-state reads, deploy record, and build-context manifest come from
+// `globalThis.__AGENTBOX_HUB_SYSTEM` — set by server.ts, which reads them from
+// @agentbox/sandbox-core in its OWN scope. This route must NOT import
+// @agentbox/sandbox-core directly: it depends on execa (serverExternalPackages),
+// and a route-level runtime import ERR_MODULE_NOT_FOUNDs in the standalone build
+// (turbopack emits a mangled execa external). The seam mirrors __AGENTBOX_HUB_CUSTODY.
 import { hubProfile } from '@/lib/auth-config';
 import type { ProviderOption } from '@/lib/boxes/types';
 import { describeHubBuild, isBaked, type ProviderBake } from '@/lib/system-info';
@@ -39,38 +33,19 @@ const PROVIDER_LABELS: Record<string, string> = {
   digitalocean: 'DigitalOcean',
 };
 
-interface PreparedBaseFields {
-  fingerprint?: string;
-  cliVersion?: string;
-  bakedAt?: string;
-  imageRef?: string;
-}
-
-function preparedBaseOf(provider: string): PreparedBaseFields | null {
-  const raw = readPreparedStateRaw(provider) as PreparedBaseSnapshot | null;
-  const base = raw?.base;
-  if (!base) return null;
-  return {
-    fingerprint: base.contextSha256 ? shortFingerprint(base.contextSha256) : undefined,
-    cliVersion: base.cliVersion,
-    bakedAt: base.createdAt,
-    imageRef: base.imageRef != null ? String(base.imageRef) : undefined,
-  };
-}
-
-async function readDeployRecord(): Promise<ControlPlaneDeployRecord | null> {
-  try {
-    return JSON.parse(await readFile(controlPlaneDeployPath(), 'utf8')) as ControlPlaneDeployRecord;
-  } catch {
-    return null; // no deploy record on this machine (a plain hub / a VPS the record lives off)
-  }
-}
+type DeployRecordView = NonNullable<
+  ReturnType<NonNullable<typeof globalThis.__AGENTBOX_HUB_SYSTEM>['deployRecord']>
+>;
 
 export async function GET(): Promise<Response> {
   const version = process.env.AGENTBOX_CLI_VERSION ?? null;
   const commit = process.env.AGENTBOX_CLI_COMMIT ?? null;
 
-  const record = await readDeployRecord();
+  // The system seam (@agentbox/sandbox-core reads, in server.ts scope). Absent on
+  // the plane / Postgres path — the route then degrades: no deploy record, nothing
+  // baked, an empty image manifest, exactly like custody's not-enabled path.
+  const sys = globalThis.__AGENTBOX_HUB_SYSTEM;
+  const record = sys?.deployRecord() ?? null;
   const build = describeHubBuild({ version, source: record?.source ?? null });
 
   // Freshness (baseStatus/baseStaleReason) is only available on the in-process
@@ -89,7 +64,7 @@ export async function GET(): Promise<Response> {
   }
 
   const providers: ProviderBake[] = BASE_PROVIDERS.map((id) => {
-    const prepared = preparedBaseOf(id);
+    const prepared = sys?.preparedBase(id) ?? null;
     const f = freshness.get(id);
     // Freshness (when the in-process backend computed it) is authoritative about
     // whether the base exists: only `unprepared` means no stored base. `unknown`
@@ -116,14 +91,13 @@ export async function GET(): Promise<Response> {
     build,
     deploy: deployView(record),
     providers,
-    imageContextKeys: Object.keys(DOCKER_CONTEXT_FILE_MAP),
+    imageContextKeys: sys?.imageContextKeys() ?? [],
   });
 }
 
-// Whitelist the non-sensitive deploy fields for the page. Excludes the SSH key
-// dir, server/firewall ids, and the admin CIDR — operational detail the CLI owns,
-// not something the build page needs.
-function deployView(record: ControlPlaneDeployRecord | null): {
+// The page's deploy panel: the non-sensitive fields only (the seam already
+// whitelisted them; here we just drop the build `source`, which feeds `build`).
+function deployView(record: DeployRecordView | null): {
   provider?: string;
   url?: string;
   publicUrl?: string;

--- a/apps/hub/global.d.ts
+++ b/apps/hub/global.d.ts
@@ -21,18 +21,65 @@ declare global {
   var __AGENTBOX_HUB_NOTIFIER: { subscribe(fn: () => void): () => void } | undefined;
 
   // The control box's custody store (agent creds / project seeds / bake records /
-  // box SSH keys). Set by the custom server; the Custody page's /api/v1/custody
-  // route reads metadata from it (never values). `null` when custody is not
-  // enabled here (no admin token — the localhost profile). Structural `list` only,
-  // so @agentbox/relay's CustodyStore type never enters Next's bundle.
+  // box SSH keys). Set by the custom server; the Custody + project-Seed routes
+  // reach it through this (never values). `null` when custody is not enabled here
+  // (no admin token — the localhost profile). Structural `list`/`get` only, so
+  // @agentbox/relay's CustodyStore type never enters Next's bundle — a RUNTIME
+  // import of it inside a route breaks the standalone build (turbopack emits a
+  // mangled execa external that ERR_MODULE_NOT_FOUNDs), which is why the routes
+  // reach the store via globalThis instead of constructing `new FsCustodyStore()`.
   // eslint-disable-next-line no-var
   var __AGENTBOX_HUB_CUSTODY:
     | {
-        list(prefix?: string): Promise<
+        list(
+          prefix?: string,
+        ): Promise<
           { path: string; size: number; sha256: string; mode: number; updatedAt: string }[]
         >;
+        get(path: string): Promise<{
+          entry: { path: string; size: number; sha256: string; mode: number; updatedAt: string };
+          data: Buffer;
+        } | null>;
       }
     | null
+    | undefined;
+
+  // System / Build facts, read from @agentbox/sandbox-core in the custom server's
+  // scope and handed across as PLAIN data. The System page's /api/v1/system route
+  // uses this instead of importing @agentbox/sandbox-core directly — that package
+  // depends on execa (serverExternalPackages), and a route-level runtime import of
+  // it fails in the standalone build exactly like the custody store above. Set by
+  // the custom server; `undefined` when unavailable (the plane / Postgres path),
+  // where the route degrades gracefully.
+  // eslint-disable-next-line no-var
+  var __AGENTBOX_HUB_SYSTEM:
+    | {
+        // The provider's baked-base record (prepared-state), fingerprint already
+        // shortened. Null when nothing is baked for it.
+        preparedBase(provider: string): {
+          fingerprint?: string;
+          cliVersion?: string;
+          bakedAt?: string;
+          imageRef?: string;
+        } | null;
+        // The control-plane deploy record's display subset (+ its build `source`),
+        // or null when this machine holds no deploy record.
+        deployRecord(): {
+          source?:
+            | { kind: 'package'; spec: string }
+            | { kind: 'source'; repoUrl: string; repoRef: string }
+            | null;
+          provider?: string;
+          url?: string;
+          publicUrl?: string;
+          tunnel?: string;
+          autostart?: boolean;
+          port?: number;
+          bind?: string;
+        } | null;
+        // The box-image build-context file keys (skills / agents / scripts baked in).
+        imageContextKeys(): string[];
+      }
     | undefined;
 }
 

--- a/apps/hub/lib/boxes/seed-slug.test.ts
+++ b/apps/hub/lib/boxes/seed-slug.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from 'vitest';
+// The canonical derivation. Safe to import here (tests aren't bundled by Next),
+// unlike seed-slug.ts itself, which inlines a copy to avoid pulling this
+// execa-carrying package into the seed route's standalone bundle.
+import { projectSlugFromOriginUrl } from '@agentbox/sandbox-core';
 import { custodyIdentityFromRegistration, seedSlugFor } from './seed-slug';
 
 /*
@@ -16,7 +20,9 @@ describe('a project built from a registration resolves its seed slug', () => {
   it('via origin-URL derivation when no slug was registered', () => {
     const proj = custodyIdentityFromRegistration({ originUrl: 'git@github.com:acme/widgets.git' });
     expect(seedSlugFor(proj)).toBe('acme__widgets');
-    const https = custodyIdentityFromRegistration({ originUrl: 'https://github.com/acme/widgets.git' });
+    const https = custodyIdentityFromRegistration({
+      originUrl: 'https://github.com/acme/widgets.git',
+    });
     expect(seedSlugFor(https)).toBe('acme__widgets');
   });
 
@@ -38,9 +44,30 @@ describe('a project built from a registration resolves its seed slug', () => {
   it('carries both fields through undefineds as explicit nulls', () => {
     // The synthetic project omitting these fields was the original bug; the
     // mapping must always produce them, never leave them undefined.
-    expect(custodyIdentityFromRegistration({ originUrl: undefined, projectSlug: undefined })).toEqual({
+    expect(
+      custodyIdentityFromRegistration({ originUrl: undefined, projectSlug: undefined }),
+    ).toEqual({
       originUrl: null,
       projectSlug: null,
     });
+  });
+
+  // seed-slug.ts inlines the slug derivation (it can't import the execa-carrying
+  // @agentbox/sandbox-core barrel in the seed route's bundle). This pins the copy
+  // to the canonical projectSlugFromOriginUrl so the two can never drift.
+  it('derives origin slugs identically to the canonical sandbox-core impl', () => {
+    for (const url of [
+      'git@github.com:acme/widgets.git',
+      'https://github.com/acme/widgets',
+      'ssh://git@github.com/acme/widgets.git',
+      'https://gitlab.com/team/sub/repo.git',
+      'git@github.com:Acme/Wid gets.git',
+      'not a url',
+      '',
+    ]) {
+      expect(seedSlugFor(custodyIdentityFromRegistration({ originUrl: url }))).toBe(
+        projectSlugFromOriginUrl(url),
+      );
+    }
   });
 });

--- a/apps/hub/lib/boxes/seed-slug.ts
+++ b/apps/hub/lib/boxes/seed-slug.ts
@@ -1,5 +1,3 @@
-import { projectSlugFromOriginUrl } from '@agentbox/sandbox-core';
-
 /*
  * Pure custody-slug resolution, shared by the two projects that need it: the
  * synthetic projects the embedded/self-hosted control box builds from a box
@@ -7,7 +5,63 @@ import { projectSlugFromOriginUrl } from '@agentbox/sandbox-core';
  * (`seed-status.ts`). Kept dependency-light (no `server-only`, no store) so it
  * unit-tests against plain objects — a regression here silently empties the
  * seed/custody panel on the primary self-hosted control box.
+ *
+ * The slug derivation is inlined below rather than imported from
+ * `@agentbox/sandbox-core` (its canonical home, `project-slug.ts`): this module
+ * is in the /api/v1/projects/{id}/seed route's bundle scope, and that package's
+ * barrel loads execa (serverExternalPackages) → a runtime import ERR_MODULE_NOT_FOUNDs
+ * in the standalone build. The copy MUST stay byte-for-byte equivalent to
+ * `projectSlugFromOriginUrl` there — both are pinned by unit tests (`owner__repo`).
  */
+
+// ── mirror of @agentbox/sandbox-core project-slug.ts (see note above) ──────────
+
+/** Parse `owner`/`repo` out of any common git remote URL shape, or null. */
+function ownerRepoFromOriginUrl(originUrl: string): { owner: string; repo: string } | null {
+  const url = originUrl.trim();
+  if (url.length === 0) return null;
+  let path: string | null = null;
+  // scp-like: git@host:owner/repo(.git)
+  const scp = /^[^@/\s]+@[^:/\s]+:(.+)$/.exec(url);
+  if (scp) {
+    path = scp[1]!;
+  } else {
+    try {
+      // Decode: `new URL` percent-encodes the path, while the scp-like branch
+      // above doesn't. Without this, the same repo spelled two ways yields two
+      // different slugs.
+      path = safeDecode(new URL(url).pathname);
+    } catch {
+      return null;
+    }
+  }
+  const segments = path
+    .replace(/\.git\/?$/, '')
+    .split('/')
+    .filter((s) => s.length > 0);
+  if (segments.length < 2) return null;
+  const owner = segments[segments.length - 2]!;
+  const repo = segments[segments.length - 1]!;
+  if (owner.length === 0 || repo.length === 0) return null;
+  return { owner, repo };
+}
+
+/** `decodeURIComponent`, falling back to the raw value on a malformed escape. */
+function safeDecode(s: string): string {
+  try {
+    return decodeURIComponent(s);
+  } catch {
+    return s;
+  }
+}
+
+/** Custody `projects/<slug>` key for an origin URL: `owner__repo`, or null. */
+function projectSlugFromOriginUrl(originUrl: string): string | null {
+  const parsed = ownerRepoFromOriginUrl(originUrl);
+  if (!parsed) return null;
+  const clean = (s: string) => s.replace(/[^A-Za-z0-9._-]/g, '-');
+  return `${clean(parsed.owner)}__${clean(parsed.repo)}`;
+}
 
 /** The git identity a project needs to resolve its custody slug. */
 export interface CustodyIdentity {
@@ -33,7 +87,10 @@ export function custodyIdentityFromRegistration(reg: {
  * origin URL (the same `owner__repo` derivation every producer uses). Null when
  * the project has neither.
  */
-export function seedSlugFor(project: { projectSlug?: string | null; originUrl?: string | null }): string | null {
+export function seedSlugFor(project: {
+  projectSlug?: string | null;
+  originUrl?: string | null;
+}): string | null {
   if (project.projectSlug) return project.projectSlug;
   if (project.originUrl) return projectSlugFromOriginUrl(project.originUrl);
   return null;

--- a/apps/hub/lib/boxes/seed-status.ts
+++ b/apps/hub/lib/boxes/seed-status.ts
@@ -1,7 +1,11 @@
 import 'server-only';
 
-import { FsCustodyStore } from '@agentbox/relay/control-plane';
 import { seedSlugFor } from './seed-slug';
+// Type-only — importing the CustodyStore VALUE (FsCustodyStore) here would bundle
+// @agentbox/relay (→ execa) into the /api/v1/projects/{id}/seed route and
+// ERR_MODULE_NOT_FOUND in the standalone build. We reach the live store through
+// `globalThis.__AGENTBOX_HUB_CUSTODY` instead (set by server.ts, out of Next's
+// bundle), exactly like the /api/v1/custody route.
 import type { CustodyEntry } from '@agentbox/relay/control-plane';
 
 export { seedSlugFor };
@@ -62,9 +66,14 @@ interface SeedManifestShape {
   createdAt?: string;
 }
 
-/** Custody is served only on a control box, which is the only hub with an admin token. */
-function custodyOrNull(): FsCustodyStore | null {
-  return (process.env.AGENTBOX_RELAY_ADMIN_TOKEN ?? '').length > 0 ? new FsCustodyStore() : null;
+/**
+ * The live custody store, or null when this hub holds none (no admin token — a
+ * localhost hub, or the plane/Postgres path). Set by server.ts outside Next's
+ * bundle; a structural `list`/`get` handle, never `new FsCustodyStore()` (which
+ * would drag @agentbox/relay → execa into this route's bundle).
+ */
+function custodyOrNull(): NonNullable<typeof globalThis.__AGENTBOX_HUB_CUSTODY> | null {
+  return globalThis.__AGENTBOX_HUB_CUSTODY ?? null;
 }
 
 function toEntry(e: CustodyEntry, prefix: string): SeedEntry {

--- a/apps/hub/server.ts
+++ b/apps/hub/server.ts
@@ -13,8 +13,21 @@
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import next from 'next';
-import { makeStore, FsCustodyStore, type Store, type CustodyStore } from '@agentbox/relay/control-plane';
+import {
+  makeStore,
+  FsCustodyStore,
+  type Store,
+  type CustodyStore,
+} from '@agentbox/relay/control-plane';
 import { startRelayDaemon } from '@agentbox/relay/daemon';
+import {
+  DOCKER_CONTEXT_FILE_MAP,
+  controlPlaneDeployPath,
+  readPreparedStateRaw,
+  shortFingerprint,
+  type ControlPlaneDeployRecord,
+  type PreparedBaseSnapshot,
+} from '@agentbox/sandbox-core';
 import { createHubBackend } from './lib/hub-backend';
 import { configureHubGitCredentials } from './lib/git-auth';
 
@@ -98,7 +111,8 @@ async function main(): Promise<void> {
   // 503 without the token, so wiring the fs store unconditionally is safe: a
   // loginless localhost hub simply never serves the routes.
   const adminToken = process.env.AGENTBOX_RELAY_ADMIN_TOKEN ?? '';
-  const custody: CustodyStore | undefined = adminToken.length > 0 ? new FsCustodyStore() : undefined;
+  const custody: CustodyStore | undefined =
+    adminToken.length > 0 ? new FsCustodyStore() : undefined;
 
   // `hub.gitAuth=gh`: make the stored GitHub token visible to git and `gh`
   // before anything can need it — the create worker clones with it, and the
@@ -141,10 +155,52 @@ async function main(): Promise<void> {
   globalThis.__AGENTBOX_HUB_BACKEND = createHubBackend(daemon.handle);
   globalThis.__AGENTBOX_HUB_NOTIFIER = daemon.handle.hubNotifier;
   // The custody store (agent creds / project seeds / bake records / box SSH keys),
-  // for the Custody page's read-only /api/v1/custody route. Null on a hub with no
-  // admin token (localhost) — the route then reports custody-not-enabled. Shared
-  // via globalThis (like the backend) so @agentbox/relay stays out of Next's bundle.
+  // for the Custody + project-Seed read-only routes. Null on a hub with no admin
+  // token (localhost) — the routes then report custody-not-enabled. Shared via
+  // globalThis (like the backend) so @agentbox/relay stays out of Next's bundle:
+  // a route that constructed `new FsCustodyStore()` itself would ERR_MODULE_NOT_FOUND
+  // on execa in the standalone build.
   globalThis.__AGENTBOX_HUB_CUSTODY = custody ?? null;
+
+  // System / Build facts for the /api/v1/system route, read from @agentbox/sandbox-core
+  // HERE (the custom server's scope, outside Next's bundle) and handed across as plain
+  // data. The route must not import @agentbox/sandbox-core itself — it depends on execa
+  // (serverExternalPackages), and a route-level runtime import fails in the standalone
+  // build the same way a bundled FsCustodyStore does.
+  globalThis.__AGENTBOX_HUB_SYSTEM = {
+    preparedBase(provider) {
+      const base = (readPreparedStateRaw(provider) as PreparedBaseSnapshot | null)?.base;
+      if (!base) return null;
+      return {
+        fingerprint: base.contextSha256 ? shortFingerprint(base.contextSha256) : undefined,
+        cliVersion: base.cliVersion,
+        bakedAt: base.createdAt,
+        imageRef: base.imageRef != null ? String(base.imageRef) : undefined,
+      };
+    },
+    deployRecord() {
+      try {
+        const rec = JSON.parse(
+          readFileSync(controlPlaneDeployPath(), 'utf8'),
+        ) as ControlPlaneDeployRecord;
+        // Whitelist the non-sensitive fields (+ the build `source`); the SSH key dir,
+        // server/firewall ids and admin CIDR are operational detail the route omits.
+        return {
+          source: rec.source ?? null,
+          provider: rec.provider,
+          url: rec.url,
+          publicUrl: rec.publicUrl,
+          tunnel: rec.tunnel,
+          autostart: rec.autostart,
+          port: rec.port,
+          bind: rec.bind,
+        };
+      } catch {
+        return null; // no deploy record on this machine (a plain hub)
+      }
+    },
+    imageContextKeys: () => Object.keys(DOCKER_CONTEXT_FILE_MAP),
+  };
 
   // Password profiles (hetzner/vercel): create/upgrade the auth tables and
   // env-seed the admin. Dynamic import so localhost never loads node:sqlite /
@@ -174,18 +230,24 @@ async function main(): Promise<void> {
 
   process.stdout.write(`agentbox-hub: listening on ${host}:${String(port)} (dev=${String(dev)})\n`);
   if (mode === 'token') {
-    process.stdout.write(`agentbox-hub: open http://${host}:${String(port)}/?token=${process.env.AGENTBOX_HUB_TOKEN ?? ''}\n`);
+    process.stdout.write(
+      `agentbox-hub: open http://${host}:${String(port)}/?token=${process.env.AGENTBOX_HUB_TOKEN ?? ''}\n`,
+    );
   }
 
   const shutdown = (signal: string): void => {
     process.stdout.write(`agentbox-hub: ${signal} — shutting down\n`);
-    void (worker?.stop() ?? Promise.resolve()).finally(() => daemon.stop().finally(() => process.exit(0)));
+    void (worker?.stop() ?? Promise.resolve()).finally(() =>
+      daemon.stop().finally(() => process.exit(0)),
+    );
   };
   process.on('SIGTERM', () => shutdown('SIGTERM'));
   process.on('SIGINT', () => shutdown('SIGINT'));
 }
 
 main().catch((err: unknown) => {
-  process.stderr.write(`agentbox-hub: fatal ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`);
+  process.stderr.write(
+    `agentbox-hub: fatal ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
+  );
   process.exit(1);
 });


### PR DESCRIPTION
Found by the final host smoke test on the merged `feat/remote-hub-improvements` tip: item 4 (System page) and item 5 (project Seed panel) were both completely dead on a real control box.

## Symptom

On a live `agentbox hub expose` running the **standalone** bundle:

| route | before | after |
|---|---|---|
| `/api/v1/boxes` `/providers` `/approvals` `/custody` | 200 | 200 |
| `/api/v1/system` | **500** | 200 |
| `/api/v1/projects/{id}/seed` | **500** | 200 |

Hub log, for both:

```
Error: Failed to load external module execa-e735fb92b3a795bd:
  ERR_MODULE_NOT_FOUND: Cannot find package 'execa-e735fb92b3a795bd'
  imported from apps/hub/dist-standalone/apps/hub/.next/server/chunks/[turbopack]_runtime.js
```

## Root cause

These were the only two new paths doing a **runtime** import of an `@agentbox` package inside Next bundle scope — `system/route.ts` imported `@agentbox/sandbox-core`, and `seed-status.ts` constructed `FsCustodyStore` from `@agentbox/relay/control-plane`. Both depend on `execa`, which `next.config` lists in `serverExternalPackages`; turbopack emits a mangled synthetic external id that does not resolve in the standalone output.

The already-working `/api/v1/custody` route showed the correct pattern: import for **types only** and take the live object from a `globalThis` seam that `server.ts` sets outside Next bundle scope.

## Fix

Both routes now go through that same seam:

- `seed-status.ts` uses the existing `globalThis.__AGENTBOX_HUB_CUSTODY` instead of constructing `FsCustodyStore`; the `@agentbox/relay` import is type-only.
- `system/route.ts` no longer imports `@agentbox/sandbox-core`; `server.ts` exposes the prepared-state / deploy-record / build-context reads it needs, declared structurally in `global.d.ts`.
- Both still degrade gracefully when the seam is absent (the plane/Postgres path), as custody already did.

## Why this escaped CI and the original smoke test

`next dev` resolves these imports fine — only the standalone build (what a control box actually runs) fails. Verified this time against `build:standalone` + `hub restart`, with `Failed to load external module` confirmed gone from the hub log.

Serial re-verify: typecheck, lint, test (40 passing) all green.

https://claude.ai/code/session_01BcoSQCZtnaWV8rVJikyy5W

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hub API wiring and duplicated slug logic; wrong seam wiring could skew System/Seed UI on control boxes, but scope is narrow and guarded by tests.
> 
> **Overview**
> Fixes **500s on `/api/v1/system` and `/api/v1/projects/{id}/seed`** in the standalone hub bundle by stopping Next route code from **runtime-importing** `@agentbox/sandbox-core` or constructing `FsCustodyStore` from `@agentbox/relay` (both pull in **execa**, which turbopack externalizes to a broken id in standalone).
> 
> **`/api/v1/system`** now reads prepared-base, deploy record, and image-context keys from **`globalThis.__AGENTBOX_HUB_SYSTEM`**, populated in **`server.ts`** from sandbox-core outside the Next bundle. **`seed-status.ts`** uses the existing **`__AGENTBOX_HUB_CUSTODY`** seam instead of `new FsCustodyStore()`; custody typing adds **`get`** on the global handle.
> 
> **`seed-slug.ts`** inlines **`projectSlugFromOriginUrl`** (same as sandbox-core) so the seed route bundle never imports sandbox-core; tests pin the copy against the canonical impl.
> 
> When the seams are missing (plane/Postgres path), behavior degrades like custody already did—no deploy/bake/manifest or custody-not-enabled rather than crashing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ed0645248c5944c4429a883ab9ea5b9202f08b2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->