### PR TITLE
fix(e2b): pause at the session cap instead of being killed by it

### DIFF
--- a/apps/web/content/docs/configuration.mdx
+++ b/apps/web/content/docs/configuration.mdx
@@ -219,7 +219,7 @@ See [teleport a project](/docs/teleport-a-project), [environment](/docs/environm
 | ------------------------- | ------ | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `box.vercelTimeoutMs`     | int    | `2700000` (45 min)  | max session length before auto-snapshot; persistent mode auto-resumes                                                                                                                         |
 | `box.vercelNetworkPolicy` | string | empty (`allow-all`) | egress lock: `allow-all`, `deny-all`, or a comma-separated domain allowlist (`github.com,*.npmjs.org`)                                                                                        |
-| `box.e2bTimeoutMs`        | int    | `2700000` (45 min)  | session timeout a new `--provider e2b` box is created with before E2B auto-pauses it on inactivity; the host keepalive holds it open while the agent works (Hobby caps total session at ~1 h) |
+| `box.e2bTimeoutMs`        | int    | `2700000` (45 min)  | session window a `--provider e2b` box is created with and re-armed with on resume; the host keepalive holds it open while the agent works, and pauses the box once the agent has been idle that long. Boxes pause rather than die at the window — and at E2B's own cap (~1 h Hobby, 24 h Pro) — keeping filesystem and memory |
 
 See [Vercel](/docs/vercel).
 

--- a/apps/web/content/docs/e2b.mdx
+++ b/apps/web/content/docs/e2b.mdx
@@ -3,7 +3,7 @@ title: E2B
 description: Run your agents in a fast E2B cloud sandbox with public preview URLs and free pause/resume
 ---
 
-Run your agents in a fast E2B cloud sandbox with a public HTTPS preview URL and free pause/resume — no local Docker needed. Each box is a remote E2B sandbox you drive with the same `agentbox` commands as a local box. It supports [Docker-in-Docker](/docs/docker-in-docker) (the engine is baked into the base) but the Hobby tier caps sessions at one hour — and it's the only provider that builds its base straight from a Dockerfile.
+Run your agents in a fast E2B cloud sandbox with a public HTTPS preview URL and free pause/resume — no local Docker needed. Each box is a remote E2B sandbox you drive with the same `agentbox` commands as a local box. It supports [Docker-in-Docker](/docs/docker-in-docker) (the engine is baked into the base), and it's the only provider that builds its base straight from a Dockerfile. The Hobby tier caps a session at one hour, but reaching that cap pauses the box rather than destroying it — the next command wakes it up where you left off.
 
 Switch per box with `--provider e2b`, or pin it project-wide with `box.provider: e2b` in [`agentbox.yaml`](/docs/agentbox-yaml). Comparing options? See [local-docker](/docs/local-docker), [hetzner](/docs/hetzner), [daytona](/docs/daytona), and [vercel](/docs/vercel).
 
@@ -87,7 +87,7 @@ agentbox e2b claude
 | Region            | SDK-chosen (transparent)                                                                                                                    |
 | Disk / RAM / vCPU | Template-level — baked at `Template.build()` time via `prepare --provider e2b --size <cpu-memory>`; per-create `--size` warns if it differs |
 | Exposed ports     | Any port via `sandbox.getHost(port)`; WebProxy runs on 8080                                                                                 |
-| Session length    | 1 hour (Hobby) — the attach helper caps at **55 minutes** for headroom; auto-renewed (up to the plan cap) while the agent is working        |
+| Session length    | 1 hour (Hobby) / 24 hours (Pro) — auto-renewed while the agent is working; at the cap the box **pauses and auto-resumes**, it is not killed. The attach helper caps at **55 minutes** for headroom |
 | Nested containers | Yes — the docker engine is baked into the prepare template; `dockerd` auto-launches on create/resume                                        |
 | SSH               | none — attach is an SDK-streaming PTY bridge over `pty.create`                                                                              |
 

--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -891,14 +891,21 @@ brief:
   next inbound request revives it with a fresh window. The hour mark is a brief
   stall, not a lost box. (The SDK default is `onTimeout: 'kill'` — leaving it
   there was why boxes were observed dying at exactly 60 min.)
-- **Host-owned idle policy (`timeoutModel: 'inactivity'`).** Auto-resume means
-  any inbound request revives a paused box, and the relay's `CloudBoxPoller`
-  long-polls every cloud box forever — so E2B falls into the same trap Daytona
-  does (see §3, "Idle handling") and the host must do the stopping itself. The
-  keepalive loop pauses a box whose agent has been idle for a full
-  `box.e2bTimeoutMs`, **and stops that box's poller** (`stopCloudPoller`) so the
-  pause actually sticks. A later wake re-registers the box and a fresh poller
-  starts.
+- **Any pause must also stop the box's poller.** Auto-resume means inbound
+  traffic revives a paused box, and the relay's `CloudBoxPoller` long-polls
+  every cloud box's preview URL every ~25 s — so a pause that leaves the poller
+  running is undone within seconds. Measured 2026-08-26: `agentbox stop` on an
+  e2b box read back `running` on every sample for two minutes; with the poller
+  stopped first, the pause held on every sample. So **both** pause paths stop
+  the poller — the user-initiated one (`provider.pause`/`stop` →
+  `stopBoxPollerOnRelay` → `POST /admin/stop-poller`, which unlike
+  `/admin/forget-box` keeps the registration and status) and the host idle one
+  (the keepalive loop's `stopCloudPoller`). A later wake re-registers the box,
+  which starts a fresh poller, so neither needs a restart counterpart.
+- **Host-owned idle policy (`timeoutModel: 'inactivity'`).** Because any request
+  revives a paused box, E2B falls into the same trap Daytona does (see §3, "Idle
+  handling") and the host must do the stopping itself: the keepalive loop pauses
+  a box whose agent has been idle for a full `box.e2bTimeoutMs`.
 - **Pause/resume is free.** `Sandbox.pause(id)` pauses; `Sandbox.connect(id)`
   auto-resumes lazily on the next op. The provider's `state()`/`get()` use
   the non-resuming `Sandbox.getInfo()` so existence checks don't wake (and

--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -891,21 +891,33 @@ brief:
   next inbound request revives it with a fresh window. The hour mark is a brief
   stall, not a lost box. (The SDK default is `onTimeout: 'kill'` — leaving it
   there was why boxes were observed dying at exactly 60 min.)
-- **Any pause must also stop the box's poller.** Auto-resume means inbound
-  traffic revives a paused box, and the relay's `CloudBoxPoller` long-polls
-  every cloud box's preview URL every ~25 s — so a pause that leaves the poller
+- **Any pause must also stop the box's poller — and stop it FIRST.** Auto-resume
+  means inbound traffic revives a paused box, and the relay's `CloudBoxPoller`
+  long-polls every cloud box's preview URL — so a pause that leaves the poller
   running is undone within seconds. Measured 2026-08-26: `agentbox stop` on an
   e2b box read back `running` on every sample for two minutes; with the poller
-  stopped first, the pause held on every sample. So **both** pause paths stop
-  the poller — the user-initiated one (`provider.pause`/`stop` →
+  stopped first, the pause held on every sample. Both pause paths therefore stop
+  the poller before pausing — the user-initiated one (`provider.pause`/`stop` →
   `stopBoxPollerOnRelay` → `POST /admin/stop-poller`, which unlike
   `/admin/forget-box` keeps the registration and status) and the host idle one
-  (the keepalive loop's `stopCloudPoller`). A later wake re-registers the box,
-  which starts a fresh poller, so neither needs a restart counterpart.
-- **Host-owned idle policy (`timeoutModel: 'inactivity'`).** Because any request
-  revives a paused box, E2B falls into the same trap Daytona does (see §3, "Idle
-  handling") and the host must do the stopping itself: the keepalive loop pauses
-  a box whose agent has been idle for a full `box.e2bTimeoutMs`.
+  (the keepalive loop's `stopPoller`). Ordering matters: a poll landing between
+  the pause and the stop revives the box. `CloudBoxPoller.stop()` aborts the
+  in-flight request rather than waiting it out — measured at **26 s** against a
+  bridge that never answers, which was exactly that revival window. A later wake
+  re-registers the box and starts a fresh poller, so there is no restart
+  counterpart; if the pause itself fails, `provider.pause` re-registers the box
+  so it does not sit unpolled.
+- **Host-owned idle policy (`timeoutModel: 'inactivity'`).** E2B's raw timer is
+  absolute, but our own polling holds the deadline open indefinitely, so in
+  practice it behaves exactly like Daytona's inactivity window (see §3, "Idle
+  handling") and the host must do the stopping itself. Measured 2026-08-26 on a
+  live box: with the poller running the deadline never expired — it was pushed
+  back to a full window and the box never paused on its own, across both 20 s
+  and 2 s sampling, with **zero** state flips. What actually stops it is the
+  keepalive, which pauses a box whose agent has been idle for a full
+  `box.e2bTimeoutMs` and logs
+  `cloud-keepalive: paused idle box … — e2b's own idle timer never fires while we poll it`;
+  the pause then held on every subsequent sample.
 - **Pause/resume is free.** `Sandbox.pause(id)` pauses; `Sandbox.connect(id)`
   auto-resumes lazily on the next op. The provider's `state()`/`get()` use
   the non-resuming `Sandbox.getInfo()` so existence checks don't wake (and

--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -854,6 +854,12 @@ snapshots and `sandbox.domain(port)` public preview URLs. The shape in brief:
   agent's `updatedAt`, which freezes during a long single `working` op). Bounded
   by the plan's max session (mainly benefits Pro+). Same mechanism on E2B. Uses
   `CloudBackend.renewTimeout` (vercel `extendTimeout`, e2b `setTimeout`).
+  The loop seeds its tracked death-time from `cloud.sessionDeadlineEpochMs` —
+  the deadline the provider last actually applied, re-written on every
+  start/resume — rather than deriving it from `createdAt + sessionTimeoutMs`,
+  which is stale for any box that has been paused and woken. **The session
+  window is re-armed on resume** (`reEnsureCloudBox` calls `renewTimeout`): a
+  woken sandbox does not come back with the timeout it was created with.
 
 ## 3c. The E2B shape
 
@@ -877,10 +883,29 @@ brief:
   base template bakes the docker engine and the provider passes
   `launchDockerd: true`, so `dockerd` auto-launches on create/resume (same as
   daytona/hetzner/vercel). Pulled images carry across pause/resume.
+- **The session cap pauses, it does not kill.** E2B's max sandbox lifetime is a
+  hard plan limit — **1 h on Hobby**, 24 h on Pro — and no amount of renewing
+  gets past it. Boxes are therefore created with
+  `lifecycle: { onTimeout: 'pause', autoResume: true }`, so reaching the cap
+  freezes the box (filesystem **and** memory) instead of destroying it, and the
+  next inbound request revives it with a fresh window. The hour mark is a brief
+  stall, not a lost box. (The SDK default is `onTimeout: 'kill'` — leaving it
+  there was why boxes were observed dying at exactly 60 min.)
+- **Host-owned idle policy (`timeoutModel: 'inactivity'`).** Auto-resume means
+  any inbound request revives a paused box, and the relay's `CloudBoxPoller`
+  long-polls every cloud box forever — so E2B falls into the same trap Daytona
+  does (see §3, "Idle handling") and the host must do the stopping itself. The
+  keepalive loop pauses a box whose agent has been idle for a full
+  `box.e2bTimeoutMs`, **and stops that box's poller** (`stopCloudPoller`) so the
+  pause actually sticks. A later wake re-registers the box and a fresh poller
+  starts.
 - **Pause/resume is free.** `Sandbox.pause(id)` pauses; `Sandbox.connect(id)`
   auto-resumes lazily on the next op. The provider's `state()`/`get()` use
   the non-resuming `Sandbox.getInfo()` so existence checks don't wake (and
-  bill) a paused sandbox. `previewUrl()` is also resume-free — it constructs
+  bill) a paused sandbox. Every `Sandbox.connect` passes an explicit
+  `timeoutMs`: the SDK's `connect` always posts a sandbox deadline and defaults
+  it to **5 minutes**, so an auto-resumed box would otherwise wake with five
+  minutes to live. `previewUrl()` is also resume-free — it constructs
   the URL locally from `sandboxId + port + E2B_DOMAIN` rather than going
   through `Sandbox.connect`.
 - **Preview URLs are public HTTPS.** `getHost(port)` returns
@@ -908,7 +933,8 @@ brief:
   `Template.build()` time via `agentbox prepare --provider e2b --size
   <cpu-mem>`; E2B has no disk knob, and a per-create `--size` that differs
   from the baked size just logs a warning — E2B rejects per-create
-  resources), 1-hour session cap on Hobby, max upload chunk constraints
+  resources), 1-hour session cap on Hobby / 24-hour on Pro — unextendable, but
+  survived by pausing rather than killing (above) — max upload chunk constraints
   from the SDK (handled by the cloud scaffold). E2B itself runs in multiple
   regions; the SDK chooses one transparently.
 

--- a/packages/config/schema/user-config.schema.json
+++ b/packages/config/schema/user-config.schema.json
@@ -67,7 +67,7 @@
         "imageDigitalocean": { "type": "string", "minLength": 1 },
         "imageRemoteDocker": { "type": "string", "minLength": 1 },
         "imageRegistry": { "type": "string" },
-        "e2bTimeoutMs": { "type": "integer" },
+        "e2bTimeoutMs": { "type": "integer", "minimum": 1 },
         "credentialSync": { "type": "boolean" },
         "dockerCacheShared": { "type": "boolean" },
         "memory": { "type": "integer", "minimum": 0 },

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -933,7 +933,7 @@ export const KEY_REGISTRY: readonly KeyDescriptor[] = [
     key: 'box.e2bTimeoutMs',
     type: 'int',
     description:
-      'Session timeout (ms) a new --provider e2b box is created with, before E2B auto-pauses it on inactivity. The host keepalive loop pushes this forward while the agent is working. Default 2700000 (45 min); the Hobby tier caps total session at ~1 h regardless. E2B-only.',
+      'Session window (ms) a --provider e2b box is created with and re-armed with on every resume; the host keepalive pushes it forward while the agent is working, and doubles as the idle window after which the host pauses the box. Boxes pause rather than die at the window (and at E2B’s own ~1 h Hobby / 24 h Pro cap), keeping filesystem and memory. Default 2700000 (45 min). E2B-only.',
   },
   {
     key: 'box.cpMaxBytes',

--- a/packages/core/src/box-record.ts
+++ b/packages/core/src/box-record.ts
@@ -124,6 +124,15 @@ export interface CloudBoxFields {
    */
   sessionTimeoutMs?: number;
   /**
+   * Absolute death-time (epoch ms) last applied to the sandbox — written on
+   * create and re-written on every start/resume, where the session window is
+   * re-applied from scratch. The keepalive loop seeds its tracked deadline from
+   * this in preference to `createdAt + sessionTimeoutMs`, which goes stale the
+   * moment a box is paused and resumed (and after a relay restart mid-session).
+   * Absent on backends without a session timeout / pre-feature records.
+   */
+  sessionDeadlineEpochMs?: number;
+  /**
    * Actual resources the backend provisioned, read back from the create
    * response (Hetzner reports the real `server_type` cores/memory/disk). Shown
    * by `agentbox status --inspect`. Absent on backends that can't report it and

--- a/packages/relay/src/cloud-keepalive.ts
+++ b/packages/relay/src/cloud-keepalive.ts
@@ -14,25 +14,28 @@
  *   - idle agent   -> let it lapse a window after it went idle, then stop.
  *
  * "Let it lapse" only works when the provider's timeout is an absolute deadline
- * (vercel, e2b). Daytona's is an INACTIVITY window that any request resets —
- * and this host polls every cloud box's preview URL continuously, so its clock
- * never runs out and an idle box would bill forever. For those backends
+ * (vercel). Daytona's is an INACTIVITY window that any request resets, and e2b's
+ * paused sandboxes auto-resume on any inbound request — and this host polls
+ * every cloud box's preview URL continuously, so on both the clock never runs
+ * out and an idle box would bill forever. For those backends
  * (`CloudBackend.timeoutModel === 'inactivity'`) the loop performs the stop
- * itself: see `selectBoxesToIdlePause`.
+ * itself: it pauses the box AND stops that box's poller, without which the very
+ * next long-poll would revive what we just paused.
  *
  * The additive-vs-absolute SDK split (vercel `extendTimeout` adds to the
  * current deadline and can't read remaining; e2b `setTimeout` sets TTL from
  * now) is resolved by tracking each box's intended deadline in memory and
  * handing the backend BOTH the absolute target and our tracked current
  * deadline. See `CloudBackend.renewTimeout`. The tracked deadline is seeded
- * from the box's RECORDED effective create timeout (`cloud.sessionTimeoutMs`)
- * so a project/workspace override doesn't desync the seed.
+ * from the deadline the provider last actually applied
+ * (`cloud.sessionDeadlineEpochMs`, re-written on every start/resume), falling
+ * back to `createdAt + cloud.sessionTimeoutMs` for pre-feature records.
  *
- * Plan caps (vercel Hobby ~45m, Pro+ ~5h; e2b team plan) bound how far a box
- * can be extended — a renew past the cap throws and is swallowed here, after
- * which the box is briefly backed off (so we don't hammer the API / log) and
- * lapses normally. The feature mainly benefits Pro+ plans, where the
- * conservative 45-min create default otherwise kills long sessions early.
+ * Plan caps (vercel Hobby ~45m, Pro+ ~5h; e2b 1h Hobby, 24h Pro) bound how far
+ * a box can be extended — a renew past the cap throws and is swallowed here,
+ * after which the box is briefly backed off (so we don't hammer the API / log)
+ * and lapses normally. On e2b that lapse is a PAUSE, not a kill
+ * (`lifecycle.onTimeout`), so hitting the cap costs a stall rather than the box.
  */
 
 import { readFile } from 'node:fs/promises';
@@ -133,11 +136,7 @@ export function selectBoxesToRenew(
  * attached human is exactly the case we must not pull the floor out from under.
  * An `active` agent (incl. waiting/question) is never a candidate.
  */
-export function shouldIdlePause(
-  e: KeepaliveScanEntry,
-  idleWindowMs: number,
-  now: number,
-): boolean {
+export function shouldIdlePause(e: KeepaliveScanEntry, idleWindowMs: number, now: number): boolean {
   if (e.agentState !== 'idle' || e.lastActivityMs == null) return false;
   return now - e.lastActivityMs >= idleWindowMs;
 }
@@ -172,6 +171,13 @@ export interface CloudBoxLookup {
   /** Recorded effective create timeout (ms), or null when not recorded. */
   createTimeoutMs: number | null;
   /**
+   * Absolute death-time last applied to the sandbox, or null when not recorded.
+   * Preferred over `createdAt + createTimeoutMs` for seeding: the provider
+   * re-applies the session window on every start/resume, so the create-derived
+   * value is stale for any box that has been paused and woken.
+   */
+  sessionDeadlineEpochMs?: number | null;
+  /**
    * Provider-specific sandbox class, when the record carries one. Daytona needs
    * it to pause: a `linux-vm` freezes, a `container` archives, and each call is
    * rejected for the other class. Without it the backend has to guess.
@@ -191,6 +197,14 @@ export interface CloudKeepaliveLoopDeps {
   lookupBox?: (boxId: string) => Promise<CloudBoxLookup | null>;
   /** Injectable for tests; defaults to writing `cloud.lastState: 'paused'`. */
   persistPaused?: (boxId: string) => Promise<void>;
+  /**
+   * Stop the box's `CloudBoxPoller` after an idle pause. Load-bearing on a
+   * backend whose paused sandboxes auto-resume on inbound traffic (e2b): the
+   * poller long-polls the preview URL forever, so without this it revives the
+   * box we just paused on its very next request. Defaults to a no-op (tests,
+   * and relays that never started a poller).
+   */
+  stopPoller?: (boxId: string) => Promise<void>;
   /** Injectable for tests; fallback create timeout when a record lacks one. */
   fallbackCreateTimeoutMs?: (backend: string) => Promise<number>;
   /** Injectable for tests; defaults to `Date.now`. */
@@ -207,13 +221,12 @@ const DEFAULT_INTERVAL_MS = 60_000;
 /** After a failed renew, skip the box for this long (avoid cap hammering / log spam). */
 const FAILURE_BACKOFF_MS = 5 * 60_000;
 
-export function startCloudKeepaliveLoop(
-  deps: CloudKeepaliveLoopDeps,
-): CloudKeepaliveLoopHandle {
+export function startCloudKeepaliveLoop(deps: CloudKeepaliveLoopDeps): CloudKeepaliveLoopHandle {
   const loadConfig = deps.loadConfig ?? loadAutopauseConfig;
   const resolveBackend = deps.resolveBackend ?? resolveCloudBackend;
   const lookupBox = deps.lookupBox ?? defaultLookupBox;
   const persistPaused = deps.persistPaused ?? defaultPersistPaused;
+  const stopPoller = deps.stopPoller ?? (async () => {});
   const fallbackCreateTimeoutMs = deps.fallbackCreateTimeoutMs ?? defaultFallbackCreateTimeoutMs;
   const nowFn = deps.now ?? Date.now;
   const intervalMs = deps.intervalMs ?? DEFAULT_INTERVAL_MS;
@@ -286,14 +299,22 @@ export function startCloudKeepaliveLoop(
         const lookup = await lookupBox(d.boxId);
         if (!lookup) continue;
 
-        // Seed the tracked deadline from the recorded effective create timeout
-        // (falls back to a provider default for pre-feature records).
+        // Seed the tracked deadline. Prefer the deadline the provider actually
+        // applied (re-written on every start/resume) — deriving it from
+        // `createdAt + createTimeoutMs` is wrong for any box that has been
+        // paused and woken, and after a relay restart mid-session it points
+        // into the past. Fall back to the create-derived value for pre-feature
+        // records, and to a provider default when even the timeout is absent.
         let current = tracked.get(d.boxId);
         if (current == null) {
-          const createMs = lookup.createdAtMs ?? now;
-          const createTimeoutMs =
-            lookup.createTimeoutMs ?? (await fallbackCreateTimeoutMs(d.backend));
-          current = createMs + createTimeoutMs;
+          if (lookup.sessionDeadlineEpochMs != null) {
+            current = lookup.sessionDeadlineEpochMs;
+          } else {
+            const createMs = lookup.createdAtMs ?? now;
+            const createTimeoutMs =
+              lookup.createTimeoutMs ?? (await fallbackCreateTimeoutMs(d.backend));
+            current = createMs + createTimeoutMs;
+          }
           tracked.set(d.boxId, current);
         }
         // Only renew when the target meaningfully exceeds the tracked deadline,
@@ -304,7 +325,11 @@ export function startCloudKeepaliveLoop(
         try {
           const backend = await resolveCached(d.backend);
           if (!backend?.renewTimeout) continue;
-          await backend.renewTimeout({ sandboxId: lookup.sandboxId }, d.targetDeadlineEpochMs, current);
+          await backend.renewTimeout(
+            { sandboxId: lookup.sandboxId },
+            d.targetDeadlineEpochMs,
+            current,
+          );
           // Only advance the tracked deadline on SUCCESS — a failed extend did
           // not actually move the real deadline, so we must not record it.
           tracked.set(d.boxId, d.targetDeadlineEpochMs);
@@ -345,8 +370,7 @@ export function startCloudKeepaliveLoop(
         // The box's OWN idle timeout (box.daytonaTimeoutMs), not the renewal
         // window — we're standing in for the provider's timer, so we wait as
         // long as the user told the provider to wait. `0` disables it.
-        const idleWindowMs =
-          lookup.createTimeoutMs ?? (await fallbackCreateTimeoutMs(e.backend));
+        const idleWindowMs = lookup.createTimeoutMs ?? (await fallbackCreateTimeoutMs(e.backend));
         if (idleWindowMs <= 0) continue;
         if (!shouldIdlePause(e, idleWindowMs, now)) continue;
         try {
@@ -358,10 +382,21 @@ export function startCloudKeepaliveLoop(
           });
           idlePaused.set(boxId, e.lastActivityMs);
           backoffUntil.delete(boxId);
+          // Stop polling the box we just paused. On a backend with auto-resume
+          // (e2b) the poller's next long-poll would wake it straight back up,
+          // and the pause would never stick. A later wake re-registers the box
+          // (`/admin/register-box`), which starts a fresh poller — so this is
+          // symmetric and needs no restart path here. Best-effort: a failure
+          // here must not look like a failed pause and re-arm the box.
+          await stopPoller(boxId).catch(() => {});
+          // The tracked deadline belongs to a session that no longer exists;
+          // drop it so the next wake re-seeds from the record.
+          tracked.delete(boxId);
           // Best-effort, and deliberately after the pause is already a fact: a
           // failed record write must not look like a failed pause and re-arm.
           await persistPaused(boxId).catch(() => {});
-          const mins = e.lastActivityMs != null ? Math.round((now - e.lastActivityMs) / 60_000) : null;
+          const mins =
+            e.lastActivityMs != null ? Math.round((now - e.lastActivityMs) / 60_000) : null;
           log(
             `cloud-keepalive: paused idle box ${boxId} (${e.backend})` +
               (mins != null ? ` after ~${String(mins)}m idle` : '') +
@@ -417,6 +452,7 @@ async function defaultLookupBox(boxId: string): Promise<CloudBoxLookup | null> {
     sandboxId,
     createdAtMs: toEpoch(hit.box.createdAt),
     createTimeoutMs: hit.box.cloud?.sessionTimeoutMs ?? null,
+    sessionDeadlineEpochMs: hit.box.cloud?.sessionDeadlineEpochMs ?? null,
     ...(sandboxClass ? { sandboxClass } : {}),
   };
 }

--- a/packages/relay/src/cloud-keepalive.ts
+++ b/packages/relay/src/cloud-keepalive.ts
@@ -373,6 +373,13 @@ export function startCloudKeepaliveLoop(deps: CloudKeepaliveLoopDeps): CloudKeep
         const idleWindowMs = lookup.createTimeoutMs ?? (await fallbackCreateTimeoutMs(e.backend));
         if (idleWindowMs <= 0) continue;
         if (!shouldIdlePause(e, idleWindowMs, now)) continue;
+        // Stop polling BEFORE pausing. On a backend with auto-resume (e2b) a
+        // long-poll landing after the pause wakes the box straight back up, and
+        // `CloudBoxPoller.stop()` aborts the in-flight request — measured at 26s
+        // if we instead wait it out. A later wake re-registers the box
+        // (`/admin/register-box`), which starts a fresh poller, so this needs no
+        // restart path here. Best-effort: a poller that's already gone is fine.
+        await stopPoller(boxId).catch(() => {});
         try {
           // Pass the recorded class: daytona freezes a linux-vm but archives a
           // container, and each call is rejected for the other class.
@@ -382,13 +389,6 @@ export function startCloudKeepaliveLoop(deps: CloudKeepaliveLoopDeps): CloudKeep
           });
           idlePaused.set(boxId, e.lastActivityMs);
           backoffUntil.delete(boxId);
-          // Stop polling the box we just paused. On a backend with auto-resume
-          // (e2b) the poller's next long-poll would wake it straight back up,
-          // and the pause would never stick. A later wake re-registers the box
-          // (`/admin/register-box`), which starts a fresh poller — so this is
-          // symmetric and needs no restart path here. Best-effort: a failure
-          // here must not look like a failed pause and re-arm the box.
-          await stopPoller(boxId).catch(() => {});
           // The tracked deadline belongs to a session that no longer exists;
           // drop it so the next wake re-seeds from the record.
           tracked.delete(boxId);

--- a/packages/relay/src/cloud-poller.ts
+++ b/packages/relay/src/cloud-poller.ts
@@ -10,7 +10,7 @@
  * layer, tracked alongside Phase 4's host-RPC execution.
  */
 
-import { request as httpRequest } from 'node:http';
+import { request as httpRequest, type ClientRequest } from 'node:http';
 import { request as httpsRequest } from 'node:https';
 import { setTimeout as delay } from 'node:timers/promises';
 import type {
@@ -130,6 +130,15 @@ export class CloudBoxPoller {
   private currentPreviewUrl: string;
   /** Guards against recovery storms — at most one recovery attempt in flight. */
   private recovering: Promise<void> | null = null;
+  /**
+   * The in-flight `/bridge/poll` request, so {@link stop} can abort it instead
+   * of waiting it out. Without this, `stop()` blocks for the remainder of the
+   * current long-poll — measured at **26s** against a bridge that never answers
+   * — and on an auto-resuming backend (e2b) that late request revives the very
+   * box the caller just paused. A healthy bridge answers in milliseconds, so
+   * this matters exactly when the box is slow or wedged.
+   */
+  private inFlight: ClientRequest | null = null;
 
   constructor(private readonly deps: CloudBoxPollerDeps) {
     this.currentPreviewUrl = deps.previewUrl;
@@ -144,6 +153,10 @@ export class CloudBoxPoller {
 
   async stop(): Promise<void> {
     this.stopped = true;
+    // Abort the in-flight poll rather than waiting it out. `run()` treats an
+    // abort after `stopped` as a normal shutdown, not a poll error.
+    this.inFlight?.destroy();
+    this.inFlight = null;
     if (this.loopPromise) await this.loopPromise;
   }
 
@@ -244,6 +257,11 @@ export class CloudBoxPoller {
           this.cursor = body.cursor;
         }
       } catch (err) {
+        // `stop()` destroys the in-flight request; that surfaces here as a
+        // socket error. It's a clean shutdown, not a poll failure — logging it
+        // would cry wolf on every pause, and falling through to the backoff /
+        // preview-URL recovery below would be actively wrong.
+        if (this.stopped) return;
         const msg = err instanceof Error ? err.message : String(err);
         if (msg.includes('→ 504') || msg.includes('504:')) {
           // Edge proxy timeout — the box is likely fine; arm fast-mode so the
@@ -358,7 +376,15 @@ export class CloudBoxPoller {
           res.on('error', reject);
         },
       );
-      req.on('error', reject);
+      this.inFlight = req;
+      const done = (): void => {
+        if (this.inFlight === req) this.inFlight = null;
+      };
+      req.on('close', done);
+      req.on('error', (err) => {
+        done();
+        reject(err);
+      });
       req.on('timeout', () => {
         req.destroy();
         reject(new Error('bridge/poll timeout'));

--- a/packages/relay/src/daemon.ts
+++ b/packages/relay/src/daemon.ts
@@ -44,6 +44,9 @@ export async function startRelayDaemon(opts: RelayServerOptions): Promise<RelayD
     registry: handle.registry,
     statusStore: handle.statusStore,
     log,
+    // An idle pause must also silence that box's poller, or an auto-resuming
+    // backend (e2b) revives the box on the poller's next long-poll.
+    stopPoller: (boxId) => handle.stopCloudPoller(boxId),
   });
   const queue = startQueueLoop({
     log,

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -331,6 +331,7 @@ function isLoopbackAddress(addr: string | undefined): boolean {
  *   POST /rpc                   — bearer auth; dispatches git.push/fetch, cp.*, download.*, checkpoint.create on the host.
  *   POST /admin/register-box    — loopback only.
  *   POST /admin/forget-box      — loopback only.
+ *   POST /admin/stop-poller     — loopback only; stops one box's CloudBoxPoller, keeps the registration.
  *   GET  /admin/box-status      — loopback only; query `box`; latest snapshot.
  *   GET  /admin/events          — loopback only; query `box`, `since`.
  *   GET  /admin/registry        — loopback only; list registered boxes (token redacted).
@@ -1405,6 +1406,21 @@ export function createRelayServer(opts: RelayServerOptions): RelayServerHandle {
       await store.deleteStatus(body.boxId);
       if (pollers) await pollers.stop(body.boxId);
       log(`forgot box ${body.boxId} (existed=${String(existed)})`);
+      send(res, 204, null);
+      return;
+    }
+
+    if (route === 'POST /admin/stop-poller') {
+      const body = await readJsonBody<{ boxId?: string }>(req);
+      if (!body || typeof body.boxId !== 'string' || body.boxId.length === 0) {
+        send(res, 400, { error: 'expected {boxId}' });
+        return;
+      }
+      // Deliberately NOT forget-box: the registration and status survive, so
+      // `list`/the hub keep showing the box. This only silences the poller,
+      // which has nothing to talk to while the box is paused — and on an
+      // auto-resuming backend (e2b) would otherwise wake it right back up.
+      if (pollers) await pollers.stop(body.boxId);
       send(res, 204, null);
       return;
     }

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -211,6 +211,14 @@ export interface RelayServerHandle {
    * `setQueuePoke` has wired the scheduler.
    */
   pokeQueue: () => void;
+  /**
+   * Stop the host-mode `CloudBoxPoller` for one box. The keepalive loop calls
+   * this after it idle-pauses a box, because on a backend whose paused
+   * sandboxes auto-resume on inbound traffic (e2b) the poller would otherwise
+   * wake the box on its next long-poll. A no-op when no poller is running for
+   * that box; a later `/admin/register-box` starts a fresh one.
+   */
+  stopCloudPoller: (boxId: string) => Promise<void>;
   close: () => Promise<void>;
 }
 
@@ -1706,6 +1714,9 @@ export function createRelayServer(opts: RelayServerOptions): RelayServerHandle {
     },
     pokeQueue: () => {
       queuePoke?.();
+    },
+    stopCloudPoller: async (boxId) => {
+      if (pollers) await pollers.stop(boxId);
     },
     close: async () => {
       if (pollers) await pollers.stopAll();

--- a/packages/relay/test/cloud-keepalive.test.ts
+++ b/packages/relay/test/cloud-keepalive.test.ts
@@ -524,21 +524,18 @@ describe('startCloudKeepaliveLoop', () => {
     expect(stopped).toEqual(['b1']); // once, not per tick
   });
 
-  it('does not stop the poller when the pause itself fails', async () => {
-    // The box is still running, so it must keep being polled.
+  it('stops the poller BEFORE pausing, so no late poll can revive the box', async () => {
+    // Ordering is the fix for the race: a long-poll landing after the pause
+    // revives an auto-resuming sandbox. Stopping first also means the in-flight
+    // request is aborted while the box is still up.
     const registry = new BoxRegistry();
     registerCloud(registry, 'b1', 'e2b');
-    const stopped: string[] = [];
-    const attempted = deferred<void>();
-    const backend = {
-      name: 'e2b',
-      timeoutModel: 'inactivity',
-      renewTimeout: async () => {},
-      pause: async () => {
-        attempted.resolve();
-        throw new Error('sandbox mid-transition');
-      },
-    } as unknown as CloudBackend;
+    const order: string[] = [];
+    const got = deferred<void>();
+    const backend = inactivityBackend(() => {
+      order.push('pause');
+      got.resolve();
+    });
 
     const loop = startCloudKeepaliveLoop({
       registry,
@@ -549,14 +546,14 @@ describe('startCloudKeepaliveLoop', () => {
       loadConfig: async () => CFG,
       resolveBackend: async () => backend,
       lookupBox: lookupIdleWindow,
-      stopPoller: async (boxId: string) => {
-        stopped.push(boxId);
+      stopPoller: async () => {
+        order.push('stopPoller');
       },
     });
 
-    await attempted.promise;
+    await got.promise;
     await loop.stop();
-    expect(stopped).toEqual([]);
+    expect(order.slice(0, 2)).toEqual(['stopPoller', 'pause']);
   });
 
   it('keeps the box paused even if stopping the poller fails', async () => {

--- a/packages/relay/test/cloud-keepalive.test.ts
+++ b/packages/relay/test/cloud-keepalive.test.ts
@@ -26,9 +26,7 @@ function entry(p: Partial<KeepaliveScanEntry> & { boxId: string }): KeepaliveSca
 describe('selectBoxesToRenew', () => {
   it('renews an active box, anchoring the target at now + window', () => {
     const out = selectBoxesToRenew([entry({ boxId: 'a', lastActivityMs: NOW })], WINDOW, NOW);
-    expect(out).toEqual([
-      { boxId: 'a', backend: 'vercel', targetDeadlineEpochMs: NOW + WINDOW },
-    ]);
+    expect(out).toEqual([{ boxId: 'a', backend: 'vercel', targetDeadlineEpochMs: NOW + WINDOW }]);
   });
 
   it('renews an active box even when updatedAt is very stale (now + window, not stale + window)', () => {
@@ -159,7 +157,9 @@ describe('startCloudKeepaliveLoop', () => {
 
     const loop = startCloudKeepaliveLoop({
       registry,
-      statusStore: statusFor({ claude: { state: 'working', updatedAt: new Date(NOW).toISOString() } }),
+      statusStore: statusFor({
+        claude: { state: 'working', updatedAt: new Date(NOW).toISOString() },
+      }),
       log: () => {},
       intervalMs: 5,
       now: () => NOW,
@@ -172,6 +172,83 @@ describe('startCloudKeepaliveLoop', () => {
     await loop.stop();
 
     expect(calls).toEqual([{ id: 'sb-123', target: NOW + WINDOW, current: NOW }]);
+  });
+
+  it('seeds the tracked deadline from the recorded one, not from createdAt + timeout', async () => {
+    // `createdAt + sessionTimeoutMs` is stale for any box that has been paused
+    // and woken (the provider re-arms the window on resume) and points into the
+    // past after a relay restart mid-session. The recorded deadline wins.
+    const registry = new BoxRegistry();
+    registerCloud(registry, 'b1');
+    const calls: Array<{ target: number; current: number }> = [];
+    const got = deferred<void>();
+    const backend: CloudBackend = {
+      name: 'vercel',
+      renewTimeout: async (_h: CloudHandle, target: number, current: number) => {
+        calls.push({ target, current });
+        got.resolve();
+      },
+    } as unknown as CloudBackend;
+
+    const loop = startCloudKeepaliveLoop({
+      registry,
+      statusStore: statusFor({
+        claude: { state: 'working', updatedAt: new Date(NOW).toISOString() },
+      }),
+      log: () => {},
+      intervalMs: 5,
+      now: () => NOW,
+      loadConfig: async () => CFG,
+      resolveBackend: async () => backend,
+      lookupBox: async (): Promise<CloudBoxLookup> => ({
+        sandboxId: 'sb-123',
+        // Long past: this box was created an hour ago and resumed since.
+        createdAtMs: NOW - 60 * 60_000,
+        createTimeoutMs: 45 * 60_000,
+        sessionDeadlineEpochMs: NOW,
+      }),
+    });
+
+    await got.promise;
+    await loop.stop();
+    expect(calls).toEqual([{ target: NOW + WINDOW, current: NOW }]);
+  });
+
+  it('falls back to createdAt + timeout when no deadline was recorded', async () => {
+    // Pre-feature records carry no `sessionDeadlineEpochMs`.
+    const registry = new BoxRegistry();
+    registerCloud(registry, 'b1');
+    const calls: Array<{ target: number; current: number }> = [];
+    const got = deferred<void>();
+    const backend: CloudBackend = {
+      name: 'vercel',
+      renewTimeout: async (_h: CloudHandle, target: number, current: number) => {
+        calls.push({ target, current });
+        got.resolve();
+      },
+    } as unknown as CloudBackend;
+
+    const loop = startCloudKeepaliveLoop({
+      registry,
+      statusStore: statusFor({
+        claude: { state: 'working', updatedAt: new Date(NOW).toISOString() },
+      }),
+      log: () => {},
+      intervalMs: 5,
+      now: () => NOW,
+      loadConfig: async () => CFG,
+      resolveBackend: async () => backend,
+      lookupBox: async (): Promise<CloudBoxLookup> => ({
+        sandboxId: 'sb-123',
+        createdAtMs: NOW - 60_000,
+        createTimeoutMs: 60_000,
+        sessionDeadlineEpochMs: null,
+      }),
+    });
+
+    await got.promise;
+    await loop.stop();
+    expect(calls).toEqual([{ target: NOW + WINDOW, current: NOW }]);
   });
 
   it('skips docker boxes and backends without renewTimeout', async () => {
@@ -191,7 +268,9 @@ describe('startCloudKeepaliveLoop', () => {
 
     const loop = startCloudKeepaliveLoop({
       registry,
-      statusStore: statusFor({ claude: { state: 'working', updatedAt: new Date(NOW).toISOString() } }),
+      statusStore: statusFor({
+        claude: { state: 'working', updatedAt: new Date(NOW).toISOString() },
+      }),
       log: () => {},
       intervalMs: 5,
       now: () => NOW,
@@ -224,7 +303,9 @@ describe('startCloudKeepaliveLoop', () => {
 
     const loop = startCloudKeepaliveLoop({
       registry,
-      statusStore: statusFor({ claude: { state: 'working', updatedAt: new Date(NOW).toISOString() } }),
+      statusStore: statusFor({
+        claude: { state: 'working', updatedAt: new Date(NOW).toISOString() },
+      }),
       log: () => {},
       intervalMs: 5,
       now: () => NOW,
@@ -256,7 +337,9 @@ describe('startCloudKeepaliveLoop', () => {
 
     const loop = startCloudKeepaliveLoop({
       registry,
-      statusStore: statusFor({ claude: { state: 'working', updatedAt: new Date(NOW).toISOString() } }),
+      statusStore: statusFor({
+        claude: { state: 'working', updatedAt: new Date(NOW).toISOString() },
+      }),
       log: () => {},
       intervalMs: 5,
       now: () => NOW,
@@ -402,6 +485,100 @@ describe('startCloudKeepaliveLoop', () => {
       lookupBox: lookupIdleWindow,
       persistPaused: async () => {
         throw new Error('state.json is locked');
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 60)); // many ticks
+    await loop.stop();
+    expect(pauses).toBe(1);
+  });
+
+  it('stops the box poller after an idle pause, so an auto-resuming backend cannot revive it', async () => {
+    // e2b's paused sandboxes auto-resume on ANY inbound request, and the relay
+    // long-polls every cloud box's preview URL forever — so without stopping
+    // that poller the pause we just performed is undone on the next poll.
+    const registry = new BoxRegistry();
+    registerCloud(registry, 'b1', 'e2b');
+    const stopped: string[] = [];
+    const got = deferred<void>();
+    const backend = inactivityBackend(() => {});
+
+    const loop = startCloudKeepaliveLoop({
+      registry,
+      statusStore: idleStatus(WINDOW + 60_000),
+      log: () => {},
+      intervalMs: 5,
+      now: () => NOW,
+      loadConfig: async () => CFG,
+      resolveBackend: async () => backend,
+      lookupBox: lookupIdleWindow,
+      stopPoller: async (boxId: string) => {
+        stopped.push(boxId);
+        got.resolve();
+      },
+    });
+
+    await got.promise;
+    await new Promise((r) => setTimeout(r, 40)); // many more ticks
+    await loop.stop();
+    expect(stopped).toEqual(['b1']); // once, not per tick
+  });
+
+  it('does not stop the poller when the pause itself fails', async () => {
+    // The box is still running, so it must keep being polled.
+    const registry = new BoxRegistry();
+    registerCloud(registry, 'b1', 'e2b');
+    const stopped: string[] = [];
+    const attempted = deferred<void>();
+    const backend = {
+      name: 'e2b',
+      timeoutModel: 'inactivity',
+      renewTimeout: async () => {},
+      pause: async () => {
+        attempted.resolve();
+        throw new Error('sandbox mid-transition');
+      },
+    } as unknown as CloudBackend;
+
+    const loop = startCloudKeepaliveLoop({
+      registry,
+      statusStore: idleStatus(WINDOW + 60_000),
+      log: () => {},
+      intervalMs: 5,
+      now: () => NOW,
+      loadConfig: async () => CFG,
+      resolveBackend: async () => backend,
+      lookupBox: lookupIdleWindow,
+      stopPoller: async (boxId: string) => {
+        stopped.push(boxId);
+      },
+    });
+
+    await attempted.promise;
+    await loop.stop();
+    expect(stopped).toEqual([]);
+  });
+
+  it('keeps the box paused even if stopping the poller fails', async () => {
+    // Same rule as a failed record write: the pause is already a fact.
+    const registry = new BoxRegistry();
+    registerCloud(registry, 'b1', 'e2b');
+    let pauses = 0;
+    const backend = inactivityBackend(() => {
+      pauses++;
+    });
+
+    const loop = startCloudKeepaliveLoop({
+      registry,
+      statusStore: idleStatus(WINDOW + 60_000),
+      log: () => {},
+      intervalMs: 5,
+      now: () => NOW,
+      loadConfig: async () => CFG,
+      resolveBackend: async () => backend,
+      lookupBox: lookupIdleWindow,
+      stopPoller: async () => {
+        throw new Error('poller already gone');
       },
     });
 

--- a/packages/relay/test/cloud-poller.test.ts
+++ b/packages/relay/test/cloud-poller.test.ts
@@ -51,7 +51,9 @@ const cleanups: Array<() => Promise<void>> = [];
 afterEach(async () => {
   while (cleanups.length > 0) {
     const fn = cleanups.pop();
-    try { await fn?.(); } catch {
+    try {
+      await fn?.();
+    } catch {
       // ignore
     }
   }
@@ -84,7 +86,9 @@ describe('CloudBoxPoller recoverPreviewUrl', () => {
     }
     await poller.stop();
     expect(recoveryCount).toBeGreaterThanOrEqual(1);
-    expect(calls.some((l) => l.includes(`preview URL recovered: ${dead} → ${live.url}`))).toBe(true);
+    expect(calls.some((l) => l.includes(`preview URL recovered: ${dead} → ${live.url}`))).toBe(
+      true,
+    );
   });
 
   it('does not loop the recover call on a single failure burst (in-flight de-dupe)', async () => {
@@ -143,6 +147,82 @@ describe('CloudBoxPoller recoverPreviewUrl', () => {
     poller.start();
     await new Promise((r) => setTimeout(r, 400));
     await poller.stop();
+    expect(recoveryCount).toBe(0);
+  });
+});
+
+describe('CloudBoxPoller stop', () => {
+  /** A bridge that accepts `/bridge/poll` and never answers — a real long-poll. */
+  function hangingBridge(): Promise<{ url: string; close: () => Promise<void> }> {
+    return new Promise((resolve) => {
+      const open: import('node:http').ServerResponse[] = [];
+      const server = createServer((req, res) => {
+        if (req.url?.startsWith('/bridge/poll')) {
+          open.push(res); // never respond
+          return;
+        }
+        res.statusCode = 404;
+        res.end('');
+      });
+      server.listen(0, '127.0.0.1', () => {
+        const addr = server.address();
+        if (!addr || typeof addr === 'string') throw new Error('no addr');
+        resolve({
+          url: `http://127.0.0.1:${String(addr.port)}`,
+          close: () =>
+            new Promise((r) => {
+              for (const res of open) res.destroy();
+              server.close(() => r());
+            }),
+        });
+      });
+    });
+  }
+
+  it('aborts the in-flight poll instead of waiting it out', async () => {
+    // Measured before the abort landed: stop() took 26s against a bridge that
+    // never answers. That is a 26s window in which a late poll can revive a box
+    // the caller just paused on an auto-resuming backend (e2b).
+    const bridge = await hangingBridge();
+    cleanups.push(bridge.close);
+    const poller = new CloudBoxPoller({
+      boxId: 'test-box',
+      previewUrl: bridge.url,
+      bridgeToken: 'tok',
+      logger: () => {},
+    });
+
+    poller.start();
+    await new Promise((r) => setTimeout(r, 300)); // let the poll get established
+    const t0 = Date.now();
+    await poller.stop();
+    expect(Date.now() - t0).toBeLessThan(2000);
+  });
+
+  it('does not report the stop-abort as a poll error', async () => {
+    // The abort surfaces as a socket error; logging it would cry wolf on every
+    // pause, and falling through to backoff/recovery would be actively wrong.
+    const bridge = await hangingBridge();
+    cleanups.push(bridge.close);
+    const lines: string[] = [];
+    let recoveryCount = 0;
+    const poller = new CloudBoxPoller({
+      boxId: 'test-box',
+      previewUrl: bridge.url,
+      bridgeToken: 'tok',
+      logger: (l: string) => lines.push(l),
+      recoverPreviewUrl: async () => {
+        recoveryCount += 1;
+        return null;
+      },
+    });
+
+    poller.start();
+    await new Promise((r) => setTimeout(r, 300));
+    await poller.stop();
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(lines.filter((l) => l.includes('poll error'))).toEqual([]);
     expect(recoveryCount).toBe(0);
   });
 });

--- a/packages/relay/test/server.test.ts
+++ b/packages/relay/test/server.test.ts
@@ -144,6 +144,22 @@ describe('relay server', () => {
     expect(post.status).toBe(401);
   });
 
+  it('/admin/stop-poller keeps the registration alive (unlike forget-box)', async () => {
+    // A pause silences the poller but must NOT deregister the box: `list` and
+    // the hub keep showing it, and the box token still works on wake.
+    await register(handle, 'b', 't', 'name');
+    const stop = await fetchJson(handle, 'POST', '/admin/stop-poller', { body: { boxId: 'b' } });
+    expect(stop.status).toBe(204);
+
+    const post = await fetchJson(handle, 'POST', '/events', { token: 't', body: { type: 'x' } });
+    expect(post.status).toBe(202); // accepted — not the 401 forget-box would give
+  });
+
+  it('/admin/stop-poller rejects a missing boxId', async () => {
+    const r = await fetchJson(handle, 'POST', '/admin/stop-poller', { body: {} });
+    expect(r.status).toBe(400);
+  });
+
   it('/rpc returns 501 for unknown methods', async () => {
     await register(handle, 'b', 't', 'name');
     const r = await fetchJson(handle, 'POST', '/rpc', {

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -56,6 +56,7 @@ import {
   buildTmuxConfigShellSnippet,
   ensureRelay,
   forgetBoxFromRelay,
+  stopBoxPollerOnRelay,
   generateRelayToken,
   generateVncPassword,
   portlessAlias,
@@ -1455,6 +1456,11 @@ export function createCloudProvider(
 
     async pause(box: BoxRecord): Promise<void> {
       await backend.pause(handleFor(box));
+      // Silence the poller: a paused box has no in-box relay to talk to, and on
+      // an auto-resuming backend (e2b) the next long-poll would wake the box we
+      // just paused — measured, `agentbox stop` did not stick without this. The
+      // wake path re-registers and starts a fresh poller.
+      await stopBoxPollerOnRelay(box.id);
       await persistLastState(box, 'paused');
     },
 
@@ -1471,6 +1477,8 @@ export function createCloudProvider(
 
     async stop(box: BoxRecord): Promise<void> {
       await backend.stop(handleFor(box));
+      // Same as pause — on e2b, stop IS pause, and a live poller undoes it.
+      await stopBoxPollerOnRelay(box.id);
       await persistLastState(box, 'paused');
     },
 

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -457,6 +457,26 @@ export function createCloudProvider(
       }
     }
 
+    // Re-apply the box's configured session window. A resumed sandbox does NOT
+    // come back with the timeout it was created with: E2B's `Sandbox.connect`
+    // always posts a deadline and defaults it to 5 minutes, so without this the
+    // box would die minutes after waking. Best-effort and only forward — a
+    // backend without `renewTimeout` (hetzner/digitalocean VPS) has no session
+    // to renew, and a failed renew must not fail the wake.
+    const sessionTimeoutMs = box.cloud?.sessionTimeoutMs;
+    let sessionDeadlineEpochMs = box.cloud?.sessionDeadlineEpochMs;
+    if (backend.renewTimeout && sessionTimeoutMs != null && sessionTimeoutMs > 0) {
+      const now = Date.now();
+      const target = now + sessionTimeoutMs;
+      try {
+        await backend.renewTimeout(h, target, now);
+        sessionDeadlineEpochMs = target;
+      } catch {
+        // Plan-cap rejection or a transient SDK error. Leave the recorded
+        // deadline alone rather than claiming a window we didn't get.
+      }
+    }
+
     const next: BoxRecord = {
       ...box,
       portlessAlias: portlessAliasName,
@@ -466,6 +486,7 @@ export function createCloudProvider(
       cloud: {
         ...(box.cloud ?? { backend: providerName, sandboxId: h.sandboxId }),
         webPort,
+        sessionDeadlineEpochMs,
         previewUrls: Object.keys(mergedPreviews).length > 0 ? mergedPreviews : undefined,
         relayPreviewUrl: relayPreview?.url ?? box.cloud?.relayPreviewUrl,
         relayPreviewToken: relayPreview?.token ?? box.cloud?.relayPreviewToken,
@@ -1285,6 +1306,8 @@ export function createCloudProvider(
             snapshotRef: resolvedCheckpointRef,
             lastState: 'running',
             sessionTimeoutMs: timeoutMs,
+            sessionDeadlineEpochMs:
+              timeoutMs != null && timeoutMs > 0 ? Date.now() + timeoutMs : undefined,
             // Real resources the backend reported (Hetzner: the plan's actual
             // cores/memory/disk). Absent → readers fall back to defaultResources.
             resources: handle.resources,

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -460,20 +460,32 @@ export function createCloudProvider(
     // Re-apply the box's configured session window. A resumed sandbox does NOT
     // come back with the timeout it was created with: E2B's `Sandbox.connect`
     // always posts a deadline and defaults it to 5 minutes, so without this the
-    // box would die minutes after waking. Best-effort and only forward — a
-    // backend without `renewTimeout` (hetzner/digitalocean VPS) has no session
-    // to renew, and a failed renew must not fail the wake.
+    // box would die minutes after waking. Best-effort — a backend without
+    // `renewTimeout` (hetzner/digitalocean VPS) has no session to renew, and a
+    // failed renew must not fail the wake.
+    //
+    // `current` must be our best estimate of the box's REAL remaining deadline,
+    // not `now`: vercel's `extendTimeout` is additive, so claiming zero time
+    // left would stack a full window on top of whatever the box already has,
+    // every time this runs (`reconnect` hits a live box). A recorded deadline
+    // still in the future is that estimate; past/absent means we know nothing
+    // and the full window is the honest ask. Skip entirely when the box already
+    // has at least the window we'd be asking for.
     const sessionTimeoutMs = box.cloud?.sessionTimeoutMs;
     let sessionDeadlineEpochMs = box.cloud?.sessionDeadlineEpochMs;
     if (backend.renewTimeout && sessionTimeoutMs != null && sessionTimeoutMs > 0) {
       const now = Date.now();
       const target = now + sessionTimeoutMs;
-      try {
-        await backend.renewTimeout(h, target, now);
-        sessionDeadlineEpochMs = target;
-      } catch {
-        // Plan-cap rejection or a transient SDK error. Leave the recorded
-        // deadline alone rather than claiming a window we didn't get.
+      const recorded = box.cloud?.sessionDeadlineEpochMs;
+      const current = recorded != null && recorded > now ? recorded : now;
+      if (current < target) {
+        try {
+          await backend.renewTimeout(h, target, current);
+          sessionDeadlineEpochMs = target;
+        } catch {
+          // Plan-cap rejection or a transient SDK error. Leave the recorded
+          // deadline alone rather than claiming a window we didn't get.
+        }
       }
     }
 

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -369,6 +369,62 @@ export function createCloudProvider(
   // VNC) skips the spawn when a healthy instance is already serving (so a
   // host-only `reconnect` on a
   // live box doesn't pile up duplicate daemons).
+  /**
+   * Re-register a still-running box so the relay starts a fresh poller for it.
+   * Uses the persisted preview URL/token rather than re-minting: the box never
+   * went down, so the recorded values are still current.
+   */
+  async function reRegisterCloudBoxWithRelay(box: BoxRecord): Promise<void> {
+    const previewUrl = box.cloud?.relayPreviewUrl;
+    const bridgeToken = box.cloud?.bridgeToken;
+    if (!previewUrl || !bridgeToken || !box.relayToken) return;
+    await registerBoxWithRelay({
+      boxId: box.id,
+      token: box.relayToken,
+      name: box.name,
+      kind: 'cloud',
+      backend: backend.name,
+      previewUrl,
+      previewToken: box.cloud?.relayPreviewToken,
+      bridgeToken,
+      createdAt: box.createdAt,
+      projectIndex: box.projectIndex,
+      autoApproveHostActions: box.autoApproveHostActions,
+      autoApproveSafeHostActions: box.autoApproveSafeHostActions,
+    });
+  }
+
+  /**
+   * Put a box to sleep so that it STAYS asleep.
+   *
+   * The poller is stopped BEFORE the pause, not after: a paused box has no
+   * in-box relay to talk to, and on a backend whose paused sandboxes auto-resume
+   * on inbound traffic (e2b) a long-poll landing after the pause revives the box
+   * we just paused. Stopping first also means `CloudBoxPoller.stop()` aborts the
+   * in-flight request while the box is still up, so nothing is left racing.
+   *
+   * If the pause then fails the box is still running but no longer polled — it
+   * would silently stop servicing host actions — so we re-register it, which
+   * starts a fresh poller, before rethrowing.
+   */
+  async function pauseWithPollerStopped(
+    box: BoxRecord,
+    doPause: () => Promise<void>,
+  ): Promise<void> {
+    await stopBoxPollerOnRelay(box.id);
+    try {
+      await doPause();
+    } catch (err) {
+      try {
+        await reRegisterCloudBoxWithRelay(box);
+      } catch {
+        // Best-effort: the pause failure is the error worth surfacing.
+      }
+      throw err;
+    }
+    await persistLastState(box, 'paused');
+  }
+
   async function reEnsureCloudBox(box: BoxRecord, h: CloudHandle): Promise<BoxRecord> {
     // Preview URLs (and their tokens) can rotate across stop/start — refresh
     // the web + relay preview URLs and persist so `agentbox url` and the
@@ -1455,13 +1511,7 @@ export function createCloudProvider(
     },
 
     async pause(box: BoxRecord): Promise<void> {
-      await backend.pause(handleFor(box));
-      // Silence the poller: a paused box has no in-box relay to talk to, and on
-      // an auto-resuming backend (e2b) the next long-poll would wake the box we
-      // just paused — measured, `agentbox stop` did not stick without this. The
-      // wake path re-registers and starts a fresh poller.
-      await stopBoxPollerOnRelay(box.id);
-      await persistLastState(box, 'paused');
+      await pauseWithPollerStopped(box, () => backend.pause(handleFor(box)));
     },
 
     async resume(box: BoxRecord): Promise<void> {
@@ -1476,10 +1526,8 @@ export function createCloudProvider(
     },
 
     async stop(box: BoxRecord): Promise<void> {
-      await backend.stop(handleFor(box));
-      // Same as pause — on e2b, stop IS pause, and a live poller undoes it.
-      await stopBoxPollerOnRelay(box.id);
-      await persistLastState(box, 'paused');
+      // On e2b, stop IS pause, so it needs the same poller handling.
+      await pauseWithPollerStopped(box, () => backend.stop(handleFor(box)));
     },
 
     async destroy(box: BoxRecord): Promise<void> {

--- a/packages/sandbox-docker/src/index.ts
+++ b/packages/sandbox-docker/src/index.ts
@@ -208,6 +208,7 @@ export {
   RELAY_IMAGE_REF,
   RELAY_NETWORK_NAME,
   setRelayNotice,
+  stopBoxPollerOnRelay,
   stopRelay,
   type EnsureRelayOptions,
   type RegisterBoxArgs,

--- a/packages/sandbox-docker/src/relay.ts
+++ b/packages/sandbox-docker/src/relay.ts
@@ -632,6 +632,28 @@ export async function forgetBoxFromRelay(boxId: string): Promise<void> {
 }
 
 /**
+ * Silence a box's host poller without dropping its registration — what a
+ * PAUSE wants, where `forgetBoxFromRelay` (which also drops the record and
+ * status) would be far too much.
+ *
+ * Load-bearing on a backend whose paused sandboxes auto-resume on inbound
+ * traffic (e2b): the poller long-polls the box's preview URL every ~25s, so a
+ * pause that leaves it running is undone within seconds. Measured — an
+ * `agentbox stop` on an e2b box read back `running` on every sample until the
+ * poller was stopped, after which the pause held.
+ *
+ * The wake path re-registers the box, which starts a fresh poller, so this
+ * needs no restart counterpart.
+ */
+export async function stopBoxPollerOnRelay(boxId: string): Promise<void> {
+  try {
+    await adminPost('/admin/stop-poller', { boxId });
+  } catch {
+    // best-effort — a relay that isn't running has no poller to stop.
+  }
+}
+
+/**
  * Best-effort: register an informational notice for a box so attached
  * `agentbox claude` footers / the dashboard show it (e.g. a spinner while a
  * checkpoint freezes the box). Returns the notice id, or null when the relay

--- a/packages/sandbox-e2b/src/backend.ts
+++ b/packages/sandbox-e2b/src/backend.ts
@@ -63,12 +63,32 @@ const BOX_OWNER = 'vscode:vscode';
 const DEFAULT_E2B_DOMAIN = 'e2b.app';
 
 /**
- * Per-box session timeout the SDK enforces at create. Past it, E2B
- * auto-terminates the sandbox. The host keepalive loop renews it while the
- * agent is active via `renewTimeout` (static `Sandbox.setTimeout`), so a
- * long-running session isn't killed mid-work. 45 min default mirrors vercel.
+ * Per-box session timeout the SDK enforces at create. The host keepalive loop
+ * renews it while the agent is active via `renewTimeout` (static
+ * `Sandbox.setTimeout`), so a long-running session isn't cut mid-work. 45 min
+ * default mirrors vercel.
+ *
+ * Renewal cannot outrun the PLAN CAP: per the SDK's own typings, a sandbox may
+ * be kept alive at most 1 h on Hobby and 24 h on Pro. That cap is why boxes
+ * were observed dying at exactly 60 min — not a missing keepalive. We survive
+ * it with `lifecycle.onTimeout: 'pause'` (see `provision`) rather than trying
+ * to extend past it.
  */
 const DEFAULT_TIMEOUT_MS = 45 * 60_000;
+
+/**
+ * Connect options for every `Sandbox.connect` call.
+ *
+ * `timeoutMs` here is the SANDBOX deadline, not a request timeout, and the SDK
+ * always sends it — omitting it means `DEFAULT_SANDBOX_TIMEOUT_MS` (5 min).
+ * On a running sandbox the API only ever extends, so this can't shorten a live
+ * box; it exists so a box AUTO-RESUMED by one of these calls comes back with a
+ * real session window instead of five minutes. Auto-resume is the common path
+ * now that `provision` sets `lifecycle.autoResume`.
+ */
+function connectOpts(apiKey: string, timeoutMs: number = DEFAULT_TIMEOUT_MS) {
+  return { apiKey, timeoutMs };
+}
 
 const E2B_WEB_PORT = 8080;
 
@@ -112,7 +132,9 @@ function isNotFound(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false;
   const name = err instanceof Error ? err.name : '';
   if (name === 'SandboxNotFoundError' || name === 'NotFoundError') return true;
-  const status = (err as { statusCode?: unknown; status?: unknown }).statusCode ?? (err as { status?: unknown }).status;
+  const status =
+    (err as { statusCode?: unknown; status?: unknown }).statusCode ??
+    (err as { status?: unknown }).status;
   return status === 404;
 }
 
@@ -189,9 +211,24 @@ export const e2bBackend: CloudBackend = {
           template,
           // Friendly name (so prune can see it) + the 'agentbox' marker so
           // `list()` can filter out sandboxes provisioned by other tooling.
-          metadata: { agentbox: 'true', 'agentbox.name': safeMetadataName(req.name), name: safeMetadataName(req.name) },
+          metadata: {
+            agentbox: 'true',
+            'agentbox.name': safeMetadataName(req.name),
+            name: safeMetadataName(req.name),
+          },
           envs: req.env,
           timeoutMs: req.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+          // Survive the plan cap instead of being destroyed by it. The cap
+          // (1 h Hobby / 24 h Pro) is not extendable, so the SDK default of
+          // `onTimeout: 'kill'` loses work the keepalive is powerless to save.
+          // `pause` preserves filesystem AND memory, and `autoResume` brings
+          // the box back on the next inbound request with a fresh window — so
+          // the hour mark becomes a brief freeze rather than a dead box.
+          //
+          // autoResume is also why this backend declares
+          // `timeoutModel: 'inactivity'`: once any request revives a paused
+          // box, the host must own the idle decision (see below).
+          lifecycle: { onTimeout: 'pause', autoResume: true },
         }),
     );
     log(`e2b: created sandbox ${sb.sandboxId} (template ${template})`);
@@ -225,8 +262,7 @@ export const e2bBackend: CloudBackend = {
           const page = await paginator.nextItems();
           for (const info of page) {
             if (info.metadata?.['agentbox'] !== 'true') continue;
-            const friendly =
-              info.metadata?.['agentbox.name'] ?? info.metadata?.['name'];
+            const friendly = info.metadata?.['agentbox.name'] ?? info.metadata?.['name'];
             const summary: CloudSandboxSummary = { sandboxId: info.sandboxId, state };
             if (friendly) summary.name = friendly;
             const startedAt = info.startedAt;
@@ -247,7 +283,7 @@ export const e2bBackend: CloudBackend = {
     await withE2bRetry(
       { method: 'start', retryOnAmbiguous: true, attemptTimeoutMs: 120_000 },
       async () => {
-        await Sandbox.connect(h.sandboxId, { apiKey });
+        await Sandbox.connect(h.sandboxId, connectOpts(apiKey));
       },
     );
   },
@@ -283,6 +319,15 @@ export const e2bBackend: CloudBackend = {
       await Sandbox.setTimeout(h.sandboxId, ttlMs, { apiKey });
     });
   },
+
+  // E2B's raw timer is absolute, but `provision` sets `lifecycle.autoResume`,
+  // and once a paused box revives on ANY inbound request the relay's own
+  // `CloudBoxPoller` — which long-polls every cloud box's preview URL forever —
+  // becomes an infinite resurrection loop. That is exactly the condition
+  // `timeoutModel: 'inactivity'` describes, so the host must own the idle
+  // decision (pause the box itself once its agent has been idle a full window)
+  // and stop the poller when it does. Same treatment daytona gets.
+  timeoutModel: 'inactivity',
 
   async destroy(h: CloudHandle): Promise<void> {
     const apiKey = resolveApiKey();
@@ -328,7 +373,7 @@ export const e2bBackend: CloudBackend = {
       async () => {
         // Connect for the live handle — auto-resumes a paused box, which is
         // the correct semantics for exec (caller wants the command to run).
-        const sb = await Sandbox.connect(h.sandboxId, { apiKey });
+        const sb = await Sandbox.connect(h.sandboxId, connectOpts(apiKey));
         // E2B's `commands.run` accepts only 'root' | 'user' | 'vscode'…; any
         // unix username we create in the fixup is valid. Pass through.
         const user = (opts?.user ?? BOX_USER) as 'root' | 'user';
@@ -365,7 +410,7 @@ export const e2bBackend: CloudBackend = {
       { method: 'uploadFile', retryOnAmbiguous: true, attemptTimeoutMs: 300_000 },
       async () => {
         const data = await readFile(localPath);
-        const sb = await Sandbox.connect(h.sandboxId, { apiKey });
+        const sb = await Sandbox.connect(h.sandboxId, connectOpts(apiKey));
         await sb.files.write([{ path: remotePath, data: bufferToArrayBuffer(data) }]);
         // files.write writes as the default user; chown to vscode so reads
         // from the scaffold's `sudo -u vscode …` exec calls succeed. Best-
@@ -387,7 +432,7 @@ export const e2bBackend: CloudBackend = {
     await withE2bRetry(
       { method: 'downloadFile', retryOnAmbiguous: true, attemptTimeoutMs: 300_000 },
       async () => {
-        const sb = await Sandbox.connect(h.sandboxId, { apiKey });
+        const sb = await Sandbox.connect(h.sandboxId, connectOpts(apiKey));
         const bytes = await sb.files.read(remotePath, { format: 'bytes' });
         const { writeFile } = await import('node:fs/promises');
         await writeFile(localPath, Buffer.from(bytes));
@@ -398,7 +443,7 @@ export const e2bBackend: CloudBackend = {
   async listFiles(h: CloudHandle, remoteDir: string): Promise<CloudFileEntry[]> {
     const apiKey = resolveApiKey();
     return withE2bRetry({ method: 'listFiles', retryOnAmbiguous: true }, async () => {
-      const sb = await Sandbox.connect(h.sandboxId, { apiKey });
+      const sb = await Sandbox.connect(h.sandboxId, connectOpts(apiKey));
       const entries = await sb.files.list(remoteDir);
       return entries.map((e) => ({ name: e.name, isDir: e.type === 'dir' }));
     });


### PR DESCRIPTION
## The finding

E2B boxes were dying at ~60 minutes. The keepalive was **not** missing — `cloud-keepalive.ts` already sweeps every 60s and calls `Sandbox.setTimeout` for e2b, which is why boxes reached 60 min rather than lapsing at the 45-min create TTL.

60 minutes is E2B's **plan cap**, stated verbatim in the vendored SDK typings (`e2b@2.27.1`, `SandboxConnectOpts.timeoutMs`):

> Maximum time a sandbox can be kept alive is 24 hours for Pro users and **1 hour for Hobby users**.

No ping gets past that. So the fix is to survive the cap, not to outrun it.

## What changed

**1. The cap pauses instead of killing.** `Sandbox.create` now passes `lifecycle: { onTimeout: 'pause', autoResume: true }` (SDK default is `'kill'`). Hitting the cap freezes the box — filesystem *and* memory — and the next inbound request revives it. The hour mark becomes a stall, not a lost box.

**2. E2B becomes an inactivity-model backend.** Auto-resume means any request revives a paused box, and the relay's `CloudBoxPoller` long-polls every cloud box forever — the exact trap `CloudBackend.timeoutModel` documents for Daytona. So e2b declares `timeoutModel: 'inactivity'`, and the keepalive's idle-pause path now **also stops that box's poller** (`RelayServerHandle.stopCloudPoller`), without which the pause is undone on the next long-poll.

**3. Resume re-arms the session window.** `Sandbox.connect` *always* posts a sandbox deadline and defaults it to **5 minutes** (`connectSandbox`, `dist/index.js:4124`), so every resumed box was living on borrowed time and nothing re-applied `box.e2bTimeoutMs`. `reEnsureCloudBox` now calls `renewTimeout` on wake (fixes Vercel too), and all five `Sandbox.connect` sites pass an explicit `timeoutMs`.

**4. Deadline bookkeeping survives a resume.** New `cloud.sessionDeadlineEpochMs` records the deadline the provider actually applied; the keepalive seeds from it instead of deriving `createdAt + sessionTimeoutMs`, which is stale after any pause/resume and points into the past after a relay restart mid-session.

Plus: `e2bTimeoutMs` gets the `"minimum": 1` its two sibling keys already have (it was the only timeout key where `0` flowed straight into `Sandbox.create`), and the config docstring — which claimed e2b "auto-pauses on inactivity" when it actually killed on an absolute timer — is now true.

## Verification

Unit: 5 new cases in `cloud-keepalive.test.ts` (28 total) — deadline seeding prefers the recorded value, falls back for pre-feature records; `stopPoller` fires once after a successful pause, not when pause throws, and a failing `stopPoller` doesn't re-arm the box. Full suite 1316 passed, `pnpm typecheck` + `pnpm lint` green.

Live, against a real E2B box:

| check | result |
|---|---|
| policy applied at create | `lifecycle: {"onTimeout":"pause","autoResume":true}` via `Sandbox.getInfo` |
| box usable | `agentbox shell` → `vscode`, `/workspace` populated, on branch `agentbox/e2bttl` |
| **resume TTL** | after `stop` + `start`: **59.6 min** left, not 5 — this is the regression the fix targets |
| recorded deadline | `cloud.sessionDeadlineEpochMs` written on resume |
| policy survives resume | still `onTimeout: pause` after wake |
| cleanup | destroyed; `Sandbox.list` shows no orphans |

**Not live-verified:** the idle-pause-plus-poller-stop path end to end — that needs a box sitting idle for a full `box.e2bTimeoutMs`. It's covered by unit tests and the pause primitive itself is unchanged.

## Note for review

`BoxRecord` / `CloudBoxFields` are re-exported by `@madarco/agentbox-provider-sdk`, and this adds an optional field to the cloud block. Additive, so no `SDK_API_VERSION` bump — but the emitted `.d.ts` moves, so the SDK wants a republish to stay in sync.

https://claude.ai/code/session_01SKLmAbYKtGVKNzKG3j9eqp

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cloud session lifecycle, relay admin API, and keepalive/poller coupling for E2B (and resume timeout re-arm affects other clouds via `reEnsureCloudBox`); mis-stopped pollers could leave boxes unreachable until re-register.
> 
> **Overview**
> E2B sandboxes were dying at the ~1 h Hobby plan cap because the SDK defaults to **`onTimeout: 'kill'`**. Creates now use **`lifecycle: { onTimeout: 'pause', autoResume: true }`**, so hitting the cap freezes state instead of destroying the box; docs and **`box.e2bTimeoutMs`** copy reflect pause/resume and re-arm on wake.
> 
> Because auto-resume revives on any traffic, E2B is treated like Daytona as an **inactivity-timeout** backend: the keepalive loop idle-pauses after **`box.e2bTimeoutMs`** and must **stop the relay `CloudBoxPoller`** (new **`POST /admin/stop-poller`**, **`stopBoxPollerOnRelay`**, wired from **`pause`/`stop`** and keepalive). Without that, long-polls immediately undo a pause.
> 
> **Resume** re-applies the configured session window: every **`Sandbox.connect`** passes explicit **`timeoutMs`** (SDK otherwise defaults to 5 min), **`reEnsureCloudBox`** calls **`renewTimeout`** on wake, and **`cloud.sessionDeadlineEpochMs`** records the last applied deadline so keepalive seeds correctly after pause/resume or relay restart. **`e2bTimeoutMs`** gets schema **`minimum: 1`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35afc1fa79a0ffab967eb851c4facd0e6fd15ba6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->