### PR TITLE
fix(hub): key a control box's projects on the repo, not its throwaway clone

### DIFF
--- a/apps/hub/lib/boxes/project-key.ts
+++ b/apps/hub/lib/boxes/project-key.ts
@@ -1,0 +1,73 @@
+// Which project card a box groups under — the pure half, so the rules are
+// testable without a hub, a Store, or a filesystem.
+//
+// A control box builds every box from a per-job clone under
+// `$TMPDIR/agentbox-hub-worker-<jobId>` and deletes it as soon as the create
+// returns. That path is recorded in two places (the box's `projectRoot` and its
+// registration's `worktrees[].hostMainRepo`), and taking either at face value
+// produces a project card named after a directory that no longer exists —
+// with no origin, no `agentbox.yaml` and no seed. Worse, the card is then a
+// projection of that one box, so destroying the box makes the "project"
+// disappear. The repo is the durable identity; use it.
+import { hashProjectPath } from '@agentbox/config';
+import path from 'node:path';
+
+/**
+ * Prefix of the per-job clone `makeHubCreateBox` builds from. Exported so the
+ * producer (`hub-worker.ts`'s `tmpDir`) and these consumers can't drift — a
+ * rename on one side would otherwise silently resurrect the ghost cards.
+ */
+export const HUB_WORKER_CLONE_PREFIX = 'agentbox-hub-worker-';
+
+/**
+ * True for a control box's throwaway per-job checkout.
+ *
+ * Deliberately a NAME test, not an existence test: during the minute a create
+ * is running the directory is still there, and a PC-created box's
+ * `hostMainRepo` legitimately doesn't exist on the control box while still
+ * being a real, durable folder on the PC that we do want to group by.
+ */
+export function isHubWorkerClone(dir: string): boolean {
+  return path.basename(dir).startsWith(HUB_WORKER_CLONE_PREFIX);
+}
+
+/** `owner/repo` from a clone URL, else the URL unchanged. */
+export function deriveRepoLabel(originUrl: string): string {
+  const m = /[:/]([^/]+\/[^/]+?)(?:\.git)?\/?$/.exec(originUrl);
+  return m?.[1] ?? originUrl;
+}
+
+/** The registration fields this needs — a structural subset of `BoxRegistration`. */
+export interface ProjectKeyRegistration {
+  name: string;
+  originUrl?: string | null;
+  projectSlug?: string | null;
+  worktrees?: { hostMainRepo?: string }[];
+}
+
+/**
+ * The synthetic project a registered box groups under. The box row and this
+ * project MUST share the id, or the dashboard counts the box but renders it
+ * under no project card (it groups strictly by `projectId`).
+ *
+ * Keyed by the box's HOST FOLDER when it has a real one — the same key
+ * `agentbox ls` uses locally (`hashProjectPath(projectRoot)`), so a PC box
+ * groups by its folder rather than its repo: two folders sharing a git origin
+ * stay separate (matching the local model), and the id matches the box's own
+ * local project, so adopting it on the PC lands it in the same card.
+ *
+ * A control box's per-job clone is NOT such a folder, so it falls through to the
+ * repo. That identity outlives every box built from it, which is the point: the
+ * card stops vanishing when its last box is destroyed.
+ */
+export function registrationProjectKey(reg: ProjectKeyRegistration): { id: string; repo: string } {
+  const hostFolder = reg.worktrees?.[0]?.hostMainRepo;
+  if (hostFolder && hostFolder.startsWith('/') && !isHubWorkerClone(hostFolder)) {
+    return { id: hashProjectPath(hostFolder), repo: path.basename(hostFolder) };
+  }
+  // Identity from the unambiguous slug/origin; the label from the readable one.
+  // Keying on the basename alone would collide two owners' `app` repos.
+  const key = reg.projectSlug ?? reg.originUrl ?? reg.name;
+  const repo = reg.originUrl ? deriveRepoLabel(reg.originUrl) : (reg.projectSlug ?? reg.name);
+  return { id: hashProjectPath(key), repo };
+}

