### PR TITLE
fix(hub): externalize remote-docker + digitalocean sandbox backends

### DIFF
--- a/apps/hub/next.config.mjs
+++ b/apps/hub/next.config.mjs
@@ -37,6 +37,8 @@ const config = {
     '@agentbox/sandbox-hetzner',
     '@agentbox/sandbox-vercel',
     '@agentbox/sandbox-e2b',
+    '@agentbox/sandbox-digitalocean',
+    '@agentbox/sandbox-remote-docker',
   ],
 };
 


### PR DESCRIPTION
## Problem

On a published (`npm i -g @madarco/agentbox`) install, any host-relay git op from a **remote-docker** box fails:

```
host executor failed: Cannot find package '@agentbox/sandbox-remote-docker'
imported from .../@madarco/agentbox/runtime/hub/apps/hub/chunk-*.js
```

This blocks `git push` / `gh pr` (and even read-only `pr list`) for remote-docker boxes, so a finished branch can't leave the box through the normal path. Fixes #298.

## Root cause

The hub's provider map dynamic-imports every backend (`apps/hub/lib/hub-backend.ts`):

```ts
const IMPORTERS: Record<ProviderKind, ...> = {
  docker:          () => import('@agentbox/sandbox-docker'),
  daytona:         () => import('@agentbox/sandbox-daytona'),
  hetzner:         () => import('@agentbox/sandbox-hetzner'),
  vercel:          () => import('@agentbox/sandbox-vercel'),
  e2b:             () => import('@agentbox/sandbox-e2b'),
  digitalocean:    () => import('@agentbox/sandbox-digitalocean'),
  'remote-docker': () => import('@agentbox/sandbox-remote-docker'),
};
```

But `serverExternalPackages` in `apps/hub/next.config.mjs` listed only `docker/daytona/hetzner/vercel/e2b` — **`remote-docker` and `digitalocean` were omitted.** Those two are the only providers not externalized, so on a published hub their dynamic import resolves to nothing at runtime, while the other five resolve fine.

This is the same failure class as #270 (`fix(relay): inject cloud backends instead of resolving them from node_modules`), which covered the CLI/relay path but not the hub's externalization list.

## Fix

Add the two missing backends to `serverExternalPackages` so they're externalized and traced into the standalone build exactly like the other five:

```diff
     '@agentbox/sandbox-e2b',
+    '@agentbox/sandbox-digitalocean',
+    '@agentbox/sandbox-remote-docker',
   ],
```

Both are already declared deps of `apps/hub` and present in the `IMPORTERS` map — only the externalization entry was missing.

## Validation

- `node --check apps/hub/next.config.mjs` passes.
- The change matches the exact, established pattern for the five working providers; the two broken ones were simply absent from the list.
- I wasn't able to run a full standalone hub build locally to assert the traced output end-to-end — CI's build should confirm. Reproduced the original failure against `@madarco/agentbox` 0.27.1 and `0.28.0-nightly` (both ship no `sandbox-remote-docker`).

## Suggested follow-up (not in this PR)

A small guard asserting `keys(IMPORTERS) ⊆ serverExternalPackages` would prevent this exact omission from recurring when a new provider is added. Happy to add it if you'd like, but `apps/hub` has no test harness today so I kept this PR to the one-line fix.
