### PR TITLE
fix(hub): keep the control box's agent credentials current

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -119,6 +119,18 @@ CLI, not the raw commits.
 
 ### Fixed
 
+- **Boxes created through a remote hub came up signed out of Claude.** A create
+  re-seeded the control box's credential from custody without checking which copy
+  was newer, overwriting a freshly refreshed token with an hours-old one — and a
+  Claude refresh rotates the token, so the older copy is dead rather than merely
+  expired. Custody is now kept current (a box that refreshes its own token
+  records it there, and every hub create path pushes yours before enqueuing) and
+  a create never replaces a credential with an older one.
+- **A box destroyed from your PC no longer lingers on the control box.** The reap
+  now also drops the control box's own record and per-box SSH key dir, so the box
+  stops showing as `running` in `hub boxes list`, the dashboard and the tray.
+- Hetzner servers are no longer named `agentbox-agentbox-…` when the box name
+  already starts with the prefix.
 - **A base baked on the control box stayed invisible to your machine**, which
   kept reporting it as stale and offering a multi-minute re-bake. The control box
   now records its bakes in its own custody (it was trying to upload them to a

--- a/apps/cli/src/commands/_cloud-agent-via-hub.ts
+++ b/apps/cli/src/commands/_cloud-agent-via-hub.ts
@@ -17,7 +17,7 @@
  */
 import type { BoxRecord } from '@agentbox/sandbox-docker';
 import { readGitOriginUrl } from '@agentbox/sandbox-cloud';
-import { resolveCustodyTarget } from './control-plane.js';
+import { resolveCustodyTarget, syncAgentCredentialsIfChanged } from './control-plane.js';
 import { enqueueCreateViaHub, pollHubJob } from '../control-plane/hub-enqueue.js';
 import { adoptHubBox } from '../control-plane/hub-adopt.js';
 import { ControlPlaneAdminClient } from '../control-plane/admin-client.js';
@@ -92,6 +92,12 @@ export async function createCloudBoxViaHubAndAdopt(
   if (!target) return null;
   const repoUrl = await readGitOriginUrl(projectRoot).catch(() => undefined);
   if (!repoUrl) return null;
+  // Refresh custody's agent credentials FIRST. The worker seeds the box from
+  // custody, and this machine holds the freshest token — without this the box
+  // comes up logged out with whatever a previous `create --via-hub` last pushed
+  // (a Claude refresh rotates the token, so a stale copy is dead, not merely
+  // expired). `create.ts` has always done this; the agent commands did not.
+  await syncAgentCredentialsIfChanged(urlFlag);
 
   const jobId = await enqueueCreateViaHub(target, {
     repoUrl,
@@ -160,6 +166,12 @@ export async function enqueueAgentJobViaHub(
   if (!target) return null;
   const repoUrl = await readGitOriginUrl(projectRoot).catch(() => undefined);
   if (!repoUrl) return null;
+  // Refresh custody's agent credentials FIRST. The worker seeds the box from
+  // custody, and this machine holds the freshest token — without this the box
+  // comes up logged out with whatever a previous `create --via-hub` last pushed
+  // (a Claude refresh rotates the token, so a stale copy is dead, not merely
+  // expired). `create.ts` has always done this; the agent commands did not.
+  await syncAgentCredentialsIfChanged(urlFlag);
 
   const jobId = await enqueueCreateViaHub(target, {
     repoUrl,

--- a/apps/hub/lib/hub-worker.ts
+++ b/apps/hub/lib/hub-worker.ts
@@ -12,9 +12,9 @@
  */
 import { execFile } from 'node:child_process';
 import { appendFileSync, mkdirSync } from 'node:fs';
-import { mkdir, readdir, rm, writeFile } from 'node:fs/promises';
+import { readdir, rm } from 'node:fs/promises';
 import { hostname, tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { isProviderKind, loadEffectiveConfig } from '@agentbox/config';
 import {
@@ -35,6 +35,9 @@ import {
   AGENT_SYNC_SPECS,
   boxSshDirForProvider,
   projectSlugFromOriginUrl,
+  readCredentialBackup,
+  shouldAcceptCredentialUpdate,
+  writeCredentialBackup,
 } from '@agentbox/sandbox-core';
 import { applyProjectSeed, startDetachedCloudAgent } from '@agentbox/sandbox-cloud';
 import { resolveAgentLauncher, type AgentKind } from '@agentbox/core';
@@ -62,8 +65,8 @@ async function runGit(
  * PC `credentials push` (phase 2) is what logs hub-created boxes in — one code
  * path, no second credential list.
  */
-async function seedHostBackupsFromCustody(
-  custody: FsCustodyStore,
+export async function seedHostBackupsFromCustody(
+  custody: Pick<FsCustodyStore, 'get'>,
   log: (l: string) => void,
 ): Promise<void> {
   for (const spec of AGENT_SYNC_SPECS) {
@@ -71,9 +74,21 @@ async function seedHostBackupsFromCustody(
     try {
       const found = await custody.get(custodyPath);
       if (!found) continue;
-      await mkdir(dirname(spec.credential.hostBackup), { recursive: true });
-      await writeFile(spec.credential.hostBackup, found.data, { mode: 0o600 });
-      log(`seeded ${spec.id} credentials from custody`);
+      const incoming = found.data.toString('utf8');
+      // NEVER downgrade. This used to overwrite unconditionally, which is how a
+      // box came up logged out: a box's refreshed token had just landed in the
+      // host backup (via CredentialsFanout), and the next create replaced it with
+      // custody's hours-old copy. Claude's OAuth refresh ROTATES the refresh
+      // token, so an older blob isn't merely expired — it is dead, and the box
+      // cannot recover from it. Same newest-wins rule the fanout applies.
+      const existing = await readCredentialBackup(spec.id);
+      const verdict = shouldAcceptCredentialUpdate(spec.id, incoming, existing);
+      if (!verdict.accept) {
+        log(`kept the local ${spec.id} credentials (custody copy ${verdict.reason})`);
+        continue;
+      }
+      await writeCredentialBackup(spec.id, incoming);
+      log(`seeded ${spec.id} credentials from custody (${verdict.reason})`);
     } catch (err) {
       log(
         `seed ${spec.id} from custody failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/apps/hub/test/seed-host-backups.test.ts
+++ b/apps/hub/test/seed-host-backups.test.ts
@@ -1,0 +1,107 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
+
+// Redirect HOME before importing anything that resolves ~/.agentbox — the
+// credential backups these tests read and write live there.
+const TEST_HOME = await mkdtemp(join(tmpdir(), 'agentbox-seed-backups-'));
+const REAL_HOME = process.env['HOME'];
+process.env['HOME'] = TEST_HOME;
+
+const { seedHostBackupsFromCustody } = await import('../lib/hub-worker');
+const { readCredentialBackup, writeCredentialBackup } = await import('@agentbox/sandbox-core');
+
+const claudeBlob = (expiresAt: number, token = 'a') =>
+  JSON.stringify({ claudeAiOauth: { accessToken: token, refreshToken: 'r', expiresAt } });
+
+/** Custody stub: only `get`, which is all the seeder uses. */
+function custodyWith(entries: Record<string, string>) {
+  return {
+    get: (path: string) =>
+      Promise.resolve(
+        entries[path] === undefined
+          ? null
+          : { entry: { path }, data: Buffer.from(entries[path], 'utf8') },
+      ),
+  } as never;
+}
+
+const CLAUDE = 'agents/claude/.credentials.json';
+
+afterEach(async () => {
+  await rm(join(TEST_HOME, '.agentbox'), { recursive: true, force: true });
+});
+afterAll(async () => {
+  process.env['HOME'] = REAL_HOME;
+  await rm(TEST_HOME, { recursive: true, force: true });
+});
+
+describe('seedHostBackupsFromCustody', () => {
+  // THE BUG: a box's refreshed token had just landed in the host backup, and the
+  // next create replaced it with custody's hours-old copy. Claude's OAuth refresh
+  // rotates the refresh token, so the older blob is dead — the box came up
+  // logged out and could not recover.
+  it('keeps a newer local backup instead of custody’s older copy', async () => {
+    const fresh = claudeBlob(9_000, 'fresh');
+    await writeCredentialBackup('claude', fresh);
+    const said: string[] = [];
+
+    await seedHostBackupsFromCustody(custodyWith({ [CLAUDE]: claudeBlob(1_000, 'stale') }), (l) =>
+      said.push(l),
+    );
+
+    expect(await readCredentialBackup('claude')).toBe(fresh);
+    expect(said.join(' ')).toContain('kept the local claude credentials');
+  });
+
+  it('takes custody’s copy when it is newer', async () => {
+    await writeCredentialBackup('claude', claudeBlob(1_000, 'old'));
+    const newer = claudeBlob(9_000, 'new');
+
+    await seedHostBackupsFromCustody(custodyWith({ [CLAUDE]: newer }), () => {});
+
+    expect(await readCredentialBackup('claude')).toBe(newer);
+  });
+
+  it('seeds when this machine has no backup at all', async () => {
+    const blob = claudeBlob(9_000);
+    await seedHostBackupsFromCustody(custodyWith({ [CLAUDE]: blob }), () => {});
+    expect(await readCredentialBackup('claude')).toBe(blob);
+  });
+
+  it('leaves the backup alone when custody holds nothing', async () => {
+    const mine = claudeBlob(9_000, 'mine');
+    await writeCredentialBackup('claude', mine);
+    await seedHostBackupsFromCustody(custodyWith({}), () => {});
+    expect(await readCredentialBackup('claude')).toBe(mine);
+  });
+
+  // codex/opencode blobs carry no ordering field — last-writer-wins by content.
+  it('accepts a changed codex blob, which has no expiry to compare', async () => {
+    await writeCredentialBackup('codex', JSON.stringify({ tokens: { access: 'old' } }));
+    const next = JSON.stringify({ tokens: { access: 'new' } });
+
+    await seedHostBackupsFromCustody(custodyWith({ 'agents/codex/auth.json': next }), () => {});
+
+    expect(await readCredentialBackup('codex')).toBe(next);
+  });
+
+  it('writes the backup 0600', async () => {
+    await seedHostBackupsFromCustody(custodyWith({ [CLAUDE]: claudeBlob(9_000) }), () => {});
+    const { stat } = await import('node:fs/promises');
+    const path = join(TEST_HOME, '.agentbox', 'claude-credentials.json');
+    expect((await stat(path)).mode & 0o777).toBe(0o600);
+    // sanity: the file really is where we think it is
+    expect(JSON.parse(await readFile(path, 'utf8'))).toMatchObject({ claudeAiOauth: {} });
+  });
+
+  it('survives a custody read that throws', async () => {
+    const mine = claudeBlob(9_000, 'mine');
+    await writeCredentialBackup('claude', mine);
+    const exploding = { get: () => Promise.reject(new Error('disk gone')) } as never;
+
+    await expect(seedHostBackupsFromCustody(exploding, () => {})).resolves.toBeUndefined();
+    expect(await readCredentialBackup('claude')).toBe(mine);
+  });
+});

--- a/apps/web/content/docs/deployed-hub.mdx
+++ b/apps/web/content/docs/deployed-hub.mdx
@@ -402,10 +402,12 @@ box's state (registration, status, SSH-key custody) — including for boxes you 
 registered against the control box. The control box drives them by reconstructing their record from
 its registry on demand (reverse-adoption), so no local record on the control box is required.
 
-A plain `agentbox destroy <box>` reaps too: after the cloud teardown it drops the box's registration
-and SSH-key custody from the control box, so a box you destroy here doesn't linger in the web UI or
-the tray. If the control box is unreachable at that moment the local destroy still succeeds and tells
-you to run `agentbox hub boxes rm <id>` once it's back.
+A plain `agentbox destroy <box>` reaps too: after the cloud teardown it drops the box's registration,
+its SSH-key custody, **and the control box's own record of it plus the per-box key dir on its disk**,
+so a box you destroy here doesn't linger in the web UI or the tray. (Before, only the registration
+went — the control box's local record survived and kept rendering the box as `running`, since a cloud
+row shows its last known state rather than probing.) If the control box is unreachable at that moment
+the local destroy still succeeds and tells you to run `agentbox hub boxes rm <id>` once it's back.
 
 ## Approvals reach you wherever you are
 
@@ -460,7 +462,9 @@ agentbox hub secrets push [--project]  # a project's .env → custody
 agentbox hub custody list [prefix]   # manifest (paths + hashes; values never leave the box)
 ```
 
-You rarely run `credentials push` by hand: **`agentbox hub setup` pushes your agent logins to the control box on its own** once the deploy is healthy (and reports what went up), so the first hub-created box is never launched signed-out. After that, the push repeats itself **only when a login actually changes** — after `agentbox claude login` refreshes a token, and before a cloud create is routed to the hub. Every push is content-hashed, so an unchanged one sends nothing and stays silent. `credentials push` is still there for the manual case (and its `--force`).
+You rarely run `credentials push` by hand: **`agentbox hub setup` pushes your agent logins to the control box on its own** once the deploy is healthy (and reports what went up), so the first hub-created box is never launched signed-out. After that, the push repeats itself **only when a login actually changes** — after `agentbox claude login` refreshes a token, and before *any* cloud create routed to the hub (`agentbox create`, and `agentbox claude|codex|opencode`). Every push is content-hashed, so an unchanged one sends nothing and stays silent. `credentials push` is still there for the manual case (and its `--force`).
+
+Custody also keeps itself current from the other direction: a Claude refresh **rotates the refresh token**, so the moment a box refreshes, every older copy is dead rather than merely expired. When a hub-created box refreshes its own token, the control box records the new one in custody, and a create never replaces a credential with an older one. That combination is what keeps a box you create hours later from coming up signed-out.
 
 ## How it stays safe
 

--- a/packages/relay/src/credentials-fanout.ts
+++ b/packages/relay/src/credentials-fanout.ts
@@ -21,6 +21,7 @@ import { execa } from 'execa';
 import {
   parseCredentialsUpdate,
   readCredentialBackup,
+  resolveAgentSpec,
   shouldAcceptCredentialUpdate,
   writeCredentialBackup,
   type CredentialAgentKind,
@@ -37,6 +38,17 @@ export interface CredentialsFanoutDeps {
   runPropagate?: (agent: CredentialAgentKind, sourceBoxId: string) => Promise<void>;
   /** Override the per-agent backup path (tests; default: the registry's). */
   backupPathFor?: (agent: CredentialAgentKind) => string;
+  /**
+   * The control box's custody store, when this relay owns one. Present ⇒ an
+   * accepted credential is mirrored into `agents/<id>/…` so the next hub create
+   * seeds from a current copy rather than the last one a PC pushed.
+   */
+  custody?: CredentialCustodyWriter | null;
+}
+
+/** The single write this needs from a custody store (structural: no import cycle). */
+export interface CredentialCustodyWriter {
+  put(path: string, data: Buffer): Promise<unknown>;
 }
 
 export interface CredentialsHandleResult {
@@ -49,6 +61,7 @@ export class CredentialsFanout {
   private readonly debounceMs: number;
   private readonly runPropagate: (agent: CredentialAgentKind, sourceBoxId: string) => Promise<void>;
   private readonly backupPathFor?: (agent: CredentialAgentKind) => string;
+  private readonly custody: CredentialCustodyWriter | null;
   private readonly pending = new Map<CredentialAgentKind, NodeJS.Timeout>();
   private readonly chains = new Map<CredentialAgentKind, Promise<void>>();
 
@@ -57,6 +70,7 @@ export class CredentialsFanout {
     this.debounceMs = deps.debounceMs ?? 3_000;
     this.runPropagate = deps.runPropagate ?? defaultRunPropagate;
     this.backupPathFor = deps.backupPathFor;
+    this.custody = deps.custody ?? null;
   }
 
   /**
@@ -73,11 +87,40 @@ export class CredentialsFanout {
       return { accepted: false, reason: verdict.reason };
     }
     await writeCredentialBackup(update.agent, update.content, { backupPath });
+    await this.recordInCustody(update.agent, update.content);
     this.log(
       `credentials: accepted ${update.agent} update from box ${sourceBoxId} (${verdict.reason}); fan-out in ${String(this.debounceMs)}ms`,
     );
     this.schedule(update.agent, sourceBoxId);
     return { accepted: true, reason: verdict.reason };
+  }
+
+  /**
+   * Mirror the accepted blob into custody, on a control box.
+   *
+   * Without this the freshest token lives ONLY in the host backup, and the next
+   * hub create re-seeds that backup from custody — a copy that is only as new as
+   * the last PC push. Since a refresh rotates the token, every box built after
+   * that came up with a dead credential. Writing here is what makes custody
+   * self-healing: the boxes refreshing their own tokens keep it current with no
+   * PC involvement.
+   *
+   * Best-effort by design — a custody failure must not cost us the fan-out,
+   * which is the part that fixes the boxes that are already running.
+   */
+  private async recordInCustody(agent: CredentialAgentKind, content: string): Promise<void> {
+    if (!this.custody) return;
+    try {
+      const spec = resolveAgentSpec(agent);
+      await this.custody.put(
+        `agents/${agent}/${spec.credential.boxRelPath}`,
+        Buffer.from(content, 'utf8'),
+      );
+    } catch (err) {
+      this.log(
+        `credentials: could not record ${agent} in custody: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   private schedule(agent: CredentialAgentKind, sourceBoxId: string): void {

--- a/packages/relay/src/remote-boxes.ts
+++ b/packages/relay/src/remote-boxes.ts
@@ -11,6 +11,8 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { rm } from 'node:fs/promises';
+import { dirname } from 'node:path';
 import { timingSafeEqual } from 'node:crypto';
 import type { CustodyStore } from './custody/store.js';
 import type { CreateJobRequest, Store } from './store/store.js';
@@ -168,12 +170,60 @@ export async function handleRemoteBoxesRequest(
         if (await deps.custody.delete(e.path).catch(() => false)) custodyRemoved += 1;
       }
     }
-    if (!existed && !reg && custodyRemoved === 0) {
+    // The control box also holds its OWN copy of a box it built: a `state.json`
+    // record and the per-box SSH key dir the provider minted. Reaping only the
+    // Store left those behind, so a box destroyed from the PC kept showing as
+    // `running` in `hub boxes list`, the dashboard and the tray (both read local
+    // state first, and a cloud row renders from `cloud.lastState` with no live
+    // probe), with its private key still on disk.
+    const localRemoved = await reapLocalBoxState(boxId, reg?.sandboxId, log);
+    if (!existed && !reg && custodyRemoved === 0 && !localRemoved) {
       return { status: 404, body: { error: 'no such box' } };
     }
-    log(`reaped box ${boxId} (registration=${String(existed)}, custody=${String(custodyRemoved)})`);
-    return { status: 200, body: { boxId, removed: existed, custodyRemoved } };
+    log(
+      `reaped box ${boxId} (registration=${String(existed)}, custody=${String(custodyRemoved)}, local=${String(localRemoved)})`,
+    );
+    return { status: 200, body: { boxId, removed: existed, custodyRemoved, localRemoved } };
   }
 
   return { status: 405, body: { error: 'method not allowed' } };
+}
+
+/**
+ * Drop the control box's own record of a box whose cloud resource is already
+ * gone: the `state.json` entry and the per-box SSH key dir the provider minted.
+ *
+ * Scoped to exactly this box's sandbox id — never a sweep. `prune --all`
+ * enumerates box dirs by the docker-shaped `<id>-<n>-<mnemonic>` run-dir name,
+ * which a VPS provider's sandboxId-keyed dir never matches, so a broad cleanup
+ * there would delete a LIVE box's private key.
+ *
+ * Best-effort and idempotent: this runs on a plain relay too, where there is no
+ * local record to remove.
+ */
+async function reapLocalBoxState(
+  boxId: string,
+  sandboxId: string | undefined,
+  log: (line: string) => void,
+): Promise<boolean> {
+  let removed = false;
+  try {
+    const { mutateState, readState, boxSshDirForProvider } = await import('@agentbox/sandbox-core');
+    const state = await readState();
+    const record = state.boxes.find((b) => b.id === boxId);
+    if (record) {
+      await mutateState((s) => ({ ...s, boxes: s.boxes.filter((b) => b.id !== boxId) }));
+      removed = true;
+      const key = record.cloud?.sandboxId ?? sandboxId;
+      const provider = record.provider;
+      if (key && provider) {
+        const sshDir = boxSshDirForProvider(provider, key);
+        // `<...>/boxes/<sandboxId>/ssh` — take the box dir, not just the keys.
+        if (sshDir) await rm(dirname(sshDir), { recursive: true, force: true }).catch(() => {});
+      }
+    }
+  } catch (err) {
+    log(`local reap for ${boxId} failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  return removed;
 }

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -382,7 +382,11 @@ export function createRelayServer(opts: RelayServerOptions): RelayServerHandle {
   // write + debounced `agentbox credentials propagate` spawn). In box mode the
   // event rides the local ring buffer to the bridge instead — the host's
   // poller hands it to this handler on the other side.
-  const credentialsFanout = mode === 'box' ? null : new CredentialsFanout({ log });
+  // `custody` is the control box's store — passing it is what lets an accepted
+  // token reach custody, so the next hub create seeds a current credential
+  // instead of the last one a PC pushed. Absent on a localhost relay (no store).
+  const credentialsFanout =
+    mode === 'box' ? null : new CredentialsFanout({ log, custody: opts.custody ?? null });
   if (mode === 'box' && (!opts.bridgeToken || opts.bridgeToken.length === 0)) {
     throw new Error("relay mode='box' requires a non-empty bridgeToken");
   }

--- a/packages/relay/test/credentials-fanout.test.ts
+++ b/packages/relay/test/credentials-fanout.test.ts
@@ -86,3 +86,68 @@ describe('CredentialsFanout', () => {
     await fanout.flush();
   });
 });
+
+describe('CredentialsFanout — custody write-back', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'fanout-custody-'));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  function makeWithCustody(put: (path: string, data: Buffer) => Promise<unknown>) {
+    return new CredentialsFanout({
+      log: () => {},
+      debounceMs: 100,
+      runPropagate: async () => {},
+      backupPathFor: (agent) => join(dir, `${agent}-credentials.json`),
+      custody: { put },
+    });
+  }
+
+  // Without this the freshest token lives only in the host backup, and the next
+  // hub create re-seeds that backup from custody's older copy — the box then
+  // starts with a rotated-away (dead) credential.
+  it('mirrors an accepted credential into custody', async () => {
+    const puts: { path: string; text: string }[] = [];
+    const fanout = makeWithCustody(async (path, data) => {
+      puts.push({ path, text: data.toString('utf8') });
+    });
+    const blob = claudeBlob(3_000);
+
+    expect((await fanout.handle('box-1', payload('claude', blob))).accepted).toBe(true);
+    expect(puts).toEqual([{ path: 'agents/claude/.credentials.json', text: blob }]);
+  });
+
+  it('does not write custody for a rejected (stale) update', async () => {
+    const puts: string[] = [];
+    const fanout = makeWithCustody(async (path) => {
+      puts.push(path);
+    });
+    await fanout.handle('box-1', payload('claude', claudeBlob(5_000)));
+    puts.length = 0;
+
+    const stale = await fanout.handle('box-2', payload('claude', claudeBlob(1_000)));
+    expect(stale.accepted).toBe(false);
+    expect(puts).toEqual([]);
+  });
+
+  it('still accepts and fans out when custody rejects the write', async () => {
+    const fanout = makeWithCustody(() => Promise.reject(new Error('custody offline')));
+    const res = await fanout.handle('box-1', payload('claude', claudeBlob(3_000)));
+    // The fan-out is what repairs boxes already running — a custody hiccup
+    // must not cost us that.
+    expect(res.accepted).toBe(true);
+  });
+
+  it('uses each agent’s own custody path', async () => {
+    const paths: string[] = [];
+    const fanout = makeWithCustody(async (path) => {
+      paths.push(path);
+    });
+    await fanout.handle('box-1', payload('codex', JSON.stringify({ tokens: { access: 'x' } })));
+    expect(paths).toEqual(['agents/codex/auth.json']);
+  });
+});

--- a/packages/relay/test/remote-boxes-local-reap.test.ts
+++ b/packages/relay/test/remote-boxes-local-reap.test.ts
@@ -1,0 +1,119 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
+
+// Redirect HOME before importing: the reap reads and writes the control box's
+// own `~/.agentbox/state.json` and per-box key dirs. The sibling
+// `remote-boxes.test.ts` has no isolation, so this lives in its own file.
+const TEST_HOME = await mkdtemp(join(tmpdir(), 'agentbox-local-reap-'));
+const REAL_HOME = process.env['HOME'];
+process.env['HOME'] = TEST_HOME;
+
+const { handleRemoteBoxesRequest } = await import('../src/remote-boxes.js');
+const { SqliteStore } = await import('../src/store/sqlite-store.js');
+const { boxSshDirForProvider } = await import('@agentbox/sandbox-core');
+
+const ADMIN = 'admin-secret';
+const STATE = join(TEST_HOME, '.agentbox', 'state.json');
+const open: InstanceType<typeof SqliteStore>[] = [];
+
+function store(): InstanceType<typeof SqliteStore> {
+  const s = new SqliteStore({ path: ':memory:' });
+  open.push(s);
+  return s;
+}
+
+/** A cloud BoxRecord as the control box would have persisted it. */
+function record(id: string, sandboxId: string) {
+  return {
+    id,
+    name: id,
+    provider: 'hetzner',
+    container: `cloud:${sandboxId}`,
+    image: 'agentbox-base',
+    workspacePath: '/tmp/ws',
+    createdAt: new Date(0).toISOString(),
+    cloud: { backend: 'hetzner', sandboxId },
+  };
+}
+
+async function writeState(records: ReturnType<typeof record>[]): Promise<void> {
+  await mkdir(dirname(STATE), { recursive: true });
+  await writeFile(STATE, JSON.stringify({ version: 1, boxes: records }), 'utf8');
+}
+
+async function readBoxIds(): Promise<string[]> {
+  const { readFile } = await import('node:fs/promises');
+  const s = JSON.parse(await readFile(STATE, 'utf8')) as { boxes: { id: string }[] };
+  return s.boxes.map((b) => b.id);
+}
+
+function del(boxId: string) {
+  return { method: 'DELETE', path: `/remote/boxes/${boxId}`, bearer: ADMIN, bodyText: '' };
+}
+
+afterEach(async () => {
+  await rm(join(TEST_HOME, '.agentbox'), { recursive: true, force: true });
+});
+afterAll(async () => {
+  await Promise.all(open.map((s) => s.close()));
+  process.env['HOME'] = REAL_HOME;
+  await rm(TEST_HOME, { recursive: true, force: true });
+});
+
+describe('DELETE reap — the control box’s own state', () => {
+  // Reaping only the Store left the control box's local record behind, so a box
+  // destroyed from the PC kept showing as `running` in `hub boxes list`, the
+  // dashboard and the tray — with its private key still on disk.
+  it('removes the local record and the per-box key dir', async () => {
+    await writeState([record('box-1', '156411131'), record('box-2', '156409612')]);
+    const sshDir = boxSshDirForProvider('hetzner', '156411131');
+    expect(sshDir).not.toBeNull();
+    await mkdir(sshDir!, { recursive: true });
+    await writeFile(join(sshDir!, 'id_ed25519'), 'PRIVATE', { mode: 0o600 });
+
+    const res = await handleRemoteBoxesRequest(del('box-1'), { store: store(), adminToken: ADMIN });
+
+    expect(res?.status).toBe(200);
+    expect((res?.body as { localRemoved: boolean }).localRemoved).toBe(true);
+    expect(await readBoxIds()).toEqual(['box-2']);
+    expect(existsSync(dirname(sshDir!))).toBe(false);
+  });
+
+  // Scoped to THIS box only — a sweep here would take a live box's key with it.
+  it('leaves another live box’s key dir untouched', async () => {
+    await writeState([record('box-1', '111'), record('box-2', '222')]);
+    const mine = boxSshDirForProvider('hetzner', '111')!;
+    const theirs = boxSshDirForProvider('hetzner', '222')!;
+    await mkdir(mine, { recursive: true });
+    await mkdir(theirs, { recursive: true });
+
+    await handleRemoteBoxesRequest(del('box-1'), { store: store(), adminToken: ADMIN });
+
+    expect(existsSync(dirname(mine))).toBe(false);
+    expect(existsSync(dirname(theirs))).toBe(true);
+  });
+
+  it('still 404s when nothing anywhere knows the box', async () => {
+    await writeState([record('box-2', '222')]);
+    const res = await handleRemoteBoxesRequest(del('box-1'), { store: store(), adminToken: ADMIN });
+    expect(res?.status).toBe(404);
+  });
+
+  // A plain relay (no state.json) must not fail the reap.
+  it('is a no-op when there is no local state at all', async () => {
+    const s = store();
+    await s.registerBox({
+      boxId: 'box-1',
+      token: 't',
+      name: 'box-1',
+      registeredAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+    });
+    const res = await handleRemoteBoxesRequest(del('box-1'), { store: s, adminToken: ADMIN });
+    expect(res?.status).toBe(200);
+    expect((res?.body as { localRemoved: boolean }).localRemoved).toBe(false);
+  });
+});

--- a/packages/sandbox-hetzner/src/naming.ts
+++ b/packages/sandbox-hetzner/src/naming.ts
@@ -45,6 +45,12 @@ export function hetznerLabelValue(name: string): string {
 export function hetznerResourceName(prefix: string, name: string, suffix: string): string {
   const fixed = `${prefix}-`.length + `-${suffix}`.length;
   const budget = Math.max(0, HETZNER_MAX_NAME - fixed);
-  const middle = clampEnds(hetznerLabelValue(name), budget);
+  const cleaned = hetznerLabelValue(name);
+  // Don't say `agentbox` twice. A box built on a control box is named after the
+  // worker's clone dir, which already starts with the prefix — the result was
+  // `agentbox-agentbox-hub-worker-<uuid>-…`, exactly 63 chars, flush against the
+  // ceiling. Dropping the repeat gives those 9 characters back to the name.
+  const deduped = cleaned.startsWith(`${prefix}-`) ? cleaned.slice(prefix.length + 1) : cleaned;
+  const middle = clampEnds(deduped, budget);
   return middle.length > 0 ? `${prefix}-${middle}-${suffix}` : `${prefix}-${suffix}`;
 }

--- a/packages/sandbox-hetzner/test/naming.test.ts
+++ b/packages/sandbox-hetzner/test/naming.test.ts
@@ -50,3 +50,31 @@ describe('hetznerResourceName', () => {
     expect(hetznerResourceName('agentbox', '///', 'm1a2b3')).toBe('agentbox-m1a2b3');
   });
 });
+
+describe('hetznerResourceName — prefix dedupe', () => {
+  // A control box names boxes after its worker clone dir, which already starts
+  // with `agentbox-`; the doubled prefix pushed the live name to exactly 63 chars.
+  it('does not repeat a prefix the name already carries', () => {
+    const n = hetznerResourceName(
+      'agentbox',
+      'agentbox-hub-worker-afa6513d-3-bdcccf2',
+      'ms51z3oo-6eu6if',
+    );
+    expect(n).toBe('agentbox-hub-worker-afa6513d-3-bdcccf2-ms51z3oo-6eu6if');
+    expect(n.startsWith('agentbox-agentbox-')).toBe(false);
+    expect(n.length).toBeLessThanOrEqual(HETZNER_MAX_NAME);
+  });
+
+  it('still prefixes a name that does not carry it', () => {
+    expect(hetznerResourceName('agentbox', 'wispy-fox', 'm1a2b3')).toBe(
+      'agentbox-wispy-fox-m1a2b3',
+    );
+  });
+
+  // `agentboxy` is not the prefix followed by a separator — only `agentbox-` is.
+  it('only strips a whole prefix segment', () => {
+    expect(hetznerResourceName('agentbox', 'agentboxy-thing', 'm1')).toBe(
+      'agentbox-agentboxy-thing-m1',
+    );
+  });
+});


### PR DESCRIPTION
Boxes created through a remote hub came up **signed out of Claude**. Measured on the live control box:

| | mtime | expiresAt | token |
|---|---|---|---|
| custody `agents/claude/.credentials.json` | 12:47 | **15:04 — expired** | `…D18SvwAA` |
| control box `~/.agentbox/claude-credentials.json` | **19:32** | **15:04 — expired** | `…D18SvwAA` |

Half an hour before that reading, the same backup held a *valid* token (`expiresAt 01:04`). The 19:32 create overwrote it with custody's 7-hour-old copy. A Claude refresh **rotates the refresh token**, so the older blob is dead rather than merely expired — the box cannot recover from it.

## Three defects, one loop

1. **`seedHostBackupsFromCustody` overwrote unconditionally** on every create. It now runs the newest-wins gate the fanout already uses (`shouldAcceptCredentialUpdate`) and writes atomically via `writeCredentialBackup`. This alone would have prevented the observed clobber — custody's `15:04` against a backup at `01:04` yields *"not newer than backup"*.
2. **Nothing ever wrote custody back.** `CredentialsFanout` already accepts a box's refreshed token into the host backup and fans it to other boxes; it now also records it in custody when the relay owns one (one-line wiring — `opts.custody` is already a `RelayServerOptions` field). Custody self-heals from the boxes instead of decaying until the next PC push.
3. **The agent-command hub path never refreshed custody.** `create --via-hub` has always called `syncAgentCredentialsIfChanged`; `agentbox <provider> claude` goes through `_cloud-agent-via-hub.ts`, which did not.

Daytona looked immune only because its credentials live on a volume the in-box agent keeps refreshing; e2b and vercel are affected identically.

## Also, from the same investigation

- **A PC destroy left state on the control box** — its own `state.json` record and per-box SSH key dir — so the box kept rendering `running` in `hub boxes list`, the dashboard and the tray (a cloud row shows its last known state, it doesn't probe). The reap endpoint now drops both, **scoped to that one sandbox id**: never a sweep, because `prune --all` matches box dirs by the docker-shaped `<id>-<n>-<mnemonic>` name and would take a *live* VPS box's private key.
- **Hetzner names no longer double the prefix.** A control-box box is named after the worker's clone dir, which already starts with `agentbox-`, so the server came out `agentbox-agentbox-hub-worker-<uuid>-…` at **exactly 63 characters** — flush against Hetzner's ceiling. Deduping returns 9 characters.

## Tests

The credential guard has a test that **fails without it** (verified by reverting the guard and watching it go red), plus custody write-back, local-reap and dedupe cases. Both new test files redirect `HOME` before importing — they read and write real credential backups and `state.json`, and the sibling relay tests have no isolation.

`pnpm build` / `typecheck` (31) / `lint` (17) / `test` (30) green.

Not verified end-to-end on the live control box yet — that needs this deployed there, then a create without any manual credential push.

https://claude.ai/code/session_01RVgJBBAsfaiZcWvZNUTCM5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication credential flow on the control box and destroy/reap behavior; scope is focused and covered by new tests, but mistakes could still affect box login or leave stale hub state.
> 
> **Overview**
> Fixes **hub-created boxes coming up signed out of Claude** and a few related control-box hygiene issues.
> 
> **Agent credentials on the control box** no longer decay or get clobbered. Before a hub-routed create, foreground/background `claude|codex|opencode` paths now call `syncAgentCredentialsIfChanged` (same as `create --via-hub`). On the worker, `seedHostBackupsFromCustody` applies the same **newest-wins** gate as credential fan-out instead of always overwriting host backups from custody. When a box refreshes a token, **`CredentialsFanout` mirrors the accepted blob into custody** (relay wired with `opts.custody`), so custody stays current without another PC push.
> 
> **Destroy/reap from a PC** now also removes the control box’s own `state.json` entry and the per-box SSH key directory, so destroyed boxes stop showing as `running` in hub list, dashboard, and tray.
> 
> **Hetzner resource names** skip a doubled `agentbox-` prefix when the box name already includes it (avoids `agentbox-agentbox-…` at the 63-char limit).
> 
> Docs/changelog updated; new tests cover seed-backup gating, custody write-back, local reap, and prefix dedupe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e0c2387e4839f8c3ebdac4e78adfad223e34e5f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->