--- a/apps/hub/lib/hub-backend.ts
+++ b/apps/hub/lib/hub-backend.ts
@@ -98,6 +98,7 @@ import type {
 import { hubProfile } from './auth-config';
 import { custodyIdentityFromRegistration } from './boxes/seed-slug';
 import { controlPlaneCreateRequest } from './boxes/control-plane-create';
+import { isHubWorkerClone, registrationProjectKey } from './boxes/project-key';
 import type {
   BakeDiff,
   Approval,
@@ -255,14 +256,6 @@ function mapBox(b: ListedBox, regroup?: ProjectRegrouping): Box {
  * hub-worker box whose temp clone was deleted — those normally render from
  * local state, not here).
  */
-function registrationProjectKey(reg: BoxRegistration): { id: string; repo: string } {
-  const hostFolder = reg.worktrees?.[0]?.hostMainRepo;
-  if (hostFolder && hostFolder.startsWith('/')) {
-    return { id: hashProjectPath(hostFolder), repo: path.basename(hostFolder) };
-  }
-  const repo = reg.projectSlug ?? (reg.originUrl ? deriveRepoLabel(reg.originUrl) : reg.name);
-  return { id: hashProjectPath(repo), repo };
-}
 
 function mapRegistrationToBox(reg: BoxRegistration): Box {
   const createdAt = Date.parse(reg.createdAt ?? reg.registeredAt) || Date.now();
@@ -292,10 +285,6 @@ function mapRegistrationToBox(reg: BoxRegistration): Box {
 }
 
 /** A short repo label from an origin URL: `owner/repo`, else the last path segment. */
-function deriveRepoLabel(originUrl: string): string {
-  const m = /[:/]([^/]+\/[^/]+?)(?:\.git)?\/?$/.exec(originUrl);
-  return m?.[1] ?? originUrl;
-}
 
 /**
  * A host repo's current branch (`git rev-parse --abbrev-ref HEAD`). Returns null when
@@ -381,7 +370,9 @@ async function listProjects(boxes: ListedBox[]): Promise<Project[]> {
     // that path would mint a project card named after the clone dir, pointing at
     // nothing: no origin, no agentbox.yaml, no seed, and a create that resolves
     // to a dead path. Such boxes group by repo identity instead (see getData).
-    if (!existsSync(root)) continue;
+    // A per-job worker clone is never a project folder, even during the minute
+    // it still exists mid-create — see `isHubWorkerClone`.
+    if (isHubWorkerClone(root) || !existsSync(root)) continue;
     const createdAt = Date.parse(b.createdAt) || Date.now();
     const existing = boxByRoot.get(root);
     if (!existing) boxByRoot.set(root, { root, provider: b.provider ?? 'docker', createdAt });
@@ -399,7 +390,9 @@ async function listProjects(boxes: ListedBox[]): Promise<Project[]> {
   // Registry entries (incl. zero-box projects). A registered path that has since
   // vanished is skipped for the same reason — including the ghosts an older build
   // wrote before the check above existed.
-  for (const e of (await listProjectsConfigured()).filter((e) => existsSync(e.originalPath))) {
+  for (const e of (await listProjectsConfigured()).filter(
+    (e) => !isHubWorkerClone(e.originalPath) && existsSync(e.originalPath),
+  )) {
     const box = boxByRoot.get(e.originalPath);
     byId.set(e.hash, {
       id: e.hash,
@@ -468,7 +461,7 @@ async function resolveProjectPath(projectId: string): Promise<string | null> {
     if (hashProjectPath(root) !== projectId) continue;
     // Only heal a root that is actually there: registering a deleted per-job
     // clone is what minted the ghost project cards in the first place.
-    if (!existsSync(root)) return root;
+    if (isHubWorkerClone(root) || !existsSync(root)) return root;
     await registerProject(root).catch(() => {});
     return root;
   }
@@ -1405,7 +1398,8 @@ export function createHubBackend(handle: RelayServerHandle): HubBackend {
       const regByBoxId = new Map(allRegistrations.map((r) => [r.boxId, r]));
       const repoGrouped = new Map<string, ProjectRegrouping>();
       for (const b of listed) {
-        if (existsSync(projectRootOf(b))) continue;
+        const root = projectRootOf(b);
+        if (!isHubWorkerClone(root) && existsSync(root)) continue;
         const reg = regByBoxId.get(b.id);
         if (!reg) continue;
         const { id, repo } = registrationProjectKey(reg);

--- a/apps/hub/lib/hub-worker.ts
+++ b/apps/hub/lib/hub-worker.ts
@@ -39,6 +39,7 @@ import {
 import { applyProjectSeed, startDetachedCloudAgent } from '@agentbox/sandbox-cloud';
 import { resolveAgentLauncher, type AgentKind } from '@agentbox/core';
 import { hydratePreparedFromCustody } from './prepared-hydrate.js';
+import { HUB_WORKER_CLONE_PREFIX } from './boxes/project-key.js';
 import { IMPORTERS } from './provider-importers.js';
 
 const execFileAsync = promisify(execFile);
@@ -313,7 +314,7 @@ export function makeHubCreateBox(opts: HubWorkerOptions): CreateBoxFn {
       return { id: created.record.id };
     },
     fetchSeedMaterial: (repoUrl, dest) => applySeedFromCustody(custody, repoUrl, dest, log),
-    tmpDir: (jobId) => join(tmpdir(), `agentbox-hub-worker-${jobId}`),
+    tmpDir: (jobId) => join(tmpdir(), `${HUB_WORKER_CLONE_PREFIX}${jobId}`),
     cleanup: (dir) => rm(dir, { recursive: true, force: true }),
     log,
     logFor: makeJobLogger(log),

--- a/apps/hub/test/project-key.test.ts
+++ b/apps/hub/test/project-key.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import {
+  HUB_WORKER_CLONE_PREFIX,
+  deriveRepoLabel,
+  isHubWorkerClone,
+  registrationProjectKey,
+} from '../lib/boxes/project-key';
+
+const CLONE = `/tmp/${HUB_WORKER_CLONE_PREFIX}f9d4a8ab-e57d-428c-9464-f5eca4bef594`;
+
+describe('isHubWorkerClone', () => {
+  it('recognizes the control box per-job checkout', () => {
+    expect(isHubWorkerClone(CLONE)).toBe(true);
+  });
+
+  it('leaves a real project folder alone', () => {
+    expect(isHubWorkerClone('/Users/marco/Projects/agentbox-test-repo')).toBe(false);
+    // A folder that merely lives in /tmp is still a folder.
+    expect(isHubWorkerClone('/tmp/my-scratch-repo')).toBe(false);
+  });
+});
+
+describe('registrationProjectKey', () => {
+  const repoReg = {
+    name: 'wispy-fox',
+    originUrl: 'https://github.com/madarco/agentbox-test-repo.git',
+    projectSlug: 'madarco__agentbox-test-repo',
+  };
+
+  it('groups a PC box by its host folder', () => {
+    const k = registrationProjectKey({
+      ...repoReg,
+      worktrees: [{ hostMainRepo: '/Users/marco/Projects/agentbox-test-repo' }],
+    });
+    expect(k.repo).toBe('agentbox-test-repo');
+  });
+
+  // The bug: the control box records its throwaway clone as `hostMainRepo`, so
+  // grouping by it named the card after a directory that is already deleted —
+  // and made the card vanish with the box that produced it.
+  it('ignores a worker clone and groups by the repo instead', () => {
+    const k = registrationProjectKey({ ...repoReg, worktrees: [{ hostMainRepo: CLONE }] });
+    expect(k.repo).toBe('madarco/agentbox-test-repo');
+    expect(k.repo).not.toContain(HUB_WORKER_CLONE_PREFIX);
+  });
+
+  // Two boxes of the same repo, built by different create jobs, must land on ONE
+  // card — otherwise every create still spawns its own project.
+  it('gives every box of a repo the same id, whatever job built it', () => {
+    const a = registrationProjectKey({ ...repoReg, worktrees: [{ hostMainRepo: `${CLONE}-a` }] });
+    const b = registrationProjectKey({
+      ...repoReg,
+      worktrees: [{ hostMainRepo: `/tmp/${HUB_WORKER_CLONE_PREFIX}totally-different-job` }],
+    });
+    expect(a.id).toBe(b.id);
+  });
+
+  it('keys on the slug, so two owners of the same repo name stay apart', () => {
+    const mine = registrationProjectKey({
+      name: 'x',
+      projectSlug: 'madarco__app',
+      originUrl: 'https://github.com/madarco/app.git',
+      worktrees: [{ hostMainRepo: CLONE }],
+    });
+    const theirs = registrationProjectKey({
+      name: 'y',
+      projectSlug: 'acme__app',
+      originUrl: 'https://github.com/acme/app.git',
+      worktrees: [{ hostMainRepo: CLONE }],
+    });
+    expect(mine.id).not.toBe(theirs.id);
+  });
+
+  it('falls back to the box name when there is no repo identity at all', () => {
+    const k = registrationProjectKey({ name: 'lonely-box', worktrees: [{ hostMainRepo: CLONE }] });
+    expect(k.repo).toBe('lonely-box');
+  });
+});
+
+describe('deriveRepoLabel', () => {
+  it('reads owner/repo from https and ssh remotes', () => {
+    expect(deriveRepoLabel('https://github.com/madarco/agentbox.git')).toBe('madarco/agentbox');
+    expect(deriveRepoLabel('git@github.com:madarco/agentbox.git')).toBe('madarco/agentbox');
+  });
+
+  it('passes an unrecognizable remote through', () => {
+    expect(deriveRepoLabel('weird')).toBe('weird');
+  });
+});


### PR DESCRIPTION
On a control box the project card was still named `agentbox-hub-worker-<uuid>` and still vanished when its box was destroyed — the half of #272 meant to fix this didn't work. Verified live: the hub runs `0.28.0-nightly.202607281802` (which contains #272) and the dashboard still showed two clone-named cards.

## Why #272 missed

That change made a box with a dead `projectRoot` regroup via its Store registration, assuming the registration carried repo identity. It doesn't — `registrationProjectKey` prefers `worktrees[].hostMainRepo`, and the cloud provider records the create-time workspace there, which on a hub worker is the same per-job clone deleted seconds later. Its own comment says so:

```ts
// hostMainRepo is the create-time seed checkout; on a hub
// worker it is a temp clone that gets deleted after create, so
// host-side git RPCs won't work against it — …
hostMainRepo: req.workspacePath,
```

So the regroup landed straight back on the doomed path and the repo-identity fallback below it never ran.

## The fix

`registrationProjectKey` ignores a hub-worker clone and falls through to the repo — keyed on the project slug (so two owners' `app` repos stay apart), labelled `owner/repo`. That identity outlives every box built from it, which is the actual fix for the disappearing card: the project stops being a projection of one box.

Two details:

- The clone is recognized **by name, not existence**. Mid-create the directory still exists, and a PC box's `hostMainRepo` legitimately doesn't exist on the control box while still being a real folder worth grouping by.
- `HUB_WORKER_CLONE_PREFIX` is shared with the worker that mints the path, so a rename can't silently resurrect the ghosts.

The pure rules move to `apps/hub/lib/boxes/project-key.ts` (9 tests, incl. "two boxes of the same repo from different jobs land on one card"); the same check now also guards the three places that adopt a box root as a project.

Not covered here: the custody "Project seeds" entry, which is never deleted — the only destroy-time custody delete is scoped to `boxes/<sandboxId>`. That list was fine; the dashboard was the broken one.

`pnpm build` / `typecheck` (31) / `lint` (17) / `test` (30) green.

https://claude.ai/code/session_01RVgJBBAsfaiZcWvZNUTCM5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hub dashboard project grouping and synthetic project ids; behavior change is targeted but affects how all control-box creates appear and regroup.
> 
> **Overview**
> Fixes control-box dashboard project cards that were still named after `agentbox-hub-worker-<uuid>` and disappeared when the last box was destroyed. Prior regrouping still preferred `worktrees[].hostMainRepo`, which on hub workers is the ephemeral create checkout—not durable repo identity.
> 
> **`registrationProjectKey`** now skips hub-worker clone paths (basename prefix match, not filesystem existence) and keys on `projectSlug` / `originUrl` with an `owner/repo` label. Real PC host folders still group by path as before.
> 
> The rules live in **`project-key.ts`**; **`hub-worker.ts`** uses shared **`HUB_WORKER_CLONE_PREFIX`** for `tmpDir`. **`hub-backend.ts`** applies **`isHubWorkerClone`** when listing projects, resolving paths, and regrouping boxes with missing roots. Vitest coverage added for clone detection and stable repo-scoped ids across jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 078ce8b1e7a2b2d69196968b05866b3615777147. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->