### PR TITLE
fix(ci): stop the CLA gate silently dropping valid signatures

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,10 +21,17 @@ jobs:
     # issue_comment fires for plain issues as well as pull requests; without the
     # `issue.pull_request` guard the sign phrase posted on any issue would invoke the
     # action with no pull-request context.
+    #
+    # `contains`, not `==`: an exact compare silently drops real signatures. A comment
+    # of "…I hereby sign the CLA." (trailing period) skips this job entirely, so the
+    # action never runs, nothing lands in the signatures file, and the stale failing
+    # check blocks the PR forever with no feedback to the contributor. This bit PR #296.
+    # The bot's own "please sign" comment quotes the phrase, hence the author guard.
     if: >-
       github.event_name == 'pull_request_target' ||
       (github.event.issue.pull_request &&
-       github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')
+       github.event.comment.user.login != 'github-actions[bot]' &&
+       contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA'))
     steps:
       - name: Check the contributor license agreement
         uses: contributor-assistant/github-action@v2.6.1
@@ -40,5 +47,9 @@ jobs:
             Thanks for your pull request. Before it can be merged, please read our
             [Contributor License Agreement](https://github.com/madarco/agentbox/blob/main/.github/CLA.md)
             and sign it by posting the comment below. You only ever have to do this once.
-          custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
+          # `custom-pr-sign-comment` is deliberately unset: supplying it switches the
+          # action's own matcher from a tolerant regex (`/^.*i \s*have \s*read ….*$/`)
+          # to a strict `===` against the trimmed, lowercased body — the same trailing-
+          # period trap as above, one layer deeper. Omitting it keeps the identical
+          # default phrase and the forgiving match.
           custom-allsigned-prcomment: All contributors have signed the CLA. Thank you!


### PR DESCRIPTION
## The bug

@francoluxor signed the CLA on #296, two minutes after the bot asked:

> I have read the CLA Document and I hereby sign the CLA**.**

That trailing period cost them the signature. The workflow run that fired on the comment ([`30650537003`](https://github.com/madarco/agentbox/actions/runs/30650537003)) came back **`skipped`** — `signatures/v1/cla.json` still lists only `madarco`, and the stale failing check from the original `pull_request_target` run kept the PR blocked. #296 needed an `--admin` merge.

There are **two** exact-match traps, stacked:

1. **The job `if`** compared `github.event.comment.body == '…sign the CLA'`. Any punctuation, greeting, or trailing whitespace skips the job — so the action never even starts.
2. **`custom-pr-sign-comment`** repeats it one layer deeper. In `contributor-assistant/github-action@v2.6.1`, setting that input switches `isCommentSignedByUser` from a tolerant regex to a strict compare:

```ts
if (getCustomPrSignComment() !== "") {
    return getCustomPrSignComment().toLowerCase() === comment   // comment = body.trim().toLowerCase()
}
// otherwise: /^.*i \s*have \s*read \s*the \s*cla \s*document \s*and \s*i \s*hereby \s*sign \s*the \s*cla.*$/
```

Relaxing only the `if` would have let the job run and still fail.

## The fix

- `contains` instead of `==` on the job `if`.
- Drop `custom-pr-sign-comment` so the action's own forgiving regex applies. `getPrSignComment()` falls back to the byte-identical default phrase, so nothing user-visible changes.
- Guard on the comment author — the bot's "please sign" message quotes the phrase, which `contains` would otherwise match. (`isCommentSignedByUser` already refuses to credit `github-actions[bot]`, so this only saves a wasted run.)

Failure mode this removes: a contributor signs, sees nothing happen, and has no way to tell whether they got the wording wrong or the check is just slow.

https://claude.ai/code/session_0131uzfwtjgE8rjkoFToQhuK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only CLA workflow tuning; no application runtime, auth, or data-path changes.
> 
> **Overview**
> Fixes CLA signatures being ignored when contributors don’t match the sign phrase **exactly** (e.g. a trailing period), which left the job **skipped**, never updated `signatures/v1/cla.json`, and blocked merges with no useful feedback.
> 
> The **`issue_comment` job `if`** now uses **`contains(...)`** on the sign phrase instead of **`==`**, and ignores comments from **`github-actions[bot]`** so the bot’s quoted phrase doesn’t trigger a run. **`custom-pr-sign-comment`** is removed so `contributor-assistant/github-action` keeps its default **regex** matcher instead of strict string equality on the trimmed body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7261483d0636806d6558ca8a7227f3d1c2a6ceb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->