### PR TITLE
feat(cli): route git ops through the hub /api/v1 (thin CLI Step 6)

### DIFF
--- a/apps/cli/src/commands/git.ts
+++ b/apps/cli/src/commands/git.ts
@@ -1,34 +1,41 @@
 import type { BoxRecord, ExecResult } from '@agentbox/core';
-import { GH_PR_OPS, hashRpcParams, injectPrCreateHead as injectHead, type GhPrOp } from '@agentbox/relay';
 import {
-  boxGitCheckout,
-  boxGitNewBranch,
-  boxGitPull,
-  boxGitPush,
-  boxGitPushHost,
-  mutateState,
-  scratchBranchName,
-  type BoxGitDeps,
-} from '@agentbox/sandbox-core';
-import { mintHostInitiatedToken, registerBoxWithRelay } from '@agentbox/sandbox-docker';
+  GH_PR_OPS,
+  hashRpcParams,
+  injectPrCreateHead as injectHead,
+  type GhPrOp,
+} from '@agentbox/relay';
+import { mintHostInitiatedToken } from '@agentbox/sandbox-docker';
 import { Command } from 'commander';
 import { resolveBoxOrExit } from '../box-ref.js';
+import type { HubApiOpResult } from '../control-plane/hub-api-client.js';
+import { withHubClient } from '../control-plane/with-hub.js';
 import { providerForBox } from '../provider/registry.js';
 import { handleLifecycleError } from './_errors.js';
 
 /**
  * `agentbox git <subcommand> <box>` — host-side proxy for git/PR operations
- * against a specific box. Every subcommand resolves the box, attaches the
- * provider, and runs the matching `agentbox-ctl git` / `agentbox-ctl gh pr`
- * (or raw `git`) inside the box's /workspace.
+ * against a specific box.
  *
- * Credentialed RPCs (push, fetch, pull-fetch, gh pr) carry a one-time scoped
- * token minted by the host via `mintHostInitiatedToken`; the relay validates
- * the token and skips its confirm prompt on match. A simple "host-initiated"
+ * The branch-mutating ops (`push`, `pull`, `checkout`, `branch`,
+ * `push --host-only`) go through the hub's public `/api/v1`
+ * (`POST /boxes/:id/git/:op` via {@link withHubClient}), so they work
+ * identically against a local hub and a remote control box — the hub owns the
+ * host-initiated-token mint + branch sanctioning that used to live here. The
+ * box command's own exit code is carried faithfully through the error envelope
+ * (`error.details.exitCode`), so e.g. `push --host-only` against a box whose
+ * host has no working copy still surfaces the server's exit 64.
+ *
+ * `fetch`, `status`, and the `pr` group stay INLINE: no `/api/v1` route exists
+ * for them yet, so they resolve the box + provider directly and run the
+ * matching `agentbox-ctl git` / `agentbox-ctl gh pr` (or raw `git`) in the
+ * box's /workspace. Their credentialed RPCs (fetch, gh pr) carry a one-time
+ * scoped token minted by the host via `mintHostInitiatedToken`; the relay
+ * validates it and skips its confirm prompt on match. A simple "host-initiated"
  * boolean would be forgeable by the box agent (the agent sees the argv); the
- * one-time token isn't (the mint endpoint is loopback-only). If the relay
- * can't mint (older relay / not running), the call still proceeds — it just
- * goes through the normal prompt path on the wrapper side.
+ * one-time token isn't (the mint endpoint is loopback-only). If the relay can't
+ * mint (older relay / not running), the call still proceeds — it just goes
+ * through the normal prompt path on the wrapper side.
  */
 
 const WORKSPACE = '/workspace';
@@ -47,84 +54,10 @@ async function runAndStream(box: BoxRecord, argv: string[]): Promise<number> {
   return r.exitCode;
 }
 
