### PR TITLE
fix(hub): pass AGENTBOX_RUNTIME_ROOT to the hub child

### DIFF
--- a/docs/hub-testing.md
+++ b/docs/hub-testing.md
@@ -314,6 +314,13 @@ Run on `0.28.0-nightly.202607260716` (npm `nightly`), from a virgin `~/.agentbox
   ```
   Symptom when you forget: a change that is definitely in the source doesn't show up — e.g.
   `hub status` missing a field the running hub never learned to report.
+- **Every provider "unverified"? Check the hub child's env, not the bakes.** Hub-side base
+  freshness (`/system`, `/settings`) and custody bake adoption both hash the staged `runtime/`
+  tree, which the hub bundle can't find on its own — `spawnHub` passes `AGENTBOX_RUNTIME_ROOT`
+  (and `AGENTBOX_DOCKER_CONTEXT`) for it. If every cloud provider reads "baked · unverified"
+  (`baseStatus: unknown`), or a control box re-bakes something custody already holds, confirm
+  with `ps eww <hub pid> | tr ' ' '\n' | grep AGENTBOX_RUNTIME_ROOT`. A dev tree masks this by
+  falling back to the monorepo sources; an npm install has no such fallback.
 - **Use a non-LFS repo** for anything the hub clones; the `agentbox-test-repo*` repos have git-LFS
   objects that break the control box's clone.
 - **`hub setup` needs a TTY** for the "copy this token?" confirm.

--- a/packages/sandbox-core/src/runtime-root.ts
+++ b/packages/sandbox-core/src/runtime-root.ts
@@ -13,9 +13,15 @@
  * a different fingerprint than the CLI baked with. The hub then rejects every
  * PC-baked custody record as "a different build context" and never adopts it.
  *
- * `AGENTBOX_RUNTIME_ROOT` closes that gap: point it at the staged `runtime/`
+ * The same miss hits a PACKAGE-installed hub, for a different reason: its bundle
+ * sits at `<cli>/runtime/hub/apps/hub`, three levels below the staged root, so
+ * neither candidate reaches `<cli>/runtime` — and with no monorepo to fall back
+ * to, every cloud provider's live fingerprint comes back undefined.
+ *
+ * `AGENTBOX_RUNTIME_ROOT` closes both gaps: point it at the staged `runtime/`
  * dir and any consumer (hub included) computes the same fingerprint the CLI
- * does. The deploy sets it for the hub container.
+ * does. Two places set it: `spawnHub` (@agentbox/sandbox-docker) for every
+ * CLI-spawned hub, and the VPS deploy Dockerfile for the hub container.
  */
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';

--- a/packages/sandbox-docker/src/hub.ts
+++ b/packages/sandbox-docker/src/hub.ts
@@ -11,6 +11,8 @@ import {
   controlPlaneDeployPath,
   EXPOSED_HUB_PROFILE,
   parseEnvFileBody,
+  resolveStagedRuntimeRoot,
+  RUNTIME_ROOT_ENV,
   type ControlPlaneDeployRecord,
 } from '@agentbox/sandbox-core';
 import { detectPortless, portlessAlias, portlessGetUrl, portlessUnalias } from './portless.js';
@@ -264,6 +266,39 @@ export function resolveHubServer(): string {
   );
 }
 
