### PR TITLE
fix(agent): read a box's in-TUI prompts from the hub that owns it

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -189,6 +189,12 @@ CLI, not the raw commits.
 
 ### Fixed
 
+- **`agentbox agent approvals` missed the in-TUI prompts of a control-box box.**
+  Plan, question and tool-permission rows were read from a status file only the
+  local relay writes, so a box parked on a plan approval reported "agent not
+  parked on a prompt" — and `agent approve` refused the same prompt as already
+  changed. Both now read the snapshot from the hub that owns the box, and a half
+  that could not be read is reported instead of rendering as "nothing pending".
 - **Remote Docker builds work on Docker 29.** The box image was streamed to
   `docker build -` alongside `-f`, which Docker 29's buildx rejects outright
   ("ambiguous Dockerfile source") — that broke every bake and every registry-miss

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -195,6 +195,11 @@ CLI, not the raw commits.
   parked on a prompt" — and `agent approve` refused the same prompt as already
   changed. Both now read the snapshot from the hub that owns the box, and a half
   that could not be read is reported instead of rendering as "nothing pending".
+- **`agent state`, `wait-for` and `get-plan-question` reported no snapshot for a
+  box the control box created.** They asked this machine's hub first, and a hub
+  box the local registry knows answers "no snapshot" rather than "no such box" —
+  so the fallback to the control box never happened. All five `agent` readers now
+  resolve the owning hub the same way.
 - **A remote-docker box's approvals were looked for on the wrong hub** when a
   control box was configured. It registers with the local relay, but an inline
   provider check treated only `docker` as local, so its host-action mailbox was

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -195,6 +195,10 @@ CLI, not the raw commits.
   parked on a prompt" — and `agent approve` refused the same prompt as already
   changed. Both now read the snapshot from the hub that owns the box, and a half
   that could not be read is reported instead of rendering as "nothing pending".
+- **A remote-docker box's approvals were looked for on the wrong hub** when a
+  control box was configured. It registers with the local relay, but an inline
+  provider check treated only `docker` as local, so its host-action mailbox was
+  read from the control box. Ownership is now decided in one place for both.
 - **Remote Docker builds work on Docker 29.** The box image was streamed to
   `docker build -` alongside `-f`, which Docker 29's buildx rejects outright
   ("ambiguous Dockerfile source") — that broke every bake and every registry-miss

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -195,6 +195,10 @@ CLI, not the raw commits.
   parked on a prompt" — and `agent approve` refused the same prompt as already
   changed. Both now read the snapshot from the hub that owns the box, and a half
   that could not be read is reported instead of rendering as "nothing pending".
+- **`agent` commands were silent about a control box they could not authenticate
+  to.** They fell back to this machine's hub, whose empty answer for a box it
+  never held was reported as "no snapshot" — they now name the plane and the
+  missing `AGENTBOX_HUB_API_KEY`, as `agent approvals` already did.
 - **`agent state`, `wait-for` and `get-plan-question` reported no snapshot for a
   box the control box created.** They asked this machine's hub first, and a hub
   box the local registry knows answers "no snapshot" rather than "no such box" —

