### PR TITLE
fix(relay): make git push + gh work from a checkout-less control box

### DIFF
--- a/packages/relay/src/gh.ts
+++ b/packages/relay/src/gh.ts
@@ -14,6 +14,9 @@
  */
 
 import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { repoSlugFromRemote } from './git-pat.js';
 import type { GitRpcResult } from './types.js';
 
 /** Whitelisted subset of `gh pr` ops exposed via RPC. Keep in sync with the ctl CLI. */
@@ -38,12 +41,7 @@ export function isGhPrOp(value: string): value is GhPrOp {
 }
 
 /** Read-only ops never trigger the host confirmation prompt. */
-export const GH_PR_READ_ONLY_OPS: ReadonlySet<GhPrOp> = new Set([
-  'view',
-  'list',
-  'diff',
-  'checks',
-]);
+export const GH_PR_READ_ONLY_OPS: ReadonlySet<GhPrOp> = new Set(['view', 'list', 'diff', 'checks']);
 
 /**
  * `gh pr` write ops that auto-approve under `box.autoApproveSafeHostActions`:
@@ -77,8 +75,7 @@ export const GH_RUN_READ_ONLY_OPS: ReadonlySet<GhRunOp> = new Set(['list', 'view
 // a review comment. The optional trailing `(\?…)` lets agents embed GET query
 // params in the path (e.g. `…/comments?per_page=50`) rather than via field flags.
 const PR_REVIEW_COMMENT = /^repos\/[^/]+\/[^/]+\/pulls\/\d+\/comments(\?.*)?$/;
-const PR_REVIEW_COMMENT_REPLY =
-  /^repos\/[^/]+\/[^/]+\/pulls\/\d+\/comments\/\d+\/replies(\?.*)?$/;
+const PR_REVIEW_COMMENT_REPLY = /^repos\/[^/]+\/[^/]+\/pulls\/\d+\/comments\/\d+\/replies(\?.*)?$/;
 
 /**
  * `gh api` endpoints on which POST (create a comment) is proxied — unprompted,
@@ -170,7 +167,9 @@ export function refuseGhApiCall(endpoint: string, args: string[]): GitRpcResult 
     // `--input` (stdin/file body) can't traverse the relay — refuse outright.
     // Its spaced value (if any) is irrelevant; we return before consuming it.
     if (arg === '--input' || arg.startsWith('--input=')) {
-      return refuse("'--input' (stdin/file body) isn't supported through the relay; use -f/-F fields");
+      return refuse(
+        "'--input' (stdin/file body) isn't supported through the relay; use -f/-F fields",
+      );
     }
     // Field flags auto-switch gh api to POST. The SPACED forms take the next
     // token as their value, so consume it — otherwise a method-looking value
@@ -184,7 +183,12 @@ export function refuseGhApiCall(endpoint: string, args: string[]): GitRpcResult 
     }
     // Glued field forms carry their value inline (`-fbody=hi`, `--field=…`). No
     // read-only flag starts with -f / -F, so the prefix match is safe.
-    if (arg.startsWith('-f') || arg.startsWith('-F') || arg.startsWith('--field=') || arg.startsWith('--raw-field=')) {
+    if (
+      arg.startsWith('-f') ||
+      arg.startsWith('-F') ||
+      arg.startsWith('--field=') ||
+      arg.startsWith('--raw-field=')
+    ) {
       hasFieldFlag = true;
     }
   }
@@ -197,7 +201,9 @@ export function refuseGhApiCall(endpoint: string, args: string[]): GitRpcResult 
       `POST is only proxied to PR review-comment endpoints (repos/:o/:r/pulls/:n/comments[/:id/replies]), not '${endpoint}'`,
     );
   }
-  return refuse(`method '${method}' is not proxied — only GET, and POST to comment endpoints, are allowed`);
+  return refuse(
+    `method '${method}' is not proxied — only GET, and POST to comment endpoints, are allowed`,
+  );
 }
 
 /**
@@ -370,6 +376,34 @@ async function probeGh(): Promise<GitRpcResult | null> {
 }
 
 /**
+ * Where to run `gh`, and whether it must be told the repo.
+ *
+ * `gh` infers the repo from its cwd's git remote, so the host checkout is the
+ * natural place to run it. A control box has no checkout: passing that path as
+ * `cwd` makes the spawn itself fail with a bare `spawn gh ENOENT` (Node reports
+ * a missing cwd exactly like a missing binary), which reads as "gh isn't
+ * installed" and sent us hunting the wrong problem. Fall back to a directory
+ * that exists and name the repo explicitly from the registered origin instead.
+ */
+export function ghRunContext(
+  workspacePath: string,
+  originUrl: string | undefined,
+  args: string[],
+): { cwd: string; args: string[] } {
+  if (workspacePath.length > 0 && existsSync(workspacePath)) {
+    return { cwd: workspacePath, args };
+  }
+  const origin = originUrl?.trim() ?? '';
+  const alreadyScoped = args.some((a) => a === '--repo' || a === '-R' || a.startsWith('--repo='));
+  if (origin.length === 0 || alreadyScoped) return { cwd: tmpdir(), args };
+  try {
+    return { cwd: tmpdir(), args: ['--repo', repoSlugFromRemote(origin), ...args] };
+  } catch {
+    return { cwd: tmpdir(), args };
+  }
+}
+
+/**
  * Spawn `gh` on the host with the given argv inside `cwd`. Returns the
  * standard `{ exitCode, stdout, stderr }` envelope. Self-contained
  * (doesn't call into `server.ts`'s `runHostCommand`) so this module has no
@@ -438,7 +472,9 @@ export async function checkoutGuards(
     return {
       exitCode: status.exitCode,
       stdout: '',
-      stderr: `gh pr checkout: failed to inspect host repo: ${status.stderr || status.stdout}`.trimEnd() + '\n',
+      stderr:
+        `gh pr checkout: failed to inspect host repo: ${status.stderr || status.stdout}`.trimEnd() +
+        '\n',
     };
   }
   if (status.stdout.trim().length > 0) {
@@ -453,7 +489,8 @@ export async function checkoutGuards(
     return {
       exitCode: head.exitCode,
       stdout: '',
-      stderr: `gh pr checkout: failed to resolve HEAD: ${head.stderr || head.stdout}`.trimEnd() + '\n',
+      stderr:
+        `gh pr checkout: failed to resolve HEAD: ${head.stderr || head.stdout}`.trimEnd() + '\n',
     };
   }
   const currentBranch = head.stdout.trim();
@@ -516,7 +553,6 @@ export function refuseCheckoutByDefault(op: GhPrOp): GitRpcResult | null {
   return {
     exitCode: 13,
     stdout: '',
-    stderr:
-      'gh pr checkout: disabled by default; set AGENTBOX_GH_PR_CHECKOUT=allow to enable\n',
+    stderr: 'gh pr checkout: disabled by default; set AGENTBOX_GH_PR_CHECKOUT=allow to enable\n',
   };
 }

--- a/packages/relay/src/host-actions.ts
+++ b/packages/relay/src/host-actions.ts
@@ -15,7 +15,7 @@
  */
 
 import { execa } from 'execa';
