### PR TITLE
feat(cli): make the local hub an /api/v1 target (thin CLI Step 0)

### DIFF
--- a/apps/cli/src/commands/control-plane.ts
+++ b/apps/cli/src/commands/control-plane.ts
@@ -109,6 +109,7 @@ import {
   HubApiError,
   type HubLifecycleAction,
 } from '../control-plane/hub-api-client.js';
+import { hubApiTargetFrom, withHubClient } from '../control-plane/with-hub.js';
 import { loadControlPlaneEnv } from '../control-plane/env-file.js';
 import { getHubJob, listHubJobs } from '../control-plane/hub-enqueue.js';
 import type { CreateJobRow } from '@agentbox/relay/control-plane';
@@ -1061,40 +1062,72 @@ export async function resolveCustodyTarget(
 }
 
 /**
- * Resolve a control box's public REST API target: its URL + the headless
- * `/api/v1` bearer (`AGENTBOX_HUB_API_KEY`). This is the client-facing hub API
- * (boxes/lifecycle/approvals), distinct from {@link resolveCustodyTarget}'s admin
- * token, which is the internal `/admin/*` wire. Seam for the shared hub-API client
- * (URL-swappable local ⇄ remote); not yet wired into commands.
+ * Bring the local hub up so it can answer `/api/v1`, returning true on success.
+ * One spinner, one clear failure line — the autostart step behind
+ * {@link resolveHubApiTarget} when the target resolves to a local hub that isn't
+ * running yet.
+ */
+async function autostartLocalHub(): Promise<boolean> {
+  // Dynamic import keeps control-plane.ts off a static edge to sandbox-docker
+  // (the eventual Step 12 moves `ensureHub` to sandbox-core so a docker-free host
+  // never pulls in docker machinery to start a hub).
+  const { ensureHub } = await import('@agentbox/sandbox-docker');
+  const s = spinner();
+  s.start('starting local hub');
+  try {
+    const ep = await ensureHub({ onLog: (line) => s.message(line) });
+    s.stop(`local hub running on ${ep.hostUrl}`);
+    return true;
+  } catch (err) {
+    s.stop('local hub failed to start');
+    log.error(err instanceof Error ? err.message : String(err));
+    return false;
+  }
+}
+
+/**
+ * Resolve the hub's public REST API target — its URL + the Bearer that authorizes
+ * `/api/v1` — for BOTH modes. Delegates the local⇄remote decision to
+ * {@link resolveHubTarget} (the same seam `agentbox hub target` and the tray
+ * follow): a configured/exposed control box yields its `AGENTBOX_HUB_API_KEY`; a
+ * local hub yields `~/.agentbox/hub/token`. The local hub's `proxy.ts` accepts
+ * that token as `Authorization: Bearer`, so the returned target is URL-swappable
+ * with a control box's with no client change.
  *
- * Returns null (actionable error unless `quiet`) when no control box is configured
- * or no API key is available — the key is minted + recorded by `control-plane
- * setup`/deploy into `~/.agentbox/control-plane/control-plane.env`.
+ * When the target is a local hub that isn't running, it is auto-started (unless
+ * `quiet`, where a best-effort probe must not spawn a daemon). Returns null (with
+ * an actionable error unless `quiet`) when a remote hub has no API key, or a local
+ * hub can't be started / still reports no token.
  */
 export async function resolveHubApiTarget(
   urlFlag: string | undefined,
   opts: { quiet?: boolean } = {},
 ): Promise<{ url: string; apiKey: string } | null> {
-  const cfg = await loadEffectiveConfig(process.cwd());
-  const configured = (urlFlag ?? cfg.effective.relay.controlPlaneUrl ?? '').replace(/\/$/, '');
-  // A hub exposed on THIS machine is reached over loopback, not its box-facing URL.
-  const url = (await applyLocalShortcut(configured, urlFlag)).replace(/\/$/, '');
-  if (!url) {
-    if (!opts.quiet)
-      log.error('No control plane configured. Run `agentbox hub set-url <url>` (or pass --url).');
-    return null;
+  // Lazy import breaks the hub.ts <-> control-plane.ts cycle: hub.ts consumes
+  // `controlPlaneSubcommands` (defined at the bottom of this file) at load time,
+  // so a static edge back the other way would read it before it's initialized.
+  const { resolveHubTarget } = await import('./hub.js');
+  let target = await resolveHubTarget(urlFlag);
+  let resolved = hubApiTargetFrom(target);
+
+  // A local hub with no token isn't running yet — bring it up, then re-read.
+  if (!resolved.ok && resolved.mode === 'local' && !opts.quiet) {
+    if (!(await autostartLocalHub())) return null;
+    target = await resolveHubTarget(urlFlag);
+    resolved = hubApiTargetFrom(target);
   }
-  loadControlPlaneEnv();
-  const apiKey = process.env.AGENTBOX_HUB_API_KEY ?? '';
-  if (!apiKey) {
+
+  if (!resolved.ok) {
     if (!opts.quiet)
       log.error(
-        'No hub API key available. Set AGENTBOX_HUB_API_KEY, or run this from the machine that\n' +
-          'ran `agentbox hub setup` (it writes the key to ~/.agentbox/control-plane).',
+        resolved.mode === 'remote'
+          ? 'No hub API key available. Set AGENTBOX_HUB_API_KEY, or run this from the machine that\n' +
+              'ran `agentbox hub setup` (it writes the key to ~/.agentbox/control-plane).'
+          : 'The local hub reports no API token. Start it with `agentbox hub` and retry.',
       );
     return null;
   }
-  return { url, apiKey };
+  return { url: resolved.url, apiKey: resolved.apiKey };
 }
 
 /**
@@ -1446,23 +1479,18 @@ const custodyCmd = new Command('custody')
 // --- control-plane box registry (the PC's admin view of the control box) ---
 
 const boxesListSub = new Command('list')
-  .description('List boxes on the control box (via its /api/v1)')
+  .description('List boxes on the hub (via its /api/v1) — a control box, or the local hub')
   .option('--url <url>', 'override the control-plane URL (default: relay.controlPlaneUrl)')
   .option('--json', 'print raw JSON')
   .action(async (opts: { url?: string; json?: boolean }) => {
-    try {
-      const client = await resolveHubApiClient(opts.url);
-      if (!client) {
-        process.exitCode = 1;
-        return;
-      }
+    await withHubClient(opts, async (client) => {
       const boxes = await client.listBoxes();
       if (opts.json) {
         process.stdout.write(`${JSON.stringify({ boxes }, null, 2)}\n`);
         return;
       }
       if (boxes.length === 0) {
-        log.info('No boxes on the control box.');
+        log.info('No boxes on the hub.');
         return;
       }
       for (const b of boxes) {
@@ -1470,65 +1498,59 @@ const boxesListSub = new Command('list')
           `${b.id}  ${b.name ?? b.task}  ${b.provider}  ${b.state ?? b.status}\n`,
         );
       }
-    } catch (err) {
-      handleLifecycleError(err);
-    }
+    });
   });
 
 const boxesRmSub = new Command('rm')
   .description(
-    'Destroy a box via the control box (tears down the cloud resource AND reaps its registration/custody)',
+    'Destroy a box via the hub (tears down the cloud resource AND reaps its registration/custody)',
   )
   .argument('<boxId>', 'the box id as shown by `hub boxes list`')
   .option('--url <url>', 'override the control-plane URL (default: relay.controlPlaneUrl)')
   .action(async (boxId: string, opts: { url?: string }) => {
-    try {
-      const client = await resolveHubApiClient(opts.url);
-      if (!client) {
-        process.exitCode = 1;
-        return;
+    await withHubClient(opts, async (client) => {
+      try {
+        // Reverse-adoption on the control box means this drives a REAL destroy even
+        // for a box created on the PC (registration-only) — not just a state reap.
+        await client.destroy(boxId);
+        log.success(`Destroyed '${boxId}' (cloud resource + hub state).`);
+      } catch (err) {
+        if (err instanceof HubApiError && err.code === 'not_found') {
+          log.info(`No box '${boxId}' on the hub.`);
+          return;
+        }
+        throw err;
       }
-      // Reverse-adoption on the control box means this drives a REAL destroy even
-      // for a box created on the PC (registration-only) — not just a state reap.
-      await client.destroy(boxId);
-      log.success(`Destroyed '${boxId}' (cloud resource + control-box state).`);
-    } catch (err) {
-      if (err instanceof HubApiError && err.code === 'not_found') {
-        log.info(`No box '${boxId}' on the control box.`);
-        return;
-      }
-      handleLifecycleError(err);
-    }
+    });
   });
 
 /** A `hub boxes <action>` lifecycle subcommand over the hub `/api/v1`. */
 function boxesLifecycleSub(action: HubLifecycleAction, verb: string, past: string): Command {
   return new Command(action)
-    .description(`${verb} a box on the control box (via its /api/v1)`)
+    .description(`${verb} a box on the hub (via its /api/v1)`)
     .argument('<boxId>', 'the box id as shown by `hub boxes list`')
     .option('--url <url>', 'override the control-plane URL (default: relay.controlPlaneUrl)')
     .action(async (boxId: string, opts: { url?: string }) => {
-      try {
-        const client = await resolveHubApiClient(opts.url);
-        if (!client) {
-          process.exitCode = 1;
-          return;
+      await withHubClient(opts, async (client) => {
+        try {
+          await client.lifecycle(boxId, action);
+          log.success(`${past} '${boxId}'.`);
+        } catch (err) {
+          if (err instanceof HubApiError && err.code === 'not_found') {
+            log.info(`No box '${boxId}' on the hub.`);
+            process.exitCode = 1;
+            return;
+          }
+          throw err;
         }
-        await client.lifecycle(boxId, action);
-        log.success(`${past} '${boxId}'.`);
-      } catch (err) {
-        if (err instanceof HubApiError && err.code === 'not_found') {
-          log.info(`No box '${boxId}' on the control box.`);
-          process.exitCode = 1;
-          return;
-        }
-        handleLifecycleError(err);
-      }
+      });
     });
 }
 
 const boxesCmd = new Command('boxes')
-  .description('List + drive boxes on the control box over its public /api/v1')
+  .description(
+    'List + drive boxes on the hub over its public /api/v1 (a control box, or the local hub)',
+  )
   .addCommand(boxesListSub)
   .addCommand(boxesLifecycleSub('start', 'Start', 'Started'))
   .addCommand(boxesLifecycleSub('stop', 'Stop', 'Stopped'))

--- a/apps/cli/src/commands/control-plane.ts
+++ b/apps/cli/src/commands/control-plane.ts
@@ -1108,15 +1108,23 @@ export async function resolveHubApiTarget(
   // so a static edge back the other way would read it before it's initialized.
   const { resolveHubTarget } = await import('./hub.js');
   let target = await resolveHubTarget(urlFlag);
-  let resolved = hubApiTargetFrom(target);
 
-  // A local hub with no token isn't running yet — bring it up, then re-read.
-  if (!resolved.ok && resolved.mode === 'local' && !opts.quiet) {
-    if (!(await autostartLocalHub())) return null;
-    target = await resolveHubTarget(urlFlag);
-    resolved = hubApiTargetFrom(target);
+  // Bring a local hub up before its token is used. The token at
+  // `~/.agentbox/hub/token` PERSISTS across `hub stop`, so token presence is NOT a
+  // liveness signal — a stopped hub still resolves with one. Gate the autostart on
+  // the hub actually running, or a stopped hub would skip autostart and only fail
+  // later at the health probe. Skipped under `quiet` (a probe must not spawn a
+  // daemon). `getHubStatus` reflects only the local hub, so it is irrelevant in
+  // remote mode.
+  if (target.mode === 'local' && !opts.quiet) {
+    const { getHubStatus } = await import('@agentbox/sandbox-docker');
+    if (!(await getHubStatus()).running) {
+      if (!(await autostartLocalHub())) return null;
+      target = await resolveHubTarget(urlFlag);
+    }
   }
 
+  const resolved = hubApiTargetFrom(target);
   if (!resolved.ok) {
     if (!opts.quiet)
       log.error(

--- a/apps/cli/src/commands/control-plane.ts
+++ b/apps/cli/src/commands/control-plane.ts
@@ -1068,14 +1068,20 @@ export async function resolveCustodyTarget(
  * running yet.
  */
 async function autostartLocalHub(): Promise<boolean> {
-  // Dynamic import keeps control-plane.ts off a static edge to sandbox-docker
+  // Dynamic imports keep control-plane.ts off a static edge to sandbox-docker
   // (the eventual Step 12 moves `ensureHub` to sandbox-core so a docker-free host
-  // never pulls in docker machinery to start a hub).
+  // never pulls in docker machinery to start a hub) and mirror how `hub start`
+  // itself is wired.
   const { ensureHub } = await import('@agentbox/sandbox-docker');
+  const { rehydrateFromState } = await import('./relay.js');
   const s = spinner();
   s.start('starting local hub');
   try {
     const ep = await ensureHub({ onLog: (line) => s.message(line) });
+    // Same as `hub start`/`restart`: a cold-started relay has an empty in-memory
+    // box registry (and no cloud pollers) until the persisted state is re-pushed,
+    // so a listing right after autostart would otherwise miss registered boxes.
+    await rehydrateFromState();
     s.stop(`local hub running on ${ep.hostUrl}`);
     return true;
   } catch (err) {
@@ -1109,16 +1115,19 @@ export async function resolveHubApiTarget(
   const { resolveHubTarget } = await import('./hub.js');
   let target = await resolveHubTarget(urlFlag);
 
-  // Bring a local hub up before its token is used. The token at
-  // `~/.agentbox/hub/token` PERSISTS across `hub stop`, so token presence is NOT a
-  // liveness signal — a stopped hub still resolves with one. Gate the autostart on
-  // the hub actually running, or a stopped hub would skip autostart and only fail
-  // later at the health probe. Skipped under `quiet` (a probe must not spawn a
-  // daemon). `getHubStatus` reflects only the local hub, so it is irrelevant in
-  // remote mode.
+  // Bring the full local hub up before its token is used. Two traps this gate
+  // avoids: (1) the token at `~/.agentbox/hub/token` PERSISTS across `hub stop`,
+  // so token presence is NOT a liveness signal — a stopped hub still resolves with
+  // one; (2) a bare `agentbox relay` (e.g. spawned by `create`) answers `/healthz`
+  // (`running:true`) but serves no `/api/v1` — so requiring the delegated Next UI
+  // (`ui`) is what distinguishes the full hub from a lean relay holding the port.
+  // `ensureHub` idempotently reclaims a lean relay / version-mismatched hub, so
+  // autostart is safe to trigger in both cases. Skipped under `quiet` (a probe
+  // must not spawn a daemon); `getHubStatus` is local-only, so irrelevant remote.
   if (target.mode === 'local' && !opts.quiet) {
     const { getHubStatus } = await import('@agentbox/sandbox-docker');
-    if (!(await getHubStatus()).running) {
+    const st = await getHubStatus();
+    if (!(st.running && st.ui)) {
       if (!(await autostartLocalHub())) return null;
       target = await resolveHubTarget(urlFlag);
     }

--- a/apps/cli/src/control-plane/hub-api-client.ts
+++ b/apps/cli/src/control-plane/hub-api-client.ts
@@ -89,6 +89,23 @@ export interface HubApiOpResult {
 export type HubLifecycleAction = 'start' | 'pause' | 'resume' | 'stop' | 'destroy';
 export type HubGitOp = 'checkout' | 'branch' | 'pull' | 'push' | 'push-host';
 
+/** The unauthenticated liveness probe (`GET /api/v1/health`). */
+export interface HubApiHealth {
+  ok: boolean;
+  /** The API contract the hub serves, e.g. `v1`. Gated against {@link SUPPORTED_HUB_API_VERSIONS}. */
+  apiVersion: string;
+  /** The AgentBox version the hub runs (a control box may differ from this CLI). */
+  version?: string;
+  profile?: string;
+}
+
+/**
+ * The `/api/v1` contract versions this CLI knows how to speak. The hub reports its
+ * own on `GET /api/v1/health` (`apiVersion`); a hub outside this set is refused up
+ * front with an upgrade hint rather than failing on a missing/changed field later.
+ */
+export const SUPPORTED_HUB_API_VERSIONS = ['v1'] as const;
+
 export interface HubApiTarget {
   url: string;
   apiKey: string;
@@ -148,6 +165,15 @@ export class HubApiClient {
       );
     }
     return parsed as T;
+  }
+
+  /**
+   * Liveness + API-version probe. Unauthenticated on the hub (the Bearer we send
+   * is harmless), so it also confirms the hub is reachable before an authed call.
+   * Throws `HubApiError` on a non-2xx (e.g. a hub too old to expose `/api/v1`).
+   */
+  health(): Promise<HubApiHealth> {
+    return this.request<HubApiHealth>('GET', '/health');
   }
 
   /** All boxes the hub knows (its own + registered). Topology-agnostic read. */
@@ -237,10 +263,10 @@ export class HubApiClient {
     onLine: (line: string) => void,
     signal?: AbortSignal,
   ): Promise<void> {
-    const res = await this.fetchImpl(
-      `${this.base}/api/v1/jobs/${encodeURIComponent(id)}/logs`,
-      { headers: { Authorization: `Bearer ${this.token}`, Accept: 'text/event-stream' }, signal },
-    );
+    const res = await this.fetchImpl(`${this.base}/api/v1/jobs/${encodeURIComponent(id)}/logs`, {
+      headers: { Authorization: `Bearer ${this.token}`, Accept: 'text/event-stream' },
+      signal,
+    });
     if (!res.ok || !res.body) return;
     const decoder = new TextDecoder();
     let buffer = '';
@@ -277,6 +303,8 @@ export class HubApiClient {
 
   /** Answer a pending approval by id. */
   async answerApproval(id: string, answer: 'y' | 'n'): Promise<void> {
-    await this.request<{ ok: true }>('POST', `/approvals/${encodeURIComponent(id)}/answer`, { answer });
+    await this.request<{ ok: true }>('POST', `/approvals/${encodeURIComponent(id)}/answer`, {
+      answer,
+    });
   }
 }

--- a/apps/cli/src/control-plane/with-hub.ts
+++ b/apps/cli/src/control-plane/with-hub.ts
@@ -1,0 +1,145 @@
+/**
+ * `withHubClient` — the one entry point CLI commands use to run an operation
+ * against the hub's `/api/v1`, in BOTH modes (a local hub or a remote control
+ * box; the only difference is the base URL + token, resolved by
+ * `resolveHubApiTarget`). It:
+ *
+ *   1. resolves the client (auto-starting a local hub when needed),
+ *   2. gates the hub's `/api/v1` version once up front — a hub outside
+ *      {@link SUPPORTED_HUB_API_VERSIONS} is refused with an upgrade hint rather
+ *      than failing on a changed field mid-operation,
+ *   3. runs the caller's op, and
+ *   4. maps a {@link HubApiError} (or an unreachable hub) to a stable CLI exit
+ *      code + an actionable message.
+ *
+ * Later steps of the `/api/v1` consolidation are then a mechanical conversion:
+ * wrap the op body in `withHubClient` and delete the inline provider code. A
+ * command that needs to special-case a code (e.g. treat `not_found` as info)
+ * catches it inside its own callback before it reaches the mapper here.
+ */
+import { log } from '@clack/prompts';
+import type { HubTarget } from '../commands/hub.js';
+import { HubApiClient, HubApiError, SUPPORTED_HUB_API_VERSIONS } from './hub-api-client.js';
+
+export interface WithHubOptions {
+  /** Override the hub URL (default: the configured control box, else the local hub). */
+  url?: string;
+}
+
+/** True when the hub's reported `apiVersion` is one this CLI speaks. */
+export function isSupportedApiVersion(version: string | undefined): boolean {
+  return (
+    version !== undefined && (SUPPORTED_HUB_API_VERSIONS as readonly string[]).includes(version)
+  );
+}
+
+// Distinct exit codes per API error class, so scripts can branch on the failure
+// kind. `not_found` reuses 2 to match the lifecycle-error convention
+// (`handleLifecycleError`). Anything unmapped (including `internal`) is a plain 1.
+const EXIT_BY_CODE: Record<string, number> = {
+  not_found: 2,
+  unauthorized: 3,
+  invalid_request: 4,
+  conflict: 5,
+  backend_unavailable: 6,
+};
+
+/** The CLI exit code for a hub `/api/v1` error code. */
+export function exitCodeForApiError(code: string): number {
+  return EXIT_BY_CODE[code] ?? 1;
+}
+
+/** An extra actionable line for the error classes where the raw message isn't enough. */
+function hintForApiError(err: HubApiError): string | null {
+  switch (err.code) {
+    case 'unauthorized':
+      return 'The hub rejected the API token. Restart a local hub with `agentbox hub restart`, or check AGENTBOX_HUB_API_KEY for a remote control box.';
+    case 'backend_unavailable':
+      return "The hub reached its backend but it was unavailable — the provider or host it needs may not be configured on the hub's machine.";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Map a resolved {@link HubTarget} to the `/api/v1` client target, or the reason
+ * it can't be used. Pure — the local⇄remote logic lives in `resolveHubTarget`;
+ * this only converts `token`→`apiKey` and decides whether a token is present.
+ * The token IS the Bearer for both modes (a local hub's token, or a control
+ * box's `AGENTBOX_HUB_API_KEY`).
+ */
+export function hubApiTargetFrom(
+  target: HubTarget,
+):
+  | { ok: true; url: string; apiKey: string }
+  | { ok: false; reason: 'no-token'; mode: 'local' | 'remote' } {
+  if (!target.token) return { ok: false, reason: 'no-token', mode: target.mode };
+  return { ok: true, url: target.url, apiKey: target.token };
+}
+
+/** Print a hub failure and set the matching exit code. Never throws. */
+function reportHubError(err: unknown, url: string): void {
+  if (err instanceof HubApiError) {
+    log.error(err.message);
+    const hint = hintForApiError(err);
+    if (hint) log.info(hint);
+    process.exitCode = exitCodeForApiError(err.code);
+    return;
+  }
+  // A fetch/network failure (hub down, wrong URL) surfaces as a plain Error.
+  log.error(`Can't reach the hub at ${url}: ${err instanceof Error ? err.message : String(err)}`);
+  process.exitCode = 1;
+}
+
+export async function withHubClient<T>(
+  opts: WithHubOptions,
+  fn: (client: HubApiClient) => Promise<T>,
+): Promise<T | undefined> {
+  // Lazy import breaks the hub.ts <-> control-plane.ts module cycle that both of
+  // those already sit in (hub.ts consumes control-plane.ts's command list at
+  // load time). Cheap after the first call — the module is cached.
+  const { resolveHubApiTarget } = await import('../commands/control-plane.js');
+  const target = await resolveHubApiTarget(opts.url);
+  if (!target) {
+    // resolveHubApiTarget already printed an actionable error (missing config /
+    // key, or a local-hub autostart failure).
+    process.exitCode = 1;
+    return undefined;
+  }
+  const client = new HubApiClient(target);
+
+  // Version gate — also the first authed-adjacent round-trip, so an unreachable
+  // hub is reported here rather than surfacing later as a confusing op failure.
+  try {
+    const health = await client.health();
+    if (!isSupportedApiVersion(health.apiVersion)) {
+      log.error(
+        `The hub at ${target.url} serves API ${health.apiVersion ? `"${health.apiVersion}"` : '(none reported)'}, ` +
+          `which this CLI doesn't support (needs ${SUPPORTED_HUB_API_VERSIONS.join(', ')}).`,
+      );
+      log.info(
+        'Upgrade it (`agentbox hub update` for a remote control box, or `agentbox hub restart` for a local hub) or update this CLI to match.',
+      );
+      process.exitCode = 1;
+      return undefined;
+    }
+  } catch (err) {
+    if (err instanceof HubApiError) {
+      // A hub too old to expose /api/v1 answers the probe with an error envelope.
+      log.error(
+        `The hub at ${target.url} didn't answer the /api/v1 health probe (${err.code}). It may be too old — upgrade it.`,
+      );
+      process.exitCode = 1;
+    } else {
+      reportHubError(err, target.url);
+    }
+    return undefined;
+  }
+
+  try {
+    return await fn(client);
+  } catch (err) {
+    reportHubError(err, target.url);
+    return undefined;
+  }
+}

--- a/apps/cli/test/hub-api-client.test.ts
+++ b/apps/cli/test/hub-api-client.test.ts
@@ -9,9 +9,10 @@ interface Call {
 }
 
 /** A fetch stub that records calls and replies from a per-path table. */
-function stub(
-  replies: Record<string, { status: number; body?: unknown }>,
-): { fetchImpl: typeof fetch; calls: Call[] } {
+function stub(replies: Record<string, { status: number; body?: unknown }>): {
+  fetchImpl: typeof fetch;
+  calls: Call[];
+} {
   const calls: Call[] = [];
   const fetchImpl = (async (url: string | URL, init?: RequestInit) => {
     const u = String(url);
@@ -23,7 +24,10 @@ function stub(
       body: init?.body ? JSON.parse(init.body as string) : undefined,
     });
     const key = `${method} ${new URL(u).pathname}`;
-    const reply = replies[key] ?? { status: 404, body: { error: { code: 'not_found', message: 'no route' } } };
+    const reply = replies[key] ?? {
+      status: 404,
+      body: { error: { code: 'not_found', message: 'no route' } },
+    };
     return new Response(reply.body === undefined ? null : JSON.stringify(reply.body), {
       status: reply.status,
     });
@@ -31,12 +35,19 @@ function stub(
   return { fetchImpl, calls };
 }
 
-const target = (fetchImpl: typeof fetch) => ({ url: 'https://hub.example/', apiKey: 'KEY', fetchImpl });
+const target = (fetchImpl: typeof fetch) => ({
+  url: 'https://hub.example/',
+  apiKey: 'KEY',
+  fetchImpl,
+});
 
 describe('HubApiClient', () => {
   it('lists boxes and unwraps the envelope', async () => {
     const { fetchImpl, calls } = stub({
-      'GET /api/v1/boxes': { status: 200, body: { boxes: [{ id: 'b1', provider: 'e2b', status: 'running', branch: 'x', task: 't' }] } },
+      'GET /api/v1/boxes': {
+        status: 200,
+        body: { boxes: [{ id: 'b1', provider: 'e2b', status: 'running', branch: 'x', task: 't' }] },
+      },
     });
     const boxes = await new HubApiClient(target(fetchImpl)).listBoxes();
     expect(boxes).toHaveLength(1);
@@ -47,27 +58,36 @@ describe('HubApiClient', () => {
   });
 
   it('posts a lifecycle action to the right path', async () => {
-    const { fetchImpl, calls } = stub({ 'POST /api/v1/boxes/b1/pause': { status: 200, body: { ok: true } } });
+    const { fetchImpl, calls } = stub({
+      'POST /api/v1/boxes/b1/pause': { status: 200, body: { ok: true } },
+    });
     await new HubApiClient(target(fetchImpl)).lifecycle('b1', 'pause');
     expect(calls[0]!.method).toBe('POST');
     expect(calls[0]!.url).toBe('https://hub.example/api/v1/boxes/b1/pause');
   });
 
   it('destroy maps to the destroy lifecycle action', async () => {
-    const { fetchImpl, calls } = stub({ 'POST /api/v1/boxes/b1/destroy': { status: 200, body: { ok: true } } });
+    const { fetchImpl, calls } = stub({
+      'POST /api/v1/boxes/b1/destroy': { status: 200, body: { ok: true } },
+    });
     await new HubApiClient(target(fetchImpl)).destroy('b1');
     expect(calls[0]!.url).toBe('https://hub.example/api/v1/boxes/b1/destroy');
   });
 
   it('answers an approval with the answer body', async () => {
-    const { fetchImpl, calls } = stub({ 'POST /api/v1/approvals/p1/answer': { status: 200, body: { ok: true } } });
+    const { fetchImpl, calls } = stub({
+      'POST /api/v1/approvals/p1/answer': { status: 200, body: { ok: true } },
+    });
     await new HubApiClient(target(fetchImpl)).answerApproval('p1', 'y');
     expect(calls[0]!.body).toEqual({ answer: 'y' });
   });
 
   it('throws a typed HubApiError carrying the envelope code + status', async () => {
     const { fetchImpl } = stub({
-      'POST /api/v1/boxes/gone/pause': { status: 404, body: { error: { code: 'not_found', message: 'box not found: gone' } } },
+      'POST /api/v1/boxes/gone/pause': {
+        status: 404,
+        body: { error: { code: 'not_found', message: 'box not found: gone' } },
+      },
     });
     const client = new HubApiClient(target(fetchImpl));
     await expect(client.lifecycle('gone', 'pause')).rejects.toMatchObject({
@@ -80,6 +100,21 @@ describe('HubApiClient', () => {
 
   it('treats 204 as a successful empty response', async () => {
     const { fetchImpl } = stub({ 'POST /api/v1/boxes/b1/stop': { status: 204 } });
-    await expect(new HubApiClient(target(fetchImpl)).lifecycle('b1', 'stop')).resolves.toBeUndefined();
+    await expect(
+      new HubApiClient(target(fetchImpl)).lifecycle('b1', 'stop'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('reads the health probe (apiVersion + version)', async () => {
+    const { fetchImpl, calls } = stub({
+      'GET /api/v1/health': {
+        status: 200,
+        body: { ok: true, apiVersion: 'v1', version: '0.28.0', profile: 'localhost' },
+      },
+    });
+    const h = await new HubApiClient(target(fetchImpl)).health();
+    expect(h.apiVersion).toBe('v1');
+    expect(h.version).toBe('0.28.0');
+    expect(calls[0]!.url).toBe('https://hub.example/api/v1/health');
   });
 });

--- a/apps/cli/test/with-hub.test.ts
+++ b/apps/cli/test/with-hub.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import type { HubTarget } from '../src/commands/hub.js';
+import {
+  exitCodeForApiError,
+  hubApiTargetFrom,
+  isSupportedApiVersion,
+} from '../src/control-plane/with-hub.js';
+
+describe('hubApiTargetFrom (target resolution, all three shapes)', () => {
+  it('remote configured control box → apiKey is its token', () => {
+    const t: HubTarget = { mode: 'remote', url: 'https://plane.example', token: 'KEY' };
+    expect(hubApiTargetFrom(t)).toEqual({ ok: true, url: 'https://plane.example', apiKey: 'KEY' });
+  });
+
+  it('remote exposed loopback (hub expose) → apiKey is AGENTBOX_HUB_API_KEY', () => {
+    const t: HubTarget = { mode: 'remote', url: 'http://127.0.0.1:8787', token: 'EXPOSED_KEY' };
+    expect(hubApiTargetFrom(t)).toEqual({
+      ok: true,
+      url: 'http://127.0.0.1:8787',
+      apiKey: 'EXPOSED_KEY',
+    });
+  });
+
+  it('local hub → apiKey is the local hub token', () => {
+    const t: HubTarget = { mode: 'local', url: 'http://127.0.0.1:8787', token: 'LOCAL_TOKEN' };
+    expect(hubApiTargetFrom(t)).toEqual({
+      ok: true,
+      url: 'http://127.0.0.1:8787',
+      apiKey: 'LOCAL_TOKEN',
+    });
+  });
+
+  it('local hub with no token (not running yet) → the autostart signal', () => {
+    const t: HubTarget = { mode: 'local', url: 'http://127.0.0.1:8787', token: '' };
+    expect(hubApiTargetFrom(t)).toEqual({ ok: false, reason: 'no-token', mode: 'local' });
+  });
+
+  it('remote hub with no key configured → not ok, remote', () => {
+    const t: HubTarget = { mode: 'remote', url: 'https://plane.example', token: '' };
+    expect(hubApiTargetFrom(t)).toEqual({ ok: false, reason: 'no-token', mode: 'remote' });
+  });
+});
+
+describe('isSupportedApiVersion (version gate)', () => {
+  it('accepts a version this CLI speaks', () => {
+    expect(isSupportedApiVersion('v1')).toBe(true);
+  });
+
+  it('rejects an unknown version', () => {
+    expect(isSupportedApiVersion('v2')).toBe(false);
+  });
+
+  it('rejects a hub that reports no version', () => {
+    expect(isSupportedApiVersion(undefined)).toBe(false);
+  });
+});
+
+describe('exitCodeForApiError (error mapping)', () => {
+  it('maps each known API error code to a distinct exit code', () => {
+    expect(exitCodeForApiError('not_found')).toBe(2);
+    expect(exitCodeForApiError('unauthorized')).toBe(3);
+    expect(exitCodeForApiError('invalid_request')).toBe(4);
+    expect(exitCodeForApiError('conflict')).toBe(5);
+    expect(exitCodeForApiError('backend_unavailable')).toBe(6);
+  });
+
+  it('falls back to 1 for internal / unmapped codes', () => {
+    expect(exitCodeForApiError('internal')).toBe(1);
+    expect(exitCodeForApiError('something_new')).toBe(1);
+  });
+});

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -479,7 +479,8 @@ agentbox hub set-url https://<your-hub-url>
 # Status of the configured remote hub (or the local hub when none is set)
 agentbox hub status
 
-# Drive the control box remotely (laptop can be off)
+# Drive boxes through the hub's /api/v1 — a remote control box (laptop can be off),
+# or the local hub, which is started automatically if it isn't already running
 agentbox hub boxes list
 agentbox hub boxes start|stop|pause|resume|rm <box>
 agentbox hub approvals list

--- a/docs/hub-api-single-path-plan.md
+++ b/docs/hub-api-single-path-plan.md
@@ -78,9 +78,31 @@ and adoption from the PC.
 
 ---
 
-## Step 0 — Foundation: make the local hub an API target
+## Step 0 — Foundation: make the local hub an API target ✅ done
 
 The blocking prerequisite. Nothing else can be converted until `HubApiClient` works in both modes.
+
+**Landed.** `resolveHubApiTarget` now delegates to `resolveHubTarget` (it was as predicted:
+`resolveHubTarget` already resolved remote / exposed-loopback / local, and the local hub's
+`proxy.ts` accepts `~/.agentbox/hub/token` as `Authorization: Bearer`). A local target that isn't
+running is auto-started via `ensureHub` (one spinner). `withHubClient()`
+(`apps/cli/src/control-plane/with-hub.ts`) is the single entry point later steps wrap an op in — it
+resolves the client, runs the `GET /api/v1/health` version gate (`apiVersion` ∈
+`SUPPORTED_HUB_API_VERSIONS = ['v1']`), and maps `HubApiError` codes to stable exit codes +
+actionable messages. The `hub boxes` group is the first converted caller (the canonical example).
+Verified end-to-end: `agentbox hub boxes list` against a local hub with no control box (empty and
+non-empty), and the remote-shaped path via `hub expose` (200 with the API key, 401 without).
+
+**Notes for later steps:**
+- **Module cycle.** `hub.ts` and `control-plane.ts` sit in a cycle (`hub.ts` consumes
+  `controlPlaneSubcommands` at load). So `resolveHubApiTarget` imports `resolveHubTarget` **lazily**
+  (`await import('./hub.js')`), and `withHubClient` imports `resolveHubApiTarget` lazily too. Keep
+  those edges lazy when converting commands, or `controlPlaneSubcommands` reads undefined at eval.
+- **Conversion shape.** A converted command is `await withHubClient(opts, async (client) => { … })`.
+  A command that special-cases an error code (e.g. `not_found` → info, not error) catches it
+  **inside** the callback before it reaches the mapper.
+- **Exit codes** (for scripts / later steps): `not_found`=2, `unauthorized`=3, `invalid_request`=4,
+  `conflict`=5, `backend_unavailable`=6, everything else (incl. `internal`) =1.
 
 - `resolveHubApiTarget` delegates to `resolveHubTarget` (`apps/cli/src/commands/hub.ts:73`),
   which already resolves remote (`relay.controlPlaneUrl` + `AGENTBOX_HUB_API_KEY`), the


### PR DESCRIPTION
## What

Step 0 of `docs/hub-api-single-path-plan.md` — **make the local hub an `/api/v1` target**. This is the blocking prerequisite for routing every CLI box operation through `/api/v1` in both local and remote modes.

Before this, `resolveHubApiTarget` hard-required `relay.controlPlaneUrl` **and** `AGENTBOX_HUB_API_KEY`, so every `/api/v1` client path in the CLI was remote-only by construction — a local hub was never a server the CLI talked to.

## Why

"Thin" was a property of the remote hub only. Making the local hub an API target is what lets steps 1–14 be a base-URL swap rather than an `if (remote)` fork in every command.

## Changes

- **`resolveHubApiTarget` now delegates to `resolveHubTarget`** (`commands/hub.ts`), which already resolves all three shapes — a configured control box, the `hub expose` loopback, and the local hub (`127.0.0.1:<port>` + `~/.agentbox/hub/token`). The local hub's `proxy.ts` already accepts that token as `Authorization: Bearer`, so `HubApiClient` needs no change. It returns a URL-swappable `{ url, apiKey }` for both modes.
- **Local-hub autostart.** When the target resolves local and the hub isn't running, it is started via `ensureHub` (one spinner, one clear failure line). Skipped under `quiet` so a best-effort probe never spawns a daemon.
- **`withHubClient()`** (new `control-plane/with-hub.ts`) — the single entry point later steps wrap an op in. It resolves the client, runs the `GET /api/v1/health` **version gate** (`apiVersion` ∈ `SUPPORTED_HUB_API_VERSIONS = ['v1']`, refusing an unsupported hub with an upgrade hint), then runs the op and maps `HubApiError` codes → stable CLI exit codes + actionable messages (`not_found`=2, `unauthorized`=3, `invalid_request`=4, `conflict`=5, `backend_unavailable`=6, else 1). The `hub boxes` group is converted to it as the canonical example.
- **Module cycle.** `hub.ts` and `control-plane.ts` sit in a cycle (`hub.ts` consumes `controlPlaneSubcommands` at load), so the `resolveHubTarget` / `resolveHubApiTarget` edges are imported **lazily** — matching the existing pattern in this file.
- Docs: `cli.mdx` `hub boxes` note (now targets the local hub too, autostarting it); Step 0 ticked in the plan doc with notes for later steps.

## How verified (end-to-end, ground truth)

- **Local hub, no control box** — the acceptance criterion (errored before): `agentbox hub boxes list` autostarts the local hub, passes the version gate, and lists boxes. Exercised **empty** (`No boxes on the hub.`, exit 0) and **non-empty** (a real docker box created from `examples/express-ready`). Confirmed against ground truth: `GET /api/v1/health` reports `apiVersion: "v1"`; `GET /api/v1/boxes` (local token as Bearer) returns the same boxes.
- **Lifecycle + error mapping** — `hub boxes pause <id>` (exit 0), `hub boxes pause <nonexistent>` → `not_found` (exit 1).
- **Remote-shaped path** via `agentbox hub expose --bind 127.0.0.1 --no-autostart`: `hub target` reports `mode: remote` with the API key; `hub boxes list` lists via the key-authenticated path. Ground truth: `/api/v1/boxes` returns **200 with the key, 401 without**. Teardown (`hub unexpose`) verified clean.
- `pnpm --filter @madarco/agentbox typecheck` clean; full CLI suite `1095 passed | 1 skipped` (17 new/updated assertions across `with-hub.test.ts` + `hub-api-client.test.ts` covering the three target shapes, version gate, error mapping, and the health probe); eslint clean on touched files.

## Notes for later steps

Converting a command is `await withHubClient(opts, async (client) => { … })`; a command that special-cases a code (e.g. `not_found` → info) catches it **inside** the callback before it reaches the mapper. Keep the `resolveHubTarget` / `resolveHubApiTarget` imports lazy.

https://claude.ai/code/session_01XyCfcZoTxhKUgf5riou9TP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hub target resolution and can autostart Docker-backed local hubs on CLI use; behavior change for users without a configured control box, but scoped to `/api/v1` entry points and covered by tests.
> 
> **Overview**
> **Step 0** of the hub `/api/v1` consolidation: the CLI is no longer remote-only for `HubApiClient` — local and control-box targets share one URL + Bearer shape.
> 
> **`resolveHubApiTarget`** now follows **`resolveHubTarget`** (local token vs `AGENTBOX_HUB_API_KEY`) via **`hubApiTargetFrom`**, instead of requiring `relay.controlPlaneUrl` and a control-plane env key. For a **local** hub that is down, it can **autostart** the full hub (`ensureHub` + `rehydrateFromState`), gated on `running && ui` so a bare relay on the port is not mistaken for the API. **`quiet`** skips autostart.
> 
> New **`withHubClient`** resolves the client, probes **`GET /api/v1/health`**, refuses unsupported **`apiVersion`** values, and maps **`HubApiError`** codes to stable exit codes and hints. **`hub boxes`** (list, lifecycle, rm) is refactored to use it as the pattern for later commands.
> 
> **`HubApiClient.health()`**, **`SUPPORTED_HUB_API_VERSIONS`**, and unit tests cover health, target shapes, version gate, and exit-code mapping. Docs note local-hub autostart for `hub boxes`; the plan marks Step 0 done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36ce91a654d90d0b4f372c485e68933f89f1ab69. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->