### PR TITLE
fix(test): stop a root vitest run from deleting the real ~/.agentbox

### DIFF
--- a/apps/cli/test/box-listing.test.ts
+++ b/apps/cli/test/box-listing.test.ts
@@ -1,8 +1,9 @@
 import { mkdtempSync } from 'node:fs';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
-import { homedir, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetTempAgentboxHome } from '../../../scripts/test-home.js';
 
 // Redirect HOME before importing anything that resolves ~/.agentbox — the box
 // listing cache lives there and apps/cli tests share the real home otherwise.
@@ -40,7 +41,7 @@ beforeEach(() => {
   state.target = null; // default: unresolvable → the cache/offline path
 });
 afterEach(async () => {
-  await rm(join(homedir(), '.agentbox'), { recursive: true, force: true });
+  await resetTempAgentboxHome();
 });
 afterAll(async () => {
   await rm(TEST_HOME, { recursive: true, force: true });

--- a/apps/cli/test/config-get-nested.test.ts
+++ b/apps/cli/test/config-get-nested.test.ts
@@ -1,8 +1,9 @@
 import { mkdtemp, rm, realpath } from 'node:fs/promises';
 import { mkdtempSync } from 'node:fs';
-import { homedir, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetTempAgentboxHome } from '../../../scripts/test-home.js';
 
 // Isolate HOME to a throwaway dir BEFORE @agentbox/config is ever loaded.
 // `@agentbox/config` captures `STATE_DIR = join(homedir(), '.agentbox')` at
@@ -45,7 +46,7 @@ afterEach(async () => {
   // written under TEST_HOME/projects/ don't leak across cases. HOME is
   // redirected to a throwaway dir at module load (see top of file), so this
   // never touches the developer's real `~/.agentbox`.
-  await rm(join(homedir(), '.agentbox'), { recursive: true, force: true });
+  await resetTempAgentboxHome();
 });
 
 afterAll(async () => {
@@ -96,11 +97,7 @@ describe('config get on a nested 3-level key', () => {
 
   it('--json carries the value and source', async () => {
     await setProjectNotionEnabled();
-    const { stdout } = await runConfigGet([
-      'get',
-      'integrations.notion.enabled',
-      '--json',
-    ]);
+    const { stdout } = await runConfigGet(['get', 'integrations.notion.enabled', '--json']);
     const parsed = JSON.parse(stdout) as { key: string; value: unknown; source: string };
     expect(parsed.key).toBe('integrations.notion.enabled');
     expect(parsed.value).toBe(true);
@@ -109,11 +106,7 @@ describe('config get on a nested 3-level key', () => {
 
   it('--all walks every layer (no silent <unset> for the project layer)', async () => {
     await setProjectNotionEnabled();
-    const { stdout } = await runConfigGet([
-      'get',
-      'integrations.notion.enabled',
-      '--all',
-    ]);
+    const { stdout } = await runConfigGet(['get', 'integrations.notion.enabled', '--all']);
     expect(stdout).toMatch(/effective: true /);
     expect(stdout).toMatch(/project:\s+true /);
     expect(stdout).toMatch(/default:\s+false/);

--- a/apps/cli/test/hub-adopt.test.ts
+++ b/apps/cli/test/hub-adopt.test.ts
@@ -1,9 +1,10 @@
 import { mkdtempSync, realpathSync } from 'node:fs';
 import { readFile, rm } from 'node:fs/promises';
-import { homedir, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execa } from 'execa';
 import { afterAll, afterEach, describe, expect, it } from 'vitest';
+import { resetTempAgentboxHome } from '../../../scripts/test-home.js';
 
 // Redirect HOME before importing anything that resolves ~/.agentbox — apps/cli
 // tests otherwise share the REAL home (see project memory), and adoption writes
@@ -20,7 +21,7 @@ type HubApiBox = import('../src/control-plane/hub-api-client.js').HubApiBox;
 const scratch: string[] = [];
 
 afterEach(async () => {
-  await rm(join(homedir(), '.agentbox'), { recursive: true, force: true });
+  await resetTempAgentboxHome();
 });
 afterAll(async () => {
   await rm(TEST_HOME, { recursive: true, force: true });

--- a/apps/cli/test/hub-list.test.ts
+++ b/apps/cli/test/hub-list.test.ts
@@ -3,6 +3,7 @@ import { rm } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, afterEach, describe, expect, it } from 'vitest';
+import { resetTempAgentboxHome } from '../../../scripts/test-home.js';
 
 // Redirect HOME before importing anything that resolves ~/.agentbox — the hub
 // listing cache lives there and apps/cli tests share the real home otherwise.
@@ -12,7 +13,7 @@ process.env['HOME'] = TEST_HOME;
 const { cacheAge, hubBoxesCachePath } = await import('../src/control-plane/hub-list.js');
 
 afterEach(async () => {
-  await rm(join(homedir(), '.agentbox'), { recursive: true, force: true });
+  await resetTempAgentboxHome();
 });
 afterAll(async () => {
   await rm(TEST_HOME, { recursive: true, force: true });

--- a/apps/cli/test/hub-pull.test.ts
+++ b/apps/cli/test/hub-pull.test.ts
@@ -3,6 +3,7 @@ import { readFile, rm, stat } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, afterEach, describe, expect, it } from 'vitest';
+import { resetTempAgentboxHome } from '../../../scripts/test-home.js';
 
 // Redirect HOME before importing anything that resolves ~/.agentbox (apps/cli
 // tests share the real HOME otherwise — see project memory). `defaultBoxSshDir`
@@ -16,7 +17,7 @@ const { CustodyClient } = await import('../src/control-plane/custody-client.js')
 type HubApiBox = import('../src/control-plane/hub-api-client.js').HubApiBox;
 
 afterEach(async () => {
-  await rm(join(homedir(), '.agentbox'), { recursive: true, force: true });
+  await resetTempAgentboxHome();
 });
 afterAll(async () => {
   await rm(TEST_HOME, { recursive: true, force: true });

--- a/packages/config/test/concurrent-set.test.ts
+++ b/packages/config/test/concurrent-set.test.ts
@@ -1,9 +1,10 @@
 import { mkdtemp, realpath, rm } from 'node:fs/promises';
-import { homedir, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { loadEffectiveConfig } from '../src/load.js';
 import { setConfigValue, unsetConfigValue } from '../src/write.js';
+import { resetTempAgentboxHome } from '../../../scripts/test-home.js';
 
 let tmpCwd: string;
 
@@ -13,7 +14,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await rm(tmpCwd, { recursive: true, force: true });
-  await rm(join(homedir(), '.agentbox'), { recursive: true, force: true });
+  await resetTempAgentboxHome();
 });
 
 // Two image bakes now run in parallel (one per provider) and each pins its own

--- a/packages/config/test/home-guard.test.ts
+++ b/packages/config/test/home-guard.test.ts
@@ -1,0 +1,45 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { assertTempHome, resetTempAgentboxHome } from '../../../scripts/test-home.js';
+
+/**
+ * The guard that stands between a mis-wired test setup and the developer's real
+ * `~/.agentbox`. Several suites `rm -rf $HOME/.agentbox` between tests; when a
+ * root-level `vitest run` dropped the per-package `setupFiles`, that deleted a
+ * real home (secrets.env, state.json, hub token). The workspace file fixes the
+ * wiring; this refuses to delete if the wiring ever breaks again.
+ */
+const REAL_HOME = process.env['HOME'];
+
+afterEach(() => {
+  if (REAL_HOME !== undefined) process.env['HOME'] = REAL_HOME;
+});
+
+describe('temp-home guard', () => {
+  it('accepts a HOME inside the OS temp dir', () => {
+    const home = mkdtempSync(join(tmpdir(), 'agentbox-guard-ok-'));
+    process.env['HOME'] = home;
+    expect(assertTempHome()).toBeTruthy();
+  });
+
+  it('accepts the temp HOME this suite already runs under', () => {
+    expect(() => assertTempHome()).not.toThrow();
+  });
+
+  it('refuses a HOME outside the temp dir', () => {
+    process.env['HOME'] = '/Users/somebody';
+    expect(() => assertTempHome()).toThrow(/not an isolated temp dir/);
+  });
+
+  it('refuses to delete .agentbox under a non-temp HOME', async () => {
+    process.env['HOME'] = '/Users/somebody';
+    await expect(resetTempAgentboxHome()).rejects.toThrow(/refusing to touch/);
+  });
+
+  it('names the likely cause so the failure is self-diagnosing', () => {
+    process.env['HOME'] = '/Users/somebody';
+    expect(() => assertTempHome()).toThrow(/vitest\.workspace\.ts/);
+  });
+});

--- a/packages/config/test/home-guard.test.ts
+++ b/packages/config/test/home-guard.test.ts
@@ -28,6 +28,14 @@ describe('temp-home guard', () => {
     expect(() => assertTempHome()).not.toThrow();
   });
 
+  it('refuses HOME set to the temp dir ITSELF (HOME=/tmp in containers/CI)', () => {
+    // A real configuration, and there `$HOME/.agentbox` is real state. Every
+    // legitimate setup here mkdtemps a subdirectory, so equality is only ever
+    // the dangerous case.
+    process.env['HOME'] = tmpdir();
+    expect(() => assertTempHome()).toThrow(/not an isolated temp dir/);
+  });
+
   it('refuses a HOME outside the temp dir', () => {
     process.env['HOME'] = '/Users/somebody';
     expect(() => assertTempHome()).toThrow(/not an isolated temp dir/);

--- a/packages/config/test/merge-precedence.test.ts
+++ b/packages/config/test/merge-precedence.test.ts
@@ -1,9 +1,10 @@
 import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
-import { homedir, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { loadEffectiveConfig } from '../src/load.js';
 import { GLOBAL_CONFIG_FILE, projectConfigFile } from '../src/paths.js';
+import { resetTempAgentboxHome } from '../../../scripts/test-home.js';
 
 let tmpCwd: string;
 
@@ -16,7 +17,7 @@ beforeEach(async () => {
 afterEach(async () => {
   await rm(tmpCwd, { recursive: true, force: true });
   // Wipe the per-file temp HOME between tests.
-  await rm(join(homedir(), '.agentbox'), { recursive: true, force: true });
+  await resetTempAgentboxHome();
 });
 
 async function writeYamlAt(path: string, body: string): Promise<void> {
@@ -104,18 +105,12 @@ describe('layered merge precedence', () => {
   });
 
   it('integrations.notion.enabled cascades global → project → cli', async () => {
-    await writeYamlAt(
-      GLOBAL_CONFIG_FILE,
-      'integrations:\n  notion:\n    enabled: true\n',
-    );
+    await writeYamlAt(GLOBAL_CONFIG_FILE, 'integrations:\n  notion:\n    enabled: true\n');
     const fromGlobal = await loadEffectiveConfig(tmpCwd);
     expect(fromGlobal.effective.integrations.notion.enabled).toBe(true);
     expect(fromGlobal.sources['integrations.notion.enabled']).toBe('global');
 
-    await writeYamlAt(
-      projectConfigFile(tmpCwd),
-      'integrations:\n  notion:\n    enabled: false\n',
-    );
+    await writeYamlAt(projectConfigFile(tmpCwd), 'integrations:\n  notion:\n    enabled: false\n');
     const fromProject = await loadEffectiveConfig(tmpCwd);
     expect(fromProject.effective.integrations.notion.enabled).toBe(false);
     expect(fromProject.sources['integrations.notion.enabled']).toBe('project');

--- a/packages/config/test/meta-json.test.ts
+++ b/packages/config/test/meta-json.test.ts
@@ -1,10 +1,11 @@
 import { readFile, realpath } from 'node:fs/promises';
 import { mkdtemp, rm } from 'node:fs/promises';
-import { homedir, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { hashProjectPath, projectMetaFile } from '../src/paths.js';
 import { listProjectsConfigured, setConfigValue, unsetConfigValue } from '../src/write.js';
+import { resetTempAgentboxHome } from '../../../scripts/test-home.js';
 
 let tmpCwd: string;
 
@@ -16,7 +17,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await rm(tmpCwd, { recursive: true, force: true });
-  await rm(join(homedir(), '.agentbox'), { recursive: true, force: true });
+  await resetTempAgentboxHome();
 });
 
 interface Meta {

--- a/packages/config/test/parse-unknown-keys.test.ts
+++ b/packages/config/test/parse-unknown-keys.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { parseUserConfig } from '../src/parse.js';
 import { loadEffectiveConfig, setConfigWarningSink } from '../src/load.js';
 import { UserConfigError } from '../src/types.js';
+import { resetTempAgentboxHome } from '../../../scripts/test-home.js';
 
 /**
  * Unknown keys must WARN, never throw. The parser is inlined into provider
@@ -73,7 +74,7 @@ describe('loadEffectiveConfig surfaces warnings', () => {
   afterEach(async () => {
     setConfigWarningSink(null);
     await rm(cwd, { recursive: true, force: true });
-    await rm(join(homedir(), '.agentbox'), { recursive: true, force: true });
+    await resetTempAgentboxHome();
   });
 
   it('collects warnings on LoadedConfig and emits them to the sink', async () => {

--- a/packages/config/test/preserve-unknown-keys.test.ts
+++ b/packages/config/test/preserve-unknown-keys.test.ts
@@ -1,10 +1,11 @@
 import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
-import { homedir, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { GLOBAL_CONFIG_FILE } from '../src/paths.js';
 import { setConfigValue, unsetConfigValue } from '../src/write.js';
 import { parse as parseYaml } from 'yaml';
+import { resetTempAgentboxHome } from '../../../scripts/test-home.js';
 
 /**
  * `config set` rewrites the whole file from the doc it read back. Now that the
@@ -22,7 +23,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await rm(tmpCwd, { recursive: true, force: true });
-  await rm(join(homedir(), '.agentbox'), { recursive: true, force: true });
+  await resetTempAgentboxHome();
 });
 
 describe('unknown keys survive a write', () => {

--- a/packages/config/test/prune-project-configs.test.ts
+++ b/packages/config/test/prune-project-configs.test.ts
@@ -1,7 +1,8 @@
 import { mkdtemp, realpath, rm, stat } from 'node:fs/promises';
-import { homedir, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resetTempAgentboxHome } from '../../../scripts/test-home.js';
 import { projectConfigDir } from '../src/paths.js';
 import {
   bumpProjectGcCounter,
@@ -18,7 +19,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await rm(tmpCwd, { recursive: true, force: true });
-  await rm(join(homedir(), '.agentbox'), { recursive: true, force: true });
+  await resetTempAgentboxHome();
 });
 
 async function exists(p: string): Promise<boolean> {

--- a/packages/config/test/set-unset-roundtrip.test.ts
+++ b/packages/config/test/set-unset-roundtrip.test.ts
@@ -1,12 +1,13 @@
 import { readFile, realpath } from 'node:fs/promises';
 import { mkdtemp, rm } from 'node:fs/promises';
-import { homedir, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { loadEffectiveConfig } from '../src/load.js';
 import { GLOBAL_CONFIG_FILE, projectConfigFile } from '../src/paths.js';
 import { setConfigValue, unsetConfigValue } from '../src/write.js';
 import { parse as parseYaml } from 'yaml';
+import { resetTempAgentboxHome } from '../../../scripts/test-home.js';
 
 let tmpCwd: string;
 
@@ -18,7 +19,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await rm(tmpCwd, { recursive: true, force: true });
-  await rm(join(homedir(), '.agentbox'), { recursive: true, force: true });
+  await resetTempAgentboxHome();
 });
 
 describe('set/unset roundtrip', () => {
@@ -51,7 +52,9 @@ describe('set/unset roundtrip', () => {
     expect(yaml['box']).toEqual({ vnc: false });
 
     await unsetConfigValue('global', 'box.vnc', tmpCwd);
-    yaml = (parseYaml(await readFile(GLOBAL_CONFIG_FILE, 'utf8')) as Record<string, unknown> | null) ?? {};
+    yaml =
+      (parseYaml(await readFile(GLOBAL_CONFIG_FILE, 'utf8')) as Record<string, unknown> | null) ??
+      {};
     expect(yaml).not.toHaveProperty('box');
   });
 
@@ -61,9 +64,7 @@ describe('set/unset roundtrip', () => {
   });
 
   it('set rejects unknown keys', async () => {
-    await expect(
-      setConfigValue('global', 'foo.bar', 'x', tmpCwd, { raw: true }),
-    ).rejects.toThrow();
+    await expect(setConfigValue('global', 'foo.bar', 'x', tmpCwd, { raw: true })).rejects.toThrow();
   });
 
   it('set rejects type-mismatched strings', async () => {
@@ -87,9 +88,10 @@ describe('set/unset roundtrip', () => {
 
     await unsetConfigValue('project', 'integrations.notion.enabled', tmpCwd);
     const after =
-      (parseYaml(await readFile(projectConfigFile(tmpCwd), 'utf8')) as
-        | Record<string, unknown>
-        | null) ?? {};
+      (parseYaml(await readFile(projectConfigFile(tmpCwd), 'utf8')) as Record<
+        string,
+        unknown
+      > | null) ?? {};
     // Both the deepest leaf AND the empty `notion` / `integrations` parents
     // must be pruned so the YAML stays tidy.
     expect(after).not.toHaveProperty('integrations');

--- a/packages/config/test/setup.ts
+++ b/packages/config/test/setup.ts
@@ -1,9 +1,8 @@
-import { mkdtempSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-
 // Per-file isolated HOME — vitest runs this setup file before the test file's
 // static imports evaluate, so the HOME-derived constants in @agentbox/config
-// (GLOBAL_CONFIG_FILE, PROJECTS_DIR) point inside this temp dir.
-const tempHome = mkdtempSync(join(tmpdir(), 'agentbox-cfg-home-'));
-process.env['HOME'] = tempHome;
+// (GLOBAL_CONFIG_FILE, PROJECTS_DIR) point inside this temp dir. These suites
+// delete `$HOME/.agentbox` between tests, so this relocation is load-bearing,
+// not a tidiness measure.
+import { useTempHome } from '../../../scripts/test-home.js';
+
+useTempHome('agentbox-cfg-home-');

--- a/packages/config/test/unregister-project.test.ts
+++ b/packages/config/test/unregister-project.test.ts
@@ -1,9 +1,10 @@
 import { mkdtemp, realpath, rm, stat } from 'node:fs/promises';
-import { homedir, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { hashProjectPath, projectConfigDir } from '../src/paths.js';
 import { listProjectsConfigured, registerProject, unregisterProject } from '../src/write.js';
+import { resetTempAgentboxHome } from '../../../scripts/test-home.js';
 
 let tmpCwd: string;
 
@@ -13,7 +14,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await rm(tmpCwd, { recursive: true, force: true });
-  await rm(join(homedir(), '.agentbox'), { recursive: true, force: true });
+  await resetTempAgentboxHome();
 });
 
 async function exists(p: string): Promise<boolean> {

--- a/packages/sandbox-cloud/test/prepared-sync.test.ts
+++ b/packages/sandbox-cloud/test/prepared-sync.test.ts
@@ -1,8 +1,9 @@
 import { mkdtempSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
-import { homedir, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, afterEach, describe, expect, it } from 'vitest';
+import { resetTempAgentboxHome } from '../../../scripts/test-home.js';
 
 // Redirect HOME before importing anything that resolves ~/.agentbox — prepared
 // state lives there and these tests write it.
@@ -15,12 +16,11 @@ const {
   pushPreparedToCustody,
   writePreparedToCustodyStore,
 } = await import('../src/prepared-sync.js');
-const { claudeInstallFingerprint, readPreparedStateRaw, writePreparedStateRaw } = await import(
-  '@agentbox/sandbox-core'
-);
+const { claudeInstallFingerprint, readPreparedStateRaw, writePreparedStateRaw } =
+  await import('@agentbox/sandbox-core');
 
 afterEach(async () => {
-  await rm(join(homedir(), '.agentbox'), { recursive: true, force: true });
+  await resetTempAgentboxHome();
 });
 afterAll(async () => {
   await rm(TEST_HOME, { recursive: true, force: true });
@@ -91,7 +91,8 @@ describe('pushPreparedToCustody', () => {
 
   it('reports failure rather than throwing when the control box rejects it', async () => {
     writePreparedStateRaw('hetzner', record(FINGERPRINT));
-    const fetchImpl = (() => Promise.resolve(new Response(null, { status: 500 }))) as unknown as typeof fetch;
+    const fetchImpl = (() =>
+      Promise.resolve(new Response(null, { status: 500 }))) as unknown as typeof fetch;
     await expect(pushPreparedToCustody('hetzner', target(fetchImpl))).resolves.toBe(false);
   });
 });
@@ -144,7 +145,8 @@ describe('pullPreparedFromCustody', () => {
 
   it('treats a 400 from an older control box like "nothing shared"', async () => {
     // A control box predating the `prepared` scope rejects the path outright.
-    const fetchImpl = (() => Promise.resolve(new Response(null, { status: 400 }))) as unknown as typeof fetch;
+    const fetchImpl = (() =>
+      Promise.resolve(new Response(null, { status: 400 }))) as unknown as typeof fetch;
     await expect(pullPreparedFromCustody('e2b', FINGERPRINT, target(fetchImpl))).resolves.toEqual({
       adopted: false,
     });
@@ -164,7 +166,7 @@ describe('pullPreparedFromCustody', () => {
     await pushPreparedToCustody('e2b', target(fetchImpl));
 
     // Machine B: same CLI (same fingerprint), nothing baked locally.
-    await rm(join(homedir(), '.agentbox'), { recursive: true, force: true });
+    await resetTempAgentboxHome();
     expect(readPreparedStateRaw('e2b')).toBeNull();
     const { fetchImpl: fetchB } = fakeCustody({ 'prepared/e2b.json': puts[0]!.body });
     const res = await pullPreparedFromCustody('e2b', FINGERPRINT, target(fetchB));

--- a/scripts/test-home.ts
+++ b/scripts/test-home.ts
@@ -1,0 +1,59 @@
+/**
+ * Temp-`$HOME` isolation shared by every suite that writes under `~/.agentbox`.
+ *
+ * Lives in `scripts/` (not a package) so all four suites — config, sandbox-cloud,
+ * cli, hub — import the SAME guard by relative path without inventing a
+ * workspace dependency edge between test dirs.
+ *
+ * Why a guard at all: these suites `rm -rf` `$HOME/.agentbox` between tests. If
+ * `$HOME` is not actually relocated, that deletes the developer's real secrets,
+ * box registry and hub token. It has happened. `setupFiles` does the relocation,
+ * but a setup file that silently fails to load (a missing root workspace config,
+ * a package with no `vitest.config.ts`) is invisible — so the destructive call
+ * itself refuses to run unless the relocation demonstrably took effect.
+ */
+import { mkdtempSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import { join, resolve, sep } from 'node:path';
+
+/** Point `$HOME` at a fresh temp dir. Call from a `setupFiles` module ONLY. */
+export function useTempHome(prefix: string): string {
+  const home = mkdtempSync(join(tmpdir(), prefix));
+  process.env['HOME'] = home;
+  process.env['USERPROFILE'] = home;
+  return home;
+}
+
+/**
+ * Throw unless `os.homedir()` resolves inside the OS temp dir. Both paths go
+ * through `realpath`-insensitive `resolve` — on macOS `tmpdir()` is a
+ * `/var → /private/var` symlink, so a raw prefix compare gives false negatives.
+ */
+export function assertTempHome(): string {
+  const home = resolve(homedir());
+  const tmp = resolve(tmpdir());
+  const under = home === tmp || home.startsWith(tmp.endsWith(sep) ? tmp : tmp + sep);
+  // Compare the realpath-collapsed forms too (/var vs /private/var on macOS).
+  const collapsed = home.replace(/^\/private\//, '/');
+  const tmpCollapsed = tmp.replace(/^\/private\//, '/');
+  const underCollapsed =
+    collapsed === tmpCollapsed ||
+    collapsed.startsWith(tmpCollapsed.endsWith(sep) ? tmpCollapsed : tmpCollapsed + sep);
+  if (!under && !underCollapsed) {
+    throw new Error(
+      `refusing to touch ${home}/.agentbox: $HOME is not an isolated temp dir.\n` +
+        `This suite deletes $HOME/.agentbox between tests, so running it against a real ` +
+        `home would destroy secrets.env, state.json and the hub token.\n` +
+        `Its vitest setupFiles did not run — use \`pnpm test\`, or check that the root ` +
+        `vitest.workspace.ts still lists this package and that it has a vitest.config.ts.`,
+    );
+  }
+  return home;
+}
+
+/** `rm -rf $HOME/.agentbox`, but only ever inside a verified temp home. */
+export async function resetTempAgentboxHome(): Promise<void> {
+  const home = assertTempHome();
+  await rm(join(home, '.agentbox'), { recursive: true, force: true });
+}

--- a/scripts/test-home.ts
+++ b/scripts/test-home.ts
@@ -26,21 +26,26 @@ export function useTempHome(prefix: string): string {
 }
 
 /**
- * Throw unless `os.homedir()` resolves inside the OS temp dir. Both paths go
- * through `realpath`-insensitive `resolve` — on macOS `tmpdir()` is a
- * `/var → /private/var` symlink, so a raw prefix compare gives false negatives.
+ * Throw unless `os.homedir()` resolves to a subdirectory INSIDE the OS temp dir.
+ *
+ * Strictly below, never equal: `HOME=/tmp` is a real configuration (containers,
+ * some CI images), and there the home's `.agentbox` is real state. Every caller
+ * here `mkdtemp`s a subdirectory, so equality is never something a legitimate
+ * setup produces — accepting it would only ever green-light the deletion this
+ * guard exists to stop.
+ *
+ * Both paths go through `resolve` — and the `/private` form is compared too,
+ * because on macOS `tmpdir()` is a `/var → /private/var` symlink and a raw
+ * prefix compare gives false negatives.
  */
 export function assertTempHome(): string {
   const home = resolve(homedir());
   const tmp = resolve(tmpdir());
-  const under = home === tmp || home.startsWith(tmp.endsWith(sep) ? tmp : tmp + sep);
-  // Compare the realpath-collapsed forms too (/var vs /private/var on macOS).
-  const collapsed = home.replace(/^\/private\//, '/');
-  const tmpCollapsed = tmp.replace(/^\/private\//, '/');
-  const underCollapsed =
-    collapsed === tmpCollapsed ||
-    collapsed.startsWith(tmpCollapsed.endsWith(sep) ? tmpCollapsed : tmpCollapsed + sep);
-  if (!under && !underCollapsed) {
+  const strictlyUnder = (child: string, parent: string): boolean =>
+    child !== parent && child.startsWith(parent.endsWith(sep) ? parent : parent + sep);
+  const collapse = (p: string): string => p.replace(/^\/private\//, '/');
+  const under = strictlyUnder(home, tmp) || strictlyUnder(collapse(home), collapse(tmp));
+  if (!under) {
     throw new Error(
       `refusing to touch ${home}/.agentbox: $HOME is not an isolated temp dir.\n` +
         `This suite deletes $HOME/.agentbox between tests, so running it against a real ` +

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,19 @@
+/**
+ * Root vitest workspace.
+ *
+ * Without this file, `vitest` run from the repo root discovers every package's
+ * tests under ONE implicit root config and silently drops each package's own
+ * `vitest.config.ts` — including its `setupFiles`.
+ *
+ * That is not cosmetic. `packages/config`'s suites import the HOME-derived
+ * constants STATICALLY (GLOBAL_CONFIG_FILE, PROJECTS_DIR), so the only place
+ * that can relocate `$HOME` in time is a setup file. Drop it and those suites
+ * run against the real home — and their `afterEach` deletes `$HOME/.agentbox`,
+ * taking secrets.env, state.json and the hub token with it.
+ *
+ * `pnpm test` (turbo → per-package `vitest`) always loaded those configs; this
+ * makes a root-level `pnpm vitest run` behave identically. `assertTempHome` in
+ * `scripts/test-home.ts` is the backstop that fails loudly rather than deleting
+ * if this wiring is ever broken again.
+ */
+export default ['packages/*', 'apps/cli', 'apps/hub'];


### PR DESCRIPTION
## The bug

`vitest` run from the repo root discovers every package's tests under **one implicit root config** and silently drops each package's own `vitest.config.ts` — including its `setupFiles`. There was no root workspace file, so nothing tied the two together.

`packages/config`'s suites import the HOME-derived constants (`GLOBAL_CONFIG_FILE`, `PROJECTS_DIR`) **statically**, so the only thing that can relocate `$HOME` in time is `test/setup.ts`. Drop it and those suites run against the developer's real home — and their `afterEach` does:

```ts
await rm(join(homedir(), '.agentbox'), { recursive: true, force: true });
```

That deletes `secrets.env` (every cloud provider credential), `state.json` (the box registry), `hub/token`, `logs/`, and the `*-prepared.json` bake records. It is not hypothetical — it happened on this machine during this work, which is how it was found. `pnpm test` (turbo → per-package vitest) was always safe; a plain `pnpm vitest run` was not, and nothing signalled the difference.

## The fix

Two layers, deliberately.

**Cause** — `vitest.workspace.ts` at the root, so a root-level run loads the per-package configs and the temp-`$HOME` relocation actually happens.

**Effect** — `scripts/test-home.ts` exports `assertTempHome()` / `resetTempAgentboxHome()`. All 15 destructive call sites (config ×8, sandbox-cloud ×2, cli ×5) now go through the guard, which refuses to delete unless `homedir()` is verifiably under `tmpdir()` — handling the macOS `/var`→`/private/var` symlink so the check can't false-negative. The error names the likely cause, so a future regression is self-diagnosing instead of silently destructive.

`apps/cli` and `packages/sandbox-cloud` already self-isolate (module-level temp `$HOME` + dynamic `import()`), so they needed the guard but not a setup file — adding one there broke the PTY drive harness, which needs the real home.

## Verification

- `pnpm vitest run` from the root: **384 files / 3892 tests pass**, and a canary file planted in `~/.agentbox` survives.
- Deliberately deleting `vitest.workspace.ts` to recreate the exact broken condition and re-running `merge-precedence.test.ts`: every case now fails with `refusing to touch /Users/marco/.agentbox: $HOME is not an isolated temp dir`, and the canary still survives.
- `pnpm typecheck` and `pnpm lint` green.
- New `packages/config/test/home-guard.test.ts` covers accept/refuse and asserts the message names the workspace file.

https://claude.ai/code/session_01UHCTcn1S1s9a87iwcd9JfJ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test harness and Vitest workspace wiring; production code is untouched and the guard reduces risk of accidental local data loss during tests.
> 
> **Overview**
> Root-level `vitest run` used to ignore per-package `vitest.config.ts` (including `setupFiles`), so suites that `rm -rf $HOME/.agentbox` in teardown could hit the developer’s real home. This PR adds **`vitest.workspace.ts`** so a repo-root run loads the same package configs as `pnpm test`.
> 
> A shared **`scripts/test-home.ts`** centralizes temp `$HOME` setup (`useTempHome`) and replaces bare deletes with **`resetTempAgentboxHome()`**, which only runs after **`assertTempHome()`** verifies `homedir()` is under the OS temp dir (including macOS `/var` vs `/private/var`). **`packages/config/test/setup.ts`** and **15** CLI/config/sandbox-cloud teardown sites now use that helper; **`home-guard.test.ts`** locks in refuse-to-delete behavior and a message that points at the workspace wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74d4e2fa8086efc1ffc313f524153f5c12bee040. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->