-import { repoSlugFromRemote, toHttpsUrl } from './git-pat.js';
+import { toHttpsUrl } from './git-pat.js';
 import { existsSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -60,6 +60,7 @@ import {
   refuseCheckoutByDefault,
   refuseGhApiCall,
   refuseMergeBypass,
+  ghRunContext,
   runHostGh,
   type GhApiRpcParams,
   type GhPrRpcParams,
@@ -382,34 +383,6 @@ export async function executeCloudAction(
     stdout: '',
     stderr: `host executor for '${action.method}' is not yet supported for cloud boxes\n`,
   };
-}
-
-/**
- * Where to run `gh`, and whether it must be told the repo.
- *
- * `gh` infers the repo from its cwd's git remote, so the host checkout is the
- * natural place to run it. A control box has no checkout: passing that path as
- * `cwd` makes the spawn itself fail with a bare `spawn gh ENOENT` (Node reports
- * a missing cwd exactly like a missing binary), which reads as "gh isn't
- * installed" and sent us hunting the wrong problem. Fall back to a directory
- * that exists and name the repo explicitly from the registered origin instead.
- */
-export function ghRunContext(
-  workspacePath: string,
-  originUrl: string | undefined,
-  args: string[],
-): { cwd: string; args: string[] } {
-  if (workspacePath.length > 0 && existsSync(workspacePath)) {
-    return { cwd: workspacePath, args };
-  }
-  const origin = originUrl?.trim() ?? '';
-  const alreadyScoped = args.some((a) => a === '--repo' || a === '-R' || a.startsWith('--repo='));
-  if (origin.length === 0 || alreadyScoped) return { cwd: tmpdir(), args };
-  try {
-    return { cwd: tmpdir(), args: ['--repo', repoSlugFromRemote(origin), ...args] };
-  } catch {
-    return { cwd: tmpdir(), args };
-  }
 }
 
 /**

--- a/packages/relay/src/host-actions.ts
+++ b/packages/relay/src/host-actions.ts
@@ -15,7 +15,7 @@
  */
 
 import { execa } from 'execa';
-import { toHttpsUrl } from './git-pat.js';
+import { repoSlugFromRemote, toHttpsUrl } from './git-pat.js';
 import { existsSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -385,6 +385,34 @@ export async function executeCloudAction(
 }
 
 /**
+ * Where to run `gh`, and whether it must be told the repo.
+ *
+ * `gh` infers the repo from its cwd's git remote, so the host checkout is the
+ * natural place to run it. A control box has no checkout: passing that path as
+ * `cwd` makes the spawn itself fail with a bare `spawn gh ENOENT` (Node reports
+ * a missing cwd exactly like a missing binary), which reads as "gh isn't
+ * installed" and sent us hunting the wrong problem. Fall back to a directory
+ * that exists and name the repo explicitly from the registered origin instead.
+ */
+export function ghRunContext(
+  workspacePath: string,
+  originUrl: string | undefined,
+  args: string[],
+): { cwd: string; args: string[] } {
+  if (workspacePath.length > 0 && existsSync(workspacePath)) {
+    return { cwd: workspacePath, args };
+  }
+  const origin = originUrl?.trim() ?? '';
+  const alreadyScoped = args.some((a) => a === '--repo' || a === '-R' || a.startsWith('--repo='));
+  if (origin.length === 0 || alreadyScoped) return { cwd: tmpdir(), args };
+  try {
+    return { cwd: tmpdir(), args: ['--repo', repoSlugFromRemote(origin), ...args] };
+  } catch {
+    return { cwd: tmpdir(), args };
+  }
+}
+
+/**
  * Cloud `gh.pr.<op>` executor. Simpler than `runGitRpc` because nothing
  * needs to round-trip into the sandbox — `gh` only needs the host repo
  * (already at the right remote in `lookup.workspacePath`).
@@ -550,7 +578,8 @@ async function runGhPrRpc(
   }
   // Never let `gh` fall back to the host repo's checked-out branch.
   if (prCreateNeedsHead(op, finalArgs)) return PR_CREATE_NO_HEAD_REFUSAL;
-  return runHostGh(['pr', op, ...finalArgs], lookup.workspacePath);
+  const prRun = ghRunContext(lookup.workspacePath, deps.originUrl, finalArgs);
+  return runHostGh(['pr', op, ...prRun.args], prRun.cwd);
 }
 
 /**
@@ -633,7 +662,8 @@ async function runGhRunRpc(
       if (denied) return denied;
     }
   }
-  return runHostGh(['run', op, ...args], lookup.workspacePath);
+  const runRun = ghRunContext(lookup.workspacePath, deps.originUrl, args);
+  return runHostGh(['run', op, ...runRun.args], runRun.cwd);
 }
 
 /**
@@ -655,7 +685,8 @@ async function runGhApiRpc(
   const ghReady = await assertGhReady();
   if (ghReady) return ghReady;
   const lookup = await lookupCloudBox(deps.boxId);
-  return runHostGh(['api', endpoint, ...args], lookup.workspacePath);
+  const apiRun = ghRunContext(lookup.workspacePath, undefined, args);
+  return runHostGh(['api', endpoint, ...apiRun.args], apiRun.cwd);
 }
 
 /**

--- a/packages/relay/src/host-actions.ts
+++ b/packages/relay/src/host-actions.ts
@@ -15,6 +15,7 @@
  */
 
 import { execa } from 'execa';
+import { toHttpsUrl } from './git-pat.js';
 import { existsSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -1213,6 +1214,21 @@ export interface HostGitRepo {
   cleanup: () => Promise<void>;
 }
 
+/**
+ * The push URL a scratch (checkout-less) host repo should use. SSH/scp remotes
+ * are rewritten to plain HTTPS; anything already HTTPS — or any URL shape
+ * `toHttpsUrl` can't parse — is passed through untouched, so an unusual remote
+ * fails at git with its own message instead of here.
+ */
+function httpsOriginForScratchPush(origin: string): string {
+  if (/^https?:\/\//i.test(origin)) return origin;
+  try {
+    return toHttpsUrl(origin);
+  } catch {
+    return origin;
+  }
+}
+
 export async function resolveHostGitRepo(
   workspacePath: string,
   deps: CloudActionExecutorDeps,
@@ -1228,13 +1244,21 @@ export async function resolveHostGitRepo(
   }
   // No host checkout. Only the REGISTERED origin can be trusted as a push
   // target — see the `originUrl` doc on CloudActionExecutorDeps.
-  const origin = deps.originUrl?.trim() ?? '';
-  if (origin.length === 0) {
+  const rawOrigin = deps.originUrl?.trim() ?? '';
+  if (rawOrigin.length === 0) {
     throw new Error(
       `host-side git is unavailable for box ${deps.boxId}: its host repo (${workspacePath || '<unset>'}) does not exist ` +
         `and the box has no registered origin URL to push to. Adopt the box on a host with a checkout, or re-register it.`,
     );
   }
+  // A checkout-less host is a control box, which authenticates git through a
+  // credential helper (`hub.gitAuth=gh`) or an App token — never an SSH key. An
+  // scp-form `git@github.com:owner/repo` origin therefore dies at host-key
+  // verification before auth is ever consulted, so rewrite it to the HTTPS URL
+  // the helper covers. Mirrors the create worker's clone (`hub-worker.ts`),
+  // which has always done this — without it the clone side works and the push
+  // side fails for every SSH-origin project.
+  const origin = httpsOriginForScratchPush(rawOrigin);
   const dir = await mkdtemp(join(tmpdir(), 'agentbox-git-scratch-'));
   const init = await execa('git', ['-C', dir, 'init', '--quiet'], { reject: false });
   if ((init.exitCode ?? 1) !== 0) {

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -38,6 +38,7 @@ import {
   PR_CREATE_NO_HEAD_REFUSAL,
   prCreateHasExplicitHead,
   prCreateNeedsHead,
+  ghRunContext,
   refuseCheckoutByDefault,
   refuseMergeBypass,
   runHostGh,
@@ -1971,7 +1972,8 @@ async function handleGhPrRpc(
   const finalArgs = injectPrCreateHead(op, worktree.sanctionedBranch ?? worktree.branch, args);
   // Never let `gh` fall back to the host repo's checked-out branch.
   if (prCreateNeedsHead(op, finalArgs)) return PR_CREATE_NO_HEAD_REFUSAL;
-  return runHostGh(['pr', op, ...finalArgs], worktree.hostMainRepo);
+  const prRun = ghRunContext(worktree.hostMainRepo, reg.originUrl, finalArgs);
+  return runHostGh(['pr', op, ...prRun.args], prRun.cwd);
 }
 
 /**
@@ -2030,7 +2032,8 @@ async function handleGhRunRpc(
       }
     }
   }
-  return runHostGh(['run', op, ...args], worktree.hostMainRepo);
+  const runRun = ghRunContext(worktree.hostMainRepo, reg.originUrl, args);
+  return runHostGh(['run', op, ...runRun.args], runRun.cwd);
 }
 
 /**
@@ -2061,7 +2064,8 @@ async function handleGhApiRpc(
   if (callRefusal) return callRefusal;
   const ghReady = await assertGhReady();
   if (ghReady) return ghReady;
-  return runHostGh(['api', endpoint, ...args], worktree.hostMainRepo);
+  const apiRun = ghRunContext(worktree.hostMainRepo, undefined, args);
+  return runHostGh(['api', endpoint, ...apiRun.args], apiRun.cwd);
 }
 
 /**

--- a/packages/relay/test/host-actions.test.ts
+++ b/packages/relay/test/host-actions.test.ts
@@ -4,12 +4,8 @@ import { existsSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import {
-  executeCloudAction,
-  ghRunContext,
-  resolveHostGitRepo,
-  resolveHostPath,
-} from '../src/host-actions.js';
+import { executeCloudAction, resolveHostGitRepo, resolveHostPath } from '../src/host-actions.js';
+import { ghRunContext } from '../src/gh.js';
 import type { HostAction } from '../src/types.js';
 
 /**

--- a/packages/relay/test/host-actions.test.ts
+++ b/packages/relay/test/host-actions.test.ts
@@ -4,7 +4,12 @@ import { existsSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { executeCloudAction, resolveHostGitRepo, resolveHostPath } from '../src/host-actions.js';
+import {
+  executeCloudAction,
+  ghRunContext,
+  resolveHostGitRepo,
+  resolveHostPath,
+} from '../src/host-actions.js';
 import type { HostAction } from '../src/types.js';
 
 /**
@@ -295,5 +300,45 @@ describe('resolveHostGitRepo', () => {
     await expect(resolveHostGitRepo(gone, deps('   '), 'origin')).rejects.toThrow(
       /no registered origin URL/,
     );
+  });
+});
+
+describe('ghRunContext', () => {
+  it('runs gh in the host checkout untouched when one exists', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'agentbox-ghctx-'));
+    try {
+      expect(ghRunContext(dir, 'git@github.com:o/r.git', ['create'])).toEqual({
+        cwd: dir,
+        args: ['create'],
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to a real cwd and names the repo when the checkout is gone', () => {
+    const gone = join(tmpdir(), 'agentbox-ghctx-does-not-exist-xyz');
+    // A missing cwd makes the spawn fail as `spawn gh ENOENT` — never pass it through.
+    expect(ghRunContext(gone, 'git@github.com:o/r.git', ['create'])).toEqual({
+      cwd: tmpdir(),
+      args: ['--repo', 'o/r', 'create'],
+    });
+  });
+
+  it('does not second-guess an explicit --repo / -R, or an unusable origin', () => {
+    const gone = join(tmpdir(), 'agentbox-ghctx-does-not-exist-xyz');
+    expect(ghRunContext(gone, 'git@github.com:o/r.git', ['--repo', 'x/y', 'view'])).toEqual({
+      cwd: tmpdir(),
+      args: ['--repo', 'x/y', 'view'],
+    });
+    expect(ghRunContext(gone, 'git@github.com:o/r.git', ['-R', 'x/y', 'view'])).toEqual({
+      cwd: tmpdir(),
+      args: ['-R', 'x/y', 'view'],
+    });
+    expect(ghRunContext(gone, undefined, ['view'])).toEqual({ cwd: tmpdir(), args: ['view'] });
+    expect(ghRunContext(gone, '/srv/mirrors/r.git', ['view'])).toEqual({
+      cwd: tmpdir(),
+      args: ['view'],
+    });
   });
 });

--- a/packages/relay/test/host-actions.test.ts
+++ b/packages/relay/test/host-actions.test.ts
@@ -115,7 +115,10 @@ describe('executeCloudAction routing', () => {
     const prev = process.env['AGENTBOX_GH_PR_CHECKOUT'];
     delete process.env['AGENTBOX_GH_PR_CHECKOUT'];
     try {
-      const result = await executeCloudAction(action('gh.pr.checkout', { args: ['1'] }), makeDeps());
+      const result = await executeCloudAction(
+        action('gh.pr.checkout', { args: ['1'] }),
+        makeDeps(),
+      );
       expect(result.exitCode).toBe(13);
       expect(result.stderr).toContain('disabled by default');
     } finally {
@@ -258,10 +261,29 @@ describe('resolveHostGitRepo', () => {
     // The push target is the URL, not the remote NAME: a scratch repo has no remotes.
     expect(repo.remote).toBe('https://github.com/o/r.git');
     expect(repo.dir).not.toBe(gone);
-    const inside = await execa('git', ['-C', repo.dir, 'rev-parse', '--git-dir'], { reject: false });
+    const inside = await execa('git', ['-C', repo.dir, 'rev-parse', '--git-dir'], {
+      reject: false,
+    });
     expect(inside.exitCode).toBe(0);
     await repo.cleanup();
     expect(existsSync(repo.dir)).toBe(false);
+  });
+
+  it('rewrites an SSH origin to HTTPS for a scratch push (a control box has no SSH key)', async () => {
+    const gone = join(tmpdir(), 'agentbox-hgr-does-not-exist-xyz');
+    const repo = await resolveHostGitRepo(gone, deps('git@github.com:o/r.git'), 'origin');
+    made.push(repo.dir);
+    expect(repo.remote).toBe('https://github.com/o/r.git');
+    const url = await resolveHostGitRepo(gone, deps('ssh://git@github.com/o/r.git'), 'origin');
+    made.push(url.dir);
+    expect(url.remote).toBe('https://github.com/o/r.git');
+  });
+
+  it('leaves an unparseable origin alone rather than failing the push early', async () => {
+    const gone = join(tmpdir(), 'agentbox-hgr-does-not-exist-xyz');
+    const repo = await resolveHostGitRepo(gone, deps('/srv/mirrors/r.git'), 'origin');
+    made.push(repo.dir);
+    expect(repo.remote).toBe('/srv/mirrors/r.git');
   });
 
   it('refuses rather than guessing when there is no checkout and no registered origin', async () => {


### PR DESCRIPTION
An SSH-origin project (`git@github.com:owner/repo`) could be cloned into a cloud box but never pushed back when a remote control box owns the box. Two host actions assumed the host has the repo checked out and an SSH key; a control box has neither — it authenticates git through the `gh` credential helper (`hub.gitAuth=gh`) or an App token.

- **`git push`** used the registered origin verbatim, so it died at `Host key verification failed` before auth was ever consulted. The scratch-repo path now rewrites SSH/scp remotes to HTTPS (`toHttpsUrl`), which is what the create worker's clone has always done.
- **`gh pr create`** passed the box's *host* workspace path as the spawn `cwd`. That path doesn't exist on a control box, and Node reports a missing cwd as `spawn gh ENOENT` — indistinguishable from a missing binary (`gh` 2.98 is installed there). `ghRunContext` now falls back to tmpdir and adds `--repo <slug>` from the registered origin. Same treatment for `gh run` / `gh api`.

The helper lives in `gh.ts` because a cloud box's `gh.pr.*` is served by **server.ts's `/rpc`** route — the in-box forwarder posts straight to the control plane — not by the cloud-poller executor in `host-actions.ts`, which serves `git.push`. Both dispatch paths needed it.

## Verification

Live, on `madarco/agentbox-test-repo` (origin `git@github.com:…`):

- **e2b box via the control box** — push + PR both failed before, both work after: https://github.com/madarco/agentbox-test-repo/pull/26
- **daytona box via the local relay** (control plane unset, host checkout present) — unchanged behavior, push over SSH from the host repo + PR: https://github.com/madarco/agentbox-test-repo/pull/27

`pnpm --filter @agentbox/relay typecheck` clean; relay suite 442 passed (5 new tests covering the rewrite, the cwd fallback, and the pass-through cases).

https://claude.ai/code/session_0172rQgK4HGXqXNvzoSR3tqY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how scratch git push targets and host `gh` invocations are resolved for control boxes, but push URLs still come only from registered `originUrl` and existing gh allowlists/prompts are unchanged.
> 
> **Overview**
> **Checkout-less control boxes** (no host project clone, git via `gh` credential helper) could clone SSH-origin repos but failed on **push** and **`gh`**.
> 
> Scratch-repo **git push** now rewrites registered **SSH/scp origins to HTTPS** before pushing, matching the create worker so pushes use the credential helper instead of dying on SSH host-key verification.
> 
> New **`ghRunContext`** picks a valid spawn **cwd** and, when the registered workspace path is missing, runs **`gh` from `tmpdir()`** with **`--repo`** derived from the registered **origin** (unless the caller already passed `--repo`/`-R`). **`gh pr`**, **`gh run`**, and **`gh api`** on both **docker `/rpc`** (`server.ts`) and **cloud executor** (`host-actions.ts`) use this helper so a missing cwd is not misreported as **`spawn gh ENOENT`**.
> 
> Tests cover SSH→HTTPS rewrite, pass-through for odd URLs, and **`ghRunContext`** fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 379bf8e0f51b4f66cd42923fce4ee222e98217e0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->