+/**
+ * The env the hub child needs beyond `process.env` to find files its own bundle
+ * doesn't carry.
+ *
+ * The hub bundle lives at `<cli>/runtime/hub/apps/hub`, three levels BELOW the
+ * staged runtime root — and every provider is inlined into it. So each
+ * self-relative lookup those providers do (`<self>/../runtime`,
+ * `<self>/../../runtime`) misses the real `<cli>/runtime`, and the hub silently
+ * degrades: cloud base fingerprints come back undefined (`baseStatus: unknown`
+ * → "baked, unverified"), and custody bake adoption — which gates creates on a
+ * control box — skips every shared record. A dev tree hides it by falling back
+ * to the monorepo sources; an npm install has no such fallback. Handing over the
+ * roots the CLI already resolved is the fix, same as the docker context below.
+ *
+ * The runtime root is marker-verified, and `resolveStagedRuntimeRoot` checks
+ * `AGENTBOX_RUNTIME_ROOT` first, so an operator override propagates. When no
+ * staged root exists (a workspace-only build) the key is OMITTED rather than set
+ * to a path that doesn't resolve — it would otherwise sit ahead of the child's
+ * own correct lookup.
+ */
+export function hubRuntimeEnv(
+  opts: { dockerContext?: string; runtimeRoot?: string } = {},
+): Record<string, string> {
+  const env: Record<string, string> = {};
+  const dockerContext = opts.dockerContext ?? BUILD_CONTEXT_DIR;
+  if (dockerContext) env.AGENTBOX_DOCKER_CONTEXT = dockerContext;
+  const runtimeRoot =
+    opts.runtimeRoot ??
+    resolveStagedRuntimeRoot(dirname(fileURLToPath(import.meta.url)), 'docker/Dockerfile.box');
+  if (runtimeRoot) env[RUNTIME_ROOT_ENV] = runtimeRoot;
+  return env;
+}
+
 /** Kill whatever holds the port (a lean relay or a stale hub) and confirm it freed. */
 async function reclaimPort(
   reportedPid: number | undefined,
@@ -391,11 +426,11 @@ async function spawnHub(
       AGENTBOX_CLI_ENTRY: cliEntry,
       // The hub is the localhost profile (token gate); bind loopback.
       AGENTBOX_HUB_HOST: HOST,
-      // The hub bundle ships no staged docker build context of its own, so its
-      // in-process docker base-freshness check couldn't fingerprint (degrading
-      // to 'unknown'). Hand it the CLI's resolved context so hub-side
-      // fingerprints match what the create/prepare workers compute.
-      AGENTBOX_DOCKER_CONTEXT: BUILD_CONTEXT_DIR,
+      // The hub bundle ships no staged build context of its own, so its
+      // in-process freshness checks couldn't fingerprint (degrading to
+      // 'unknown'). Hand it the CLI's resolved roots so hub-side fingerprints
+      // match what the create/prepare workers compute. See hubRuntimeEnv.
+      ...hubRuntimeEnv(),
       // `hub expose` overrides the above (bind 0.0.0.0, profile hetzner, auth,
       // worker, public URL, tokens). Empty/absent → the plain localhost hub.
       ...(exposedEnv ?? {}),

--- a/packages/sandbox-docker/test/hub-runtime-env.test.ts
+++ b/packages/sandbox-docker/test/hub-runtime-env.test.ts
@@ -1,0 +1,53 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// `hub.ts` resolves ~/.agentbox at module load, so HOME has to be redirected
+// before the import — hence the hoisted temp dir. Without it this file would
+// read and REWRITE the real user's hub state (this suite has no HOME isolation
+// of its own).
+const { homeDir } = await vi.hoisted(async () => {
+  const { mkdtempSync } = await import('node:fs');
+  const { tmpdir } = await import('node:os');
+  const { join: j } = await import('node:path');
+  return { homeDir: mkdtempSync(j(tmpdir(), 'agentbox-hub-env-test-')) };
+});
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return { ...actual, homedir: () => homeDir };
+});
+
+const { hubRuntimeEnv } = await import('../src/hub.js');
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('hubRuntimeEnv', () => {
+  it('hands the child both roots the CLI resolved', () => {
+    expect(
+      hubRuntimeEnv({ dockerContext: '/cli/runtime/docker', runtimeRoot: '/cli/runtime' }),
+    ).toEqual({
+      AGENTBOX_DOCKER_CONTEXT: '/cli/runtime/docker',
+      AGENTBOX_RUNTIME_ROOT: '/cli/runtime',
+    });
+  });
+
+  it('omits the runtime root when there is no staged tree beside this module', () => {
+    // Workspace-dev layout (packages/sandbox-docker/src, no sibling runtime/):
+    // never plant a root that doesn't resolve — it is candidate 0 in the child's
+    // own lookup and would shadow its correct self-resolution.
+    vi.stubEnv('AGENTBOX_RUNTIME_ROOT', '');
+    const env = hubRuntimeEnv({ dockerContext: '/repo' });
+    expect(env.AGENTBOX_RUNTIME_ROOT).toBeUndefined();
+    expect(env.AGENTBOX_DOCKER_CONTEXT).toBe('/repo');
+  });
+
+  it('propagates an operator AGENTBOX_RUNTIME_ROOT override to the child', () => {
+    const staged = join(homeDir, 'staged-runtime');
+    mkdirSync(join(staged, 'docker'), { recursive: true });
+    writeFileSync(join(staged, 'docker', 'Dockerfile.box'), 'FROM scratch\n');
+    vi.stubEnv('AGENTBOX_RUNTIME_ROOT', staged);
+    expect(hubRuntimeEnv({ dockerContext: '/repo' }).AGENTBOX_RUNTIME_ROOT).toBe(staged);
+  });
+});