-/**
- * Record `branch` as the box's host-sanctioned branch after a host-driven
- * `agentbox git checkout`/`branch`/`pull <branch>`. The relay auto-approves a
- * push only to a scratch branch or this value, so a host branch switch must
- * update it (otherwise the box would prompt to push the branch the host just
- * put it on). Persists to `~/.agentbox/state.json` (docker root worktree +
- * cloud field) and re-registers docker boxes so the in-memory relay registry
- * picks up the new value. Best-effort: a failure here just means the next push
- * to that branch prompts — it never blocks the branch switch itself.
- */
-async function sanctionBoxBranch(box: BoxRecord, branch: string): Promise<void> {
-  try {
-    await mutateState((state) => {
-      const b = state.boxes.find((x) => x.id === box.id);
-      if (!b) return state;
-      if (b.gitWorktrees) {
-        for (const w of b.gitWorktrees) {
-          if (w.kind === 'root') w.sanctionedBranch = branch;
-        }
-      }
-      if (b.cloud) b.cloud.sanctionedBranch = branch;
-      return state;
-    });
-  } catch {
-    return; // couldn't persist → leave the gate as-is
-  }
-  // Docker's push gate reads the in-memory registry, so re-register to refresh
-  // the worktree's sanctionedBranch. Cloud's gate reads state.json per RPC, so
-  // the persist above is enough — no cloud re-register needed.
-  const isDocker = box.provider === 'docker' || box.provider === undefined;
-  if (isDocker && box.relayToken) {
-    const worktrees = (box.gitWorktrees ?? []).map((w) =>
-      w.kind === 'root' ? { ...w, sanctionedBranch: branch } : w,
-    );
-    try {
-      await registerBoxWithRelay({
-        boxId: box.id,
-        token: box.relayToken,
-        name: box.name,
-        containerName: box.container,
-        createdAt: box.createdAt,
-        projectIndex: box.projectIndex,
-        worktrees,
-        autoApproveHostActions: box.autoApproveHostActions,
-        autoApproveSafeHostActions: box.autoApproveSafeHostActions,
-      });
-    } catch (err) {
-      // The new sanctioned branch is persisted to state.json but the running
-      // relay's in-memory registry still holds the old one — so its push /
-      // PR-head gate keeps following the stale branch until the relay
-      // re-registers (next `agentbox relay restart` / rehydrate reads
-      // state.json). Surface it rather than swallow: silent staleness would
-      // leave `git push` gated on the wrong branch with no signal.
-      process.stderr.write(
-        `agentbox git: warning — recorded ${branch} as the box's branch, but the relay did not pick it up ` +
-          `(${err instanceof Error ? err.message : String(err)}). Run \`agentbox relay restart\` so pushes to ${branch} are gated correctly.\n`,
-      );
-    }
-  }
-}
-
-/** Stream a shared-helper exec result to the terminal, then exit with its code. */
-async function streamExit(r: ExecResult): Promise<never> {
+/** Write a hub git-op result's captured stdout/stderr to the terminal. */
+function streamOp(r: HubApiOpResult): void {
   if (r.stdout) process.stdout.write(r.stdout);
   if (r.stderr) process.stderr.write(r.stderr);
-  return exitWith(r.exitCode);
-}
-
-/**
- * BoxGitDeps for the shared helpers: forward each credentialed RPC's
- * `(method, params)` to the host-initiated-token minter. The helpers only ever
- * build `{ path, remote?, args? }`, so the cast to PredictedGitParams is safe
- * (path is always set) and the params hash round-trips with what ctl sends.
- */
-function gitDeps(box: BoxRecord): BoxGitDeps {
-  return {
-    hostInitiatedArgs: (method, params) => hostInitiatedArgs(box.id, method, params as PredictedGitParams),
-  };
 }
 
 /**
@@ -169,7 +102,10 @@ async function hostInitiatedArgs(
 }
 
 /** Build the `{ path, remote?, args? }` ctl will send for git RPCs. */
-function buildPredictedGitParams(remote: string | undefined, extraArgs: string[]): PredictedGitParams {
+function buildPredictedGitParams(
+  remote: string | undefined,
+  extraArgs: string[],
+): PredictedGitParams {
   const out: PredictedGitParams = { path: WORKSPACE };
   if (remote) out.remote = remote;
   if (extraArgs.length > 0) out.args = extraArgs;
@@ -192,11 +128,23 @@ async function exitWith(code: number): Promise<never> {
 const pushCommand = new Command('push')
   .description("Push the box's branch via the host relay (host creds, no prompt)")
   .argument('<box>', 'box ref: project index, id, id prefix, name, or container')
-  .argument('[args...]', 'extra flags forwarded to `agentbox-ctl git push` (e.g. --force-with-lease, --tags)')
+  .argument(
+    '[args...]',
+    'extra flags forwarded to `agentbox-ctl git push` (e.g. --force-with-lease, --tags)',
+  )
   .option('--remote <name>', 'remote name (default: origin)')
-  .option('--host-only', "land the branch in the host's local repo only; do NOT push to the remote (nothing is published online)")
-  .option('--as <branch>', "with --host-only: destination branch name in the host repo (default: the box's branch name)")
-  .option('--force', 'with --host-only: allow a non-fast-forward overwrite of the destination branch')
+  .option(
+    '--host-only',
+    "land the branch in the host's local repo only; do NOT push to the remote (nothing is published online)",
+  )
+  .option(
+    '--as <branch>',
+    "with --host-only: destination branch name in the host repo (default: the box's branch name)",
+  )
+  .option(
+    '--force',
+    'with --host-only: allow a non-fast-forward overwrite of the destination branch',
+  )
   .allowExcessArguments(true)
   .allowUnknownOption(true)
   .action(
@@ -207,22 +155,23 @@ const pushCommand = new Command('push')
     ) => {
       try {
         if (opts.hostOnly && opts.remote) {
-          process.stderr.write('agentbox git push: --host-only does not use a remote; drop --remote\n');
+          process.stderr.write(
+            'agentbox git push: --host-only does not use a remote; drop --remote\n',
+          );
           await exitWith(64);
         }
         const box = await resolveBoxOrExit(boxRef);
-        const provider = await providerForBox(box);
-        if (opts.hostOnly) {
-          // Host-only landing publishes nothing, so the relay skips its
-          // push-confirm gate entirely — no host-initiated token needed.
-          await streamExit(await boxGitPushHost(provider, box, { as: opts.as, force: opts.force, args }));
-          return;
-        }
-        // --force is a real remote-push flag; the helper appends it to the args
-        // tail and folds it into the params hash so the minted token matches.
-        await streamExit(
-          await boxGitPush(provider, box, { remote: opts.remote, force: opts.force, args }, gitDeps(box)),
-        );
+        await withHubClient({}, async (client) => {
+          // No `mode` pre-check for --host-only: a `hub expose`d machine reports
+          // mode 'remote' yet IS the host with the checkout, so host-only
+          // succeeds there. The real condition — does this box's host have a
+          // working copy — is checked server-side, which returns exit 64 (carried
+          // faithfully via the error envelope) when it genuinely doesn't.
+          const r = opts.hostOnly
+            ? await client.git(box.id, 'push-host', { as: opts.as, force: opts.force, args })
+            : await client.git(box.id, 'push', { remote: opts.remote, force: opts.force, args });
+          streamOp(r);
+        });
       } catch (err) {
         handleLifecycleError(err);
       }
@@ -255,7 +204,7 @@ const fetchCommand = new Command('fetch')
 
 const pullCommand = new Command('pull')
   .description(
-    "Fetch via the relay then merge in /workspace. With <branch>: first `git checkout <branch>` so the box switches base branch and pulls latest — useful for reusing a box on a new task.",
+    'Fetch via the relay then merge in /workspace. With <branch>: first `git checkout <branch>` so the box switches base branch and pulls latest — useful for reusing a box on a new task.',
   )
   .argument('<box>', 'box ref')
   .argument('[branch]', 'optional branch to switch to before pulling (e.g. main)')
@@ -273,19 +222,17 @@ const pullCommand = new Command('pull')
     ) => {
       try {
         const box = await resolveBoxOrExit(boxRef);
-        const provider = await providerForBox(box);
-        if (branch) {
-          const switched = await boxGitCheckout(provider, box, branch);
-          if (switched.stdout) process.stdout.write(switched.stdout);
-          if (switched.stderr) process.stderr.write(switched.stderr);
-          if (switched.exitCode !== 0) await exitWith(switched.exitCode);
-          // Host switched the box onto <branch> — sanction it so the following
-          // pull/push don't prompt to touch the branch the host just picked.
-          await sanctionBoxBranch(box, branch);
-        }
-        await streamExit(
-          await boxGitPull(provider, box, { remote: opts.remote, ffOnly: opts.ffOnly, args }, gitDeps(box)),
-        );
+        await withHubClient({}, async (client) => {
+          if (branch) {
+            // The hub sanctions <branch> after a 0-exit checkout, so the
+            // following pull/push don't prompt to touch the branch the host
+            // just picked. A non-zero checkout throws → the pull is skipped.
+            streamOp(await client.git(box.id, 'checkout', { branch }));
+          }
+          streamOp(
+            await client.git(box.id, 'pull', { remote: opts.remote, ffOnly: opts.ffOnly, args }),
+          );
+        });
       } catch (err) {
         handleLifecycleError(err);
       }
@@ -293,7 +240,7 @@ const pullCommand = new Command('pull')
   );
 
 const checkoutCommand = new Command('checkout')
-  .description('Change the box\'s working branch (runs `git checkout <branch>` in /workspace)')
+  .description("Change the box's working branch (runs `git checkout <branch>` in /workspace)")
   .argument('<box>', 'box ref')
   .argument('<branch>', 'branch to check out inside the box')
   .argument('[args...]', 'extra flags forwarded to `git checkout`')
@@ -302,39 +249,38 @@ const checkoutCommand = new Command('checkout')
   .action(async (boxRef: string, branch: string, args: string[]) => {
     try {
       const box = await resolveBoxOrExit(boxRef);
-      const provider = await providerForBox(box);
-      const r = await boxGitCheckout(provider, box, branch, args);
-      // Host-sanctioned branch switch: record it so pushing this branch skips
-      // the confirm prompt (an in-box agent's own checkout does not).
-      if (r.exitCode === 0) await sanctionBoxBranch(box, branch);
-      await streamExit(r);
+      // The hub sanctions <branch> after a 0-exit checkout, so pushing this
+      // branch skips the confirm prompt (an in-box agent's own checkout does not).
+      await withHubClient({}, async (client) => {
+        streamOp(await client.git(box.id, 'checkout', { branch, args }));
+      });
     } catch (err) {
       handleLifecycleError(err);
     }
   });
 
 const branchCommand = new Command('branch')
-  .description('Create a new agentbox/* branch from HEAD (or a given base) and switch the box onto it')
+  .description(
+    'Create a new agentbox/* branch from HEAD (or a given base) and switch the box onto it',
+  )
   .argument('<box>', 'box ref')
   .argument('<name>', "new branch name (an 'agentbox/' prefix is added when missing)")
-  .option('--from <ref>', 'base ref to fork from (default: the box\'s current HEAD)')
+  .option('--from <ref>', "base ref to fork from (default: the box's current HEAD)")
   .action(async (boxRef: string, name: string, opts: { from?: string }) => {
     try {
       const box = await resolveBoxOrExit(boxRef);
-      const provider = await providerForBox(box);
-      const r = await boxGitNewBranch(provider, box, name, opts.from);
-      // The new branch is always an `agentbox/*` scratch branch (already
-      // gate-exempt), but record it as sanctioned for consistency + in case
-      // the scratch-prefix policy ever changes.
-      if (r.exitCode === 0) await sanctionBoxBranch(box, scratchBranchName(name));
-      await streamExit(r);
+      // The hub records the new `agentbox/*` scratch branch as sanctioned (it's
+      // already gate-exempt, but kept for consistency + a future prefix policy).
+      await withHubClient({}, async (client) => {
+        streamOp(await client.git(box.id, 'branch', { name, from: opts.from }));
+      });
     } catch (err) {
       handleLifecycleError(err);
     }
   });
 
 const statusCommand = new Command('status')
-  .description('Run `git status` in the box\'s /workspace (read-only, no relay)')
+  .description("Run `git status` in the box's /workspace (read-only, no relay)")
   .argument('<box>', 'box ref')
   .argument('[args...]', 'extra flags forwarded to `git status`')
   .allowExcessArguments(true)
@@ -379,7 +325,11 @@ const PR_OP_DESCRIPTIONS: Record<GhPrOp, string> = {
  * `worktree.hostMainRepo` is the cwd `gh` runs in, so passing `--head` is
  * sufficient — base stays whatever the user picked / repo default.
  */
-function injectPrCreateHead(op: GhPrOp, box: { gitWorktrees?: { kind: string; branch: string }[] }, args: string[]): string[] {
+function injectPrCreateHead(
+  op: GhPrOp,
+  box: { gitWorktrees?: { kind: string; branch: string }[] },
+  args: string[],
+): string[] {
   const rootWt = (box.gitWorktrees ?? []).find((w) => w.kind === 'root');
   return injectHead(op, rootWt?.branch, args);
 }

--- a/apps/cli/src/control-plane/hub-api-client.ts
+++ b/apps/cli/src/control-plane/hub-api-client.ts
@@ -151,12 +151,19 @@ export interface HubApiTarget {
   fetchImpl?: typeof fetch;
 }
 
-/** An error carrying the `/api/v1` envelope's code + HTTP status. */
+/** An error carrying the `/api/v1` envelope's code + HTTP status (+ optional details). */
 export class HubApiError extends Error {
   constructor(
     message: string,
     readonly code: string,
     readonly status: number,
+    /**
+     * The envelope's `error.details`, when present. Git ops carry the box
+     * command's own `exitCode` here so a caller can surface a faithful exit
+     * (e.g. 64 for `push --host-only` with no host checkout) that the coarse
+     * code→exit mapping can't express.
+     */
+    readonly details?: unknown,
   ) {
     super(message);
     this.name = 'HubApiError';
@@ -201,6 +208,7 @@ export class HubApiClient {
         err?.message ?? `request failed: ${res.status}`,
         err?.code ?? 'internal',
         res.status,
+        err?.details,
       );
     }
     return parsed as T;

--- a/apps/cli/src/control-plane/with-hub.ts
+++ b/apps/cli/src/control-plane/with-hub.ts
@@ -49,6 +49,18 @@ export function exitCodeForApiError(code: string): number {
   return EXIT_BY_CODE[code] ?? 1;
 }
 
+/**
+ * The exit code to report for a hub error. A carried `details.exitCode` (a box
+ * command's own exit — e.g. 64 for `git push --host-only` with no host checkout)
+ * wins, so the CLI surfaces the box's faithful exit rather than the coarse
+ * code→exit mapping. Falls back to the per-code table otherwise.
+ */
+function exitCodeForHubError(err: HubApiError): number {
+  const carried = (err.details as { exitCode?: unknown } | undefined)?.exitCode;
+  if (typeof carried === 'number' && Number.isInteger(carried) && carried > 0) return carried;
+  return exitCodeForApiError(err.code);
+}
+
 /** An extra actionable line for the error classes where the raw message isn't enough. */
 function hintForApiError(err: HubApiError): string | null {
   switch (err.code) {
@@ -83,7 +95,7 @@ function reportHubError(err: unknown, url: string): void {
     log.error(err.message);
     const hint = hintForApiError(err);
     if (hint) log.info(hint);
-    process.exitCode = exitCodeForApiError(err.code);
+    process.exitCode = exitCodeForHubError(err);
     return;
   }
   // A fetch/network failure (hub down, wrong URL) surfaces as a plain Error.

--- a/apps/hub/app/(dashboard)/api/v1/boxes/[id]/git/[op]/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/boxes/[id]/git/[op]/route.ts
@@ -18,7 +18,10 @@ import {
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-export async function POST(req: Request, ctx: { params: Promise<{ id: string; op: string }> }): Promise<Response> {
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<{ id: string; op: string }> },
+): Promise<Response> {
   const { id, op } = await ctx.params;
   if (!isGitOp(op)) {
     return fail('invalid_request', `unknown git op: ${op}`, { allowed: [...GIT_OPS] });
@@ -42,7 +45,7 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string; op
     case 'checkout': {
       const p = parseGitCheckout(body);
       if (!p.ok) return fail('invalid_request', p.message, p.details);
-      res = await backend.gitCheckout(id, p.value.branch);
+      res = await backend.gitCheckout(id, p.value.branch, p.value.args);
       break;
     }
     case 'branch': {
@@ -71,6 +74,14 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string; op
     }
   }
 
-  if (!res.ok) return failFromAction(res.error);
+  if (!res.ok) {
+    // Carry the box command's exit code so the client can surface a faithful
+    // exit (e.g. 64 for `push-host` with no host checkout) the code→exit table
+    // can't express. The classified error code (409/404) is unchanged.
+    return failFromAction(
+      res.error,
+      res.exitCode !== undefined ? { exitCode: res.exitCode } : undefined,
+    );
+  }
   return ok({ ok: true, stdout: res.stdout ?? '', stderr: res.stderr ?? '' });
 }

--- a/apps/hub/app/(dashboard)/api/v1/lib/envelope.ts
+++ b/apps/hub/app/(dashboard)/api/v1/lib/envelope.ts
@@ -26,7 +26,10 @@ export function ok(data: unknown, status = 200): Response {
 
 export function fail(code: ApiErrorCode, message: string, details?: unknown): Response {
   const status = STATUS_HINT[code];
-  return Response.json({ error: { code, message, ...(details === undefined ? {} : { details }) } }, { status });
+  return Response.json(
+    { error: { code, message, ...(details === undefined ? {} : { details }) } },
+    { status },
+  );
 }
 
 // Map a backend ActionResult error into an envelope. Genuine missing-resource
@@ -36,10 +39,10 @@ export function fail(code: ApiErrorCode, message: string, details?: unknown): Re
 // "unknown project …", and "no pending approval". A bare "unknown" (e.g. a Docker
 // "unknown flag" / "unknown: not found" daemon message) must NOT be mistaken for
 // a 404, or an operational failure would masquerade as a missing resource.
-export function failFromAction(error: string): Response {
+export function failFromAction(error: string, details?: unknown): Response {
   const notFound =
     /\b(not found|no such|does not exist)\b/i.test(error) ||
     /\bunknown (project|box)\b/i.test(error) ||
     /no pending approval/i.test(error);
-  return fail(notFound ? 'not_found' : 'conflict', error);
+  return fail(notFound ? 'not_found' : 'conflict', error, details);
 }

--- a/apps/hub/app/(dashboard)/api/v1/lib/validate.ts
+++ b/apps/hub/app/(dashboard)/api/v1/lib/validate.ts
@@ -36,13 +36,18 @@ export function parseCreateBox(body: unknown): Parsed<CreateBoxInput> {
     return { ok: false, message: 'projectId is required (string)' };
   }
   if (typeof agent !== 'string' || !(AGENTS as readonly string[]).includes(agent)) {
-    return { ok: false, message: `agent must be one of ${AGENTS.join(', ')}`, details: { got: agent } };
+    return {
+      ok: false,
+      message: `agent must be one of ${AGENTS.join(', ')}`,
+      details: { got: agent },
+    };
   }
   // A host-qualified `docker:<alias>` / `remote-docker:<alias>` spec picks a
   // registered remote-docker host (alias rule mirrors the hosts registry). The
   // backend validates the alias exists; here we only gate the shape.
   const isHostSpec =
-    typeof provider === 'string' && /^(?:docker|remote-docker):[A-Za-z0-9][A-Za-z0-9._-]*$/.test(provider);
+    typeof provider === 'string' &&
+    /^(?:docker|remote-docker):[A-Za-z0-9][A-Za-z0-9._-]*$/.test(provider);
   if (
     provider !== undefined &&
     !isHostSpec &&
@@ -54,8 +59,10 @@ export function parseCreateBox(body: unknown): Parsed<CreateBoxInput> {
       details: { got: provider },
     };
   }
-  if (name !== undefined && typeof name !== 'string') return { ok: false, message: 'name must be a string' };
-  if (prompt !== undefined && typeof prompt !== 'string') return { ok: false, message: 'prompt must be a string' };
+  if (name !== undefined && typeof name !== 'string')
+    return { ok: false, message: 'name must be a string' };
+  if (prompt !== undefined && typeof prompt !== 'string')
+    return { ok: false, message: 'prompt must be a string' };
   const fb = optionalString(fromBranch, 'fromBranch');
   if (!fb.ok) return fb;
   const sw = optionalBool(setupWizard, 'setupWizard');
@@ -198,7 +205,15 @@ export function isGitOp(v: string): v is GitOp {
 
 // Host apps a box can be launched in (mirrors OPEN_IN_APPS in the CLI's
 // _open-in.ts; hardcoded to keep @agentbox/* out of the Next bundle).
-export const OPEN_IN_APPS = ['claude', 'codex', 'herdr', 'cmux', 'vscode', 'iterm2', 'finder'] as const;
+export const OPEN_IN_APPS = [
+  'claude',
+  'codex',
+  'herdr',
+  'cmux',
+  'vscode',
+  'iterm2',
+  'finder',
+] as const;
 export type OpenInApp = (typeof OPEN_IN_APPS)[number];
 
 export function isOpenInApp(v: string): v is OpenInApp {
@@ -209,7 +224,11 @@ export function parseOpenIn(body: unknown): Parsed<{ app: OpenInApp }> {
   if (!isObject(body)) return { ok: false, message: 'body must be a JSON object' };
   const { app } = body;
   if (typeof app !== 'string' || !isOpenInApp(app)) {
-    return { ok: false, message: `app must be one of ${OPEN_IN_APPS.join(', ')}`, details: { got: app } };
+    return {
+      ok: false,
+      message: `app must be one of ${OPEN_IN_APPS.join(', ')}`,
+      details: { got: app },
+    };
   }
   return { ok: true, value: { app } };
 }
@@ -226,13 +245,28 @@ function optionalBool(v: unknown, field: string): Parsed<boolean | undefined> {
   return { ok: true, value: v };
 }
 
-export function parseGitCheckout(body: unknown): Parsed<{ branch: string }> {
+// Extra passthrough flags for a git op (e.g. --tags, --force-with-lease). Every
+// element must be a string; an absent/empty list is normalized to undefined so
+// it stays out of the RPC params hash the relay's host-initiated token binds to.
+function optionalStringArray(v: unknown, field: string): Parsed<string[] | undefined> {
+  if (v === undefined) return { ok: true, value: undefined };
+  if (!Array.isArray(v)) return { ok: false, message: `${field} must be an array of strings` };
+  for (const el of v) {
+    if (typeof el !== 'string')
+      return { ok: false, message: `${field} must be an array of strings` };
+  }
+  return { ok: true, value: v.length > 0 ? (v as string[]) : undefined };
+}
+
+export function parseGitCheckout(body: unknown): Parsed<{ branch: string; args?: string[] }> {
   if (!isObject(body)) return { ok: false, message: 'body must be a JSON object' };
   const { branch } = body;
   if (typeof branch !== 'string' || branch.trim().length === 0) {
     return { ok: false, message: 'branch is required (non-empty string)' };
   }
-  return { ok: true, value: { branch } };
+  const args = optionalStringArray(body.args, 'args');
+  if (!args.ok) return args;
+  return { ok: true, value: { branch, args: args.value } };
 }
 
 export function parseGitBranch(body: unknown): Parsed<{ name: string; from?: string }> {
@@ -246,31 +280,43 @@ export function parseGitBranch(body: unknown): Parsed<{ name: string; from?: str
   return { ok: true, value: { name, from: f.value } };
 }
 
-export function parseGitPush(body: unknown): Parsed<{ remote?: string; force?: boolean }> {
+export function parseGitPush(
+  body: unknown,
+): Parsed<{ remote?: string; force?: boolean; args?: string[] }> {
   if (!isObject(body)) return { ok: false, message: 'body must be a JSON object' };
   const remote = optionalString(body.remote, 'remote');
   if (!remote.ok) return remote;
   const force = optionalBool(body.force, 'force');
   if (!force.ok) return force;
-  return { ok: true, value: { remote: remote.value, force: force.value } };
+  const args = optionalStringArray(body.args, 'args');
+  if (!args.ok) return args;
+  return { ok: true, value: { remote: remote.value, force: force.value, args: args.value } };
 }
 
-export function parseGitPull(body: unknown): Parsed<{ remote?: string; ffOnly?: boolean }> {
+export function parseGitPull(
+  body: unknown,
+): Parsed<{ remote?: string; ffOnly?: boolean; args?: string[] }> {
   if (!isObject(body)) return { ok: false, message: 'body must be a JSON object' };
   const remote = optionalString(body.remote, 'remote');
   if (!remote.ok) return remote;
   const ffOnly = optionalBool(body.ffOnly, 'ffOnly');
   if (!ffOnly.ok) return ffOnly;
-  return { ok: true, value: { remote: remote.value, ffOnly: ffOnly.value } };
+  const args = optionalStringArray(body.args, 'args');
+  if (!args.ok) return args;
+  return { ok: true, value: { remote: remote.value, ffOnly: ffOnly.value, args: args.value } };
 }
 
-export function parseGitPushHost(body: unknown): Parsed<{ as?: string; force?: boolean }> {
+export function parseGitPushHost(
+  body: unknown,
+): Parsed<{ as?: string; force?: boolean; args?: string[] }> {
   if (!isObject(body)) return { ok: false, message: 'body must be a JSON object' };
   const as = optionalString(body.as, 'as');
   if (!as.ok) return as;
   const force = optionalBool(body.force, 'force');
   if (!force.ok) return force;
-  return { ok: true, value: { as: as.value, force: force.value } };
+  const args = optionalStringArray(body.args, 'args');
+  if (!args.ok) return args;
+  return { ok: true, value: { as: as.value, force: force.value, args: args.value } };
 }
 
 export function parseServiceRestart(body: unknown): Parsed<{ name?: string }> {

--- a/apps/hub/lib/boxes/backend-types.ts
+++ b/apps/hub/lib/boxes/backend-types.ts
@@ -6,7 +6,13 @@ export type ActionResult = { ok: true } | { ok: false; error: string };
 // Result of a box git/service operation that runs a command in the box. On
 // success it carries the command's stdout/stderr so the UI can surface git's
 // output; on failure `error` is the trimmed stderr (or a resolve error).
-export type BoxOpResult = { ok: true; stdout?: string; stderr?: string } | { ok: false; error: string };
+// `exitCode` is the failing box command's own exit code when the failure came
+// from a non-zero exec (not a resolve error) — carried so a client can surface a
+// faithful exit (e.g. 64 for `git push --host-only` with no host checkout), which
+// the /api/v1 code→exit table can't otherwise express.
+export type BoxOpResult =
+  | { ok: true; stdout?: string; stderr?: string }
+  | { ok: false; error: string; exitCode?: number };
 
 // Host apps a box can be opened in (`agentbox open --in <app>`). Mirrors the
 // CLI's OPEN_IN_APPS (apps/cli/src/commands/_open-in.ts); duplicated here to keep
@@ -219,15 +225,26 @@ export interface HubBackend {
 
   // ── box git operations ──
   // Change the box's working branch (git checkout, local to the worktree).
-  gitCheckout(id: string, branch: string): Promise<BoxOpResult>;
+  // `args` are extra flags forwarded to `git checkout` (e.g. a pathspec).
+  gitCheckout(id: string, branch: string, args?: string[]): Promise<BoxOpResult>;
   // Create a fresh agentbox/* branch from HEAD (or `from`) and switch onto it.
   gitNewBranch(id: string, input: { name: string; from?: string }): Promise<BoxOpResult>;
-  // Push the box's branch to the remote via the host relay.
-  gitPush(id: string, input?: { remote?: string; force?: boolean }): Promise<BoxOpResult>;
-  // Fetch via the relay then merge locally in the box.
-  gitPull(id: string, input?: { remote?: string; ffOnly?: boolean }): Promise<BoxOpResult>;
+  // Push the box's branch to the remote via the host relay. `args` are extra
+  // flags forwarded to the host-built `git push` (e.g. --tags, --force-with-lease).
+  gitPush(
+    id: string,
+    input?: { remote?: string; force?: boolean; args?: string[] },
+  ): Promise<BoxOpResult>;
+  // Fetch via the relay then merge locally in the box. `args` forward to the op.
+  gitPull(
+    id: string,
+    input?: { remote?: string; ffOnly?: boolean; args?: string[] },
+  ): Promise<BoxOpResult>;
   // Land the box's branch in the host's local repo only (publishes nothing).
-  gitPushHost(id: string, input?: { as?: string; force?: boolean }): Promise<BoxOpResult>;
+  gitPushHost(
+    id: string,
+    input?: { as?: string; force?: boolean; args?: string[] },
+  ): Promise<BoxOpResult>;
   // Live git summary (current branch + dirty/ahead/behind) for the detail panel.
   getGit(id: string): Promise<GitInfo>;
 

--- a/apps/hub/lib/hub-backend.ts
+++ b/apps/hub/lib/hub-backend.ts
@@ -60,9 +60,11 @@ import {
   boxServicesStatusRaw,
   boxSshDirForProvider,
   matchClaudeInstallFingerprint,
+  mutateState,
   readPreparedStateRaw,
   readState,
   recordBox,
+  scratchBranchName,
   secretsEnvPath,
   setBoxDisplayName,
   syncAgentboxSshConfig,
@@ -80,6 +82,7 @@ import {
   generateRelayToken,
   listBoxes,
   mintHostInitiatedToken,
+  registerBoxWithRelay,
   type ListedBox,
 } from '@agentbox/sandbox-docker';
 import type {
@@ -1248,14 +1251,82 @@ async function gitOp(
     if (!rp) return { ok: false, error: `box ${id} not found` };
     const r = await fn(rp.box, rp.provider);
     if (r.exitCode !== 0) {
+      // Carry the box command's own exit code so a client can surface a faithful
+      // exit — e.g. 64 from `git push --host-only` when the box's host has no
+      // working copy — instead of the /api/v1 code→exit table's coarse mapping.
       return {
         ok: false,
         error: (r.stderr || r.stdout || `command exited ${String(r.exitCode)}`).trim(),
+        exitCode: r.exitCode,
       };
     }
     return { ok: true, stdout: r.stdout, stderr: r.stderr };
   } catch (err) {
     return { ok: false, error: errMsg(err) };
+  }
+}
+
+/**
+ * Record `branch` as the box's host-sanctioned branch after a host-driven
+ * checkout/branch. The relay auto-approves an in-box push only to a scratch
+ * branch or this value, so a host branch switch must update it — otherwise the
+ * agent would be prompted to push the branch the host just put it on. Persists
+ * to state.json (docker root worktree + cloud field) and re-registers docker
+ * boxes so the running relay's in-memory registry picks up the new value. This
+ * hub server IS the relay process, so `registerBoxWithRelay`'s loopback
+ * admin-post reaches it in-process (same path as `mintHostInitiatedToken`).
+ *
+ * Best-effort: a failure here only means the next push to that branch prompts —
+ * it never blocks the branch switch. Moved here from the CLI's `git.ts` so both
+ * frontends sanction identically, in both local and remote-hub modes.
+ */
+async function sanctionBranch(box: BoxRecord, branch: string): Promise<void> {
+  try {
+    await mutateState((state) => {
+      const b = state.boxes.find((x) => x.id === box.id);
+      if (!b) return state;
+      if (b.gitWorktrees) {
+        for (const w of b.gitWorktrees) {
+          if (w.kind === 'root') w.sanctionedBranch = branch;
+        }
+      }
+      if (b.cloud) b.cloud.sanctionedBranch = branch;
+      return state;
+    });
+  } catch {
+    return; // couldn't persist → leave the gate as-is
+  }
+  // Docker's push gate reads the in-memory registry, so re-register to refresh
+  // the root worktree's sanctionedBranch. Cloud's gate reads state.json per RPC,
+  // so the persist above is enough — no cloud re-register needed.
+  const isDocker = box.provider === 'docker' || box.provider === undefined;
+  if (isDocker && box.relayToken) {
+    const worktrees = (box.gitWorktrees ?? []).map((w) =>
+      w.kind === 'root' ? { ...w, sanctionedBranch: branch } : w,
+    );
+    try {
+      await registerBoxWithRelay({
+        boxId: box.id,
+        token: box.relayToken,
+        name: box.name,
+        containerName: box.container,
+        createdAt: box.createdAt,
+        projectIndex: box.projectIndex,
+        worktrees,
+        autoApproveHostActions: box.autoApproveHostActions,
+        autoApproveSafeHostActions: box.autoApproveSafeHostActions,
+      });
+    } catch (err) {
+      // Persisted to state.json, but the running relay still holds the old
+      // sanctioned branch until it re-registers (next restart/rehydrate reads
+      // state.json). Best-effort — the branch switch itself already succeeded —
+      // but log it: silent staleness would leave the push gate following the
+      // wrong branch with no signal (the CLI used to warn on stderr here).
+      console.warn(
+        `[hub] sanction ${branch} for ${box.name}: persisted, but the relay did not pick it up ` +
+          `(${errMsg(err)}); pushes to ${branch} stay gated until \`agentbox relay restart\`.`,
+      );
+    }
   }
 }
 
@@ -1909,10 +1980,28 @@ export function createHubBackend(handle: RelayServerHandle): HubBackend {
     },
 
     // ── box git operations (delegate to the shared, provider-agnostic helpers) ──
-    gitCheckout: (id, branch) =>
-      gitOp(id, (box, provider) => boxGitCheckout(provider, box, branch), hydrate),
+    // checkout/branch additionally sanction the resulting branch so a later
+    // in-box push to it isn't prompted (best-effort; see sanctionBranch).
+    gitCheckout: (id, branch, args) =>
+      gitOp(
+        id,
+        async (box, provider) => {
+          const r = await boxGitCheckout(provider, box, branch, args);
+          if (r.exitCode === 0) await sanctionBranch(box, branch);
+          return r;
+        },
+        hydrate,
+      ),
     gitNewBranch: (id, input) =>
-      gitOp(id, (box, provider) => boxGitNewBranch(provider, box, input.name, input.from), hydrate),
+      gitOp(
+        id,
+        async (box, provider) => {
+          const r = await boxGitNewBranch(provider, box, input.name, input.from);
+          if (r.exitCode === 0) await sanctionBranch(box, scratchBranchName(input.name));
+          return r;
+        },
+        hydrate,
+      ),
     gitPush: (id, input = {}) =>
       gitOp(id, (box, provider) => boxGitPush(provider, box, input, hubGitDeps(id)), hydrate),
     gitPull: (id, input = {}) =>

--- a/apps/web/content/docs/deployed-hub.mdx
+++ b/apps/web/content/docs/deployed-hub.mdx
@@ -409,6 +409,16 @@ agentbox attach from-web-ui      # adopts it, then attaches
 
 Adoption writes the local box record from the control box's registration and downloads the box's per-box SSH key from custody, so `attach`, `cp`, `download`, `url`, and `screen` then work exactly as for a box you created here. If the box's repo is also cloned on your laptop, adoption links it to that clone, so it appears in the project-scoped `agentbox ls` too, and its `git push` targets your local repo.
 
+<Callout type="warn" title="`git push --host-only` needs a host working copy">
+  `agentbox git push <box> --host-only` lands the box's branch in the **host repo of the machine
+  that runs the box** — for a control-box-created cloud box, that's the control box, which has no
+  working copy (it clones each box as a bundle, not a checkout). So it fails with a clear
+  `--host-only is unavailable … no working copy` message (exit 64); push to the remote instead
+  (`agentbox git push <box>`). Host-only still works normally for a box whose host does have the
+  checkout — a docker box, or a box on a machine you've `hub expose`d — regardless of whether you
+  reach that hub locally or as a remote.
+</Callout>
+
 To adopt without attaching (or to refresh a record after the box's VPS IP changed):
 
 ```bash

--- a/docs/hub-api-single-path-plan.md
+++ b/docs/hub-api-single-path-plan.md
@@ -290,19 +290,63 @@ adopt, for one SSH provider (hetzner) and one SDK provider (e2b).
 
 ---
 
-## Step 6 — Git
+## Step 6 — Git ✅ done
 
 - `agentbox git push|pull|checkout|branch|push --host-only` → `POST /api/v1/boxes/:id/git/:op`
-  (routes exist, unused by the CLI).
+  (routes existed, unused by the CLI; now the CLI's path via `withHubClient` + `client.git`).
 - `packages/sandbox-core/src/box-git.ts` stays the shared implementation — only the *caller*
-  moves. The CLI stops minting host-initiated tokens; the hub does it via `hubGitDeps`
-  (`hub-backend.ts:1154`).
-- `push --host-only` is definitionally host-checkout-bound: on a remote hub it must fail with the
-  existing clear error (exit 64), not a cryptic `git -C` failure.
+  moved. The CLI stopped minting host-initiated tokens for these ops; the hub mints them via
+  `hubGitDeps` (`hub-backend.ts`).
+- `push --host-only` is definitionally host-checkout-bound: on a hub whose box has no host
+  working copy it fails with the existing clear error (exit 64), not a cryptic `git -C` failure.
 
-**Files:** `commands/git.ts`, `hub-api-client.ts` (`git()` already exists).
-**Verify:** push from a box through a local hub and through a control box; check ground truth
-with `git ls-remote`, not the exit code.
+**Files:** `commands/git.ts`, `hub-api-client.ts` (`HubApiError.details` added), `with-hub.ts`
+(exit-code carry), plus server-side parity: `hub-backend.ts` (`sanctionBranch` +
+`gitOp` exit-code), `backend-types.ts`, `validate.ts` (`args`), `envelope.ts`,
+`api/v1/boxes/[id]/git/[op]/route.ts`.
+**Verified end-to-end (docker box, ground truth via `git ls-remote` on a local bare remote):**
+- **Local mode:** `git push`, `git branch <box> foo` + push, and `git checkout` all land the
+  branch on the remote. Sanctioning moved server-side is proven directly: `git checkout <box>
+  <branch>` triggers a hub-backend re-register (`sanctionBranch`), after which an *in-box* push
+  (no host token) to that branch auto-approves (no pending approval) and lands — the CLI never
+  touches the relay registry.
+- **Remote mode** (CLI pointed at the same hub as a `mode: 'remote'` target — `controlPlaneUrl`
+  + `AGENTBOX_HUB_API_KEY`): `git push` lands on the remote, and — the case the correction is
+  about — `git push <box> --host-only` **SUCCEEDS** even in remote mode, because the machine IS
+  the host with the checkout. A `resolveHubTarget().mode` pre-check would have wrongly refused it;
+  the code has none.
+- **Exit-code carry:** a git failure surfaced the box command's real exit code faithfully
+  (observed **128** for a host-only run whose host workspace was removed) rather than the coarse
+  code→exit table's `conflict`=5 — proving `error.details.exitCode` round-trips through the
+  `withHubClient` mapper for any value, including >6.
+
+**Not reproducible in the dev sandbox (documented gap, not a code gap):** the *clean* exit-**64**
+`--host-only is unavailable … no working copy` message comes from the cloud `runGitRpc` path,
+which needs a **control-box-created cloud box** (empty registered `workspacePath`). That requires
+`gh auth` for the control-plane git credential (absent here) and a machine where the fallback
+`/workspace` doesn't exist. Exit 64 is unchanged existing code sitting behind the carry proven
+above (128); a docker box's artificially-absent workspace takes the docker `git -C` path (exit
+128), not the cloud 64 guard. Worth a follow-up check against a real Hetzner control box.
+
+### Notes for later steps
+
+- **Sanctioning moved server-side.** The host-sanctioned-branch record (so a later in-box agent
+  push isn't prompted) now lives in the hub backend (`sanctionBranch` in `hub-backend.ts`),
+  driven by `gitCheckout`/`gitNewBranch`. The CLI no longer touches `registerBoxWithRelay` /
+  `mutateState` for git — steps converting other mutating ops should keep that pattern (mutate
+  host/relay state in the hub backend, not the CLI).
+- **Exit-code carry.** Git error envelopes now carry the box command's own exit code in
+  `error.details.exitCode`; `HubApiError` exposes it as `details`, and `with-hub.ts`'s
+  `exitCodeForHubError` honors it (falling back to the Step-0 code→exit table). Any later step
+  that must surface a faithful box exit code — or an exit outside the 1–6 table (e.g. 64) —
+  should reuse this carry rather than the code→exit table alone.
+- **Host-only keys on the real condition, not transport mode.** `push --host-only` must NOT
+  pre-check `resolveHubTarget().mode`: a `hub expose`d machine is `mode: 'remote'` yet IS the
+  host with the checkout. The server's `runGitRpc` host-only branch already returns exit 64 on a
+  genuinely-absent `workspacePath`; let the request through in all modes and surface that verdict.
+- **`fetch`, `status`, and the `pr` group stay INLINE** and still mint their own host-initiated
+  tokens — no `/api/v1` route exists for them yet. Converging them needs new routes in a later
+  step (a `git/fetch` op, and a `gh pr` surface).
 
 ---
 


### PR DESCRIPTION
## What

Step 6 of the thin-CLI `/api/v1` consolidation (`docs/hub-api-single-path-plan.md`): move `agentbox git push | pull | checkout | branch | push --host-only` off the inline provider path and onto the hub's public REST API (`POST /api/v1/boxes/:id/git/:op`), so they behave identically against a local hub and a remote control box. The shared implementation (`packages/sandbox-core/src/box-git.ts`) is unchanged — only the caller moves.

- **CLI caller-swap** (`commands/git.ts`): each op now runs inside `withHubClient` + `client.git(id, op, body)`. Host-initiated-token minting and branch sanctioning are deleted from the CLI; the hub owns them now. `fetch`, `status`, and the `pr` group stay inline (no `/api/v1` route exists for them yet) and keep their own token minting.
- **Server-side parity** so the swap is lossless: `gitCheckout`/`gitNewBranch` sanction the resulting branch in the hub backend (`sanctionBranch`); `push`/`pull`/`checkout` accept extra git flags (`args`) end to end.
- **Exit-code carry**: the box command's own exit code rides the error envelope (`error.details.exitCode`) — `HubApiError.details` + `with-hub.ts`'s `exitCodeForHubError` honor it, so a git failure surfaces its real exit (incl. values outside the Step-0 1–6 table) instead of the coarse code→exit mapping.

## Why

One path, no regression. "Enable remote hub" becomes a base-URL swap. `push --host-only` is deliberately **not** gated on `resolveHubTarget().mode`: a `hub expose`d machine reports `remote` but IS the host with the checkout, so a mode pre-check would be a false negative. The real condition (does this box's host have a working copy) is checked server-side.

## Verified e2e (docker box, ground truth via `git ls-remote` on a local bare remote)

- **Local mode:** `push`, `branch`+push, `checkout` all land the branch on the remote. Sanctioning-moved-server-side proven directly: `git checkout <box> <branch>` triggers a hub-backend re-register, after which an in-box push (no host token) to that branch auto-approves (no pending approval) and lands.
- **Remote mode** (CLI pointed at the same hub as a `mode: 'remote'` target): `push` lands; `push --host-only` **SUCCEEDS** even in remote mode (the false-negative case the design correction is about).
- **Exit-code carry:** a git failure surfaced the box's real exit code (observed **128**) faithfully, not the coarse `conflict`=5 — proving the carry round-trips for any value including >6.
- The clean exit-**64** `--host-only … no working copy` message is unchanged cloud `runGitRpc` code behind the same proven carry; it needs a control-box-created cloud box (empty `workspacePath`), which the dev sandbox can't reproduce (documented in the plan doc's Step 6 notes).

`pnpm build`, `pnpm typecheck`, `eslint`, and the `git-creds-gate` unit test are green.

## Docs

`apps/web/content/docs/deployed-hub.mdx` gains a note on `--host-only` against a control box; `docs/hub-api-single-path-plan.md` ticks Step 6 with a "Notes for later steps" block (sanctioning location, exit-code carry, host-only-not-mode-gated, inline `fetch`/`status`/`pr`).

https://claude.ai/code/session_01AGx42GtMTwLSMLASdXcWxJ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moves git push/pull and relay push-gating (sanctioned branches, host-initiated tokens) to the hub path used by local and remote clients; behavior is intended to be parity-preserving but touches security-sensitive approval flows.
> 
> **Overview**
> **Thin-CLI Step 6:** branch-mutating `agentbox git` commands (`push`, `pull`, `checkout`, `branch`, including `push --host-only`) now go through `withHubClient` and `POST /api/v1/boxes/:id/git/:op` instead of calling `boxGit*` in-process on the laptop. **`fetch`**, **`status`**, and **`pr`** stay inline (no API routes yet).
> 
> The CLI drops local **host-initiated token minting**, **`sanctionBoxBranch`**, and **`registerBoxWithRelay`** for those ops; the **hub backend** owns **`hubGitDeps`**, **`sanctionBranch`** after successful checkout/branch, and the same shared `box-git` helpers. Git API bodies accept optional **`args`** (e.g. `--tags`, checkout pathspecs) end-to-end.
> 
> Failed git ops propagate the box command’s real exit via **`error.details.exitCode`** (`BoxOpResult` → `failFromAction` → **`HubApiError.details`** → **`exitCodeForHubError`** in `with-hub`), so cases like **`push --host-only`** without a host working copy can surface exit **64** instead of the coarse `conflict`→5 mapping. **`push --host-only`** is not gated on hub “remote” mode; the server decides whether a host checkout exists.
> 
> Docs: deployed-hub callout for `--host-only` on control boxes; plan doc marks Step 6 done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faacfadeb028747424ec9abf813f30355c0decc6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->