--- a/apps/cli/src/commands/agent.ts
+++ b/apps/cli/src/commands/agent.ts
@@ -22,7 +22,6 @@ import {
 import { resolveDriveSession } from '../lib/drive/session.js';
 import { sendKey, sendLiteral } from '../lib/drive/tmux.js';
 import { providerForBox } from '../provider/registry.js';
-import { withOwningHub } from '../control-plane/with-hub.js';
 import { resolveBoxPromptSource, type BoxPromptSource } from '../control-plane/box-plane.js';
 import { resolveHubApiClient } from './control-plane.js';
 import { HubApiError } from '../control-plane/hub-api-client.js';
@@ -94,31 +93,34 @@ const agentWaitForCommand = new Command('wait-for')
           ? parsePositiveInt(opts.timeout, '--timeout')
           : DEFAULT_WAIT_TIMEOUT_MS;
 
-      // Poll the box's agent snapshot through the owning hub until it reaches the
+      // Poll the box's agent snapshot on the hub that owns it until it reaches the
       // target state (or the timeout elapses). Polling — not an event subscription
       // — because `/api/v1` carries no agent-event stream; the command's own docs
-      // already sanction it, and `agent approvals --wait` polls the same way. One
-      // withOwningHub call wraps the whole loop so the owner-first + not_found
-      // retry happens once, not per poll.
+      // already sanction it, and `agent approvals --wait` polls the same way. The
+      // source is resolved ONCE, outside the loop.
+      const source = await resolveBoxPromptSource(box);
+      if (!source) {
+        log.error("Could not reach a hub to read this box's agent state.");
+        process.exit(1);
+      }
       let matched: BoxStatusClaude | undefined;
       let elapsedMs = 0;
-      const r = await withOwningHub(box, async (client) => {
-        const start = Date.now();
-        for (;;) {
-          const claude = (await client.getAgentState(box.id)).claude as BoxStatusClaude | null;
-          if (claude && matchesAgentWaitState(claude, target)) {
-            matched = claude;
-            return;
+      const start = Date.now();
+      for (;;) {
+        const claude = await agentClaudeFrom(source, box.id).catch((err: unknown) => {
+          if (err instanceof HubApiError && err.code === 'not_found') {
+            log.error(`box ${box.name} was not found on ${describeHub(source)}.`);
+            process.exit(2);
           }
-          elapsedMs = Date.now() - start;
-          if (elapsedMs >= timeoutMs) return;
-          await sleep(Math.min(500, timeoutMs - elapsedMs));
+          throw err;
+        });
+        if (claude && matchesAgentWaitState(claude, target)) {
+          matched = claude;
+          break;
         }
-      });
-      if (r === undefined) return; // hub error; withHubClient reported + set exit code
-      if (r === 'not-found') {
-        log.error(`box ${box.name} was not found on any hub AgentBox knows.`);
-        process.exit(2);
+        elapsedMs = Date.now() - start;
+        if (elapsedMs >= timeoutMs) break;
+        await sleep(Math.min(500, timeoutMs - elapsedMs));
       }
       if (matched) {
         emitMatch(matched, opts.json === true);
@@ -407,7 +409,7 @@ async function approveInTui(id: string, opts: ApproveOpts): Promise<void> {
     claude = await agentClaudeFrom(source, box.id);
   } catch (err) {
     log.error(
-      `could not read the agent snapshot for ${box.name} from the ${source.remote ? 'control box' : 'hub'}: ` +
+      `could not read the agent snapshot for ${box.name} from ${describeHub(source)}: ` +
         (err instanceof Error ? err.message : String(err)),
     );
     process.exit(1);
@@ -638,29 +640,56 @@ function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-/** Sentinel: `withOwningHub` already reported a hub error + set the exit code. */
+/** Sentinel: the hub read failed and was already reported (+ exit code set). */
 const HUB_ERROR = Symbol('hub-error');
 /** Sentinel: no hub AgentBox knows owns the box (distinct from a null snapshot). */
 const HUB_NOT_FOUND = Symbol('hub-not-found');
 
 /**
- * Read the box's Claude status snapshot through the hub that owns it. Returns:
+ * Read the box's Claude status snapshot from the hub that owns it, resolved by
+ * `resolveBoxPromptSource` — the SAME resolver `approvals`/`approve` use, so all
+ * five agent commands agree about ownership.
+ *
+ * It cannot be `withOwningHub` here. That routes by provider family and retries
+ * the other hub on `not_found`, which sounds equivalent but isn't: a hub box the
+ * local registry knows (every hub create adopts one) makes the local hub answer
+ * `{claude: null}` — a 200, not a `not_found` — so the retry never fires and the
+ * command reports "no snapshot yet" for a box that is parked on a prompt.
+ * Observed live on a `docker:hub` box: `approvals` listed its plan while `state`
+ * and `get-plan-question` both said there was nothing.
+ *
+ * Returns:
  *   - the snapshot, or null when the box is known but has no snapshot yet,
- *   - {@link HUB_NOT_FOUND} when no hub owns the box (a missing box is NOT the same
- *     as a null snapshot — conflating them would hide an unreachable box behind a
- *     misleading "no snapshot yet, exit 0", the inconsistency `wait-for` avoids),
+ *   - {@link HUB_NOT_FOUND} when its hub does not know the box (a missing box is
+ *     NOT the same as a null snapshot — conflating them would hide an unreachable
+ *     box behind a misleading "no snapshot yet, exit 0"),
  *   - {@link HUB_ERROR} when the hub call itself failed (already reported).
  */
 async function fetchAgentClaude(
   box: BoxRecord,
 ): Promise<BoxStatusClaude | null | typeof HUB_ERROR | typeof HUB_NOT_FOUND> {
-  let claude: BoxStatusClaude | null = null;
-  const r = await withOwningHub(box, async (client) => {
-    claude = ((await client.getAgentState(box.id)).claude ?? null) as BoxStatusClaude | null;
-  });
-  if (r === undefined) return HUB_ERROR;
-  if (r === 'not-found') return HUB_NOT_FOUND;
-  return claude;
+  const source = await resolveBoxPromptSource(box);
+  if (!source) {
+    log.error("Could not reach a hub to read this box's agent state.");
+    process.exitCode = 1;
+    return HUB_ERROR;
+  }
+  try {
+    return await agentClaudeFrom(source, box.id);
+  } catch (err) {
+    if (err instanceof HubApiError && err.code === 'not_found') return HUB_NOT_FOUND;
+    log.error(
+      `could not read the agent snapshot for ${box.name} from ${describeHub(source)}: ` +
+        (err instanceof Error ? err.message : String(err)),
+    );
+    process.exitCode = 1;
+    return HUB_ERROR;
+  }
+}
+
+/** "the control box" / "the hub", for messages that name where a read went. */
+function describeHub(source: BoxPromptSource): string {
+  return source.remote ? 'the control box' : 'the hub';
 }
 
 /**
@@ -672,7 +701,7 @@ function reportAgentBoxNotFound(box: BoxRecord, asJson: boolean): void {
   if (asJson) {
     process.stdout.write(JSON.stringify(null) + '\n');
   } else {
-    log.error(`box ${box.name} was not found on any hub AgentBox knows.`);
+    log.error(`box ${box.name} was not found on the hub that owns it.`);
   }
   process.exit(2);
 }

--- a/apps/cli/src/commands/agent.ts
+++ b/apps/cli/src/commands/agent.ts
@@ -103,6 +103,10 @@ const agentWaitForCommand = new Command('wait-for')
         log.error("Could not reach a hub to read this box's agent state.");
         process.exit(1);
       }
+      // Never poll the local hub for a box we know lives on a plane we can't
+      // reach: it would answer `{claude: null}` for the full timeout, then
+      // report the agent "did not reach" a state nobody ever asked about.
+      if (reportedUnauthenticatedPlane(source)) process.exit(1);
       let matched: BoxStatusClaude | undefined;
       let elapsedMs = 0;
       const start = Date.now();
@@ -404,6 +408,7 @@ async function approveInTui(id: string, opts: ApproveOpts): Promise<void> {
     log.error("Could not reach a hub to read this box's agent state.");
     process.exit(1);
   }
+  if (reportedUnauthenticatedPlane(source)) process.exit(1);
   let claude: BoxStatusClaude | null;
   try {
     claude = await agentClaudeFrom(source, box.id);
@@ -674,6 +679,7 @@ async function fetchAgentClaude(
     process.exitCode = 1;
     return HUB_ERROR;
   }
+  if (reportedUnauthenticatedPlane(source)) return HUB_ERROR;
   try {
     return await agentClaudeFrom(source, box.id);
   } catch (err) {
@@ -690,6 +696,24 @@ async function fetchAgentClaude(
 /** "the control box" / "the hub", for messages that name where a read went. */
 function describeHub(source: BoxPromptSource): string {
   return source.remote ? 'the control box' : 'the hub';
+}
+
+/**
+ * True (having reported it) when the box's plane is one we can name but cannot
+ * authenticate to. {@link resolveBoxPromptSource} then falls back to the LOCAL
+ * hub, which answers `{claude: null}` for a box it does not hold — and passing
+ * that off as "no snapshot yet", or as "the prompt changed", states an answer
+ * about a hub we never actually asked. `approvals` already refuses to; every
+ * snapshot reader has to as well.
+ */
+function reportedUnauthenticatedPlane(source: BoxPromptSource): boolean {
+  if (source.unauthenticatedPlane === undefined) return false;
+  log.error(
+    `this box's agent state lives on ${source.unauthenticatedPlane}, but no hub API key is ` +
+      'available here — set AGENTBOX_HUB_API_KEY (or run `agentbox hub setup`) to read it.',
+  );
+  process.exitCode = 1;
+  return true;
 }
 
 /**

--- a/apps/cli/src/commands/agent.ts
+++ b/apps/cli/src/commands/agent.ts
@@ -1,7 +1,6 @@
 import { log } from '@clack/prompts';
 import type { BoxRecord } from '@agentbox/core';
 import { type BoxStatusClaude } from '@agentbox/ctl';
-import { readBoxStatus } from '@agentbox/sandbox-docker';
 import { Command } from 'commander';
 import { resolveBoxOrExit } from '../box-ref.js';
 import {
@@ -217,26 +216,26 @@ const agentApprovalsCommand = new Command('approvals')
         }
       }
       const rows = gathered.rows;
+      const missing = missingHalves(gathered);
+      const where = source.remote ? 'control box' : 'hub';
 
       if (opts.json === true) {
         // Array shape is a contract (orchestration reads it) — keep stdout pure
-        // and put the degraded-mailbox warning on stderr.
-        if (gathered.relayError !== undefined) {
+        // and put the degraded-read warning on stderr.
+        if (missing.length > 0) {
           process.stderr.write(
-            `warning: could not read the ${source.remote ? 'control box' : 'hub'} approval mailbox (${gathered.relayError}); host-action rows may be missing\n`,
+            `warning: could not read ${missing.join(' or ')} from the ${where}; those rows may be missing\n`,
           );
         }
         process.stdout.write(JSON.stringify(rows) + '\n');
-        if (gathered.relayError !== undefined) process.exitCode = 1;
+        if (missing.length > 0) process.exitCode = 1;
         return;
       }
-      if (gathered.relayError !== undefined) {
-        // The in-TUI rows below are still trustworthy — they come from the box's
-        // own status — so show them, but never let a missing mailbox read as
-        // "nothing pending".
+      if (missing.length > 0) {
+        // Whatever the other half DID answer is still shown — but a half we
+        // could not read must never render as "nothing pending".
         log.warn(
-          `could not read the ${source.remote ? 'control box' : 'hub'} approval mailbox (${gathered.relayError}) — ` +
-            'host-action approvals are not shown.',
+          `could not read ${missing.join(' or ')} from the ${where} — those rows are not shown.`,
         );
         process.exitCode = 1;
       }
@@ -251,7 +250,7 @@ const agentApprovalsCommand = new Command('approvals')
           process.exitCode = 1;
           return;
         }
-        if (gathered.relayError === undefined) {
+        if (missing.length === 0) {
           log.info(
             'nothing pending for this box (no host-action approvals, agent not parked on a prompt)',
           );
@@ -389,8 +388,16 @@ async function approveInTui(id: string, opts: ApproveOpts): Promise<void> {
     process.exit(2);
   }
   const box = await resolveBoxOrExit(parsed.boxId);
-  const status = await readBoxStatus(box);
-  const claude = status?.claude;
+  // Through the OWNING hub, for the same reason `state`/`wait-for` do: the
+  // snapshot is written by whichever relay the box reports to, so a control-box
+  // box has none on this laptop. Reading the local file here made every such
+  // prompt fail the race guard below as "it changed or was answered".
+  const claude = await fetchAgentClaude(box);
+  if (claude === HUB_ERROR) return; // withOwningHub reported + set the exit code
+  if (claude === HUB_NOT_FOUND) {
+    reportAgentBoxNotFound(box, false);
+    return;
+  }
   // Race guard: the prompt must still be the one this id was minted for.
   const current = claude ? mintTuiId(box.id, claude) : null;
   if (!current || current.id !== id) {
@@ -482,28 +489,49 @@ type ApprovalRow =
   | { id: string; kind: 'question'; message: string; options: string[] }
   | { id: string; kind: 'permission'; message: string; state: string };
 
-interface GatheredApprovals {
+export interface GatheredApprovals {
   rows: ApprovalRow[];
   /** Set when the relay mailbox couldn't be read; its rows are missing, not absent. */
   relayError?: string;
+  /** Set when the agent snapshot couldn't be read; in-TUI rows are missing, not absent. */
+  tuiError?: string;
+}
+
+/**
+ * What a partial read could not answer for, phrased for the user. Empty when
+ * both halves succeeded — the ONLY case in which an empty row list is allowed to
+ * be reported as "nothing pending".
+ */
+export function missingHalves(g: GatheredApprovals): string[] {
+  const missing: string[] = [];
+  if (g.relayError !== undefined) missing.push(`host-action approvals (${g.relayError})`);
+  if (g.tuiError !== undefined) missing.push(`the agent's in-TUI prompts (${g.tuiError})`);
+  return missing;
 }
 
 /**
  * Merge the hub's host-action approvals with the box's current in-TUI block (if
- * any).
+ * any). Both come from the hub that OWNS the box — for a local box a loopback
+ * `/api/v1` call, for a hub box a WAN request to the control box.
  *
- * The hub half is allowed to fail without taking the command down. For a local
- * box it is a loopback `/api/v1` call; for a hub box it is a WAN request to the
- * control box, and a blip there must not hide the in-TUI plan/question/permission
- * rows, which come from the box's own status and are entirely independent.
+ * The in-TUI half used to read `~/.agentbox/boxes/<box>/status.json` directly.
+ * That file is written by whichever relay the box reports to, so it never exists
+ * for a control-box box and those rows silently vanished — a box parked on a plan
+ * approval read as "agent not parked on a prompt". `getAgentState` returns the
+ * hub's own copy of that snapshot (falling back to its in-memory status store),
+ * which for a local box is exactly what the file read returned.
+ *
+ * Each half is allowed to fail on its own without taking the command down, and
+ * reports separately: a partial answer must never render as "nothing pending".
  * `listApprovals` returns every box's pending approvals; filter to this box.
  */
-async function gatherApprovals(
+export async function gatherApprovals(
   source: BoxPromptSource,
   box: BoxRecord,
 ): Promise<GatheredApprovals> {
   const rows: ApprovalRow[] = [];
   let relayError: string | undefined;
+  let tuiError: string | undefined;
 
   try {
     const approvals = await source.client.listApprovals();
@@ -524,7 +552,12 @@ async function gatherApprovals(
     relayError = err instanceof Error ? err.message : String(err);
   }
 
-  const claude = (await readBoxStatus(box))?.claude;
+  let claude: BoxStatusClaude | null = null;
+  try {
+    claude = ((await source.client.getAgentState(box.id)).claude ?? null) as BoxStatusClaude | null;
+  } catch (err) {
+    tuiError = err instanceof Error ? err.message : String(err);
+  }
   const tui = claude ? mintTuiId(box.id, claude) : null;
   if (claude && tui) {
     if (tui.kind === 'plan') {
@@ -551,7 +584,7 @@ async function gatherApprovals(
       });
     }
   }
-  return { rows, relayError };
+  return { rows, relayError, tuiError };
 }
 
 function approvalDisplay(row: ApprovalRow): string {
@@ -606,8 +639,9 @@ async function fetchAgentClaude(
 
 /**
  * Report a box no hub owns, for the snapshot readers (`state` /
- * `get-plan-question`) — exit 2, matching `wait-for`. Distinct from a null
- * snapshot: the box is genuinely unknown, not merely un-reported-on yet.
+ * `get-plan-question` / `approve`'s race guard) — exit 2, matching `wait-for`.
+ * Distinct from a null snapshot: the box is genuinely unknown, not merely
+ * un-reported-on yet.
  */
 function reportAgentBoxNotFound(box: BoxRecord, asJson: boolean): void {
   if (asJson) {

--- a/apps/cli/src/commands/agent.ts
+++ b/apps/cli/src/commands/agent.ts
@@ -388,15 +388,29 @@ async function approveInTui(id: string, opts: ApproveOpts): Promise<void> {
     process.exit(2);
   }
   const box = await resolveBoxOrExit(parsed.boxId);
-  // Through the OWNING hub, for the same reason `state`/`wait-for` do: the
-  // snapshot is written by whichever relay the box reports to, so a control-box
-  // box has none on this laptop. Reading the local file here made every such
-  // prompt fail the race guard below as "it changed or was answered".
-  const claude = await fetchAgentClaude(box);
-  if (claude === HUB_ERROR) return; // withOwningHub reported + set the exit code
-  if (claude === HUB_NOT_FOUND) {
-    reportAgentBoxNotFound(box, false);
-    return;
+  // Through the hub that owns the box: the snapshot is written by whichever
+  // relay the box reports to, so a control-box box has none on this laptop, and
+  // reading the local file here made every such prompt fail the race guard below
+  // as "it changed or was answered".
+  //
+  // Resolved by `resolveBoxPromptSource` — the SAME resolver `agent approvals`
+  // used to mint this id. Two different answers to "which hub owns this box"
+  // would race-check an id against a hub that never listed it, which is
+  // indistinguishable from the prompt having changed.
+  const source = await resolveBoxPromptSource(box);
+  if (!source) {
+    log.error("Could not reach a hub to read this box's agent state.");
+    process.exit(1);
+  }
+  let claude: BoxStatusClaude | null;
+  try {
+    claude = await agentClaudeFrom(source, box.id);
+  } catch (err) {
+    log.error(
+      `could not read the agent snapshot for ${box.name} from the ${source.remote ? 'control box' : 'hub'}: ` +
+        (err instanceof Error ? err.message : String(err)),
+    );
+    process.exit(1);
   }
   // Race guard: the prompt must still be the one this id was minted for.
   const current = claude ? mintTuiId(box.id, claude) : null;
@@ -498,6 +512,18 @@ export interface GatheredApprovals {
 }
 
 /**
+ * The box's agent snapshot as the OWNING hub holds it. `getAgentState` reads the
+ * hub's own `status.json` for the box (falling back to its in-memory status
+ * store), so for a local box this is exactly what reading the file here returned.
+ */
+async function agentClaudeFrom(
+  source: BoxPromptSource,
+  boxId: string,
+): Promise<BoxStatusClaude | null> {
+  return ((await source.client.getAgentState(boxId)).claude ?? null) as BoxStatusClaude | null;
+}
+
+/**
  * What a partial read could not answer for, phrased for the user. Empty when
  * both halves succeeded — the ONLY case in which an empty row list is allowed to
  * be reported as "nothing pending".
@@ -554,7 +580,7 @@ export async function gatherApprovals(
 
   let claude: BoxStatusClaude | null = null;
   try {
-    claude = ((await source.client.getAgentState(box.id)).claude ?? null) as BoxStatusClaude | null;
+    claude = await agentClaudeFrom(source, box.id);
   } catch (err) {
     tuiError = err instanceof Error ? err.message : String(err);
   }
@@ -639,9 +665,8 @@ async function fetchAgentClaude(
 
 /**
  * Report a box no hub owns, for the snapshot readers (`state` /
- * `get-plan-question` / `approve`'s race guard) — exit 2, matching `wait-for`.
- * Distinct from a null snapshot: the box is genuinely unknown, not merely
- * un-reported-on yet.
+ * `get-plan-question`) — exit 2, matching `wait-for`. Distinct from a null
+ * snapshot: the box is genuinely unknown, not merely un-reported-on yet.
  */
 function reportAgentBoxNotFound(box: BoxRecord, asJson: boolean): void {
   if (asJson) {

--- a/apps/cli/src/control-plane/box-plane.ts
+++ b/apps/cli/src/control-plane/box-plane.ts
@@ -11,6 +11,7 @@
 import type { BoxRecord } from '@agentbox/core';
 import { DEFAULT_RELAY_PORT } from '@agentbox/relay';
 import { HubApiClient } from './hub-api-client.js';
+import { boxOwningHubIsLocal } from './with-hub.js';
 
 /** The laptop's own relay daemon. */
 export const LOCAL_RELAY_URL = `http://127.0.0.1:${String(DEFAULT_RELAY_PORT)}`;
@@ -31,6 +32,27 @@ export type BoxPlane = { url: string; adminToken: string } | 'none' | 'no-token'
 export type PlaneAddressable = Pick<BoxRecord, 'provider' | 'cloud'>;
 
 /**
+ * True when this box's relay, mailbox and status all live on THIS machine's hub,
+ * so there is no plane to resolve at all.
+ *
+ * Two signals, in this order:
+ *   1. A RECORDED plane wins. `cloud.controlPlaneUrl` is written by the
+ *      hub-create and adopt paths, i.e. exactly on the boxes a control box owns
+ *      — including a `remote-docker` box it built on its own engine
+ *      (`docker:hub`), which the provider family alone would misroute back here.
+ *   2. Otherwise the owning-hub family decides, via {@link boxOwningHubIsLocal}
+ *      and NOT an inline `provider === 'docker'` test. `remote-docker` is a
+ *      container on another machine's engine, but the box registers with the
+ *      LOCAL relay (the local hub drives that engine over SSH), so its approvals
+ *      and its status snapshot are here. Calling it remote sent both reads to a
+ *      hub that never wrote them.
+ */
+export function boxAnswersOnLocalHub(box: PlaneAddressable): boolean {
+  if (box.cloud?.controlPlaneUrl) return false;
+  return boxOwningHubIsLocal(box);
+}
+
+/**
  * Resolve the control box holding this box's state, and the bearer for it.
  *
  * The URL comes from the box's own record first: `cloud.controlPlaneUrl` is the
@@ -44,15 +66,15 @@ export type PlaneAddressable = Pick<BoxRecord, 'provider' | 'cloud'>;
  * plane at all means there is genuinely nothing to ask, while a known plane we
  * can't authenticate to is an answer we never got.
  *
- * Docker boxes short-circuit to `none` — they register on the laptop loopback
- * relay and are never on a plane, the same rule `mergeHubBoxes` applies.
+ * A box the local hub owns short-circuits to `none` — see
+ * {@link boxAnswersOnLocalHub}, the same rule `mergeHubBoxes` applies.
  *
  * Imports lazily: this runs on paths that also serve hosts with no control box
  * at all (every attach, every destroy), which shouldn't pay to load config +
  * relay code.
  */
 export async function resolveBoxPlane(box: PlaneAddressable): Promise<BoxPlane> {
-  if ((box.provider ?? 'docker') === 'docker') return 'none';
+  if (boxAnswersOnLocalHub(box)) return 'none';
   const { loadEffectiveConfig } = await import('@agentbox/config');
   const { loadControlPlaneEnv } = await import('./env-file.js');
   const configured = await loadEffectiveConfig(process.cwd())
@@ -71,13 +93,13 @@ export async function resolveBoxPlane(box: PlaneAddressable): Promise<BoxPlane> 
  * Mirrors {@link resolveBoxPlane} but for the *client* surface: the URL comes
  * from `cloud.controlPlaneUrl` first (survives a config change on this host),
  * else `relay.controlPlaneUrl`, and the Bearer is the hub API key
- * (`AGENTBOX_HUB_API_KEY`) — not the admin token. A docker box short-circuits to
- * `none` (its approvals live on the local hub).
+ * (`AGENTBOX_HUB_API_KEY`) — not the admin token. A box the local hub owns
+ * short-circuits to `none` (see {@link boxAnswersOnLocalHub}).
  */
 type BoxHubTarget = { url: string; apiKey: string } | 'none' | 'no-token';
 
 async function resolveBoxHubTarget(box: PlaneAddressable): Promise<BoxHubTarget> {
-  if ((box.provider ?? 'docker') === 'docker') return 'none';
+  if (boxAnswersOnLocalHub(box)) return 'none';
   const { loadEffectiveConfig } = await import('@agentbox/config');
   const { loadControlPlaneEnv } = await import('./env-file.js');
   const configured = await loadEffectiveConfig(process.cwd())
@@ -110,7 +132,7 @@ export interface BoxPromptSource {
 /**
  * Resolve the prompt mailbox for a box as a hub `/api/v1` client + SSE target.
  *
- * A docker box (or a cloud box with no control box) answers on the **local hub**,
+ * A box the local hub owns (or a cloud box with no control box) answers on the **local hub**,
  * which is auto-started here so `/api/v1` is actually available (a bare relay
  * can't serve it). A cloud box on a plane answers on that control box, keyed by
  * the hub API key. A named-but-unauthenticated plane degrades to the local hub

--- a/apps/cli/test/agent-approvals-source.test.ts
+++ b/apps/cli/test/agent-approvals-source.test.ts
@@ -150,3 +150,19 @@ describe('boxAnswersOnLocalHub', () => {
     }
   });
 });
+
+// A plane we can NAME but not authenticate to: `resolveBoxPromptSource` falls
+// back to the local hub, which holds nothing for that box. Every reader has to
+// say so — an empty answer from a hub we never asked is not "no snapshot".
+describe('gatherApprovals on an unauthenticated plane', () => {
+  it('does not let the local hub’s empty answer read as "nothing pending"', async () => {
+    const s = source({ claude: null }, false);
+    const withPlane: BoxPromptSource = { ...s, unauthenticatedPlane: 'https://cp.example' };
+    const g = await gatherApprovals(withPlane, BOX);
+    expect(g.rows).toEqual([]);
+    // Both halves "answered" — so the caller must key off unauthenticatedPlane,
+    // which is exactly what the approvals command does before saying anything.
+    expect(missingHalves(g)).toEqual([]);
+    expect(withPlane.unauthenticatedPlane).toBe('https://cp.example');
+  });
+});

--- a/apps/cli/test/agent-approvals-source.test.ts
+++ b/apps/cli/test/agent-approvals-source.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import type { BoxRecord } from '@agentbox/core';
+import type { BoxStatusClaude } from '@agentbox/ctl';
+import { gatherApprovals, missingHalves } from '../src/commands/agent.js';
+import type { BoxPromptSource } from '../src/control-plane/box-plane.js';
+
+// Pure: both halves of `gatherApprovals` are hub calls now, so a stub client is
+// the whole world. The regression this pins: the in-TUI half used to read
+// `~/.agentbox/boxes/<box>/status.json` off THIS machine's disk, which never
+// exists for a box a control box created — those rows silently vanished and the
+// box read as "agent not parked on a prompt".
+
+const BOX = { id: 'b0x1', name: 'smoke' } as BoxRecord;
+
+const PLAN: BoxStatusClaude = {
+  state: 'waiting',
+  updatedAt: '2026-08-26T00:00:00.000Z',
+  sessionRunning: true,
+  plan: { plan: '## do the thing', capturedAt: '2026-08-26T00:00:00.000Z' },
+};
+
+interface Stub {
+  approvals?: unknown[];
+  claude?: BoxStatusClaude | null;
+  approvalsError?: Error;
+  agentStateError?: Error;
+}
+
+/** A `BoxPromptSource` whose client answers from `stub` — no fs, no network. */
+function source(stub: Stub, remote = true): BoxPromptSource {
+  return {
+    client: {
+      listApprovals: async () => {
+        if (stub.approvalsError) throw stub.approvalsError;
+        return stub.approvals ?? [];
+      },
+      getAgentState: async () => {
+        if (stub.agentStateError) throw stub.agentStateError;
+        return { claude: stub.claude ?? null };
+      },
+    },
+    baseUrl: 'https://cp.example',
+    remote,
+  } as unknown as BoxPromptSource;
+}
+
+describe('gatherApprovals in-TUI rows come from the owning hub', () => {
+  it('surfaces a hub box plan prompt (the bug: it read a local file that never exists)', async () => {
+    const g = await gatherApprovals(source({ claude: PLAN }), BOX);
+    expect(g.rows.map((r) => r.kind)).toEqual(['plan']);
+    expect(g.rows[0]?.id.startsWith('tui:b0x1:plan:')).toBe(true);
+    expect(missingHalves(g)).toEqual([]);
+  });
+
+  it('reports no in-TUI row when the hub has no snapshot for the box', async () => {
+    const g = await gatherApprovals(source({ claude: null }), BOX);
+    expect(g.rows).toEqual([]);
+    // Both halves ANSWERED — only then may the caller say "nothing pending".
+    expect(missingHalves(g)).toEqual([]);
+  });
+
+  it('merges host-action rows with the in-TUI row, filtered to this box', async () => {
+    const g = await gatherApprovals(
+      source({
+        claude: PLAN,
+        approvals: [
+          { id: 'u-1', boxId: 'b0x1', command: 'git', argv: ['push'], message: 'push?' },
+          { id: 'u-2', boxId: 'other', command: 'git', argv: ['push'], message: 'push?' },
+        ],
+      }),
+      BOX,
+    );
+    expect(g.rows.map((r) => r.id)).toEqual(['u-1', g.rows[1]?.id]);
+    expect(g.rows.map((r) => r.kind)).toEqual(['host-action', 'plan']);
+  });
+});
+
+describe('gatherApprovals degrades one half at a time', () => {
+  it('keeps in-TUI rows when the approval mailbox fails', async () => {
+    const g = await gatherApprovals(
+      source({ claude: PLAN, approvalsError: new Error('502 bad gateway') }),
+      BOX,
+    );
+    expect(g.rows.map((r) => r.kind)).toEqual(['plan']);
+    expect(missingHalves(g)).toEqual(['host-action approvals (502 bad gateway)']);
+  });
+
+  it('keeps host-action rows when the agent snapshot fails', async () => {
+    const g = await gatherApprovals(
+      source({
+        approvals: [{ id: 'u-1', boxId: 'b0x1', command: 'git', message: 'push?' }],
+        agentStateError: new Error('ETIMEDOUT'),
+      }),
+      BOX,
+    );
+    expect(g.rows.map((r) => r.kind)).toEqual(['host-action']);
+    // Non-empty is what stops the caller printing "nothing pending" — the whole
+    // point of tracking the two failures separately.
+    expect(missingHalves(g)).toEqual(["the agent's in-TUI prompts (ETIMEDOUT)"]);
+  });
+
+  it('names both when neither half answers', async () => {
+    const g = await gatherApprovals(
+      source({
+        approvalsError: new Error('502 bad gateway'),
+        agentStateError: new Error('ETIMEDOUT'),
+      }),
+      BOX,
+    );
+    expect(g.rows).toEqual([]);
+    expect(missingHalves(g)).toEqual([
+      'host-action approvals (502 bad gateway)',
+      "the agent's in-TUI prompts (ETIMEDOUT)",
+    ]);
+  });
+});

--- a/apps/cli/test/agent-approvals-source.test.ts
+++ b/apps/cli/test/agent-approvals-source.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { BoxRecord } from '@agentbox/core';
 import type { BoxStatusClaude } from '@agentbox/ctl';
 import { gatherApprovals, missingHalves } from '../src/commands/agent.js';
+import { boxAnswersOnLocalHub } from '../src/control-plane/box-plane.js';
 import type { BoxPromptSource } from '../src/control-plane/box-plane.js';
 
 // Pure: both halves of `gatherApprovals` are hub calls now, so a stub client is
@@ -112,5 +113,40 @@ describe('gatherApprovals degrades one half at a time', () => {
       'host-action approvals (502 bad gateway)',
       "the agent's in-TUI prompts (ETIMEDOUT)",
     ]);
+  });
+});
+
+// Which hub owns a box — the decision BOTH `approvals` and `approve` now share.
+// Bugbot Medium x2 on the first cut: an inline `provider === 'docker'` test sent
+// a locally-created remote-docker box to the control box, which never wrote its
+// snapshot, and made `approve` disagree with the listing that minted the id.
+describe('boxAnswersOnLocalHub', () => {
+  it('keeps a docker box local', () => {
+    expect(boxAnswersOnLocalHub({ provider: 'docker' })).toBe(true);
+    expect(boxAnswersOnLocalHub({})).toBe(true); // undefined provider defaults to docker
+  });
+
+  it('keeps a LOCALLY-created remote-docker box local', () => {
+    // The container is on another machine's engine, but the box registers with
+    // this laptop's relay — which is what writes its status.json and holds its
+    // approval mailbox.
+    expect(boxAnswersOnLocalHub({ provider: 'remote-docker' })).toBe(true);
+  });
+
+  it('sends a remote-docker box the CONTROL BOX created to that control box', () => {
+    // `docker:hub`: same provider family, opposite owner. Only the recorded
+    // plane can tell the two apart.
+    expect(
+      boxAnswersOnLocalHub({
+        provider: 'remote-docker',
+        cloud: { controlPlaneUrl: 'https://cp.example' },
+      } as never),
+    ).toBe(false);
+  });
+
+  it('sends cloud boxes to their plane', () => {
+    for (const p of ['e2b', 'vercel', 'hetzner', 'daytona', 'digitalocean']) {
+      expect(boxAnswersOnLocalHub({ provider: p }), p).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
Fixes the Bugbot finding on #312 ("Hub boxes miss in-TUI approvals"), which is real.

## The bug

`readBoxStatus` reads `~/.agentbox/boxes/<box>/status.json` — a file written by **whichever relay the box reports to**. A box a control box created reports there, so the file is on that machine's disk and never exists on your laptop. The codebase already states this invariant twice (`prompt-client.ts:18`, `hub-list.ts:6`).

The `/api/v1` conversion moved `agent state`, `wait-for` and `get-plan-question` onto `client.getAgentState(box.id)`. Two call sites were left on the local read:

- `gatherApprovals` — the plan / question / tool-permission rows of `agent approvals`
- `approveInTui` — the race guard in `agent approve`

So for a control-box box, `agent approvals` showed only host-action rows (those *do* come from the hub) and a box parked on a plan approval reported **"agent not parked on a prompt"**. `agent approve` then re-read the same absent file and refused the prompt as already changed.

Same root cause as a bug already fixed in this range — the attach footer, which "read a status file only the local relay writes".

## The fix

Both call sites go through the hub that owns the box. `approveInTui` uses the existing `fetchAgentClaude` helper (so it inherits the `HUB_ERROR` / `HUB_NOT_FOUND` handling); `gatherApprovals` uses `source.client`, the same client its host-action half already used — so there is one decision about which hub owns the box, not two that could disagree.

**No change for a local box.** The hub's `getAgentState` reads that very same `status.json` on its own disk, falling back to its in-memory status store — a superset of what the direct file read returned.

One behavioural consequence worth calling out: the two halves of `approvals` are no longer independent, since both now hit the same hub. The old code assumed the in-TUI half was "entirely independent" and reported only a mailbox failure. Each half is now tracked and named separately, because a half we could not read must never render as "nothing pending".

## Testing

New `apps/cli/test/agent-approvals-source.test.ts` (6 tests, pure — a stub client, no fs or network): a hub box's plan prompt surfaces; a null snapshot yields no row *with both halves answered*; host-action rows are merged and filtered to the box; and each half degrades on its own, naming the other. Test 1 fails without the fix.

Full CLI suite (2520), `pnpm typecheck` and `pnpm lint` green.

Live, against the real control box at `46.225.235.16`:

- `GET /api/v1/boxes/<id>/agent` over the WAN with the Bearer key returns `{"claude":{"state":"unknown","updatedAt":null,"sessionRunning":false}}` for a hub-created box — the exact `BoxStatusClaude` shape the new code reads, and a structured `not_found` for an unknown id.
- That same box has **no `~/.agentbox/boxes/<seg>/` directory at all** on this laptop, so the old read returned null unconditionally. The bug was total for such boxes, not intermittent.

The snapshot→row transformation itself (`inTuiKind`/`mintTuiId`) is pure and covered by the new tests plus the existing `agent-answer.test.ts`.

https://claude.ai/code/session_0172rQgK4HGXqXNvzoSR3tqY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hub routing and agent snapshot/approval reads across local, control-box, and remote-docker setups; mistakes would mis-list or mis-approve prompts, but behavior is covered by new tests and stays CLI-side.
> 
> **Overview**
> Fixes **control-box boxes** where `agent approvals` / `approve` missed plan, question, and permission rows because the in-TUI half still read local `status.json` (only the local relay writes it). **Both halves now use the owning hub’s** `getAgentState`, same as host-action approvals.
> 
> All **`agent` snapshot readers** (`state`, `wait-for`, `get-plan-question`, and the in-TUI race guard) share **`resolveBoxPromptSource`** instead of `withOwningHub`, so a locally-adopted hub box no longer gets stuck on this laptop’s `{claude: null}` while the control box holds the real snapshot. **`boxAnswersOnLocalHub`** replaces inline `provider === 'docker'` checks so **`remote-docker`** boxes register locally vs on the control box (`docker:hub`) route to the right hub.
> 
> **Partial failures** are tracked separately (`missingHalves`, `tuiError`): a half that couldn’t be read no longer prints “nothing pending”, and missing **`AGENTBOX_HUB_API_KEY`** is reported consistently instead of looking like an empty snapshot.
> 
> Adds **`agent-approvals-source.test.ts`** (stub hub client) and **CHANGELOG** entries for these fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a99010f618b26dc8e1ed913ad1f1ddf0c83fcb29. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->