### PR DESCRIPTION
## Problem

`/system` showed **every** cloud provider as "baked · unverified" while docker read "baked and up to date". Not a bake problem — the hub can't compute the *live* fingerprint to compare against.

The hub bundle sits at `<cli>/runtime/hub/apps/hub`, three levels below the staged runtime root, and every provider is inlined into it. `resolveStagedRuntimeRoot` only tries `<self>/../runtime` and `<self>/../../runtime`, so it never reaches `<cli>/runtime` — structurally, for all providers. `currentBaseFingerprintLive()` returns `undefined` → `baseFreshnessFromFingerprints(stored, undefined)` → `{ state: 'unknown' }` → the badge.

A dev tree masks this via the monorepo fallback (`guessRepoRoot`); an npm install has none. Docker was the lone exception only because `spawnHub` already handed it `AGENTBOX_DOCKER_CONTEXT`.

**Not cosmetic:** the same undefined fingerprint silently disables custody bake adoption — `hydratePreparedFromCustody` bails at `if (!nativeFingerprint) return;`. That runs in the hub backend *and* in the control box's in-process create worker, so an exposed hub refuses a perfectly good shared bake and fails creates with "run `agentbox prepare` first". `AGENTBOX_RUNTIME_ROOT` already existed as the documented fix but was set in exactly one place: the hetzner VPS deploy Dockerfile.

## Change

`spawnHub` now passes the runtime root alongside the docker context, via a new pure `hubRuntimeEnv()` helper. The root is marker-verified; when no staged tree exists (workspace-only build) the key is **omitted** rather than set to a path that doesn't resolve — it would otherwise sit ahead of the child's own correct self-resolution. `resolveStagedRuntimeRoot` checks the env var first, so an operator override propagates for free.

`spawnRelay` is deliberately untouched: the lean relay does no in-process fingerprinting and its queue workers are CLI children that resolve their own layout.

## Verification

Reproduced the npm layout by running the CLI from a copy outside the repo (no `pnpm-workspace.yaml` above it, so no monorepo fallback):

| | e2b `baseStatus` |
|---|---|
| before | `unknown` |
| after | `stale — baked runtime differs (base 44655c9a2319, current d5799451281b)` |

e2b is the discriminator — the only cloud provider with a stored bake on that host; the rest are genuinely `unprepared`. Child env carried `AGENTBOX_RUNTIME_ROOT=.../runtime`, and the computed fingerprint matches what the CLI computes from source, so hub and CLI now agree.

Green: `pnpm -w build`, `pnpm typecheck`, 308 sandbox-docker tests (incl. 3 new), eslint. In-repo hub restarted and re-checked for regression — docker `fresh` / e2b `stale` / rest `unprepared`, no "unverified".

https://claude.ai/code/session_01NST5Yhby55ZaxKXwjqRAVr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hub spawn env and create/custody fingerprinting on the control box path; behavior is constrained by marker verification and omitting invalid roots, but wrong resolution would still affect hub-driven creates.
> 
> **Overview**
> **CLI-spawned hubs** now get `AGENTBOX_RUNTIME_ROOT` (alongside the existing docker context) so in-process base fingerprints match the CLI and npm installs no longer show every cloud provider as "baked · unverified" or skip custody bake adoption.
> 
> `spawnHub` delegates to a new **`hubRuntimeEnv()`** helper that resolves the staged `runtime/` tree via `resolveStagedRuntimeRoot` and only sets the env var when a marker-verified root exists—workspace-only builds omit it so a bad path does not shadow the child’s own lookup; operator `AGENTBOX_RUNTIME_ROOT` still propagates.
> 
> Docs in **`runtime-root.ts`** and **`hub-testing.md`** explain the npm layout gap and how to debug missing env on the hub child. Three **vitest** cases cover explicit roots, omission without a staged tree, and override propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f2e6bd4c9afb8b2c2ae5299616821768ed9d8e7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->