### PR TITLE
feat(providers): declarative ProviderDescriptor — community providers in the hub, tray and CLI

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -11,6 +11,16 @@ CLI, not the raw commits.
 
 ## [Unreleased]
 
+### Added
+
+- Community providers now appear in the create pickers (web UI and tray) and get
+  a real credential form, from a new `ProviderDescriptor` a plugin declares and
+  `agentbox plugin add` snapshots. Existing plugins keep working unchanged —
+  declaring one is optional.
+- `agentbox code`, `open`, `prune`, `checkpoint set-default` and `fork` now gate
+  on a provider's declared capabilities instead of hardcoded name lists, so a
+  plugin that supports them gets them. DigitalOcean gains `code`/`open` this way.
+
 ### Fixed
 
 - `relay.port` now actually moves the host daemon. It was documented and

--- a/apps/cli/src/commands/_open-in.ts
+++ b/apps/cli/src/commands/_open-in.ts
@@ -11,6 +11,7 @@
 import { existsSync as realExistsSync } from 'node:fs';
 import { homedir as realHomedir } from 'node:os';
 import { delimiter, join } from 'node:path';
+import { listProviderDescriptors } from '@agentbox/sandbox-core';
 
 // `finder` is a first-class open target: `agentbox open <box>` (no `--in`) is
 // equivalent to `--in finder` and sshfs-mounts /workspace + reveals it. It's an
@@ -30,6 +31,22 @@ export const OPEN_IN_APPS: readonly OpenInApp[] = [
 ];
 
 /**
+ * Providers matching a capability, from the descriptor table — built-ins AND
+ * registered plugins. Sync + offline (the descriptor is a snapshot, never a
+ * module load), which is what `detectOpenTargets` needs: it must stay a cheap
+ * fs-only probe.
+ *
+ * These replaced hardcoded name arrays, so a community provider that declares
+ * the capability is listed here automatically instead of being permanently
+ * opted out.
+ */
+function providersWith(cap: 'persistentSsh' | 'ssh'): string[] {
+  return listProviderDescriptors()
+    .filter((d) => d.capabilities[cap])
+    .map((d) => d.name);
+}
+
+/**
  * Providers whose per-box SSH identity outlives the CLI call (see
  * packages/sandbox-core/src/cloud-ssh.ts). Codex connects on its own later, so
  * an expiring token credential (Daytona) or no SSH at all (vercel/e2b)
@@ -37,35 +54,21 @@ export const OPEN_IN_APPS: readonly OpenInApp[] = [
  * per-box key that persists under the box dir (only the loopback host port
  * changes across restart, and `agentbox open`/start re-syncs `~/.ssh/config`).
  */
-export const PERSISTENT_SSH_PROVIDERS: readonly string[] = [
-  'docker',
-  'hetzner',
-  // remote-docker qualifies for the same reason docker does: a per-box key that
-  // outlives the CLI call. Its box sshd is reached by `ProxyJump`ing through the
-  // engine (ssh's own transport — no AgentBox-held tunnel to keep alive), and
-  // start/open re-resolve the published port into `~/.ssh/config`.
-  'remote-docker',
-];
+export function persistentSshProviders(): string[] {
+  return providersWith('persistentSsh');
+}
 
 /**
- * Providers `agentbox code` can attach an IDE to: docker via the Dev Containers
- * attached-container URI, clouds via a Remote-SSH alias.
+ * Providers `agentbox code` can attach an IDE to (docker via the Dev Containers
+ * attached-container URI, clouds via a Remote-SSH alias) and `agentbox open` can
+ * sshfs-mount `/workspace` from. Both need the same thing — real SSH into the
+ * box — so both read `capabilities.ssh`. Vercel/E2B have none (their
+ * `buildAttach` yields an SDK PTY bridge), so `open` fails fast with a readable
+ * pointer to `agentbox download`.
  */
-export const IDE_PROVIDERS: readonly string[] = ['docker', 'hetzner', 'daytona', 'remote-docker'];
-
-/**
- * Providers `agentbox open` can sshfs-mount `/workspace` from — they expose real
- * SSH: docker's localhost sshd, Hetzner's VPS, Daytona's token gateway. Vercel/E2B
- * have no SSH (their `buildAttach` yields a non-SSH `sbx exec` / SDK PTY bridge),
- * so `open` fails fast with a readable pointer to `agentbox download`. Plugin
- * providers stay opted out until they declare SSH support.
- */
-export const SSH_MOUNT_PROVIDERS: readonly string[] = [
-  'docker',
-  'hetzner',
-  'daytona',
-  'remote-docker',
-];
+export function sshProviders(): string[] {
+  return providersWith('ssh');
+}
 
 export interface DetectSeams {
   env: NodeJS.ProcessEnv;
@@ -163,7 +166,10 @@ const VSCODE_APPS: readonly VscodeApp[] = [
  * is a flavor CLI name (`code` / `cursor`); returns undefined when neither the
  * CLI nor its bundle is present.
  */
-export function resolveVscodeCli(cli: string, seams: DetectSeams = realSeams()): string | undefined {
+export function resolveVscodeCli(
+  cli: string,
+  seams: DetectSeams = realSeams(),
+): string | undefined {
   if (pathHasBinary(cli, seams)) return cli;
   if (seams.platform !== 'darwin') return undefined;
   const app = VSCODE_APPS.find((a) => a.cli === cli);
@@ -196,7 +202,10 @@ export function resolveCmuxBinary(seams: DetectSeams = realSeams()): string | un
 }
 
 /** `{ available, reason? }` — reason present only when unavailable. */
-function targetInfo(available: boolean, reason: string): Pick<OpenTargetInfo, 'available' | 'reason'> {
+function targetInfo(
+  available: boolean,
+  reason: string,
+): Pick<OpenTargetInfo, 'available' | 'reason'> {
   return available ? { available } : { available, reason };
 }
 
@@ -208,11 +217,11 @@ export function detectOpenTargets(seams: DetectSeams = realSeams()): OpenTargets
       // box into the app's own settings (sshConfigs) instead — same persistent
       // SSH requirement as codex, since the app connects on its own later.
       ...targetInfo(macAppInstalled('Claude.app', seams), 'Claude desktop is not installed'),
-      providers: [...PERSISTENT_SSH_PROVIDERS],
+      providers: persistentSshProviders(),
     },
     codex: {
       ...targetInfo(macAppInstalled('Codex.app', seams), 'Codex is not installed'),
-      providers: [...PERSISTENT_SSH_PROVIDERS],
+      providers: persistentSshProviders(),
     },
     herdr: targetInfo(
       pathHasBinary('herdr', seams) || defaultHerdrSocketPath(seams) !== undefined,
@@ -230,7 +239,7 @@ export function detectOpenTargets(seams: DetectSeams = realSeams()): OpenTargets
         VSCODE_APPS.some((a) => pathHasBinary(a.cli, seams) || macAppInstalled(a.appName, seams)),
         'VS Code / Cursor is not installed',
       ),
-      providers: [...IDE_PROVIDERS],
+      providers: sshProviders(),
     },
     iterm2: targetInfo(macAppInstalled('iTerm.app', seams), 'iTerm2 is not installed'),
     finder: {
@@ -241,7 +250,7 @@ export function detectOpenTargets(seams: DetectSeams = realSeams()): OpenTargets
         pathHasBinary('sshfs', seams),
         'sshfs is not installed — install with `brew install macfuse sshfs`',
       ),
-      providers: [...SSH_MOUNT_PROVIDERS],
+      providers: sshProviders(),
     },
   };
 }

--- a/apps/cli/src/commands/checkpoint.ts
+++ b/apps/cli/src/commands/checkpoint.ts
@@ -1,7 +1,6 @@
 import { confirm, log } from '../lib/prompt.js';
 import { Command } from 'commander';
 import {
-  CLOUD_PROVIDER_NAMES,
   defaultCheckpointConfigKey,
   findProjectRoot,
   setConfigValue,
@@ -16,6 +15,7 @@ import type {
 } from '../control-plane/hub-api-client.js';
 import { boxOwningHubIsLocal, withHubClient, withOwningHub } from '../control-plane/with-hub.js';
 import { handleLifecycleError } from './_errors.js';
+import { listProviderDescriptors, resolveProviderDescriptor } from '@agentbox/sandbox-core';
 
 /**
  * `agentbox checkpoint` — capture and manage the warm box states new boxes start
@@ -38,8 +38,22 @@ import { handleLifecycleError } from './_errors.js';
  * of path-hash-keyed stores, not a routing gap.)
  */
 
-/** Docker + built-in cloud providers, for `set-default --provider` validation. */
-const KNOWN_PROVIDERS: ProviderKind[] = ['docker', ...CLOUD_PROVIDER_NAMES];
+/**
+ * Providers `set-default --provider` accepts: every runtime provider — built-in
+ * or registered plugin — that supports checkpoints at all. Read from the
+ * descriptor rather than a hardcoded list, so a community provider with a
+ * `checkpoint` capability can carry a project default like any built-in.
+ */
+function checkpointProviders(): string[] {
+  return listProviderDescriptors()
+    .filter((d) => d.capabilities.checkpoints)
+    .map((d) => d.name);
+}
+
+/** Whether capturing a checkpoint stops and reboots the box (vercel, daytona). */
+function checkpointReboots(name: string): boolean {
+  return resolveProviderDescriptor(name)?.capabilities.checkpointReboots ?? false;
+}
 
 interface CreateOpts {
   name?: string;
@@ -75,11 +89,7 @@ const createSub = new Command('create')
       // The vercel/daytona snapshot stops + reboots the box (the live agent process
       // doesn't survive). Confirm here on the laptop before yanking it — a TTY
       // interaction that must stay client-side; -y skips it.
-      if (
-        (providerName === 'vercel' || providerName === 'daytona') &&
-        !opts.yes &&
-        process.stdin.isTTY
-      ) {
+      if (checkpointReboots(providerName) && !opts.yes && process.stdin.isTTY) {
         const ok = await confirm({
           message: `Create checkpoint? The ${providerName} box will stop and reboot.`,
           initialValue: false,
@@ -197,21 +207,35 @@ const setDefaultSub = new Command('set-default')
   .option('--clear', 'unset the project default instead of setting one')
   .option(
     '--provider <name>',
-    'set the default for only this provider (docker|daytona|hetzner|vercel); without it, sets the cross-provider fallback',
+    'set the default for only this provider; without it, sets the cross-provider fallback',
   )
   .action(async (ref: string | undefined, opts: { clear?: boolean; provider?: string }) => {
     try {
       const projectRoot = (await findProjectRoot(process.cwd())).root;
       const providerArg = opts.provider as ProviderKind | undefined;
-      if (providerArg !== undefined && !KNOWN_PROVIDERS.includes(providerArg)) {
+      if (providerArg !== undefined && !checkpointProviders().includes(providerArg)) {
         throw new Error(
-          `unknown provider '${opts.provider ?? ''}' (known: ${KNOWN_PROVIDERS.join(', ')})`,
+          `unknown provider '${opts.provider ?? ''}' (known: ${checkpointProviders().join(', ')})`,
         );
       }
       const configKey = defaultCheckpointConfigKey(providerArg);
-      const label = providerArg
-        ? `${providerArg} default checkpoint`
-        : 'project default checkpoint';
+      // Only BUILT-IN providers have a `box.defaultCheckpoint<P>` key; for a
+      // plugin, `defaultCheckpointConfigKey` falls back to the generic
+      // `box.defaultCheckpoint`, which EVERY provider without its own default
+      // reads. Writing that silently under a `--provider` flag would hand a
+      // plugin's snapshot to docker boxes, so say so instead of implying a
+      // per-provider write happened.
+      const perProvider = configKey !== 'box.defaultCheckpoint';
+      if (providerArg !== undefined && !perProvider) {
+        log.warn(
+          `${providerArg} is a plugin provider, which has no per-provider default key — ` +
+            `this sets the cross-provider ${configKey}, used by every provider without its own default.`,
+        );
+      }
+      const label =
+        providerArg && perProvider
+          ? `${providerArg} default checkpoint`
+          : 'project default checkpoint';
       if (opts.clear) {
         if (ref !== undefined) throw new Error('pass either a <ref> or --clear, not both');
         // Pure local config write — no hub round-trip needed to CLEAR a pointer.

--- a/apps/cli/src/commands/fork.ts
+++ b/apps/cli/src/commands/fork.ts
@@ -1,12 +1,12 @@
 import { log } from '@clack/prompts';
 import { Command } from 'commander';
-import { PROVIDER_NAMES } from '@agentbox/config';
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { detectHostTerminal } from '../terminal/host.js';
 import { encodeClaudeProjectsDir } from '../session-teleport/cwd-encoding.js';
 import { claudeCommand } from './claude.js';
+import { getRuntimeProviderNames } from '../provider/loaders.js';
 import { codexCommand } from './codex.js';
 import { opencodeCommand } from './opencode.js';
 
@@ -14,8 +14,11 @@ type ForkAgent = 'claude' | 'codex' | 'opencode';
 const FORK_AGENTS = ['claude', 'codex', 'opencode'] as const;
 
 /** Providers fork accepts positionally (`agentbox fork hetzner`) or via
- *  --provider. Sourced from the central `PROVIDERS` table (single source of truth). */
-const FORK_PROVIDERS = PROVIDER_NAMES;
+ *  --provider: every runtime provider, built-in or registered plugin. Resolved
+ *  per call, not at import — a plugin can be registered while the process runs. */
+function forkProviders(): string[] {
+  return getRuntimeProviderNames();
+}
 
 /** Resolve the provider from the positional arg (`agentbox fork <provider>`,
  *  the skill's `$ARGUMENTS` shape) and/or --provider. A blank value (an LLM
@@ -29,11 +32,13 @@ export function resolveForkProvider(
   const pos = positional?.trim();
   const fl = flag?.trim();
   if (pos && fl && pos !== fl) {
-    throw new Error(`provider given twice: "${pos}" (positional) and --provider "${fl}" — pass it once.`);
+    throw new Error(
+      `provider given twice: "${pos}" (positional) and --provider "${fl}" — pass it once.`,
+    );
   }
   const provider = fl || pos;
-  if (provider && !(FORK_PROVIDERS as readonly string[]).includes(provider)) {
-    throw new Error(`provider: expected one of ${FORK_PROVIDERS.join(', ')}, got "${provider}"`);
+  if (provider && !forkProviders().includes(provider)) {
+    throw new Error(`provider: expected one of ${forkProviders().join(', ')}, got "${provider}"`);
   }
   return provider || undefined;
 }
@@ -149,7 +154,7 @@ function resolveAttachArgs(attachIn: string): string[] {
 
 export const forkCommand = new Command('fork')
   .description(
-    'Fork the current host agent session into a new box and resume it there. Autodetects the agent (Claude / Codex) and the current session from the launching agent\'s env, so a bare `agentbox fork` forks whatever you ran it from. Opens the box in a new terminal tab under iTerm/tmux; otherwise starts it in the background.',
+    "Fork the current host agent session into a new box and resume it there. Autodetects the agent (Claude / Codex) and the current session from the launching agent's env, so a bare `agentbox fork` forks whatever you ran it from. Opens the box in a new terminal tab under iTerm/tmux; otherwise starts it in the background.",
   )
   .argument(
     '[provider]',

--- a/apps/cli/src/commands/open.ts
+++ b/apps/cli/src/commands/open.ts
@@ -34,10 +34,10 @@ import {
   codexAddUrl,
   defaultHerdrSocketPath,
   detectOpenTargets,
-  PERSISTENT_SSH_PROVIDERS,
+  persistentSshProviders,
   renderTargets,
   resolveCmuxBinary,
-  SSH_MOUNT_PROVIDERS,
+  sshProviders,
   type OpenTarget,
 } from './_open-in.js';
 
@@ -84,10 +84,7 @@ export const openCommand = new Command('open')
   )
   .option('--path', 'print the host mount path instead of launching Finder')
   .option('--print', 'alias of --path')
-  .option(
-    '--unmount',
-    'unmount any existing sshfs mount for the box and exit',
-  )
+  .option('--unmount', 'unmount any existing sshfs mount for the box and exit')
   .option(
     '--in <app>',
     'open the box in a host app instead of Finder: codex | herdr | cmux | vscode | iterm2 | finder',
@@ -140,7 +137,7 @@ export const openCommand = new Command('open')
       // localhost sshd, Hetzner's VPS, Daytona's token gateway). A docker box
       // that predates the localhost sshd (no `sshEnabled`) still falls through to
       // the rsync-snapshot export below.
-      if (SSH_MOUNT_PROVIDERS.includes(providerName) && (providerName !== 'docker' || box.sshEnabled)) {
+      if (sshProviders().includes(providerName) && (providerName !== 'docker' || box.sshEnabled)) {
         await runSshfsMount(box, opts);
         return;
       }
@@ -188,7 +185,7 @@ export const openCommand = new Command('open')
  */
 async function ensurePersistentSshAlias(box: BoxRecord, appLabel: string): Promise<string> {
   const providerName = box.provider ?? 'docker';
-  if (!PERSISTENT_SSH_PROVIDERS.includes(providerName)) {
+  if (!persistentSshProviders().includes(providerName)) {
     throw new Error(
       `'--in ${appLabel.toLowerCase()}' needs a box with a persistent SSH key — docker (localhost sshd) and ` +
         `Hetzner cloud boxes qualify (this box is '${providerName}'). Daytona uses a 60-min ` +
@@ -197,7 +194,7 @@ async function ensurePersistentSshAlias(box: BoxRecord, appLabel: string): Promi
   }
 
   // A docker box created before the localhost sshd shipped has no SSH surface —
-  // `PERSISTENT_SSH_PROVIDERS` gates by provider, so catch that here with a clear
+  // `persistentSshProviders()` gates by provider, so catch that here with a clear
   // message instead of a confusing "sshd may have failed to start" downstream.
   if (providerName === 'docker' && !box.sshEnabled) {
     throw new Error(
@@ -383,7 +380,9 @@ async function openInTerminalApp(box: BoxRecord, host: 'herdr' | 'cmux' | 'iterm
           : ' Is iTerm2 installed?';
     throw new Error(`could not open in ${host}: ${r.error ?? 'unknown error'}.${hint}`);
   }
-  log.success(`opened ${box.name} in a new ${host} ${host === 'iterm2' ? 'window' : 'workspace'} (agentbox attach)`);
+  log.success(
+    `opened ${box.name} in a new ${host} ${host === 'iterm2' ? 'window' : 'workspace'} (agentbox attach)`,
+  );
 }
 
 /**
@@ -433,7 +432,7 @@ async function runSshfsMount(box: BoxRecord, opts: OpenOpts): Promise<void> {
   const sshfsBin = await locateBinary('sshfs');
   if (!sshfsBin) {
     throw new Error(
-      'sshfs not found on PATH. Install with `brew install macfuse sshfs` (macOS) or your distro\'s package manager, then retry. `agentbox open` mounts the box /workspace via sshfs.',
+      "sshfs not found on PATH. Install with `brew install macfuse sshfs` (macOS) or your distro's package manager, then retry. `agentbox open` mounts the box /workspace via sshfs.",
     );
   }
 
@@ -530,4 +529,3 @@ async function tryUnmount(path: string): Promise<boolean> {
   }
   return false;
 }
-

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -19,12 +19,14 @@ import { Command } from 'commander';
 import { confirm, log } from '../lib/prompt.js';
 import {
   addPluginRecord,
+  deriveDescriptor,
   isSupportedApiVersion,
   readPluginRegistrySync,
   removePluginRecord,
   SUPPORTED_SDK_API_VERSIONS,
+  type ProviderModule,
 } from '@agentbox/sandbox-core';
-import { PROVIDER_NAMES } from '@agentbox/config';
+import { PROVIDER_NAMES, type ProviderDescriptor } from '@agentbox/config';
 
 interface ResolvedPackage {
   packageName: string;
@@ -123,6 +125,12 @@ function pickEntry(pkgJson: { main?: string; module?: string; exports?: unknown 
 interface LoadedProvider {
   name: string;
   hasBackend: boolean;
+  /**
+   * What the module declares, else what could be derived from it. Snapshotted
+   * into the registry so every later consumer resolves capabilities without
+   * re-importing an external package.
+   */
+  descriptor: ProviderDescriptor;
 }
 
 /** Import the resolved package and validate it exposes provider module(s). */
@@ -130,8 +138,8 @@ async function loadAndValidate(
   pkg: ResolvedPackage,
 ): Promise<{ providers: LoadedProvider[]; apiVersion: number }> {
   const mod = (await import(pathToFileURL(pkg.entryPath).href)) as {
-    providerModule?: { provider?: { name?: string }; backend?: unknown };
-    providerModules?: { provider?: { name?: string }; backend?: unknown }[];
+    providerModule?: ProviderModule;
+    providerModules?: ProviderModule[];
     SDK_API_VERSION?: number;
     apiVersion?: number;
   };
@@ -145,14 +153,20 @@ async function loadAndValidate(
   for (const pm of all) {
     const name = pm.provider?.name;
     if (!name || typeof name !== 'string') {
-      throw new Error(`package "${pkg.packageName}" has a providerModule with no \`provider.name\``);
+      throw new Error(
+        `package "${pkg.packageName}" has a providerModule with no \`provider.name\``,
+      );
     }
     if ((PROVIDER_NAMES as readonly string[]).includes(name)) {
       throw new Error(
         `package "${pkg.packageName}" tries to register provider "${name}", which is a built-in — a plugin cannot shadow a built-in provider`,
       );
     }
-    providers.push({ name, hasBackend: Boolean(pm.backend) });
+    providers.push({
+      name,
+      hasBackend: Boolean(pm.backend),
+      descriptor: deriveDescriptor(name, pm),
+    });
   }
   const apiVersion = pkg.agentboxApiVersion ?? mod.apiVersion ?? mod.SDK_API_VERSION ?? 1;
   if (!isSupportedApiVersion(apiVersion)) {
@@ -222,6 +236,7 @@ pluginCommand
       resolvedEntry: pkg.entryPath,
       version: pkg.version,
       providers: validated.providers.map((p) => p.name),
+      descriptors: Object.fromEntries(validated.providers.map((p) => [p.name, p.descriptor])),
       apiVersion: validated.apiVersion,
       addedAt: new Date().toISOString(),
     });

--- a/apps/cli/src/commands/prune.ts
+++ b/apps/cli/src/commands/prune.ts
@@ -9,6 +9,7 @@ import type {
   HubApiPruneResult,
 } from '../control-plane/hub-api-client.js';
 import { handleLifecycleError } from './_errors.js';
+import { listProviderDescriptors, resolveProviderDescriptor } from '@agentbox/sandbox-core';
 
 /**
  * `agentbox prune` — fleet cleanup through the hub's public `/api/v1`
@@ -77,18 +78,21 @@ function summary(r: HubApiPruneResult, projectConfigs: string[]): string {
   return lines.length > 0 ? lines.join('\n') : '  (nothing to remove)';
 }
 
-/** Cloud providers whose orphan sandboxes `prune --provider <p>` can enumerate + delete. */
-const CLOUD_PRUNE_PROVIDERS = [
-  'daytona',
-  'hetzner',
-  'vercel',
-  'e2b',
-  'digitalocean',
-  'remote-docker',
-] as const;
-
+/**
+ * Whether `prune --provider <p>` can enumerate + delete this provider's orphan
+ * sandboxes — i.e. whether its backend implements `list`. Read from the
+ * descriptor rather than a hardcoded name list, so a community provider with a
+ * listable backend is prunable too.
+ */
 function isCloudPruneProvider(name: string): boolean {
-  return (CLOUD_PRUNE_PROVIDERS as readonly string[]).includes(name);
+  return resolveProviderDescriptor(name)?.capabilities.prune ?? false;
+}
+
+/** Prunable provider names, for the `--provider` error message. */
+function cloudPruneProviders(): string[] {
+  return listProviderDescriptors()
+    .filter((d) => d.capabilities.prune)
+    .map((d) => d.name);
 }
 
 export const pruneCommand = new Command('prune')
@@ -108,7 +112,7 @@ export const pruneCommand = new Command('prune')
       const provider = opts.provider;
       if (provider !== undefined && provider !== 'docker' && !isCloudPruneProvider(provider)) {
         log.error(
-          `unknown provider '${provider}'; expected docker, daytona, hetzner, vercel, e2b, or digitalocean`,
+          `unknown provider '${provider}'; expected docker or one of ${cloudPruneProviders().join(', ')}`,
         );
         process.exit(2);
       }

--- a/apps/cli/src/lib/cloud-sizing.ts
+++ b/apps/cli/src/lib/cloud-sizing.ts
@@ -1,8 +1,5 @@
-import {
-  resolveBoxSize,
-  resolveDaytonaClass,
-  type EffectiveConfig,
-} from '@agentbox/config';
+import { resolveBoxSize, resolveDaytonaClass, type EffectiveConfig } from '@agentbox/config';
+import { resolveProviderDescriptor } from '@agentbox/sandbox-core';
 
 /** Per-create overrides from the CLI; each wins over the resolved config value. */
 export interface CloudSizingFlags {
@@ -36,8 +33,12 @@ export interface CloudSizingFlags {
  * - **digitalocean**: `project` — the DO Project the box is placed in (name or
  *   UUID), from `box.digitaloceanProject`. Config-only, no flag. Absent = the
  *   account's default project.
- * - **hetzner + digitalocean**: `inbound` — per-box firewall access policy
- *   (`locked`/`open`/CIDR list), `--inbound` flag first, else `box.inbound`.
+ * - **any provider declaring `capabilities.inbound`** (hetzner + digitalocean
+ *   today): `inbound` — per-box firewall access policy (`locked`/`open`/CIDR
+ *   list), `--inbound` flag first, else `box.inbound`.
+ * - **any provider declaring `regions`**: an explicit `--location`. The built-in
+ *   arms above take precedence since they also read a per-provider config key;
+ *   this is the flag-only path a community provider gets.
  * - **vercel**: `timeoutMs` (session length before auto-snapshot), `networkPolicy`.
  * - **e2b**: `timeoutMs` — the session timeout the box is created with (and
  *   records as `cloud.sessionTimeoutMs`, which seeds the host keepalive loop so
@@ -61,6 +62,7 @@ export function cloudSizingProviderOptions(
 ): Record<string, unknown> {
   const size = flags.size?.trim() || resolveBoxSize(cfg, providerName);
   const out: Record<string, unknown> = size.length > 0 ? { size } : {};
+  const descriptor = resolveProviderDescriptor(providerName);
   if (providerName === 'hetzner') {
     const location = (flags.location?.trim() || cfg.box.hetznerLocation || '').trim();
     if (location.length > 0) out.location = location;
@@ -76,11 +78,20 @@ export function cloudSizingProviderOptions(
     const project = (cfg.box.digitaloceanProject || '').trim();
     if (project.length > 0) out.project = project;
   }
-  // VPS-only inbound-access policy (`--inbound` / `box.inbound`). Passed through
-  // to the backend's per-box firewall; other providers ignore it. Only emitted
-  // when non-default — the backend treats an absent value as `locked`, so the
-  // common case carries nothing.
-  if (providerName === 'hetzner' || providerName === 'digitalocean') {
+  // An explicit `--location` for a provider with no per-provider region config
+  // key of its own — i.e. a community provider that declares `regions`. The
+  // built-in arms above win because they also read their config key; this is the
+  // flag-only path, so a plugin isn't silently denied a region it supports.
+  if (out.location === undefined && descriptor?.regions?.length) {
+    const location = flags.location?.trim() ?? '';
+    if (location.length > 0) out.location = location;
+  }
+  // Per-box inbound-access policy (`--inbound` / `box.inbound`), for providers
+  // whose backend implements `setInbound`. Passed through to the per-box
+  // firewall; other providers ignore it. Only emitted when non-default — the
+  // backend treats an absent value as `locked`, so the common case carries
+  // nothing.
+  if (descriptor?.capabilities.inbound) {
     const inbound = (flags.inbound?.trim() || cfg.box.inbound || '').trim();
     if (inbound.length > 0 && !/^lock(ed)?$/i.test(inbound)) out.inbound = inbound;
   }

--- a/apps/cli/src/provider/loaders.ts
+++ b/apps/cli/src/provider/loaders.ts
@@ -23,6 +23,7 @@
 import { pathToFileURL } from 'node:url';
 import { PROVIDER_NAMES, isProviderKind, type ProviderKind } from '@agentbox/config';
 import {
+  ensureProviderDescriptor,
   pluginForProvider,
   pluginProviderNames,
   isSupportedApiVersion,
@@ -86,6 +87,12 @@ export async function loadProviderModule(name: string): Promise<ProviderModule> 
       `plugin "${plugin.packageName}" does not export a providerModule for "${name}"`,
     );
   }
+  // Back-fill the descriptor snapshot for a plugin registered before descriptors
+  // existed (a v1 plugins.json) — we hold the module here, which is the only
+  // moment deriving one is free. Deliberately NOT awaited: it is a cache write
+  // whose only cost when lost is another derivation later, so it must never add
+  // latency or a new failure mode to loading a provider.
+  void ensureProviderDescriptor(name, providerModule).catch(() => {});
   return providerModule;
 }
 

--- a/apps/cli/src/wizard.ts
+++ b/apps/cli/src/wizard.ts
@@ -369,7 +369,7 @@ export async function maybeRunSetupWizard(args: WizardArgs): Promise<WizardOutco
  * daytona: docker Image.build).
  */
 function rebuildMinutesFor(provider: ProviderName): string {
-  return isProviderKind(provider) ? providerMeta(provider).rebuildMinutes : '1';
+  return isProviderKind(provider) ? providerMeta(provider).bake.approxMinutes : '1';
 }
 
 /**

--- a/apps/cli/test/open-in.test.ts
+++ b/apps/cli/test/open-in.test.ts
@@ -3,9 +3,8 @@ import {
   codexAddUrl,
   defaultHerdrSocketPath,
   detectOpenTargets,
-  IDE_PROVIDERS,
-  PERSISTENT_SSH_PROVIDERS,
-  SSH_MOUNT_PROVIDERS,
+  persistentSshProviders,
+  sshProviders,
   pathHasBinary,
   renderTargets,
   resolveCmuxBinary,
@@ -47,7 +46,7 @@ describe('detectOpenTargets', () => {
     const mac = seams({ existing: ['/Applications/Claude.app'] });
     expect(detectOpenTargets(mac).claude).toEqual({
       available: true,
-      providers: [...PERSISTENT_SSH_PROVIDERS],
+      providers: persistentSshProviders(),
     });
     const home = seams({ existing: ['/home/u/Applications/Claude.app'] });
     expect(detectOpenTargets(home).claude.available).toBe(true);
@@ -60,7 +59,7 @@ describe('detectOpenTargets', () => {
     const mac = seams({ existing: ['/Applications/Codex.app'] });
     expect(detectOpenTargets(mac).codex).toEqual({
       available: true,
-      providers: [...PERSISTENT_SSH_PROVIDERS],
+      providers: persistentSshProviders(),
     });
     const linux = seams({ platform: 'linux', existing: ['/Applications/Codex.app'] });
     expect(detectOpenTargets(linux).codex.available).toBe(false);
@@ -96,7 +95,7 @@ describe('detectOpenTargets', () => {
     const viaCode = seams({ path: '/bin', existing: ['/bin/code'] });
     expect(detectOpenTargets(viaCode).vscode).toEqual({
       available: true,
-      providers: [...IDE_PROVIDERS],
+      providers: sshProviders(),
     });
     const viaCursor = seams({ platform: 'linux', path: '/bin', existing: ['/bin/cursor'] });
     expect(detectOpenTargets(viaCursor).vscode.available).toBe(true);
@@ -127,7 +126,7 @@ describe('detectOpenTargets', () => {
     const withSshfs = seams({ path: '/usr/local/bin', existing: ['/usr/local/bin/sshfs'] });
     expect(detectOpenTargets(withSshfs).finder).toEqual({
       available: true,
-      providers: [...SSH_MOUNT_PROVIDERS],
+      providers: sshProviders(),
     });
     // sshfs is cross-platform — PATH presence is the gate on linux too.
     const linux = seams({ platform: 'linux', path: '/usr/bin', existing: ['/usr/bin/sshfs'] });
@@ -157,31 +156,56 @@ describe('detectOpenTargets', () => {
   });
 });
 
-describe('provider eligibility constants', () => {
-  it('codex/persistent-ssh covers docker + hetzner + remote-docker; vscode covers docker + ssh clouds', () => {
-    expect(PERSISTENT_SSH_PROVIDERS).toEqual(['docker', 'hetzner', 'remote-docker']);
-    expect(IDE_PROVIDERS).toEqual(['docker', 'hetzner', 'daytona', 'remote-docker']);
+// These lists now come from each provider's declared capabilities rather than a
+// hardcoded array, so a community provider that declares the capability is
+// included automatically. The built-in membership is still pinned here: it is
+// user-visible behavior (which boxes the tray's Open In… menu offers).
+describe('provider eligibility from capabilities', () => {
+  it('codex/persistent-ssh covers the providers with a per-box key that outlives the call', () => {
+    // digitalocean joins hetzner here for the same reason: a cloud-init-injected
+    // per-box identity file that survives across sessions.
+    expect(persistentSshProviders()).toEqual([
+      'docker',
+      'hetzner',
+      'digitalocean',
+      'remote-docker',
+    ]);
   });
 
-  it('open sshfs-mounts docker + hetzner + daytona + remote-docker; vercel/e2b excluded (no SSH)', () => {
-    expect(SSH_MOUNT_PROVIDERS).toEqual(['docker', 'hetzner', 'daytona', 'remote-docker']);
-    expect(SSH_MOUNT_PROVIDERS).not.toContain('vercel');
-    expect(SSH_MOUNT_PROVIDERS).not.toContain('e2b');
+  it('ssh (vscode + sshfs mount) covers the providers with a real sshd', () => {
+    // digitalocean is a VPS with the same sshd as hetzner. The pre-capability
+    // arrays omitted it while listing it in the direct-box-ssh set — an
+    // oversight, so `agentbox code` / `open` now work there too.
+    expect(sshProviders()).toEqual([
+      'docker',
+      'daytona',
+      'hetzner',
+      'digitalocean',
+      'remote-docker',
+    ]);
+  });
+
+  it('excludes the no-SSH providers — their attach is an SDK PTY bridge', () => {
+    expect(sshProviders()).not.toContain('vercel');
+    expect(sshProviders()).not.toContain('e2b');
+    expect(persistentSshProviders()).not.toContain('daytona'); // expiring token
   });
 });
 
 describe('codexAddUrl', () => {
   it('encodes the alias', () => {
-    expect(codexAddUrl('my box+1')).toBe(
-      'codex://settings/connections/ssh/add?name=my%20box%2B1',
-    );
+    expect(codexAddUrl('my box+1')).toBe('codex://settings/connections/ssh/add?name=my%20box%2B1');
     expect(codexAddUrl('smoke')).toBe('codex://settings/connections/ssh/add?name=smoke');
   });
 });
 
 describe('resolveCmuxBinary', () => {
   it('prefers the env override', () => {
-    const s = seams({ env: { CMUX_BUNDLED_CLI_PATH: '/custom/cmux' }, path: '/bin', existing: ['/bin/cmux'] });
+    const s = seams({
+      env: { CMUX_BUNDLED_CLI_PATH: '/custom/cmux' },
+      path: '/bin',
+      existing: ['/bin/cmux'],
+    });
     expect(resolveCmuxBinary(s)).toBe('/custom/cmux');
   });
 

--- a/apps/cli/test/provider-descriptors.test.ts
+++ b/apps/cli/test/provider-descriptors.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Guard the BUILT-IN descriptor table against the real provider modules.
+ *
+ * The table is hand-authored because method presence on `Provider` is not a
+ * capability signal — `createCloudProvider` defines `setInbound`,
+ * `repairReachability`, `enableDirectGit` and `checkpoint` on every cloud
+ * provider, and docker has working checkpoints with no `provider.checkpoint` at
+ * all. See `packages/config/src/providers.ts`.
+ *
+ * `CloudBackend` methods ARE authored per provider, so the three capabilities
+ * that mirror one must agree with it. Those are asserted here; the rest of the
+ * table is prose that only a human can check.
+ *
+ * This lives in apps/cli because `@agentbox/config` cannot depend on the
+ * provider packages (they depend on it).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { PROVIDERS, type ProviderCapabilities, type ProviderKind } from '@agentbox/config';
+import type { ProviderModule } from '@agentbox/sandbox-core';
+
+const IMPORTERS: Record<ProviderKind, () => Promise<{ providerModule: ProviderModule }>> = {
+  docker: () => import('@agentbox/sandbox-docker'),
+  daytona: () => import('@agentbox/sandbox-daytona'),
+  hetzner: () => import('@agentbox/sandbox-hetzner'),
+  vercel: () => import('@agentbox/sandbox-vercel'),
+  e2b: () => import('@agentbox/sandbox-e2b'),
+  digitalocean: () => import('@agentbox/sandbox-digitalocean'),
+  'remote-docker': () => import('@agentbox/sandbox-remote-docker'),
+};
+
+describe('built-in descriptors agree with their modules', () => {
+  it.each(PROVIDERS.map((p) => p.name))('%s', async (name) => {
+    const { providerModule } = await IMPORTERS[name]();
+    const declared = PROVIDERS.find((p) => p.name === name);
+    expect(declared).toBeDefined();
+    if (!declared) return;
+    const backend = providerModule.backend;
+
+    // `kind` is what tells the hub whether to expect a CloudBackend at all.
+    expect(declared.kind, `${name}.kind`).toBe(backend ? 'cloud' : 'local');
+
+    // prune ⇔ backend.list — matches the retired CLOUD_PRUNE_PROVIDERS exactly.
+    expect(declared.capabilities.prune, `${name}.capabilities.prune`).toBe(!!backend?.list);
+
+    // inbound ⇔ backend.setInbound — true for the two VPS providers only.
+    expect(declared.capabilities.inbound, `${name}.capabilities.inbound`).toBe(
+      !!backend?.setInbound,
+    );
+
+    // timeoutModel is copied, not invented. (`as const` narrows each row to its
+    // own literal type, so rows that omit the optional key lose it from the
+    // union — read it through the interface.)
+    const caps: ProviderCapabilities = declared.capabilities;
+    expect(caps.timeoutModel, `${name}.capabilities.timeoutModel`).toBe(backend?.timeoutModel);
+  });
+
+  it('a credential form is declared only where setCredentials can consume it', async () => {
+    for (const p of PROVIDERS) {
+      const { providerModule } = await IMPORTERS[p.name]();
+      // The field keys go straight to setCredentials; declaring fields for a
+      // module that has no such method would render a form that cannot save.
+      if (p.credentials.fields.length > 0) {
+        expect(providerModule.setCredentials, `${p.name} declares fields`).toBeDefined();
+      }
+    }
+  });
+
+  it('every provider the table calls bakeable actually has a prepare', async () => {
+    for (const p of PROVIDERS) {
+      if (!p.bake.required) continue;
+      const { providerModule } = await IMPORTERS[p.name]();
+      expect(providerModule.provider.prepare, `${p.name} needs a prepare`).toBeDefined();
+    }
+  });
+});

--- a/apps/hub/app/(dashboard)/api/v1/lib/validate.ts
+++ b/apps/hub/app/(dashboard)/api/v1/lib/validate.ts
@@ -236,8 +236,14 @@ export function isLifecycleAction(v: string): v is LifecycleAction {
 }
 
 // ── provider install / bake ──
+// A community provider has credentials to set and (often) a base to bake, so
+// rejecting unknown names here would leave a registered plugin creatable but
+// unconfigurable. Same treatment as `parseCreateBox`: check only the SHAPE of an
+// unknown name — the plugin registry lives behind @agentbox/sandbox-core, which
+// stays out of the Next bundle — and let the backend resolve it against the
+// registry and reject it there with a precise message.
 export function isProviderId(v: string): boolean {
-  return (PROVIDERS as readonly string[]).includes(v);
+  return (PROVIDERS as readonly string[]).includes(v) || /^[a-z][a-z0-9-]{0,39}$/.test(v);
 }
 
 // Credential fields are a provider-specific record of string values (e.g.

--- a/apps/hub/app/(dashboard)/settings/components/provider-actions.tsx
+++ b/apps/hub/app/(dashboard)/settings/components/provider-actions.tsx
@@ -26,31 +26,37 @@ interface CredField {
   optional?: boolean;
 }
 
-// Per-provider credential fields (token/key only — no interactive browser flow).
-const CRED_FIELDS: Record<string, CredField[]> = {
-  docker: [],
-  e2b: [{ key: 'apiKey', label: 'API key', placeholder: 'e2b_…' }],
-  daytona: [{ key: 'apiKey', label: 'API key', placeholder: 'dtn_…' }],
-  hetzner: [{ key: 'token', label: 'API token', placeholder: 'project read+write token' }],
-  vercel: [
-    { key: 'token', label: 'Access token', placeholder: 'vercel token' },
-    { key: 'teamId', label: 'Team ID', placeholder: 'team_… (optional)', optional: true },
-    { key: 'projectId', label: 'Project ID', placeholder: 'prj_… (optional)', optional: true },
-  ],
-  digitalocean: [
-    { key: 'token', label: 'API token', placeholder: 'personal access token (read+write)' },
-    // Not a secret — this writes the `box.digitaloceanProject` config key. Blank means
-    // "leave as-is", NOT "clear": the form drops empty fields before sending and never
-    // shows the saved value, so treating blank as a clear would wipe the setting on any
-    // save. Clearing is `agentbox config unset box.digitaloceanProject`.
-    {
-      key: 'project',
-      label: 'Project',
-      placeholder: 'name or UUID — blank leaves it unchanged',
-      optional: true,
-    },
-  ],
+/**
+ * Credential fields for a provider row, from the descriptor the API serves.
+ *
+ * This replaced a hardcoded per-provider table, which is what let a registered
+ * community provider render a correct form: the hub sends `credentials.fields`
+ * for built-ins and plugins alike. `PLACEHOLDERS` is cosmetic only — an example
+ * value AgentBox happens to know for a built-in — and its absence just means a
+ * plain input.
+ *
+ * A field with `optional` is one the form drops when left empty (blank means
+ * "leave as-is", never "clear"; clearing is a CLI `config unset`).
+ */
+const PLACEHOLDERS: Record<string, string> = {
+  'e2b.apiKey': 'e2b_…',
+  'daytona.apiKey': 'dtn_…',
+  'hetzner.token': 'project read+write token',
+  'vercel.token': 'vercel token',
+  'vercel.teamId': 'team_… (optional)',
+  'vercel.projectId': 'prj_… (optional)',
+  'digitalocean.token': 'personal access token (read+write)',
+  'digitalocean.project': 'name or UUID — blank leaves it unchanged',
 };
+
+function credFields(p: ProviderOption): CredField[] {
+  return (p.credentials?.fields ?? []).map((f) => ({
+    key: f.key,
+    label: f.label,
+    placeholder: PLACEHOLDERS[`${p.id}.${f.key}`] ?? f.hint,
+    optional: f.optional,
+  }));
+}
 
 export function ProvidersSection() {
   const { state } = useStore();
@@ -143,7 +149,7 @@ const MASK = '••••••••••••';
 
 function ProviderRow({ provider: p }: { provider: ProviderOption }) {
   const router = useRouter();
-  const fields = CRED_FIELDS[p.id] ?? [];
+  const fields = credFields(p);
   // Required fields re-mask when emptied; optional ones (e.g. vercel team/project) don't.
   const maskableKeys = new Set(fields.filter((f) => !f.optional).map((f) => f.key));
   const [values, setValues] = useState<Record<string, string>>({});
@@ -236,7 +242,9 @@ function ProviderRow({ provider: p }: { provider: ProviderOption }) {
   // alternative (proxying every action through this hub) would make two UIs
   // responsible for one machine's state.
   const onHub = p.origin === 'hub';
-  const canBake = p.id === 'docker' || p.hasCredentials;
+  // A bake needs credentials only when the provider actually takes some. Gating
+  // on `id === 'docker'` left every credential-free plugin unbakeable.
+  const canBake = fields.length === 0 || p.hasCredentials;
   const hasFields = fields.length > 0;
   const expandable = !onHub && (hasFields || isRD);
 

--- a/apps/hub/lib/boxes/types.ts
+++ b/apps/hub/lib/boxes/types.ts
@@ -160,6 +160,49 @@ export interface ProviderOption {
   id: string;
   label: string;
   configured: boolean;
+  // ── the provider's declarative descriptor, straight through ──
+  // Sourced from a sync snapshot (the built-in table, or `~/.agentbox/plugins.json`
+  // for a community provider), so these are always present and cost nothing to
+  // serve. Clients use them INSTEAD of hardcoding provider names: render the
+  // credential form from `credentials.fields`, pace a progress bar with
+  // `bake.*ProgressSteps`, gate capability-specific UI on `capabilities`.
+  kind?: 'local' | 'cloud';
+  credentials?: {
+    envKeys: readonly string[];
+    fields: readonly {
+      key: string;
+      label: string;
+      optional?: boolean;
+      /** Absent means secret — mask it. */
+      secret?: boolean;
+      hint?: string;
+    }[];
+  };
+  bake?: {
+    required: boolean;
+    approxMinutes: string;
+    createProgressSteps?: number;
+    bakeProgressSteps?: number;
+  };
+  capabilities?: {
+    checkpoints: boolean;
+    checkpointReboots: boolean;
+    ssh: boolean;
+    persistentSsh: boolean;
+    directBoxSsh: boolean;
+    inbound: boolean;
+    directGit: boolean;
+    resync: boolean;
+    prune: boolean;
+    vnc: boolean;
+    dind: boolean;
+    /** 'stop' = pause powers the box off. Relabel the control; don't hide it. */
+    pauseSemantics: 'freeze' | 'stop';
+    hubRoutable: boolean;
+    timeoutModel?: 'absolute' | 'inactivity';
+  };
+  sizes?: readonly { key: string; label: string }[];
+  regions?: readonly { key: string; label: string }[];
   // Whether the provider has credentials on this host (docker: always true). A
   // cloud provider can have credentials but not yet be `configured` (baked).
   hasCredentials?: boolean;

--- a/apps/hub/lib/hub-backend.ts
+++ b/apps/hub/lib/hub-backend.ts
@@ -14,8 +14,6 @@ import {
   isProviderKind,
   listProjectsConfigured,
   loadEffectiveConfig,
-  PROVIDER_NAMES,
-  providerMeta,
   pruneOrphanProjectConfigs,
   registerProject,
   resolveDefaultCheckpoint,
@@ -56,11 +54,7 @@ import {
 import { mergeRemoteProviders } from './boxes/provider-origin.js';
 import { hydratePreparedFromCustody } from './prepared-hydrate.js';
 import { fetchRemoteProviders, resolveRemoteHub } from './remote-hub.js';
-import {
-  IMPORTERS,
-  isRuntimeProviderName,
-  loadProviderModuleByName,
-} from './provider-importers.js';
+import { isRuntimeProviderName, loadProviderModuleByName } from './provider-importers.js';
 import type { BoxGitDeps } from '@agentbox/sandbox-core';
 import {
   BOX_WORKSPACE,
@@ -85,6 +79,8 @@ import {
   setBoxDisplayName,
   syncAgentboxSshConfig,
   diffFileManifests,
+  listProviderDescriptors,
+  resolveProviderDescriptor,
   type FileManifest,
 } from '@agentbox/sandbox-core';
 import {
@@ -647,29 +643,17 @@ function remoteDockerHostCount(): number {
   }
 }
 
-function isProviderConfigured(id: ProviderKind): boolean {
-  if (id === 'docker') return true;
+function isProviderConfigured(id: string): boolean {
   // remote-docker is usable as soon as one host alias is registered (the image
   // builds lazily on first create); it never writes a top-level `base` marker.
   if (id === 'remote-docker') return remoteDockerHostCount() > 0;
+  // A provider whose base self-heals on create (docker) — or a plugin that owns
+  // its own setup story and declares no bake — is ready as soon as it exists.
+  // Demanding a `base` marker of those would report every one of them as broken.
+  if (!resolveProviderDescriptor(id)?.bake.required) return true;
   const raw = readPreparedStateRaw(id);
   return !!(raw && typeof raw === 'object' && (raw as { base?: unknown }).base);
 }
-
-// secrets.env key(s) whose presence means a provider has credentials. Checked by
-// name only (never the value) so credential status is cheap + SDK-free. docker
-// needs none.
-const PROVIDER_CRED_KEYS: Record<ProviderKind, readonly string[]> = {
-  docker: [],
-  e2b: ['E2B_API_KEY'],
-  daytona: ['DAYTONA_API_KEY', 'DAYTONA_JWT_TOKEN'],
-  hetzner: ['HCLOUD_TOKEN'],
-  vercel: ['VERCEL_TOKEN', 'VERCEL_OIDC_TOKEN', 'VERCEL_AUTH_SOURCE'],
-  digitalocean: ['DIGITALOCEAN_TOKEN'],
-  // remote-docker authenticates as you, over your own ~/.ssh/config — there is
-  // no credential to store, so there is none to check.
-  'remote-docker': [],
-};
 
 /** Set of KEY names present in `~/.agentbox/secrets.env` (values ignored). */
 function readSecretsKeys(): Set<string> {
@@ -688,10 +672,19 @@ function readSecretsKeys(): Set<string> {
   return out;
 }
 
-/** Whether a provider has credentials configured (secrets.env or the shell env). */
-function hasProviderCredentials(id: ProviderKind, keys: Set<string>): boolean {
-  if (id === 'docker') return true;
-  return PROVIDER_CRED_KEYS[id].some((k) => keys.has(k) || !!process.env[k]);
+/**
+ * Whether a provider has credentials configured (secrets.env or the shell env).
+ *
+ * The key NAMES come from the provider's descriptor; the values are never read,
+ * so this stays cheap and SDK-free. A provider that declares no keys needs no
+ * credentials (docker, remote-docker) and is therefore always satisfied — which
+ * is also the right answer for a plugin that hasn't declared any, since a `false`
+ * there would disable its bake button for a credential it never wanted.
+ */
+function hasProviderCredentials(id: string, keys: Set<string>): boolean {
+  const envKeys = resolveProviderDescriptor(id)?.credentials.envKeys ?? [];
+  if (envKeys.length === 0) return true;
+  return envKeys.some((k) => keys.has(k) || !!process.env[k]);
 }
 
 /** Cheap `docker info` reachability probe (short timeout) for the bake precheck. */
@@ -721,7 +714,7 @@ async function binOnPath(name: string): Promise<boolean> {
  * fast with a clear message instead of a confusing mid-bake error. Returns an
  * error string when unmet, else null.
  */
-async function preparePrecheck(id: ProviderKind): Promise<string | null> {
+async function preparePrecheck(id: string): Promise<string | null> {
   if (id === 'docker') {
     return (await dockerDaemonReachable())
       ? null
@@ -740,13 +733,20 @@ async function preparePrecheck(id: ProviderKind): Promise<string | null> {
   return null;
 }
 
+/**
+ * Every provider a box can be created on — built-ins AND registered plugins.
+ *
+ * Iterating descriptors rather than `PROVIDER_NAMES` is what makes a community
+ * provider visible: the create path has always accepted plugin names, but a
+ * provider absent from this list never reaches a picker in the web UI or tray.
+ */
 function listProviders(jobs: QueueJob[]): ProviderOption[] {
   const keys = readSecretsKeys();
-  return PROVIDER_NAMES.map((id) => {
+  return listProviderDescriptors().map((d) => {
+    const id = d.name;
     // Keep "Docker (local)" but drop the "(cloud …)" qualifier from cloud labels
     // — the picker just wants the provider name.
-    const label =
-      id === 'docker' ? providerMeta(id).label : providerMeta(id).label.replace(/\s*\(.*\)$/, '');
+    const label = id === 'docker' ? d.label : d.label.replace(/\s*\(.*\)$/, '');
     const configured = isProviderConfigured(id);
     const hasCredentials = hasProviderCredentials(id, keys);
     // An in-flight bake for this provider (queued or running) — lets the UI show
@@ -766,7 +766,25 @@ function listProviders(jobs: QueueJob[]): ProviderOption[] {
             ? 'Credentials set — bake the base image to finish setup.'
             : 'Not set up — add credentials, then bake the base image.';
     }
-    return { id, label, configured, hasCredentials, jobId: bake?.id, reason };
+    return {
+      id,
+      label,
+      configured,
+      hasCredentials,
+      jobId: bake?.id,
+      reason,
+      // The declarative half of the descriptor, straight through to the client.
+      // It comes from a sync snapshot (the config table, or plugins.json for a
+      // plugin), so serving it costs nothing and needs no opt-in flag — clients
+      // use it to render credential forms, pace progress bars, and gate
+      // capability-specific UI without hardcoding provider names.
+      kind: d.kind,
+      credentials: d.credentials,
+      bake: d.bake,
+      capabilities: d.capabilities,
+      ...(d.sizes ? { sizes: d.sizes } : {}),
+      ...(d.regions ? { regions: d.regions } : {}),
+    };
   });
 }
 
@@ -792,14 +810,11 @@ async function withRemoteProviders(local: ProviderOption[]): Promise<ProviderOpt
 // entry misses and recomputes, so a fresh bake is reflected immediately (no
 // stale window from a TTL that outlives the bake — Bugbot #151).
 const FRESHNESS_TTL_MS = 60_000;
-const freshnessCache = new Map<
-  ProviderKind,
-  { at: number; stored: string; live: string | undefined }
->();
+const freshnessCache = new Map<string, { at: number; stored: string; live: string | undefined }>();
 
 /**
  * Live base-image/snapshot freshness for one provider, over the hub's own
- * provider `IMPORTERS` — the one place this now runs (the CLI reads it back from
+ * provider loader — the one place this now runs (the CLI reads it back from
  * `GET /api/v1/providers?freshness=1`). Docker gets a real check too (unlike the
  * CLI, which lets `ensureImage` self-heal silently): the tray/web create
  * flows use `unprepared`/`stale` to announce the upcoming bake instead of
@@ -807,7 +822,7 @@ const freshnessCache = new Map<
  * the live fingerprint degrades to 'unknown' (never a false 'stale').
  */
 async function providerBaseFreshness(
-  id: ProviderKind,
+  id: string,
   claudeInstall?: 'native' | 'npm',
 ): Promise<BaseStatus> {
   if (id === 'docker') {
@@ -827,7 +842,7 @@ async function providerBaseFreshness(
   // shared bakes instead of showing every provider as "needs baking". No-op on a
   // local hub (local prepared-state already set) or when custody has no match.
   try {
-    const mod = (await IMPORTERS[id]()).providerModule;
+    const mod = await loadProviderModuleByName(id);
     await hydratePreparedFromCustody(
       new FsCustodyStore(),
       id,
@@ -853,7 +868,7 @@ async function providerBaseFreshness(
     live = cached.live;
   } else {
     try {
-      const mod = (await IMPORTERS[id]()).providerModule;
+      const mod = await loadProviderModuleByName(id);
       live = await mod.currentBaseFingerprintLive?.('native');
     } catch {
       live = undefined;
@@ -882,7 +897,13 @@ async function listProvidersWithFreshness(base: ProviderOption[]): Promise<Provi
   }
   return Promise.all(
     base.map(async (p) => {
-      if (!isProviderKind(p.id)) return p;
+      // Plugins are probed too, not just built-ins: a plugin that implements
+      // `currentBaseFingerprintLive` gets the same staleness nagging, and one
+      // that doesn't degrades to 'unknown' inside providerBaseFreshness rather
+      // than being skipped here. (docker is probed despite needing no bake — the
+      // create flows use `unprepared`/`stale` to ANNOUNCE the upcoming build
+      // instead of hiding it inside the create job.)
+      //
       // A control-box row already carries THAT machine's freshness, computed
       // against ITS build context. Recomputing it here would answer a question
       // about the wrong host — the "adopted-then-nagged" bug, one level up.
@@ -908,12 +929,12 @@ async function listProvidersWithFreshness(base: ProviderOption[]): Promise<Provi
  * answer is to say so — inventing a diff from mtimes or from the aggregate hash
  * would be a guess dressed as a fact.
  */
-async function providerBakeDiff(id: ProviderKind): Promise<BakeDiff | undefined> {
+async function providerBakeDiff(id: string): Promise<BakeDiff | undefined> {
   try {
     const raw = readPreparedStateRaw(id) as { base?: { files?: FileManifest } } | null;
     const stored = raw?.base?.files;
     if (!stored || Object.keys(stored).length === 0) return { hasManifest: false };
-    const mod = (await IMPORTERS[id]()).providerModule;
+    const mod = await loadProviderModuleByName(id);
     const current = await mod.currentBaseFileHashes?.();
     // A manifest IS recorded here — the live side just couldn't be hashed (a dev
     // tree with no staged runtime). Reporting `hasManifest: false` would tell the
@@ -2268,9 +2289,11 @@ export function createHubBackend(handle: RelayServerHandle): HubBackend {
     },
     async setProviderCredentials(id, fields): Promise<ActionResult> {
       try {
-        if (!isProviderKind(id)) return { ok: false, error: `unknown provider ${id}` };
-        if (id === 'docker') return { ok: true }; // docker needs no credentials
-        const mod = (await IMPORTERS[id]()).providerModule;
+        if (!isRuntimeProviderName(id)) return { ok: false, error: `unknown provider ${id}` };
+        // Nothing to store for a provider that declares no credential fields
+        // (docker; remote-docker connects as you over your own ssh config).
+        if (resolveProviderDescriptor(id)?.credentials.fields.length === 0) return { ok: true };
+        const mod = await loadProviderModuleByName(id);
         if (!mod.setCredentials) {
           return { ok: false, error: `provider ${id} does not support credential setup` };
         }
@@ -2282,7 +2305,7 @@ export function createHubBackend(handle: RelayServerHandle): HubBackend {
       }
     },
     prepareProvider(id, opts): Promise<CreateBoxResult> {
-      if (!isProviderKind(id))
+      if (!isRuntimeProviderName(id))
         return Promise.resolve({ ok: false, error: `unknown provider ${id}` });
       // Serialize per provider so concurrent POSTs can't both miss the in-flight
       // job and enqueue duplicates (the check+enqueue below isn't atomic on its own).

--- a/apps/hub/lib/hub-backend.ts
+++ b/apps/hub/lib/hub-backend.ts
@@ -911,6 +911,7 @@ async function listProvidersWithFreshness(base: ProviderOption[]): Promise<Provi
       const fresh = await providerBaseFreshness(p.id, claudeInstall);
       return {
         ...p,
+        hasCredentials: await refineCredStatus(p),
         baseStatus: fresh.state,
         baseStaleReason: fresh.state === 'stale' ? fresh.reason : undefined,
         // Only stale rows pay for the diff: it re-hashes the whole build context,
@@ -919,6 +920,30 @@ async function listProvidersWithFreshness(base: ProviderOption[]): Promise<Provi
       };
     }),
   );
+}
+
+/**
+ * Ask the provider itself whether it has credentials, for providers whose
+ * descriptor names no `secrets.env` keys.
+ *
+ * The sync `listProviders` path can only check key NAMES, and answers "yes" when
+ * a provider declares none — the non-blocking default. But a plugin may hold its
+ * credentials somewhere we can't see (a CLI keychain, an OAuth cache) and still
+ * know whether it is authenticated; `readCredStatus()` is how it says so. Only
+ * this async path can ask, since it means loading the module.
+ *
+ * Best-effort: any failure keeps the row's existing answer rather than reporting
+ * a provider as unconfigured because its probe threw.
+ */
+async function refineCredStatus(p: ProviderOption): Promise<boolean | undefined> {
+  if ((p.credentials?.envKeys.length ?? 0) > 0) return p.hasCredentials;
+  try {
+    const mod = await loadProviderModuleByName(p.id);
+    if (!mod.readCredStatus) return p.hasCredentials;
+    return (await mod.readCredStatus()).configured;
+  } catch {
+    return p.hasCredentials;
+  }
 }
 
 /**

--- a/apps/hub/lib/provider-importers.ts
+++ b/apps/hub/lib/provider-importers.ts
@@ -14,6 +14,7 @@ import { pathToFileURL } from 'node:url';
 import { isProviderKind, type ProviderKind } from '@agentbox/config';
 import type { CloudBackendLoader, CloudCpModule } from '@agentbox/relay';
 import {
+  ensureProviderDescriptor,
   isSupportedApiVersion,
   pluginForProvider,
   pluginProviderNames,
@@ -95,6 +96,12 @@ export async function loadProviderModuleByName(name: string): Promise<ProviderMo
       `plugin "${plugin.packageName}" does not export a providerModule for "${name}"`,
     );
   }
+  // Back-fill the descriptor snapshot for a plugin registered before descriptors
+  // existed (a v1 plugins.json) — we hold the module here, which is the only
+  // moment deriving one is free. Deliberately NOT awaited: it is a cache write
+  // whose only cost when lost is another derivation later, so it must never add
+  // latency or a new failure mode to loading a provider.
+  void ensureProviderDescriptor(name, picked).catch(() => {});
   return picked;
 }
 

--- a/apps/web/content/docs/build-a-provider.mdx
+++ b/apps/web/content/docs/build-a-provider.mdx
@@ -83,6 +83,63 @@ Only `provider` and `doctorChecks` are required — `createCloudProvider` suppli
 - Depend on `@madarco/agentbox-provider-sdk` (`^2`).
 - Export a `providerModule` (or `providerModules` for a multi-provider package).
 
+## Describe your provider
+
+Declare a `descriptor` and AgentBox's UIs can render your provider properly — a real name in the create pickers, the right credential form, and correct capability gating:
+
+```ts
+import type { ProviderDescriptor } from '@madarco/agentbox-provider-sdk';
+
+const descriptor: ProviderDescriptor = {
+  name: 'myprovider',
+  kind: 'cloud',
+  label: 'MyProvider (cloud microVM)',
+  loginHint: 'paste an API token from the MyProvider console',
+  credentials: {
+    envKeys: ['MYPROVIDER_TOKEN'], // presence = "configured"
+    fields: [{ key: 'token', label: 'API token' }], // the form a UI renders
+  },
+  bake: { required: true, approxMinutes: '5-10' },
+  capabilities: {
+    checkpoints: true,
+    checkpointReboots: false,
+    ssh: false,
+    persistentSsh: false,
+    directBoxSsh: false,
+    inbound: false,
+    directGit: true,
+    resync: true,
+    prune: true,
+    vnc: true,
+    dind: true,
+    pauseSemantics: 'freeze',
+    hubRoutable: true,
+  },
+  blurb: 'MyProvider microVMs',
+  sizeDesc: 'Per-provider override of `box.size` for myprovider.',
+  imageDesc: 'Per-provider override of `box.image` for myprovider.',
+};
+
+export const providerModule: ProviderModule = { provider, backend, descriptor /* … */ };
+```
+
+`agentbox plugin add` snapshots this, so the CLI, hub and tray all read it without importing your package.
+
+**Declare what code can't reveal.** AgentBox doesn't infer capabilities from your `Provider` object: `createCloudProvider` gives _every_ cloud provider a `checkpoint`, `setInbound` and `enableDirectGit`, so their presence says which scaffold you used, not what you support. Three values are cross-checked against your `CloudBackend` (which you wrote, so it means something) — `prune` must equal `!!backend.list`, `inbound` must equal `!!backend.setInbound`, and `timeoutModel` must equal `backend.timeoutModel`.
+
+Three capabilities are easy to get wrong:
+
+- **`pauseSemantics`** — `'freeze'` if pause preserves the running processes, `'stop'` if it powers the box off and only the disk survives. It's a labelling hint, not a reason to hide a pause control (powering a VPS down is what stops the billing).
+- **`persistentSsh`** — whether the per-box SSH identity outlives the CLI call. A gateway handing out an expiring token doesn't qualify, even though SSH works right now.
+- **`checkpointReboots`** — `true` if capturing a snapshot stops and restarts the box, so the CLI confirms before yanking a live agent.
+
+<Callout title="Already published a plugin?">
+  You don't have to change anything. `descriptor` is optional and the SDK's contract version didn't
+  move, so an existing plugin loads exactly as before — AgentBox derives what it can from your
+  module and defaults the rest to preserve current behavior. Declaring one just upgrades you from a
+  bare provider name to a real label, credential form and capability gating.
+</Callout>
+
 ## Cloud overrides (optional)
 
 A cloud provider that bakes its own base image typically overrides three optional capabilities on top of `createCloudProvider` — the SDK re-exports the helpers each one needs, so they're all buildable on the SDK alone:

--- a/docs/provider-descriptor-plan.md
+++ b/docs/provider-descriptor-plan.md
@@ -79,32 +79,84 @@ export interface ProviderDescriptor {
   imageDesc: string;              // unchanged — drives the box.image<P> KEY_REGISTRY entry
 }
 
+/**
+ * All DECLARED. See "Why capabilities are declared, not derived" below — method
+ * presence on `Provider` signals which scaffold a provider was built with, not
+ * what it can do.
+ */
 export interface ProviderCapabilities {
-  // ── DERIVED from the module (see "derivation" below) ──
-  checkpoints: boolean;      // !!provider.checkpoint
-  bakeable: boolean;         // !!provider.prepare
-  ssh: boolean;              // !!provider.sshTarget
-  resync: boolean;           // !!provider.resyncWorkspace
-  directGit: boolean;        // !!provider.enableDirectGit
-  inbound: boolean;          // !!provider.setInbound
-  prune: boolean;            // !!backend?.list
-  timeoutModel?: 'absolute' | 'inactivity';   // backend?.timeoutModel
-
-  // ── DECLARED (not knowable from code shape) ──
-  vnc: boolean;
-  dind: boolean;
-  /** true = pause preserves state; false = pause degrades to stop. */
-  realPause: boolean;
+  /** Checkpoint capture/restore is supported at all. */
+  checkpoints: boolean;
   /** Capturing a checkpoint stops + reboots the box (vercel, daytona). */
   checkpointReboots: boolean;
-  /** `buildAttach` yields a plain `ssh user@host` at the box (cloud-ssh auto-config). */
-  directBoxSsh: boolean;
+  /** Real SSH into the box: `agentbox code` (IDE) and `open` (sshfs mount). */
+  ssh: boolean;
   /** Per-box SSH identity outlives the CLI call (`open --in claude|codex`). */
   persistentSsh: boolean;
-  /** Creates can be handed to a remote control box. Default `kind === 'cloud'`. */
+  /** `buildAttach` yields a plain `ssh user@host` at the box (cloud-ssh auto-config). */
+  directBoxSsh: boolean;
+  /** Per-box inbound firewall policy (`--inbound`, `agentbox inbound`). */
+  inbound: boolean;
+  /** `git.pushMode=direct` can be switched on post-create (`--with-credentials`). */
+  directGit: boolean;
+  /** Host->box workspace resync. */
+  resync: boolean;
+  /** Orphan sandboxes are enumerable + deletable (`prune --provider`). */
+  prune: boolean;
+  vnc: boolean;
+  dind: boolean;
+  /**
+   * What `pause` does. 'freeze' preserves the running process tree (docker
+   * pause, daytona linux-vm, vercel/e2b snapshot-resume); 'stop' powers the box
+   * off and only the disk survives (hetzner, digitalocean — both literally
+   * `pause ≡ stop`). NOT a gate on showing a pause control: powering a VPS down
+   * is useful (it stops billing), so a UI should relabel, not hide.
+   */
+  pauseSemantics: 'freeze' | 'stop';
+  /** Creates can be handed to a remote control box. */
   hubRoutable: boolean;
+  /** Session-lifetime model, when the backend declares one. */
+  timeoutModel?: 'absolute' | 'inactivity';
 }
 ```
+
+### Why capabilities are declared, not derived
+
+The original design derived most of this from optional-method presence. **Probing the
+real modules showed that does not work**, and the table is hand-authored instead:
+
+- `packages/sandbox-cloud/src/cloud-provider.ts` unconditionally defines
+  `repairReachability` (1448), `setInbound` (1454), `enableDirectGit` (1475) and `checkpoint`
+  (1783) on *every* cloud provider, each delegating to an optional `backend.*?` at call time.
+  So `!!provider.setInbound` is `true` for vercel and e2b, which have no firewall — the flag
+  signals *"built on the cloud scaffold"*, not *"has this capability"*.
+- `sandbox-docker`'s provider has **no** `checkpoint` key at all (verified: its keys are
+  `create, destroy, downloadPath, exec, inspect, name, pause, prepare, probeState, reconnect,
+  resolveUrl, resume, resyncWorkspace, start, stats, stop, sync, syncTransport, uploadPath`),
+  yet docker checkpoints are the oldest feature in the repo — they run through a hardcoded
+  `providerName === 'docker'` branch at `hub-backend.ts:2609`.
+- `provider.prepare` is present on all seven including docker, so it cannot mean
+  "must bake before first use".
+
+The dividing line is **which object the method hangs off**. `CloudBackend` methods are written
+by the provider author, so they are honest signals; `Provider` methods are supplied by the
+scaffold, so they are not. Verified against the live backends:
+
+| Derivation | Result | Verdict |
+|---|---|---|
+| `!!backend.list` | true for all 6 clouds, false for docker | matches `CLOUD_PRUNE_PROVIDERS` exactly ✓ |
+| `!!backend.setInbound` | true for hetzner + digitalocean only | matches the `--inbound` reality exactly ✓ |
+| `backend.timeoutModel` | `'inactivity'` for daytona + e2b | authoritative ✓ |
+| `!!provider.setInbound` | true for **all 6 clouds** | scaffold artifact ✗ |
+| `!!provider.checkpoint` | **false for docker** | wrong ✗ |
+| `!!provider.prepare` | true for all 7 incl. docker | can't mean "must bake" ✗ |
+
+So `prune`, `inbound` and `timeoutModel` are asserted by the guard test against the live
+modules; every other capability is declared.
+
+Derivation survives as the **fallback for a descriptor-less plugin**, where it is sound
+precisely because such plugins are nearly always `createCloudProvider`-based — a scaffold-given
+`checkpoint` really does work for them. It is the built-in table that can't be derived.
 
 ### Where descriptors live, and why everything stays synchronous
 
@@ -175,17 +227,21 @@ working UI from an existing provider:
 |---|---|---|
 | `kind` | `backend ? 'cloud' : 'local'` | derived |
 | `label` | provider name | what the UI shows today |
-| `bake.required` | `!!provider.prepare` | derived. Must **not** default true — the hub's create gate deliberately skips `isProviderConfigured` for plugins (`hub-backend.ts:2159`), so a `true` default would newly block creates |
+| `bake.required` | **`false`** | must **not** default true — the hub's create gate deliberately skips `isProviderConfigured` for plugins (`hub-backend.ts:2159`), so a `true` default would newly block creates. (`!!provider.prepare` is *not* usable: all seven built-ins including docker have `prepare`.) |
 | `bake.approxMinutes` | `'1'` | matches `wizard.ts:372`'s existing plugin fallback |
 | `credentials.fields` | `setCredentials ? [{key:'apiKey',label:'API key'}] : []` | matches the tray's current `metaFor` fallback (`SettingsPanel.swift:63`) |
 | `credentials.envKeys` | `[]`, and `hasCredentials` answered by `ProviderModule.readCredStatus()` when present, else left **undefined** | `undefined` = "unknown", which consumers must treat as *don't block* — a `false` would disable the tray's bake button |
 | `capabilities.vnc` | **`true`** | `createCloudProvider` wires VNC unconditionally and degrades best-effort; `false` would delete a working VNC button |
 | `capabilities.dind` | **`true`** | `launchDockerd` defaults true in `cloud-provider.ts:127` |
-| `capabilities.realPause` | **`true`** | the tray shows Pause for every running box today |
+| `capabilities.pauseSemantics` | **`'freeze'`** | the tray shows an unqualified Pause for every running box today |
+| `capabilities.checkpoints` | `!!provider.checkpoint` | sound for a plugin (scaffold-based ⇒ working checkpoints); only *docker* breaks this derivation |
+| `capabilities.prune` | `!!backend.list` | honest derivation |
+| `capabilities.timeoutModel` | `backend.timeoutModel` | honest derivation |
+| `capabilities.ssh` | `!!provider.sshTarget` | matches the existing escape hatch in `cloud-ssh.ts:153` |
 | `capabilities.checkpointReboots` | `false` | the confirm prompt only fires for vercel/daytona today |
 | `capabilities.directBoxSsh` / `persistentSsh` | `false` | plugins are excluded from those arrays today — `false` is the status quo, and a plugin opts *in* |
+| `capabilities.inbound` / `directGit` / `resync` | `false` / `false` / `true` | **not** derived (the scaffold defines all three on every cloud provider); `resync: true` matches the scaffold actually providing it |
 | `capabilities.hubRoutable` | `kind === 'cloud'` | matches `HUB_ROUTABLE_PROVIDER_NAMES` |
-| everything else | derived from method presence | exact, never a guess |
 
 Net effect for an un-migrated plugin: it **gains** the dropdown, a credential form, and
 `prune`/`checkpoint`/`fork` eligibility (all derived), and loses nothing. Declaring a descriptor

--- a/docs/provider-descriptor-plan.md
+++ b/docs/provider-descriptor-plan.md
@@ -259,11 +259,19 @@ One phase per session. Tick a phase off here as it lands.
 
 | # | Phase | Status |
 |---|---|---|
-| 1 | Descriptor type, built-in table, registry snapshot | not started |
-| 2 | Hub API serves plugin providers + capabilities | not started |
-| 3 | Tray consumes descriptors | not started |
-| 4 | Retire the CLI provider-name arrays | not started |
-| 5 | Docs, web UI, changelog | not started |
+| 1 | Descriptor type, built-in table, registry snapshot | done |
+| 2 | Hub API serves plugin providers + capabilities | done |
+| 3 | Tray consumes descriptors | done (agentbox-tray `3db893a`) |
+| 4 | Retire the CLI provider-name arrays | done |
+| 5 | Docs, web UI, changelog | done |
+
+Live-verified against the published third-party `agentbox-provider-sprites`
+(SDK v2, declares no descriptor): it lists as `configured`, derives
+`prune`/`timeoutModel: inactivity` correctly from its backend, and
+`prune --provider sprites` enumerated real orphan sandboxes — a command that
+was rejected outright before. Two things its derived descriptor gets wrong that
+only a declared one can fix: the guessed `apiKey` credential field (it wants
+`SPRITE_TOKEN`) and `vnc: true` (Sprites ships no VNC stack and forces it off).
 
 ### Phase 1 — the descriptor + registry snapshot
 

--- a/docs/provider-descriptor-plan.md
+++ b/docs/provider-descriptor-plan.md
@@ -1,0 +1,360 @@
+# Provider descriptors: community providers in the tray, capabilities over the API
+
+## Context
+
+Community providers (external npm packages registered via `agentbox plugin add`) can already
+be **created** through the hub: `POST /api/v1/boxes` accepts a plugin provider name
+(`apps/hub/app/(dashboard)/api/v1/lib/validate.ts:76`), and `hub-worker.ts:302` loads the
+module through `loadProviderModuleByName` (`apps/hub/lib/provider-importers.ts:63`). But they
+are **invisible**: `listProviders` (`apps/hub/lib/hub-backend.ts:766`) maps over
+`PROVIDER_NAMES` — built-ins only — so a plugin never reaches `GET /api/v1/providers`, and
+therefore never reaches the tray's provider dropdown or the web create modal.
+
+The second half of the problem is that AgentBox has **no declarative provider metadata**.
+Today a provider's capabilities are expressed two ways, neither of which a client can read:
+
+1. **Implicitly**, as optional-method presence on `Provider`/`CloudBackend` (`checkpoint?`,
+   `sshTarget?`, `prepare?`, `setInbound?`, `backend.list?`).
+2. **As hardcoded provider-name arrays** scattered across the CLI and hub — ~20 of them
+   (`PERSISTENT_SSH_PROVIDERS`, `IDE_PROVIDERS`, `SSH_MOUNT_PROVIDERS`,
+   `CLOUD_PRUNE_PROVIDERS`, `KNOWN_PROVIDERS`, `FORK_PROVIDERS`,
+   `PROVIDERS_WITH_DIRECT_BOX_SSH`, `PROVIDER_CRED_KEYS`, plus per-name `switch`es in the
+   tray). A plugin can never enter any of them, so it silently loses `open --in`, `code`,
+   `prune`, `checkpoint set-default`, `fork`, SSH-config auto-write, and a credential form.
+
+The tray mirrors this: `Menu/SettingsPanel.swift:31` hardcodes a `providerMeta` table of SF
+Symbols + credential fields per provider id, and `CreateBoxPanel.swift:13` /
+`SettingsPanel.swift:6` hardcode progress-bar pacing per provider id.
+
+**Outcome:** one `ProviderDescriptor` shape that built-ins and plugins both declare, snapshotted
+so every consumer can read it *synchronously and offline*, exposed over `GET /api/v1/providers`,
+and consumed by the tray, the web UI and the CLI — replacing the name arrays. `bake-share.ts:23`
+already states this principle ("derive the provider set from it, never a hardcoded list"); this
+generalizes it.
+
+---
+
+## Design
+
+### The descriptor — one shape for built-ins and plugins
+
+New in `packages/config/src/providers.ts` (extends the existing `ProviderMeta`, which becomes
+this):
+
+```ts
+export interface ProviderCredentialField {
+  key: string;          // the key `ProviderModule.setCredentials` expects ('apiKey', 'token', 'teamId')
+  label: string;
+  optional?: boolean;
+  secret?: boolean;     // default true; DigitalOcean's `project` is false (it lands in config, not secrets)
+  hint?: string;
+}
+
+/** What a UI/CLI can know about a provider WITHOUT loading its module. */
+export interface ProviderDescriptor {
+  name: string;
+  kind: 'local' | 'cloud';
+  label: string;
+  loginHint: string;
+  blurb: string;
+  credentials: {
+    /** secrets.env key names whose presence means "credentials configured" (value never read). */
+    envKeys: readonly string[];
+    /** fields a UI prompts for; empty = no credentials needed (docker, remote-docker). */
+    fields: readonly ProviderCredentialField[];
+  };
+  bake: {
+    /** false = base self-heals on create (docker); true = must bake before first use. */
+    required: boolean;
+    approxMinutes: string;        // was `rebuildMinutes`
+    /** Typical streamed-log line counts, for client progress pacing (tray). */
+    createProgressSteps?: number;
+    bakeProgressSteps?: number;
+  };
+  capabilities: ProviderCapabilities;
+  /** Create-time knobs. Absent = free-form string the backend interprets. */
+  sizes?: readonly { key: string; label: string }[];
+  regions?: readonly { key: string; label: string }[];
+  sizeDesc: string;               // unchanged — drives the box.size<P> KEY_REGISTRY entry
+  imageDesc: string;              // unchanged — drives the box.image<P> KEY_REGISTRY entry
+}
+
+export interface ProviderCapabilities {
+  // ── DERIVED from the module (see "derivation" below) ──
+  checkpoints: boolean;      // !!provider.checkpoint
+  bakeable: boolean;         // !!provider.prepare
+  ssh: boolean;              // !!provider.sshTarget
+  resync: boolean;           // !!provider.resyncWorkspace
+  directGit: boolean;        // !!provider.enableDirectGit
+  inbound: boolean;          // !!provider.setInbound
+  prune: boolean;            // !!backend?.list
+  timeoutModel?: 'absolute' | 'inactivity';   // backend?.timeoutModel
+
+  // ── DECLARED (not knowable from code shape) ──
+  vnc: boolean;
+  dind: boolean;
+  /** true = pause preserves state; false = pause degrades to stop. */
+  realPause: boolean;
+  /** Capturing a checkpoint stops + reboots the box (vercel, daytona). */
+  checkpointReboots: boolean;
+  /** `buildAttach` yields a plain `ssh user@host` at the box (cloud-ssh auto-config). */
+  directBoxSsh: boolean;
+  /** Per-box SSH identity outlives the CLI call (`open --in claude|codex`). */
+  persistentSsh: boolean;
+  /** Creates can be handed to a remote control box. Default `kind === 'cloud'`. */
+  hubRoutable: boolean;
+}
+```
+
+### Where descriptors live, and why everything stays synchronous
+
+The load-bearing decision: **derived capabilities are computed once, at registration time, and
+snapshotted** — so no consumer ever has to `import()` a provider to answer "does it support
+checkpoints?".
+
+- **Built-ins** declare the full descriptor in the `PROVIDERS` table
+  (`packages/config/src/providers.ts`). A new vitest (`packages/config` can't import the
+  provider packages, so this lives in `apps/cli/test/provider-descriptors.test.ts`) loads each
+  built-in `ProviderModule` and asserts the *derived* half matches real method presence — drift
+  fails CI instead of rotting.
+- **Plugins** declare `ProviderModule.descriptor?: ProviderDescriptor` (declared half only).
+  `agentbox plugin add` already imports and validates the module
+  (`apps/cli/src/commands/plugin.ts:129` `loadAndValidate`) — it computes the derived half there
+  and writes the merged descriptor into `~/.agentbox/plugins.json`.
+
+`plugins.json` goes to `version: 2`: `PluginRecord` gains
+`descriptors?: Record<string, ProviderDescriptor>` alongside the existing `providers: string[]`.
+A v1 file still loads; see **Compatibility & migration** below for exactly what an
+un-migrated plugin gets.
+
+New sync resolver in `packages/sandbox-core/src/provider-descriptor.ts` (it can import both
+`@agentbox/config` and the plugin registry; `@agentbox/config` must not import sandbox-core):
+
+```ts
+export function resolveProviderDescriptor(name: string): ProviderDescriptor | undefined;
+export function listProviderDescriptors(): ProviderDescriptor[];   // built-ins ∪ registered plugins
+export function deriveCapabilities(mod: ProviderModule): Partial<ProviderCapabilities>;  // used at plugin-add
+```
+
+`getRuntimeProviderNames()` (`apps/cli/src/provider/loaders.ts`) is already the
+built-ins-∪-plugins name list; `listProviderDescriptors()` is its descriptor-shaped sibling.
+
+### SDK impact
+
+Additive only — `ProviderModule.descriptor` is optional, so `SDK_API_VERSION` **stays 2** and
+`SUPPORTED_SDK_API_VERSIONS` is untouched. Bump `packages/provider-sdk/package.json` to `2.7.0`,
+re-export `ProviderDescriptor`, `ProviderCredentialField`, `ProviderCapabilities`,
+`resolveProviderDescriptor`, `listProviderDescriptors` from
+`packages/provider-sdk/src/index.ts`, then rebuild + **republish** per
+`docs/provider-plugins.md` → "Publishing the SDK".
+
+---
+
+## Compatibility & migration
+
+**Nothing breaks, and no plugin author is required to act.** Three mechanisms, in order:
+
+**1. The field is optional, in both directions.** An existing plugin (built against SDK `2.6.0`
+or even `apiVersion: 1`) exports no `descriptor`; it still passes `loadAndValidate` and still
+loads. A plugin built against `2.7.0` running on an older CLI has its `descriptor` ignored. No
+`SDK_API_VERSION` bump means the `SUPPORTED_SDK_API_VERSIONS` gate never rejects anything it
+accepts today.
+
+**2. Auto-backfill, so migration is invisible.** When `resolveProviderDescriptor(name)` finds a
+registered plugin with no snapshotted descriptor (a v1 `plugins.json`, or a plugin that declares
+none), the first code path that loads the module anyway derives the derivable half and writes it
+back to `plugins.json`. Users never run a migration command; `agentbox plugin add <pkg>` also
+upserts. Consumers that must stay sync and have no snapshot yet fall through to (3).
+
+**3. Fallback defaults reproduce today's behavior exactly — they are NOT "safe = false".**
+This is the load-bearing rule. Every default below was chosen by asking "what does AgentBox do
+for a plugin *today*?", because a `false` default on `vnc`/`realPause` would silently *remove*
+working UI from an existing provider:
+
+| Field | Fallback | Why that value preserves current behavior |
+|---|---|---|
+| `kind` | `backend ? 'cloud' : 'local'` | derived |
+| `label` | provider name | what the UI shows today |
+| `bake.required` | `!!provider.prepare` | derived. Must **not** default true — the hub's create gate deliberately skips `isProviderConfigured` for plugins (`hub-backend.ts:2159`), so a `true` default would newly block creates |
+| `bake.approxMinutes` | `'1'` | matches `wizard.ts:372`'s existing plugin fallback |
+| `credentials.fields` | `setCredentials ? [{key:'apiKey',label:'API key'}] : []` | matches the tray's current `metaFor` fallback (`SettingsPanel.swift:63`) |
+| `credentials.envKeys` | `[]`, and `hasCredentials` answered by `ProviderModule.readCredStatus()` when present, else left **undefined** | `undefined` = "unknown", which consumers must treat as *don't block* — a `false` would disable the tray's bake button |
+| `capabilities.vnc` | **`true`** | `createCloudProvider` wires VNC unconditionally and degrades best-effort; `false` would delete a working VNC button |
+| `capabilities.dind` | **`true`** | `launchDockerd` defaults true in `cloud-provider.ts:127` |
+| `capabilities.realPause` | **`true`** | the tray shows Pause for every running box today |
+| `capabilities.checkpointReboots` | `false` | the confirm prompt only fires for vercel/daytona today |
+| `capabilities.directBoxSsh` / `persistentSsh` | `false` | plugins are excluded from those arrays today — `false` is the status quo, and a plugin opts *in* |
+| `capabilities.hubRoutable` | `kind === 'cloud'` | matches `HUB_ROUTABLE_PROVIDER_NAMES` |
+| everything else | derived from method presence | exact, never a guess |
+
+Net effect for an un-migrated plugin: it **gains** the dropdown, a credential form, and
+`prune`/`checkpoint`/`fork` eligibility (all derived), and loses nothing. Declaring a descriptor
+buys it a real label, correct SSH/pause/VNC gating, and size/region pickers.
+
+A regression test pins this: `apps/cli/test/provider-descriptor-fallback.test.ts` feeds a
+descriptor-less `ProviderModule` (the shape of a 2.6.0-era plugin) through the resolver and
+asserts the table above.
+
+---
+
+## Phases
+
+One phase per session. Tick a phase off here as it lands.
+
+| # | Phase | Status |
+|---|---|---|
+| 1 | Descriptor type, built-in table, registry snapshot | not started |
+| 2 | Hub API serves plugin providers + capabilities | not started |
+| 3 | Tray consumes descriptors | not started |
+| 4 | Retire the CLI provider-name arrays | not started |
+| 5 | Docs, web UI, changelog | not started |
+
+### Phase 1 — the descriptor + registry snapshot
+
+Files:
+- `packages/config/src/providers.ts` — `ProviderMeta` → `ProviderDescriptor`; fill all 7 rows
+  (label/loginHint/blurb/sizeDesc/imageDesc already there). Move `PROVIDER_CRED_KEYS`
+  (`apps/hub/lib/hub-backend.ts:661`) and the tray's `providerMeta` field specs
+  (`agentbox-tray/Sources/AgentBox/Menu/SettingsPanel.swift:31`) into `credentials`. Keep
+  `PROVIDER_NAMES` / `CLOUD_PROVIDER_NAMES` / `isProviderKind` / `perProviderConfigKey`
+  unchanged. `HUB_ROUTABLE_PROVIDER_NAMES` derives from `capabilities.hubRoutable`.
+- `packages/sandbox-core/src/plugin-registry.ts` — `PluginsFile.version: 2`, `PluginRecord
+  .descriptors`, tolerant v1 read.
+- `packages/sandbox-core/src/provider-descriptor.ts` — new resolver + `deriveCapabilities`.
+- `apps/cli/src/commands/plugin.ts` — `loadAndValidate` merges declared + derived, passes to
+  `addPluginRecord`. `plugin info` prints the descriptor.
+- `packages/provider-sdk/src/index.ts` + `package.json` — re-export, `2.7.0`.
+- `examples/agentbox-provider-example` — declare a descriptor (this is the E2E fixture).
+
+Tests: `packages/sandbox-core/test/provider-descriptor.test.ts` (resolution order, v1
+`plugins.json` read + auto-backfill), `packages/config/test/providers.test.ts` (the existing
+drift test extends to the new fields), `apps/cli/test/provider-descriptors.test.ts` (built-in
+declared-vs-derived guard), `apps/cli/test/provider-descriptor-fallback.test.ts` (the
+descriptor-less-plugin defaults table from **Compatibility & migration** — this is the test that
+proves old providers don't break).
+
+### Phase 2 — hub API
+
+- `apps/hub/lib/hub-backend.ts`
+  - `listProviders` (766): iterate `listProviderDescriptors()` instead of `PROVIDER_NAMES`.
+  - `isProviderConfigured` (650) → `descriptor.bake.required ? preparedBase : true`; keep the
+    remote-docker host-count special case.
+  - `hasProviderCredentials` (692) → `descriptor.credentials.envKeys`; delete
+    `PROVIDER_CRED_KEYS`.
+  - `preparePrecheck` (724), `providerBaseFreshness` (809), `listProvidersWithFreshness` (885),
+    `providerBakeDiff` (911): `IMPORTERS[id]` → `loadProviderModuleByName(id)`; drop the
+    `isProviderKind` guards; skip freshness when `!bake.required`.
+  - `setProviderCredentials` (2270) / `prepareProvider` (2284): `isProviderKind` →
+    `isRuntimeProviderName` + `loadProviderModuleByName`.
+- `apps/hub/lib/boxes/types.ts` — `ProviderOption` gains `kind`, `credentials`, `bake`,
+  `capabilities`, `sizes?`, `regions?`. All come from the sync snapshot, so they are **always**
+  populated (no new opt-in flag; `?freshness=1` keeps its existing meaning).
+- `apps/hub/app/(dashboard)/api/v1/providers/{credentials,prepare}/route.ts` — replace the
+  closed `isProviderId()` list with `isRuntimeProviderName`.
+- `apps/hub/app/(dashboard)/api/v1/lib/openapi.ts:2048` — `Provider.id` enum → open string;
+  document the new fields. Fix the drifted `CreateBox` schema while here (missing `repoUrl`,
+  `agentArgs`, `startAgent`, `foreground`, `opts`).
+
+### Phase 3 — tray (`../agentbox-tray`)
+
+- `Sources/AgentBox/Models/Project.swift` — `ProviderOption` Codable gains the new optional
+  fields.
+- `Menu/SettingsPanel.swift` — `providerMeta` credential fields come from
+  `option.credentials.fields`; the SF-Symbol half stays local (a macOS detail a plugin should
+  not own) with a `cube.fill` fallback. `PrepareProgressSteps` and `CreateBoxPanel
+  .ProgressSteps` read `bake.bakeProgressSteps` / `bake.createProgressSteps`, hardcoded tables
+  demoted to fallbacks. `bakeButton.isEnabled` (1000, 1123): `id == "docker"` →
+  `!bake.required || hasCredentials`.
+- `Menu/CreateBoxPanel.swift:587` — `provider != "docker"` stale-base gate → `bake.required`.
+  The dropdown itself needs **no change**: it already renders whatever `/api/v1/providers`
+  returns, so plugins appear once Phase 2 lands.
+- `Menu/MenuBuilder.swift` — gate Pause on `capabilities.realPause` (today it renders for every
+  running box). VNC/Web stay data-driven (`Box.hasVNC`) — already correct.
+- Update `agentbox-tray/CLAUDE.md`'s `/providers` contract section.
+
+### Phase 4 — retire the CLI name arrays
+
+Each becomes a `resolveProviderDescriptor(name)?.capabilities.<flag>` lookup (sync, no module
+load — that is the whole point of the Phase 1 snapshot):
+
+| File | Array | Replacement |
+|---|---|---|
+| `apps/cli/src/commands/_open-in.ts:40` | `PERSISTENT_SSH_PROVIDERS` | `capabilities.persistentSsh` |
+| `apps/cli/src/commands/_open-in.ts:54` | `IDE_PROVIDERS` | `capabilities.ssh \|\| directBoxSsh` |
+| `apps/cli/src/commands/_open-in.ts:57` | `SSH_MOUNT_PROVIDERS` | same |
+| `packages/sandbox-core/src/cloud-ssh.ts:153` | `PROVIDERS_WITH_DIRECT_BOX_SSH` | `capabilities.directBoxSsh` |
+| `apps/cli/src/commands/prune.ts:81` | `CLOUD_PRUNE_PROVIDERS` | `capabilities.prune` |
+| `apps/cli/src/commands/checkpoint.ts:42` | `KNOWN_PROVIDERS` | `capabilities.checkpoints` |
+| `apps/cli/src/commands/checkpoint.ts:79` | `=== 'vercel' \|\| 'daytona'` | `capabilities.checkpointReboots` |
+| `apps/cli/src/commands/fork.ts:18` | `FORK_PROVIDERS` | `getRuntimeProviderNames()` |
+| `apps/cli/src/commands/install.ts:538` | `KNOWN_PROVIDERS` picker | `listProviderDescriptors()` |
+| `apps/cli/src/wizard.ts:372` | `providerMeta().rebuildMinutes` | `descriptor.bake.approxMinutes` |
+| `apps/cli/src/lib/cloud-sizing.ts:57` | per-name `if` chain | emit `location` when `descriptor.regions`, `inbound` when `capabilities.inbound`; the `timeoutMs`/`sandboxClass`/`networkPolicy` arms stay name-keyed (their config keys are built-in-only by design) |
+
+Out of scope (deliberately): `perProviderConfigKey` still returns `''` for plugins — documented
+behavior (`packages/config/src/image.ts:20`), plugins own their prepared-state.
+
+### Phase 5 — docs + web UI
+
+- `docs/provider-plugins.md` — the main doc deliverable, three new pieces:
+  1. **"Declaring a descriptor"** — the full `ProviderDescriptor` shape, a worked example
+     lifted from `examples/agentbox-provider-example`, and a field-by-field note on *which*
+     fields are declared vs derived (with "don't declare what the module already proves").
+  2. **"Migrating an existing plugin"** — explicitly: *you don't have to*. Then what you gain
+     if you do, the fallback table from **Compatibility & migration** verbatim so an author can
+     see exactly what they get by default, and the two-line change (`descriptor` export +
+     `@madarco/agentbox-provider-sdk@^2.7`, then `agentbox plugin add <pkg>` to refresh the
+     snapshot).
+  3. **"Choosing capability values"** — the three that are easy to get wrong: `realPause`
+     (does pause preserve state, or degrade to stop?), `persistentSsh` (does the per-box SSH
+     identity outlive the CLI call? — Daytona's expiring token says no), and `checkpointReboots`.
+  While here, fix the two stale facts (says "five built-in providers" — there are seven; says
+  depend on SDK `^1` / `providerApiVersion: 1` — the SDK is `2.x`).
+- `apps/web/content/docs/**` — mirror the descriptor contract on the public provider-plugins
+  page; API reference for the `GET /api/v1/providers` response.
+- `docs/cloud-providers.md` — one line pointing at the descriptor as the capability source.
+- `apps/hub/app/(dashboard)/boxes/components/create-box-modal.tsx` — no change needed (already
+  renders the fetched list); `settings/components/provider-actions.tsx:239`'s
+  `p.id === 'docker'` → `!bake.required`.
+- `CHANGELOG.md` — 1–2 sentences.
+
+---
+
+## Verification
+
+`examples/agentbox-provider-example` is the E2E fixture (a working Vercel-backed provider clone
+with `prepare`, `buildAttach` and an id-addressed `checkpoint`).
+
+1. **Unit:** `pnpm test` + `pnpm typecheck` (tsup does not typecheck — CI will fail without it).
+2. **Registration snapshot:**
+   `cd examples/agentbox-provider-example && npm pack` → install → `agentbox plugin add …` →
+   `jq '.plugins[].descriptors' ~/.agentbox/plugins.json` shows the merged declared+derived
+   descriptor, with `checkpoints: true` (it overrides `checkpoint`) and `bakeable: true`.
+3. **API:** rebuild + restart the hub — mandatory, it serves the standalone bundle:
+   ```
+   pnpm --filter @agentbox/hub build:standalone
+   AGENTBOX_HUB_BIN="$PWD/apps/hub/dist-standalone/apps/hub/server.js" node apps/cli/dist/index.js hub restart
+   curl -s -H "Authorization: Bearer $(cat ~/.agentbox/hub/token)" \
+     'http://127.0.0.1:8787/api/v1/providers?freshness=1&hosts=expand' | jq '.data.providers[] | {id,kind,capabilities,credentials}'
+   ```
+   The example provider must appear with `configured: true` once baked, and every built-in row
+   must carry the same field set as before plus `capabilities`.
+4. **Tray:** build + run `../agentbox-tray`; the example provider is in the create dropdown, its
+   Settings row renders the API-supplied credential fields, and Pause is hidden for a provider
+   with `realPause: false`.
+5. **Create:** `agentbox create -y -n plug-smoke --provider <example>` in the background, then
+   `tail -f ~/.agentbox/logs/create.log` until `box ... ready` — do not block on a long timeout.
+   Then create the same box from the tray dropdown and confirm the job streams to completion.
+6. **CLI arrays:** `agentbox open --targets --json` lists the example provider under the SSH
+   apps it qualifies for; `agentbox checkpoint set-default --provider <example>` is accepted;
+   `agentbox prune --provider <example> --dry-run` enumerates.
+7. **Back-compat with a real un-migrated plugin** — the check that answers "does this break old
+   providers?" against something other than a unit test. Register the example provider
+   **without** a descriptor (or check out its pre-Phase-1 revision), then confirm:
+   its row appears in `GET /api/v1/providers` with `capabilities.vnc/dind/realPause: true` and
+   `bake.required` matching `!!provider.prepare`; the tray still offers Pause and an enabled
+   bake button; `agentbox create --provider <example>` still succeeds. Then confirm the
+   auto-backfill fired: `jq '.version, .plugins[].descriptors' ~/.agentbox/plugins.json` shows
+   `2` and a populated snapshot after that first load.
+8. **SDK republish gate:** `pnpm --filter @madarco/agentbox-provider-sdk pack:test`, then
+   `cd packages/provider-sdk && npm publish` (manual, per `/release-notes`).

--- a/docs/provider-plugins.md
+++ b/docs/provider-plugins.md
@@ -82,6 +82,131 @@ that:
    checkpoints, cp) on top of the thin ~13-method `CloudBackend` — "a cloud is one
    file."
 
+## Declaring a descriptor
+
+A **`ProviderDescriptor`** is how your provider tells AgentBox's UIs what it is
+and what it can do — a real label in the tray/web create pickers, the right
+credential form, and correct capability gating. Built-in providers declare the
+same shape in `@agentbox/config`'s `PROVIDERS` table; you declare it on your
+`providerModule`:
+
+```ts
+import type { ProviderDescriptor } from '@madarco/agentbox-provider-sdk';
+
+const descriptor: ProviderDescriptor = {
+  name: 'myprovider',
+  kind: 'cloud',                       // 'local' = a docker-style local engine
+  label: 'MyProvider (cloud microVM)',
+  loginHint: 'paste an API token from the MyProvider console',
+  credentials: {
+    // secrets.env key NAMES that mean "configured". Only names are ever read.
+    envKeys: ['MYPROVIDER_TOKEN'],
+    // The form a UI renders. Each `key` is passed verbatim to setCredentials.
+    fields: [
+      { key: 'token', label: 'API token' },
+      { key: 'region', label: 'Region', optional: true, secret: false },
+    ],
+  },
+  bake: {
+    required: true,                    // false if your base self-heals on create
+    approxMinutes: '5-10',
+    createProgressSteps: 40,           // typical streamed log lines, for pacing
+    bakeProgressSteps: 500,
+  },
+  capabilities: {
+    checkpoints: true, checkpointReboots: false,
+    ssh: false, persistentSsh: false, directBoxSsh: false,
+    inbound: false, directGit: true, resync: true, prune: true,
+    vnc: true, dind: true,
+    pauseSemantics: 'freeze',
+    hubRoutable: true,
+  },
+  blurb: 'MyProvider microVMs',
+  sizeDesc: 'Per-provider override of `box.size` for myprovider (vCPU count).',
+  imageDesc: 'Per-provider override of `box.image` for myprovider (snapshot id).',
+};
+
+export const providerModule: ProviderModule = { provider, backend, descriptor, /* … */ };
+```
+
+`agentbox plugin add` snapshots this into `~/.agentbox/plugins.json`, so every
+consumer — the CLI's sync `open --targets` probe, the hub's hot `listProviders`
+path, the tray — resolves it without importing your package.
+
+**Declare what code can't reveal; don't mirror method presence.** AgentBox
+deliberately does *not* infer capabilities from your `Provider` object, because
+`createCloudProvider` defines `checkpoint`, `setInbound`, `repairReachability`
+and `enableDirectGit` on *every* cloud provider — their presence says which
+scaffold you used, not what you support. (The built-in docker provider is the
+sharp end of this: it has working `docker commit` checkpoints and no
+`provider.checkpoint` at all.)
+
+Three values ARE cross-checked against your `CloudBackend`, which you wrote and
+which therefore means something — declare them to match or a test will disagree:
+
+| Descriptor field | Must equal |
+|---|---|
+| `capabilities.prune` | `!!backend.list` |
+| `capabilities.inbound` | `!!backend.setInbound` |
+| `capabilities.timeoutModel` | `backend.timeoutModel` |
+
+## Choosing capability values
+
+Most fields are obvious. These three are the ones people get wrong:
+
+- **`pauseSemantics`** — what `pause` *actually* does. `'freeze'` preserves the
+  running process tree (a real pause/resume or snapshot-resume). `'stop'` powers
+  the box off so only the disk survives — that's what hetzner and digitalocean
+  do (`pause ≡ stop` in both backends). This is **not** a gate on showing a pause
+  control: powering a VPS down is useful, it stops the billing. A UI should
+  relabel on `'stop'`, never hide.
+- **`persistentSsh`** — whether the per-box SSH identity outlives the CLI call.
+  An app like Codex connects again on its own later, so a gateway handing out an
+  expiring token (Daytona's 60-minute credential) does **not** qualify even
+  though SSH works right now. A per-box key file on disk does.
+- **`checkpointReboots`** — whether capturing a checkpoint stops and restarts the
+  box. If your snapshot API requires a stopped sandbox, this is `true` and the
+  CLI will confirm before yanking a live agent.
+
+`ssh` means a real sshd you can `agentbox code` (IDE) and `agentbox open`
+(sshfs-mount) into. `directBoxSsh` is narrower: your `buildAttach` yields a plain
+`ssh … user@host` pointing AT the box, the one shape AgentBox can parse a target
+out of — leave it false if you implement `sshTarget` yourself.
+
+## Migrating an existing plugin
+
+**You don't have to.** `descriptor` is optional and `SDK_API_VERSION` did not
+change, so a plugin built against an older SDK loads exactly as before. When one
+is missing, AgentBox derives what it can from your module and fills the rest with
+defaults chosen to reproduce pre-descriptor behavior:
+
+| Field | Without a descriptor | Why |
+|---|---|---|
+| `label` | your provider name | what UIs showed before |
+| `kind` | `'cloud'` if you export a `backend` | derived |
+| `bake.required` | **`false`** | a `true` default would newly BLOCK creates that work today |
+| `credentials.fields` | one `apiKey` field if you export `setCredentials`, else none | matches the old tray fallback |
+| `capabilities.vnc` / `dind` | **`true`** | the scaffold wires both; `false` would delete working UI |
+| `capabilities.pauseSemantics` | `'freeze'` | UIs showed an unqualified pause |
+| `capabilities.checkpoints` / `ssh` | `!!provider.checkpoint` / `!!provider.sshTarget` | sound for a scaffold-based plugin |
+| `capabilities.prune` / `inbound` / `timeoutModel` | from your `CloudBackend` | authored by you, so honest |
+| `persistentSsh` / `directBoxSsh` / `inbound` | `false` | plugins were excluded from those paths before; opt in by declaring |
+
+So an un-migrated plugin **gains** the create dropdown, a credential form, and
+`prune` / `checkpoint` / `fork` eligibility, and loses nothing. AgentBox
+back-fills the derived descriptor into `plugins.json` the first time it loads
+your module, so this happens with no user action.
+
+Migrating is two lines: bump to `@madarco/agentbox-provider-sdk@^2.8`, export a
+`descriptor`, then `agentbox plugin add <pkg>` to refresh the snapshot.
+
+One thing a plugin still doesn't get: a `box.image<P>` / `box.size<P>` /
+`box.defaultCheckpoint<P>` config key. Those are statically typed per built-in.
+Your provider falls back to the generic `box.image` / `box.size`, and
+`checkpoint set-default --provider <you>` warns that it is writing the
+cross-provider default. Own your base via your own prepared-state file instead
+(see "Prepare, attach, and checkpoints" below).
+
 ## The box user
 
 Everything AgentBox puts in a box belongs to **`vscode`** with `$HOME` at

--- a/examples/agentbox-provider-example/src/index.ts
+++ b/examples/agentbox-provider-example/src/index.ts
@@ -28,6 +28,7 @@ import {
   type BoxRecord,
   type Provider,
   type ProviderCheckpoint,
+  type ProviderDescriptor,
   type ProviderModule,
 } from '@madarco/agentbox-provider-sdk';
 import {
@@ -114,10 +115,65 @@ export const exampleProvider: Provider = {
   baseFingerprint: () => currentExampleBaseFingerprintLive(),
 };
 
+/**
+ * Declarative metadata for AgentBox's UIs (the tray create picker, the hub web
+ * settings card, `agentbox install`). Optional — omit it and AgentBox derives a
+ * usable descriptor from the module below — but declaring one is what buys a
+ * real label, the right credential form, and correct capability gating.
+ *
+ * Declare only what code can't reveal. Do NOT try to mirror method presence
+ * here: `createCloudProvider` gives every cloud provider a `checkpoint` /
+ * `setInbound` / `enableDirectGit`, so those say nothing about YOUR backend.
+ * AgentBox cross-checks `prune`, `inbound` and `timeoutModel` against your
+ * `CloudBackend`, which is authored by you and therefore meaningful.
+ */
+export const exampleDescriptor: ProviderDescriptor = {
+  name: BACKEND_NAME,
+  kind: 'cloud',
+  label: 'Example (community provider)',
+  loginHint: 'paste an API token for the example cloud',
+  credentials: {
+    // Presence of the KEY in ~/.agentbox/secrets.env means "configured". The
+    // value is never read for this check.
+    envKeys: ['EXAMPLE_API_TOKEN'],
+    fields: [{ key: 'token', label: 'API token' }],
+  },
+  bake: {
+    // This provider snapshots a base before first use, so a create can't run
+    // until `agentbox prepare --provider example` has. A provider whose base
+    // self-heals (like docker) sets this false.
+    required: true,
+    approxMinutes: '5-10',
+    createProgressSteps: 33,
+    bakeProgressSteps: 400,
+  },
+  capabilities: {
+    checkpoints: true,
+    // Our snapshot stops the box, so the CLI confirms before yanking a live agent.
+    checkpointReboots: true,
+    // No SSH: attach rides the SDK, so `agentbox code` / `open` can't work here.
+    ssh: false,
+    persistentSsh: false,
+    directBoxSsh: false,
+    inbound: false,
+    directGit: true,
+    resync: true,
+    prune: true,
+    vnc: true,
+    dind: true,
+    pauseSemantics: 'freeze',
+    hubRoutable: true,
+  },
+  blurb: 'the example community provider',
+  sizeDesc: 'Per-provider override of `box.size` for example (vCPU count).',
+  imageDesc: 'Per-provider override of `box.image` for example (snapshot id).',
+};
+
 /** Uniform surface the CLI provider loader resolves this package through. */
 export const providerModule: ProviderModule = {
   provider: exampleProvider,
   backend: exampleBackend,
+  descriptor: exampleDescriptor,
   ensureCredentials: ensureExampleCredentials,
   readCredStatus: readCredStatusSummary,
   currentBaseFingerprintLive: (claudeInstall) => currentExampleBaseFingerprintLive(claudeInstall),

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -31,7 +31,9 @@ export {
   providerMeta,
   providerKeyCap,
   perProviderConfigKey,
-  type ProviderMeta,
+  type ProviderDescriptor,
+  type ProviderCapabilities,
+  type ProviderCredentialField,
 } from './providers.js';
 export {
   parseProviderSpec,

--- a/packages/config/src/providers.ts
+++ b/packages/config/src/providers.ts
@@ -16,7 +16,89 @@
  * drifts from this table.
  */
 
-export interface ProviderMeta {
+/** One credential a UI prompts for, keyed as `ProviderModule.setCredentials` expects. */
+export interface ProviderCredentialField {
+  /** Field key passed to `setCredentials` (e.g. `apiKey`, `token`, `teamId`). */
+  readonly key: string;
+  readonly label: string;
+  readonly optional?: boolean;
+  /**
+   * Mask in UIs and never echo back. Defaults to true when omitted — a field is
+   * a secret unless it says otherwise. DigitalOcean's `project` is the exception:
+   * it lands in the `box.digitaloceanProject` config key, not `secrets.env`.
+   */
+  readonly secret?: boolean;
+  readonly hint?: string;
+}
+
+/**
+ * What a provider can do. Every flag is DECLARED, not inferred from method
+ * presence: `createCloudProvider` defines `setInbound`/`repairReachability`/
+ * `enableDirectGit`/`checkpoint` on every cloud provider (delegating to an
+ * optional backend method at call time), so `Provider` method presence says
+ * which scaffold was used, not what the provider supports. Docker is the sharp
+ * case — it has no `provider.checkpoint` at all, yet `docker commit` checkpoints
+ * are the oldest feature in the repo.
+ *
+ * `CloudBackend` methods, being written by the provider author, ARE honest —
+ * `prune`, `inbound` and `timeoutModel` below must agree with `backend.list`,
+ * `backend.setInbound` and `backend.timeoutModel`, and a test asserts it.
+ */
+export interface ProviderCapabilities {
+  /** Checkpoint capture/restore is supported at all. */
+  readonly checkpoints: boolean;
+  /** Capturing a checkpoint stops and reboots the box (the capture prompt). */
+  readonly checkpointReboots: boolean;
+  /** Real SSH into the box: `agentbox code` (IDE) and `agentbox open` (sshfs mount). */
+  readonly ssh: boolean;
+  /**
+   * The per-box SSH identity outlives the CLI call, so an app that connects on
+   * its own later works (`open --in claude|codex`). An expiring token gateway
+   * (daytona) does not qualify.
+   */
+  readonly persistentSsh: boolean;
+  /**
+   * `buildAttach` yields a plain `ssh … user@host` pointing AT the box — the only
+   * shape `resolveCloudSshTarget` can parse a target out of. A provider with its
+   * own `sshTarget` needs this false.
+   */
+  readonly directBoxSsh: boolean;
+  /** Per-box inbound firewall policy (`--inbound`). Must match `!!backend.setInbound`. */
+  readonly inbound: boolean;
+  /** `git.pushMode=direct` can be switched on post-create (`--with-credentials`). */
+  readonly directGit: boolean;
+  /** Host-to-box workspace resync. */
+  readonly resync: boolean;
+  /** Orphan sandboxes are enumerable + deletable. Must match `!!backend.list`. */
+  readonly prune: boolean;
+  readonly vnc: boolean;
+  /** Nested containers (in-box dockerd) work. */
+  readonly dind: boolean;
+  /**
+   * What `pause` actually does. 'freeze' preserves the running process tree
+   * (docker pause, daytona linux-vm, vercel/e2b snapshot-resume); 'stop' powers
+   * the box off so only the disk survives (hetzner and digitalocean are both
+   * literally `pause ≡ stop`).
+   *
+   * NOT a gate on offering a pause control — powering a VPS down is useful, it
+   * stops billing. A UI should relabel on 'stop', never hide.
+   */
+  readonly pauseSemantics: 'freeze' | 'stop';
+  /** Creates can be handed to a remote control box (`cloud.viaHub`). */
+  readonly hubRoutable: boolean;
+  /** Session-lifetime model. Must match `backend.timeoutModel`. */
+  readonly timeoutModel?: 'absolute' | 'inactivity';
+}
+
+/**
+ * Everything a UI or CLI can know about a provider WITHOUT loading its module.
+ *
+ * Built-ins declare this in the `PROVIDERS` table below. External plugins
+ * declare the same shape on `ProviderModule.descriptor`, which `agentbox plugin
+ * add` snapshots into `~/.agentbox/plugins.json` — so every consumer resolves a
+ * descriptor synchronously and offline, whichever kind of provider it is.
+ */
+export interface ProviderDescriptor {
   /** Canonical name — MUST equal the `@agentbox/sandbox-<name>` package suffix. */
   readonly name: string;
   /** 'local' = docker; 'cloud' = has a CloudBackend + a prepared base snapshot. */
@@ -25,8 +107,35 @@ export interface ProviderMeta {
   readonly label: string;
   /** One-line hint for the install-wizard picker. */
   readonly loginHint: string;
-  /** Rough base-image/snapshot bake time (minutes) shown by the install wizard. */
-  readonly rebuildMinutes: string;
+  readonly credentials: {
+    /**
+     * `secrets.env` key names whose presence means "credentials configured".
+     * Only the NAME is ever read, never the value. Empty = none needed.
+     */
+    readonly envKeys: readonly string[];
+    /** Fields a credential form prompts for. Empty = none needed. */
+    readonly fields: readonly ProviderCredentialField[];
+  };
+  readonly bake: {
+    /**
+     * Whether a base image/snapshot must exist before the provider is usable.
+     * False for docker (its base self-heals on create) and remote-docker (the
+     * image builds lazily on first create). Note this is NOT `!!provider.prepare`
+     * — all seven built-ins have a `prepare`.
+     */
+    readonly required: boolean;
+    /** Rough bake time in minutes, shown by the install wizard. */
+    readonly approxMinutes: string;
+    /** Typical streamed create-log line count, for client progress pacing. */
+    readonly createProgressSteps?: number;
+    /** Typical streamed bake-log line count. Bakes are far more verbose. */
+    readonly bakeProgressSteps?: number;
+  };
+  readonly capabilities: ProviderCapabilities;
+  /** Known VM sizes. Absent = free-form string the backend interprets. */
+  readonly sizes?: readonly { readonly key: string; readonly label: string }[];
+  /** Known regions/datacenters. Absent = the provider has no region choice. */
+  readonly regions?: readonly { readonly key: string; readonly label: string }[];
   /** Fragment describing this backend, joined into the `box.provider` enum description. */
   readonly blurb: string;
   /** Description of the per-provider `box.size<P>` KEY_REGISTRY entry. */
@@ -41,7 +150,30 @@ export const PROVIDERS = [
     kind: 'local',
     label: 'Docker (local)',
     loginHint: 'builds a ~1GB local image; no login needed',
-    rebuildMinutes: '1',
+    credentials: { envKeys: [], fields: [] },
+    // The base self-heals: `ensureImage` pulls or builds on create, so a missing
+    // base is a slow first create, never a blocked one.
+    bake: { required: false, approxMinutes: '1', createProgressSteps: 52, bakeProgressSteps: 420 },
+    capabilities: {
+      // `docker commit` — the oldest checkpoint implementation in the repo. It
+      // does NOT hang off `provider.checkpoint` (see the interface doc).
+      checkpoints: true,
+      checkpointReboots: false,
+      ssh: true,
+      persistentSsh: true,
+      // Its localhost sshd is reached by published port, not a direct `ssh
+      // user@host` attach argv.
+      directBoxSsh: false,
+      inbound: false,
+      directGit: false,
+      resync: true,
+      prune: false,
+      vnc: true,
+      dind: true,
+      pauseSemantics: 'freeze',
+      // Local engine — there is no hub to route a create to.
+      hubRoutable: false,
+    },
     blurb: 'local Docker containers',
     sizeDesc:
       'Per-provider override of `box.size` for docker. Reserved — docker sizing is controlled via `box.memory` / `box.cpus` / `box.disk`.',
@@ -53,7 +185,37 @@ export const PROVIDERS = [
     kind: 'cloud',
     label: 'Daytona (cloud sandbox)',
     loginHint: 'paste an API key from the Daytona dashboard',
-    rebuildMinutes: '7',
+    credentials: {
+      envKeys: ['DAYTONA_API_KEY', 'DAYTONA_JWT_TOKEN'],
+      fields: [{ key: 'apiKey', label: 'API key' }],
+    },
+    bake: {
+      required: true,
+      approxMinutes: '7',
+      createProgressSteps: 1900,
+      bakeProgressSteps: 1500,
+    },
+    capabilities: {
+      checkpoints: true,
+      // `sb._experimental_createSnapshot` stops the sandbox to capture it.
+      checkpointReboots: true,
+      ssh: true,
+      // The SSH gateway is reached with an expiring token, so an app that dials
+      // in on its own later (codex) finds a dead credential.
+      persistentSsh: false,
+      directBoxSsh: true,
+      inbound: false,
+      directGit: true,
+      resync: true,
+      prune: true,
+      vnc: true,
+      dind: true,
+      // linux-vm `pause()` freezes CPU + memory. The `container` class has no
+      // pause primitive and archives instead (filesystem only) — see backend.ts.
+      pauseSemantics: 'freeze',
+      hubRoutable: true,
+      timeoutModel: 'inactivity',
+    },
     blurb: 'Daytona Cloud sandboxes',
     sizeDesc:
       'Per-provider override of `box.size` for daytona. `cpu-memory-disk` GB spec (e.g. `4-8-20`). Only honored on the image/Dockerfile create path; on the snapshot path the size is fixed at bake time (Daytona rejects custom resources on snapshot-resume).',
@@ -65,7 +227,33 @@ export const PROVIDERS = [
     kind: 'cloud',
     label: 'Hetzner (cloud VPS)',
     loginHint: 'paste an API token from the Hetzner Console',
-    rebuildMinutes: '7-10',
+    credentials: {
+      envKeys: ['HCLOUD_TOKEN'],
+      fields: [{ key: 'token', label: 'API token' }],
+    },
+    bake: {
+      required: true,
+      approxMinutes: '7-10',
+      createProgressSteps: 41,
+      bakeProgressSteps: 900,
+    },
+    capabilities: {
+      checkpoints: true,
+      // `create_image` defaults to no-pause, matching `docker commit`.
+      checkpointReboots: false,
+      ssh: true,
+      persistentSsh: true,
+      directBoxSsh: true,
+      inbound: true,
+      directGit: true,
+      resync: true,
+      prune: true,
+      vnc: true,
+      dind: true,
+      // "Hetzner has no archive primitive. Pause ≡ stop." (backend.ts)
+      pauseSemantics: 'stop',
+      hubRoutable: true,
+    },
     blurb: 'Hetzner Cloud VPSes',
     sizeDesc:
       'Per-provider override of `box.size` for hetzner. Server type string (e.g. `cx23`, `cx33`, `cx43`).',
@@ -77,7 +265,38 @@ export const PROVIDERS = [
     kind: 'cloud',
     label: 'Vercel (cloud microVM)',
     loginHint: 'installs the Vercel sandbox CLI, then a browser sign-in',
-    rebuildMinutes: '5-10',
+    credentials: {
+      envKeys: ['VERCEL_TOKEN', 'VERCEL_OIDC_TOKEN', 'VERCEL_AUTH_SOURCE'],
+      fields: [
+        { key: 'token', label: 'Access token' },
+        { key: 'teamId', label: 'Team ID', optional: true },
+        { key: 'projectId', label: 'Project ID', optional: true },
+      ],
+    },
+    bake: {
+      required: true,
+      approxMinutes: '5-10',
+      createProgressSteps: 33,
+      bakeProgressSteps: 400,
+    },
+    capabilities: {
+      checkpoints: true,
+      // `sb.snapshot()` stops the box; the live agent process doesn't survive.
+      checkpointReboots: true,
+      // No SSH at all — attach is a custom tmux bridge over the SDK.
+      ssh: false,
+      persistentSsh: false,
+      directBoxSsh: false,
+      inbound: false,
+      directGit: true,
+      resync: true,
+      prune: true,
+      vnc: true,
+      // Nested containers verified working 2026-06-30 (`launchDockerd: true`).
+      dind: true,
+      pauseSemantics: 'freeze',
+      hubRoutable: true,
+    },
     blurb: 'Vercel Sandboxes',
     sizeDesc:
       'Per-provider override of `box.size` for vercel. vCPU count — one of `1`, `2`, `4`, `8` (Vercel couples RAM at 2048 MB/vCPU). Default 2.',
@@ -89,7 +308,29 @@ export const PROVIDERS = [
     kind: 'cloud',
     label: 'E2B (cloud microVM)',
     loginHint: 'paste an API key from the E2B dashboard',
-    rebuildMinutes: '2',
+    credentials: {
+      envKeys: ['E2B_API_KEY'],
+      fields: [{ key: 'apiKey', label: 'API key' }],
+    },
+    bake: { required: true, approxMinutes: '2', createProgressSteps: 34, bakeProgressSteps: 500 },
+    capabilities: {
+      checkpoints: true,
+      checkpointReboots: false,
+      // No SSH — attach is an SDK-streaming PTY bridge.
+      ssh: false,
+      persistentSsh: false,
+      directBoxSsh: false,
+      inbound: false,
+      directGit: true,
+      resync: true,
+      prune: true,
+      vnc: true,
+      // Full root + cap_sys_admin, verified 2026-06-23.
+      dind: true,
+      pauseSemantics: 'freeze',
+      hubRoutable: true,
+      timeoutModel: 'inactivity',
+    },
     blurb: 'E2B microVMs',
     sizeDesc:
       'Per-provider override of `box.size` for e2b. `cpu-memory` GB spec (e.g. `4-8`). Template-level: baked by `agentbox prepare --provider e2b --size <spec>`; E2B rejects per-create resources.',
@@ -101,7 +342,47 @@ export const PROVIDERS = [
     kind: 'cloud',
     label: 'DigitalOcean (cloud VPS)',
     loginHint: 'paste a Personal Access Token from the DigitalOcean Console',
-    rebuildMinutes: '7-10',
+    credentials: {
+      envKeys: ['DIGITALOCEAN_TOKEN'],
+      fields: [
+        { key: 'token', label: 'API token' },
+        // Not a secret: the host writes it to `box.digitaloceanProject`. Blank
+        // means "leave unchanged", never "clear" — clearing is a `config unset`.
+        {
+          key: 'project',
+          label: 'Project',
+          optional: true,
+          secret: false,
+          hint: 'blank leaves it unchanged',
+        },
+      ],
+    },
+    bake: {
+      required: true,
+      approxMinutes: '7-10',
+      createProgressSteps: 41,
+      bakeProgressSteps: 900,
+    },
+    capabilities: {
+      checkpoints: true,
+      checkpointReboots: false,
+      // A VPS with a real sshd, same shape as hetzner. The pre-descriptor
+      // `IDE_PROVIDERS` / `SSH_MOUNT_PROVIDERS` arrays omitted digitalocean while
+      // listing it in `PROVIDERS_WITH_DIRECT_BOX_SSH` — an oversight, not a
+      // limitation, so `agentbox code` / `open` start working here.
+      ssh: true,
+      persistentSsh: true,
+      directBoxSsh: true,
+      inbound: true,
+      directGit: true,
+      resync: true,
+      prune: true,
+      vnc: true,
+      dind: true,
+      // "DigitalOcean has no archive primitive. Pause ≡ stop (power off)."
+      pauseSemantics: 'stop',
+      hubRoutable: true,
+    },
     blurb: 'DigitalOcean Droplets',
     sizeDesc:
       'Per-provider override of `box.size` for digitalocean. Droplet size slug (e.g. `s-2vcpu-4gb`, `s-4vcpu-8gb`).',
@@ -112,15 +393,37 @@ export const PROVIDERS = [
     name: 'remote-docker',
     kind: 'cloud',
     label: 'Remote Docker (your own machine over SSH)',
+    // It connects as you, over your own ~/.ssh/config — there is no credential
+    // to store, so there is none to check.
     loginHint: 'point it at an SSH host you can already reach (no login needed)',
-    rebuildMinutes: '1-3',
+    credentials: { envKeys: [], fields: [] },
+    // Usable as soon as one host alias is registered: the image builds lazily on
+    // first create. Readiness is the alias count, not a base marker.
+    bake: { required: false, approxMinutes: '1-3' },
+    capabilities: {
+      checkpoints: true,
+      checkpointReboots: false,
+      ssh: true,
+      persistentSsh: true,
+      // Reached by ProxyJump through the engine, via its own `sshTarget`.
+      directBoxSsh: false,
+      inbound: false,
+      directGit: true,
+      resync: true,
+      prune: true,
+      vnc: true,
+      dind: true,
+      pauseSemantics: 'freeze',
+      // Docker on YOUR OWN machine — a control box can't reach it.
+      hubRoutable: false,
+    },
     blurb: 'Docker on a remote machine over SSH',
     sizeDesc:
-      'Per-provider override of `box.size` for remote-docker. `cpu-memory` GB spec (e.g. `4-8`) mapped to the container\'s `--cpus` / `--memory`. Empty = unlimited (the remote engine\'s defaults).',
+      "Per-provider override of `box.size` for remote-docker. `cpu-memory` GB spec (e.g. `4-8`) mapped to the container's `--cpus` / `--memory`. Empty = unlimited (the remote engine's defaults).",
     imageDesc:
       'Per-provider override of `box.image` for remote-docker (a docker image ref on the REMOTE engine). Normally left empty: the provider derives a fingerprint-tagged ref (`agentbox/box:<sha12>`) and ensures it on the remote itself.',
   },
-] as const satisfies readonly ProviderMeta[];
+] as const satisfies readonly ProviderDescriptor[];
 
 /** Sandbox backend new boxes are created on. Derived from the `PROVIDERS` table. */
 export type ProviderKind = (typeof PROVIDERS)[number]['name'];
@@ -141,9 +444,9 @@ export const CLOUD_PROVIDER_NAMES: readonly ProviderKind[] = PROVIDERS.filter(
  * {@link CLOUD_PROVIDER_NAMES}, which counts `remote-docker` as cloud for the
  * git-bundle staging / SSH-sync it shares with the real clouds.
  */
-export const HUB_ROUTABLE_PROVIDER_NAMES: readonly ProviderKind[] = CLOUD_PROVIDER_NAMES.filter(
-  (n) => n !== 'remote-docker',
-);
+export const HUB_ROUTABLE_PROVIDER_NAMES: readonly ProviderKind[] = PROVIDERS.filter(
+  (p) => p.capabilities.hubRoutable,
+).map((p) => p.name);
 
 /** True when `name`'s creates can be handed to a remote control box. */
 export function isHubRoutableProvider(name: string): boolean {
@@ -154,7 +457,13 @@ export function isProviderKind(name: string): name is ProviderKind {
   return (PROVIDER_NAMES as readonly string[]).includes(name);
 }
 
-export function providerMeta(name: ProviderKind): ProviderMeta {
+/**
+ * The BUILT-IN descriptor for `name`. Throws on an unknown name, so it is only
+ * safe behind `isProviderKind`. To resolve a descriptor for any runtime provider
+ * — built-in OR registered plugin — use `resolveProviderDescriptor` from
+ * `@agentbox/sandbox-core`, which falls back to the plugin registry snapshot.
+ */
+export function providerMeta(name: ProviderKind): ProviderDescriptor {
   const m = PROVIDERS.find((p) => p.name === name);
   if (!m) throw new Error(`unknown provider: ${String(name)}`);
   return m;

--- a/packages/config/test/providers.test.ts
+++ b/packages/config/test/providers.test.ts
@@ -36,7 +36,10 @@ describe('provider table is the single source of truth', () => {
     for (const p of PROVIDERS) {
       for (const base of BASES) {
         const leaf = perProviderConfigKey(base, p.name).slice('box.'.length);
-        expect(boxSchemaKeys[leaf], `box.${leaf} missing from user-config.schema.json`).toBeDefined();
+        expect(
+          boxSchemaKeys[leaf],
+          `box.${leaf} missing from user-config.schema.json`,
+        ).toBeDefined();
       }
     }
   });
@@ -82,6 +85,65 @@ describe('provider table is the single source of truth', () => {
     expect(isHubRoutableProvider('docker')).toBe(false);
     expect(isHubRoutableProvider('remote-docker')).toBe(false);
     expect(isHubRoutableProvider('nonsense')).toBe(false);
+  });
+
+  // The descriptor is the contract every UI reads. A row missing a field would
+  // surface as an undefined capability in the tray/web create pickers rather than
+  // as a type error, since `satisfies` only checks what is present.
+  describe('every row declares a complete descriptor', () => {
+    const CAPS = [
+      'checkpoints',
+      'checkpointReboots',
+      'ssh',
+      'persistentSsh',
+      'directBoxSsh',
+      'inbound',
+      'directGit',
+      'resync',
+      'prune',
+      'vnc',
+      'dind',
+      'pauseSemantics',
+      'hubRoutable',
+    ] as const;
+
+    it.each(PROVIDERS.map((p) => p.name))('%s', (name) => {
+      const p = PROVIDERS.find((x) => x.name === name);
+      expect(p).toBeDefined();
+      if (!p) return;
+      expect(Array.isArray(p.credentials.envKeys)).toBe(true);
+      expect(Array.isArray(p.credentials.fields)).toBe(true);
+      expect(typeof p.bake.required).toBe('boolean');
+      expect(p.bake.approxMinutes).toBeTruthy();
+      const caps = p.capabilities as unknown as Record<string, unknown>;
+      for (const c of CAPS) expect(caps[c], `${name}.capabilities.${c}`).toBeDefined();
+      expect(['freeze', 'stop']).toContain(p.capabilities.pauseSemantics);
+    });
+
+    it('a credential field maps to a key setCredentials understands', () => {
+      // The field `key` is passed verbatim to ProviderModule.setCredentials, so a
+      // provider that declares fields must have somewhere to put them.
+      for (const p of PROVIDERS) {
+        if (p.credentials.fields.length === 0) continue;
+        expect(
+          p.credentials.envKeys.length,
+          `${p.name} declares fields but no envKeys`,
+        ).toBeGreaterThan(0);
+        for (const f of p.credentials.fields) {
+          expect(f.key).toMatch(/^[a-zA-Z][a-zA-Z0-9]*$/);
+          expect(f.label).toBeTruthy();
+        }
+      }
+    });
+
+    it('only providers that need a bake demand one', () => {
+      // docker's base self-heals on create; remote-docker builds lazily on first
+      // create. Everything else is unusable until `agentbox prepare` has run.
+      expect(PROVIDERS.filter((p) => !p.bake.required).map((p) => p.name)).toEqual([
+        'docker',
+        'remote-docker',
+      ]);
+    });
   });
 
   it('cloud.viaHub defaults on (remote hub is the default for cloud creates)', () => {

--- a/packages/provider-sdk/package.json
+++ b/packages/provider-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madarco/agentbox-provider-sdk",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Public SDK for building AgentBox sandbox providers as installable community packages",
   "license": "MIT",
   "author": "Marco D'Alia",

--- a/packages/provider-sdk/src/index.ts
+++ b/packages/provider-sdk/src/index.ts
@@ -76,6 +76,26 @@ export {
   type CredStatusSummary,
 } from '@agentbox/sandbox-core';
 
+// ---- declarative provider metadata ----
+// Declare a `descriptor` on your `providerModule` and AgentBox's UIs can render
+// your provider properly: a real label, the right credential fields, and correct
+// checkpoint / SSH / pause / VNC gating. `agentbox plugin add` snapshots it into
+// `~/.agentbox/plugins.json`, so every consumer reads it without importing you.
+//
+// OPTIONAL: omit it and you get a descriptor derived from your module plus
+// defaults that reproduce pre-descriptor behavior — nothing breaks, you just
+// show up as your bare provider name.
+export {
+  type ProviderDescriptor,
+  type ProviderCapabilities,
+  type ProviderCredentialField,
+} from '@agentbox/config';
+export {
+  resolveProviderDescriptor,
+  listProviderDescriptors,
+  deriveDescriptor,
+} from '@agentbox/sandbox-core';
+
 // ---- box-state + host helpers a backend/CLI surface may touch ----
 export {
   recordBox,
@@ -103,11 +123,7 @@ export {
 } from '@agentbox/sandbox-core';
 
 // ---- config access ----
-export {
-  loadEffectiveConfig,
-  findProjectRoot,
-  type EffectiveConfig,
-} from '@agentbox/config';
+export { loadEffectiveConfig, findProjectRoot, type EffectiveConfig } from '@agentbox/config';
 
 // ---- interactive attach helpers (build a cloud box's `buildAttach` argv) ----
 // A provider with no SSH (like vercel/e2b) overrides `buildAttach` and drives

--- a/packages/sandbox-core/src/cloud-ssh.ts
+++ b/packages/sandbox-core/src/cloud-ssh.ts
@@ -1,4 +1,5 @@
 import type { BoxRecord, Provider } from '@agentbox/core';
+import { resolveProviderDescriptor } from './provider-descriptor.js';
 import { recordBoxSsh } from './state.js';
 import { agentboxAliasFor, parseSshTarget, syncAgentboxSshConfig } from './ssh-config.js';
 
@@ -132,6 +133,20 @@ export async function ensureCloudSshAlias(
 }
 
 /**
+ * Whether a provider's `buildAttach` yields a plain `ssh … <user>@<host>` argv
+ * pointing AT the box — the only shape `resolveCloudSshTarget` can parse a box
+ * SSH target out of. Vercel/E2B have no SSH at all, and must not warn about it
+ * on every start. A provider with its own `sshTarget` needs this false.
+ *
+ * Read from the provider's descriptor rather than a hardcoded name list, so a
+ * community provider that attaches over plain SSH gets its `~/.ssh/config`
+ * entry written too.
+ */
+function hasDirectBoxSsh(name: string): boolean {
+  return resolveProviderDescriptor(name)?.capabilities.directBoxSsh ?? false;
+}
+
+/**
  * Proactive, default-on SSH-config write on create/start/resume — gated by the
  * `ssh.autoConfig` config key so a user who manages `~/.ssh/config` themselves
  * can opt out. Only persistent-identity providers qualify (Hetzner/DigitalOcean:
@@ -144,14 +159,6 @@ export async function ensureCloudSshAlias(
  * brought it up), so `bringOnline: false` avoids a redundant lifecycle pass.
  * Re-resolving on start is what refreshes a Hetzner box's changed public IP.
  */
-/**
- * Cloud providers whose `buildAttach` yields a plain `ssh … <user>@<host>` argv
- * pointing AT the box — the only shape `resolveCloudSshTarget` can parse a box
- * SSH target out of. Vercel/E2B have no SSH at all, and must not warn about it
- * on every start. A provider with its own `sshTarget` needs no entry here.
- */
-const PROVIDERS_WITH_DIRECT_BOX_SSH: readonly string[] = ['hetzner', 'digitalocean', 'daytona'];
-
 export async function autoWriteSshConfig(
   box: BoxRecord,
   provider: Provider,
@@ -162,7 +169,7 @@ export async function autoWriteSshConfig(
   // A provider with neither its own `sshTarget` nor a direct-ssh attach argv has
   // no box target to write (vercel/e2b have no SSH at all). That is a shape, not
   // a failure, and must not warn on every start/unpause.
-  if (!provider.sshTarget && !PROVIDERS_WITH_DIRECT_BOX_SSH.includes(provider.name)) return;
+  if (!provider.sshTarget && !hasDirectBoxSsh(provider.name)) return;
   try {
     const conn = await resolveCloudSshTarget(box, provider, { bringOnline: false });
     if (!conn.identityFile) return;

--- a/packages/sandbox-core/src/doctor.ts
+++ b/packages/sandbox-core/src/doctor.ts
@@ -10,6 +10,7 @@
  * generically via a lazy `import()`.
  */
 
+import type { ProviderDescriptor } from '@agentbox/config';
 import type { CloudBackend, Provider } from '@agentbox/core';
 import type { FileManifest } from './prepared-state.js';
 
@@ -57,6 +58,18 @@ export interface ProviderModule {
   provider: Provider;
   /** Cloud backend (host-side executor). Absent for the local docker provider. */
   backend?: CloudBackend;
+  /**
+   * Declarative metadata — label, credential fields, bake story, capabilities —
+   * for UIs and the CLI. Built-in providers declare this in `@agentbox/config`'s
+   * `PROVIDERS` table instead; an external plugin declares it here and
+   * `agentbox plugin add` snapshots it into `~/.agentbox/plugins.json`.
+   *
+   * OPTIONAL, and safe to omit: a plugin without one gets a descriptor derived
+   * from this module plus defaults chosen to reproduce pre-descriptor behavior
+   * (see `provider-descriptor.ts`). Declaring one buys a real label, a credential
+   * form, and correct SSH / pause / VNC gating.
+   */
+  descriptor?: ProviderDescriptor;
   /**
    * First-run credential gate. Called before `create`/`claude`/etc. hand out
    * the provider. Absent for docker (no login). `force` re-runs the flow.

--- a/packages/sandbox-core/src/index.ts
+++ b/packages/sandbox-core/src/index.ts
@@ -165,9 +165,18 @@ export {
   removePluginRecord,
   pluginProviderNames,
   pluginForProvider,
+  recordPluginDescriptor,
+  PLUGINS_FILE_VERSION,
   type PluginRecord,
   type PluginsFile,
+  type PluginsFileVersion,
 } from './plugin-registry.js';
+export {
+  resolveProviderDescriptor,
+  listProviderDescriptors,
+  deriveDescriptor,
+  ensureProviderDescriptor,
+} from './provider-descriptor.js';
 export {
   carryPlaceholderContext,
   renderCarryEntries,

--- a/packages/sandbox-core/src/plugin-registry.ts
+++ b/packages/sandbox-core/src/plugin-registry.ts
@@ -19,6 +19,7 @@ import { mkdir, open, readFile, rename, rm, stat, writeFile } from 'node:fs/prom
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
+import type { ProviderDescriptor } from '@agentbox/config';
 
 export const PLUGINS_FILE = join(homedir(), '.agentbox', 'plugins.json');
 
@@ -46,18 +47,41 @@ export interface PluginRecord {
   version: string;
   /** Provider names this package contributes (from each `providerModule.provider.name`). */
   providers: string[];
+  /**
+   * Per-provider descriptor snapshot, captured at `plugin add` from the module's
+   * declared `ProviderModule.descriptor` merged with what could be derived from
+   * the loaded module. Keyed by provider name.
+   *
+   * Snapshotting is what lets every consumer — the CLI's sync `open --targets`
+   * probe, the hub's hot `listProviders` path — resolve capabilities WITHOUT an
+   * `import()` of an external package. Absent on a v1 record; back-filled the
+   * first time something loads the module anyway.
+   */
+  descriptors?: Record<string, ProviderDescriptor>;
   /** `SDK_API_VERSION` the package declared (compat gate). */
   apiVersion: number;
   /** ISO timestamp the package was added. */
   addedAt: string;
 }
 
+/**
+ * v2 added `PluginRecord.descriptors`. A v1 file is read as-is and upgraded in
+ * place on the next write — the field is optional, so nothing breaks in between.
+ */
+export type PluginsFileVersion = 1 | 2;
+
 export interface PluginsFile {
-  version: 1;
+  version: PluginsFileVersion;
   plugins: PluginRecord[];
 }
 
-const EMPTY: PluginsFile = { version: 1, plugins: [] };
+export const PLUGINS_FILE_VERSION = 2;
+
+const EMPTY: PluginsFile = { version: PLUGINS_FILE_VERSION, plugins: [] };
+
+function isKnownVersion(v: unknown): v is PluginsFileVersion {
+  return v === 1 || v === 2;
+}
 
 const LOCK_STALE_MS = 15_000;
 const LOCK_ACQUIRE_TIMEOUT_MS = 20_000;
@@ -99,7 +123,7 @@ async function withFileLock<T>(path: string, fn: () => Promise<T>): Promise<T> {
 
 function normalize(raw: unknown): PluginsFile {
   const parsed = raw as PluginsFile;
-  if (!parsed || parsed.version !== 1 || !Array.isArray(parsed.plugins)) {
+  if (!parsed || !isKnownVersion(parsed.version) || !Array.isArray(parsed.plugins)) {
     // Unrecognized shape → treat as empty (a fresh registry), never throw:
     // a corrupt plugins.json must not brick every CLI command.
     return { ...EMPTY };
@@ -150,7 +174,7 @@ async function readForWrite(path: string): Promise<PluginsFile> {
     );
   }
   const p = parsed as PluginsFile;
-  if (!p || p.version !== 1 || !Array.isArray(p.plugins)) {
+  if (!p || !isKnownVersion(p.version) || !Array.isArray(p.plugins)) {
     throw new Error(
       `refusing to modify an unrecognized plugin registry at ${path} — fix or delete the file and retry.`,
     );
@@ -161,8 +185,31 @@ async function readForWrite(path: string): Promise<PluginsFile> {
 async function writeRegistry(file: PluginsFile, path: string = PLUGINS_FILE): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   const tmp = `${path}.tmp.${String(process.pid)}.${String(Date.now())}`;
-  await writeFile(tmp, JSON.stringify(file, null, 2) + '\n', 'utf8');
+  // Any write upgrades a v1 file: the added field is optional, so an older CLI
+  // reading the result still sees every record it understands.
+  const out: PluginsFile = { ...file, version: PLUGINS_FILE_VERSION };
+  await writeFile(tmp, JSON.stringify(out, null, 2) + '\n', 'utf8');
   await rename(tmp, path);
+}
+
+/**
+ * Record a descriptor snapshot for one provider of an already-registered
+ * package (the back-fill path for a v1 record, or a plugin that declared none).
+ * A no-op when the package isn't registered — losing a snapshot only costs the
+ * next caller another derivation, so this must never throw into a hot path.
+ */
+export async function recordPluginDescriptor(
+  providerName: string,
+  descriptor: ProviderDescriptor,
+  path: string = PLUGINS_FILE,
+): Promise<void> {
+  await withFileLock(path, async () => {
+    const file = await readForWrite(path);
+    const rec = file.plugins.find((p) => p.providers.includes(providerName));
+    if (!rec) return;
+    rec.descriptors = { ...rec.descriptors, [providerName]: descriptor };
+    await writeRegistry(file, path);
+  });
 }
 
 /** Upsert a plugin by `packageName` (idempotent re-add updates the record). */
@@ -174,7 +221,7 @@ export async function addPluginRecord(
     const file = await readForWrite(path);
     const next = file.plugins.filter((p) => p.packageName !== record.packageName);
     next.push(record);
-    await writeRegistry({ version: 1, plugins: next }, path);
+    await writeRegistry({ version: PLUGINS_FILE_VERSION, plugins: next }, path);
   });
 }
 
@@ -194,7 +241,7 @@ export async function removePluginRecord(
       if (match) removed += 1;
       return !match;
     });
-    await writeRegistry({ version: 1, plugins: next }, path);
+    await writeRegistry({ version: PLUGINS_FILE_VERSION, plugins: next }, path);
   });
   return removed;
 }

--- a/packages/sandbox-core/src/provider-descriptor.ts
+++ b/packages/sandbox-core/src/provider-descriptor.ts
@@ -1,0 +1,164 @@
+/**
+ * Resolve a {@link ProviderDescriptor} for ANY runtime provider — built-in or
+ * registered plugin — synchronously and offline.
+ *
+ * Built-ins declare their descriptor in `@agentbox/config`'s `PROVIDERS` table.
+ * A plugin declares one on `ProviderModule.descriptor`, which `agentbox plugin
+ * add` snapshots into `~/.agentbox/plugins.json`. Both are plain data by the
+ * time anything asks, which is the point: the CLI's `open --targets` probe and
+ * the hub's `listProviders` are hot, sync paths that must never `import()` an
+ * external package to answer "does this provider support checkpoints?".
+ *
+ * A plugin that predates descriptors (or simply declares none) still resolves —
+ * see {@link deriveDescriptor} for the fallback and why each default is what it
+ * is.
+ */
+
+import { PROVIDERS, isProviderKind, providerMeta } from '@agentbox/config';
+import type { ProviderCapabilities, ProviderDescriptor } from '@agentbox/config';
+import type { ProviderModule } from './doctor.js';
+import {
+  PLUGINS_FILE,
+  pluginForProvider,
+  readPluginRegistrySync,
+  recordPluginDescriptor,
+} from './plugin-registry.js';
+
+/**
+ * The descriptor for `name`, or undefined when nothing provides it.
+ *
+ * Built-in table first — a plugin can never shadow a built-in (`plugin add`
+ * rejects that), so the order is a formality that also keeps the common case
+ * off the filesystem.
+ */
+export function resolveProviderDescriptor(
+  name: string,
+  path: string = PLUGINS_FILE,
+): ProviderDescriptor | undefined {
+  if (isProviderKind(name)) return providerMeta(name);
+  return pluginForProvider(name, path)?.descriptors?.[name];
+}
+
+/** Every resolvable descriptor: built-ins in canonical order, then plugins. */
+export function listProviderDescriptors(path: string = PLUGINS_FILE): ProviderDescriptor[] {
+  // PROVIDERS is already in canonical order (docker first).
+  const builtIns: ProviderDescriptor[] = [...PROVIDERS];
+  const plugins: ProviderDescriptor[] = [];
+  for (const rec of readPluginRegistrySync(path).plugins) {
+    for (const providerName of rec.providers) {
+      const d = rec.descriptors?.[providerName];
+      // A plugin with no snapshot yet is still a real, creatable provider — list
+      // it on a placeholder rather than hiding it until something back-fills.
+      plugins.push(d ?? placeholderDescriptor(providerName));
+    }
+  }
+  return [...builtIns, ...plugins];
+}
+
+/**
+ * Defaults for a provider we know exists but have no descriptor for. Every value
+ * is chosen to reproduce what AgentBox did for a plugin BEFORE descriptors — a
+ * "safe = false" default would silently delete working UI (see `vnc`/`dind`/
+ * `pauseSemantics`).
+ */
+const FALLBACK_CAPABILITIES: ProviderCapabilities = {
+  // Cloud plugins are near-universally built on `createCloudProvider`, which
+  // gives them a working `checkpoint`. `deriveDescriptor` refines this from the
+  // real module when one is available.
+  checkpoints: false,
+  checkpointReboots: false,
+  ssh: false,
+  // Plugins were excluded from PERSISTENT_SSH_PROVIDERS / the direct-ssh list,
+  // so false IS the status quo — a plugin opts in by declaring a descriptor.
+  persistentSsh: false,
+  directBoxSsh: false,
+  inbound: false,
+  directGit: false,
+  resync: true,
+  prune: false,
+  // TRUE on purpose: `createCloudProvider` wires VNC unconditionally and
+  // degrades best-effort, and `launchDockerd` defaults true. Defaulting these
+  // false would remove a VNC button / DinD that works today.
+  vnc: true,
+  dind: true,
+  // The pre-descriptor UI showed an unqualified Pause for every running box.
+  pauseSemantics: 'freeze',
+  hubRoutable: true,
+};
+
+function placeholderDescriptor(name: string): ProviderDescriptor {
+  return {
+    name,
+    kind: 'cloud',
+    label: name,
+    loginHint: '',
+    credentials: { envKeys: [], fields: [] },
+    // NOT `true`: the hub's create gate deliberately skips the configured check
+    // for plugins, so demanding a bake here would newly block creates that work.
+    bake: { required: false, approxMinutes: '1' },
+    capabilities: { ...FALLBACK_CAPABILITIES },
+    blurb: `the ${name} provider`,
+    sizeDesc: `Per-provider override of \`box.size\` for ${name}.`,
+    imageDesc: `Per-provider override of \`box.image\` for ${name}.`,
+  };
+}
+
+/**
+ * Build a descriptor for a LOADED plugin module: what it declares, else what can
+ * be honestly derived from it, else the fallback defaults.
+ *
+ * Derivation reads `CloudBackend` methods, never `Provider` ones. Provider
+ * methods are supplied by `createCloudProvider` for every cloud provider
+ * (`setInbound`, `repairReachability`, `enableDirectGit`, `checkpoint`), so their
+ * presence says which scaffold was used, not what the provider supports. Backend
+ * methods are written by the provider author, so they mean something.
+ *
+ * `provider.checkpoint` and `provider.sshTarget` are the two exceptions worth
+ * reading: unlike the built-in table (where docker has working checkpoints and no
+ * `provider.checkpoint`), a plugin that has the scaffold-supplied `checkpoint`
+ * really does get working checkpoints from it.
+ */
+export function deriveDescriptor(name: string, mod: ProviderModule): ProviderDescriptor {
+  const declared = mod.descriptor;
+  if (declared) return declared;
+  const base = placeholderDescriptor(name);
+  const { provider, backend } = mod;
+  return {
+    ...base,
+    kind: backend ? 'cloud' : 'local',
+    credentials: {
+      envKeys: [],
+      // Only offer a credential form when the module can actually consume one.
+      fields: mod.setCredentials ? [{ key: 'apiKey', label: 'API key' }] : [],
+    },
+    capabilities: {
+      ...base.capabilities,
+      checkpoints: !!provider.checkpoint,
+      ssh: !!provider.sshTarget,
+      resync: !!provider.resyncWorkspace,
+      prune: !!backend?.list,
+      inbound: !!backend?.setInbound,
+      ...(backend?.timeoutModel ? { timeoutModel: backend.timeoutModel } : {}),
+    },
+  };
+}
+
+/**
+ * Resolve `name`'s descriptor, deriving and back-filling the registry snapshot
+ * when the plugin has none. Call this from paths that are loading the module
+ * anyway; everything else should use the sync {@link resolveProviderDescriptor}.
+ *
+ * The write is best-effort: a lost snapshot only costs the next caller another
+ * derivation, so a read-only HOME or a concurrent writer must not fail a create.
+ */
+export async function ensureProviderDescriptor(
+  name: string,
+  mod: ProviderModule,
+  path: string = PLUGINS_FILE,
+): Promise<ProviderDescriptor> {
+  const existing = resolveProviderDescriptor(name, path);
+  if (existing) return existing;
+  const derived = deriveDescriptor(name, mod);
+  await recordPluginDescriptor(name, derived, path).catch(() => {});
+  return derived;
+}

--- a/packages/sandbox-core/test/plugin-registry.test.ts
+++ b/packages/sandbox-core/test/plugin-registry.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   addPluginRecord,
   isSupportedApiVersion,
+  PLUGINS_FILE_VERSION,
   pluginForProvider,
   pluginProviderNames,
   readPluginRegistry,
@@ -35,14 +36,14 @@ const rec = (overrides: Partial<PluginRecord> = {}): PluginRecord => ({
 
 describe('plugin registry', () => {
   it('missing file reads as empty (sync + async)', async () => {
-    expect(readPluginRegistrySync(path)).toEqual({ version: 1, plugins: [] });
-    expect(await readPluginRegistry(path)).toEqual({ version: 1, plugins: [] });
+    expect(readPluginRegistrySync(path)).toEqual({ version: PLUGINS_FILE_VERSION, plugins: [] });
+    expect(await readPluginRegistry(path)).toEqual({ version: PLUGINS_FILE_VERSION, plugins: [] });
   });
 
   it('add → read round-trips and is atomic JSON', async () => {
     await addPluginRecord(rec(), path);
     const file = readPluginRegistrySync(path);
-    expect(file.version).toBe(1);
+    expect(file.version).toBe(PLUGINS_FILE_VERSION);
     expect(file.plugins).toHaveLength(1);
     expect(file.plugins[0]?.providers).toEqual(['fly']);
     // valid JSON with trailing newline
@@ -59,7 +60,10 @@ describe('plugin registry', () => {
 
   it('resolves a provider name to its plugin and lists names', async () => {
     await addPluginRecord(rec(), path);
-    await addPluginRecord(rec({ packageName: 'agentbox-provider-render', providers: ['render'] }), path);
+    await addPluginRecord(
+      rec({ packageName: 'agentbox-provider-render', providers: ['render'] }),
+      path,
+    );
     expect(pluginProviderNames(path).sort()).toEqual(['fly', 'render']);
     expect(pluginForProvider('render', path)?.packageName).toBe('agentbox-provider-render');
     expect(pluginForProvider('nope', path)).toBeNull();
@@ -76,9 +80,9 @@ describe('plugin registry', () => {
 
   it('corrupt registry degrades to empty on READ, never throws', () => {
     writeFileSync(path, '{ not json', 'utf8');
-    expect(readPluginRegistrySync(path)).toEqual({ version: 1, plugins: [] });
+    expect(readPluginRegistrySync(path)).toEqual({ version: PLUGINS_FILE_VERSION, plugins: [] });
     writeFileSync(path, JSON.stringify({ version: 99, plugins: [] }), 'utf8');
-    expect(readPluginRegistrySync(path)).toEqual({ version: 1, plugins: [] });
+    expect(readPluginRegistrySync(path)).toEqual({ version: PLUGINS_FILE_VERSION, plugins: [] });
   });
 
   it('a WRITE refuses to clobber a corrupt registry (no data loss)', async () => {

--- a/packages/sandbox-core/test/provider-descriptor.test.ts
+++ b/packages/sandbox-core/test/provider-descriptor.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Descriptor resolution, and — the part that matters most — what a provider
+ * PLUGIN that predates descriptors resolves to. Those defaults are load-bearing
+ * back-compat: each one reproduces what AgentBox did for a plugin before
+ * descriptors existed, so registering an old plugin against a new CLI can only
+ * add capability, never remove it.
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ProviderModule } from '../src/doctor.js';
+import type { PluginsFile } from '../src/plugin-registry.js';
+import {
+  deriveDescriptor,
+  ensureProviderDescriptor,
+  listProviderDescriptors,
+  resolveProviderDescriptor,
+} from '../src/provider-descriptor.js';
+
+let dir: string;
+let registry: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'agentbox-desc-'));
+  registry = join(dir, 'plugins.json');
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+function writeRegistry(file: PluginsFile): void {
+  writeFileSync(registry, JSON.stringify(file, null, 2), 'utf8');
+}
+
+/** A minimal module shaped like a 2.6.0-era plugin: no `descriptor` export. */
+function legacyModule(over: Partial<ProviderModule> = {}): ProviderModule {
+  return {
+    provider: { name: 'acme' } as ProviderModule['provider'],
+    doctorChecks: () => Promise.resolve([]),
+    ...over,
+  };
+}
+
+describe('resolveProviderDescriptor', () => {
+  it('returns the built-in table entry for a built-in', () => {
+    const d = resolveProviderDescriptor('hetzner', registry);
+    expect(d?.name).toBe('hetzner');
+    expect(d?.kind).toBe('cloud');
+    expect(d?.capabilities.inbound).toBe(true);
+  });
+
+  it('returns undefined for a name nothing provides', () => {
+    expect(resolveProviderDescriptor('nope', registry)).toBeUndefined();
+  });
+
+  it('reads a plugin snapshot from the registry', () => {
+    const descriptor = deriveDescriptor('acme', legacyModule());
+    writeRegistry({
+      version: 2,
+      plugins: [
+        {
+          packageName: 'agentbox-provider-acme',
+          resolvedEntry: '/tmp/acme/index.js',
+          version: '1.0.0',
+          providers: ['acme'],
+          descriptors: { acme: { ...descriptor, label: 'Acme Cloud' } },
+          apiVersion: 2,
+          addedAt: new Date(0).toISOString(),
+        },
+      ],
+    });
+    expect(resolveProviderDescriptor('acme', registry)?.label).toBe('Acme Cloud');
+  });
+});
+
+describe('a v1 registry (no descriptors) still works', () => {
+  beforeEach(() => {
+    // Exactly what an existing user's plugins.json looks like today.
+    writeFileSync(
+      registry,
+      JSON.stringify({
+        version: 1,
+        plugins: [
+          {
+            packageName: 'agentbox-provider-acme',
+            resolvedEntry: '/tmp/acme/index.js',
+            version: '1.0.0',
+            providers: ['acme'],
+            apiVersion: 1,
+            addedAt: new Date(0).toISOString(),
+          },
+        ],
+      }),
+      'utf8',
+    );
+  });
+
+  it('the provider is still LISTED — never hidden for lacking a snapshot', () => {
+    const names = listProviderDescriptors(registry).map((d) => d.name);
+    expect(names).toContain('acme');
+    expect(names).toContain('docker');
+  });
+
+  it('back-fills the snapshot the first time a module is available', async () => {
+    const d = await ensureProviderDescriptor('acme', legacyModule(), registry);
+    expect(d.name).toBe('acme');
+    expect(resolveProviderDescriptor('acme', registry)?.name).toBe('acme');
+    const after = JSON.parse(readFileSync(registry, 'utf8')) as PluginsFile;
+    expect(after.version).toBe(2);
+    expect(after.plugins[0]?.descriptors?.acme).toBeDefined();
+  });
+});
+
+describe('fallback defaults preserve pre-descriptor behavior', () => {
+  it('does NOT demand a bake — that would newly block creates that work today', () => {
+    // The hub's create gate deliberately skips isProviderConfigured for plugins.
+    expect(deriveDescriptor('acme', legacyModule()).bake.required).toBe(false);
+  });
+
+  it('keeps VNC and DinD ON — the cloud scaffold wires both unconditionally', () => {
+    const caps = deriveDescriptor('acme', legacyModule()).capabilities;
+    expect(caps.vnc).toBe(true);
+    expect(caps.dind).toBe(true);
+  });
+
+  it("keeps pause labelled 'freeze' — the pre-descriptor UI showed a plain Pause", () => {
+    expect(deriveDescriptor('acme', legacyModule()).capabilities.pauseSemantics).toBe('freeze');
+  });
+
+  it('leaves the SSH capabilities OFF — plugins were excluded from those lists', () => {
+    const caps = deriveDescriptor('acme', legacyModule()).capabilities;
+    expect(caps.persistentSsh).toBe(false);
+    expect(caps.directBoxSsh).toBe(false);
+  });
+
+  it('offers a credential form only when the module can consume one', () => {
+    expect(deriveDescriptor('acme', legacyModule()).credentials.fields).toEqual([]);
+    const withCreds = legacyModule({
+      setCredentials: () => Promise.resolve({ ok: true, status: { configured: true } }),
+    });
+    expect(deriveDescriptor('acme', withCreds).credentials.fields).toEqual([
+      { key: 'apiKey', label: 'API key' },
+    ]);
+  });
+});
+
+describe('derivation reads BACKEND methods, not provider methods', () => {
+  it('derives prune / inbound / timeoutModel from the backend', () => {
+    const mod = legacyModule({
+      backend: {
+        name: 'acme',
+        list: () => Promise.resolve([]),
+        setInbound: () => Promise.resolve({ sources: [] }),
+        timeoutModel: 'absolute',
+      } as unknown as ProviderModule['backend'],
+    });
+    const caps = deriveDescriptor('acme', mod).capabilities;
+    expect(caps.prune).toBe(true);
+    expect(caps.inbound).toBe(true);
+    expect(caps.timeoutModel).toBe('absolute');
+  });
+
+  it('a backend-less module is local and prunes nothing', () => {
+    const d = deriveDescriptor('acme', legacyModule());
+    expect(d.kind).toBe('local');
+    expect(d.capabilities.prune).toBe(false);
+    expect(d.capabilities.inbound).toBe(false);
+  });
+
+  it('a declared descriptor wins over every derivation', () => {
+    const declared = { ...deriveDescriptor('acme', legacyModule()), label: 'Declared' };
+    const mod = legacyModule({ descriptor: declared });
+    expect(deriveDescriptor('acme', mod).label).toBe('Declared');
+  });
+});


### PR DESCRIPTION
Closes #306.

A registered provider plugin was creatable from the CLI but invisible everywhere else: the hub's `listProviders()` built its response from the static `PROVIDER_NAMES` list, so a plugin never reached `GET /api/v1/providers` and therefore never reached the tray's **New Box → Provider** dropdown or the web create modal.

The deeper problem was that a plugin could declare only a name and an SDK major. Everything else a UI needs — a label, which credentials to prompt for, whether it needs a bake, whether it supports checkpoints/VNC/SSH — lived either in per-provider tables the hub and tray hardcoded, or in ~20 provider-name arrays across the CLI that a plugin could never enter.

## What this adds

One **`ProviderDescriptor`** that built-ins and plugins both declare: label, credential fields, bake story, and capabilities. Built-ins declare it in the `PROVIDERS` table; a plugin declares it on `ProviderModule.descriptor`, and `agentbox plugin add` snapshots it into `~/.agentbox/plugins.json` (v2). Every consumer — the CLI's sync `open --targets` probe, the hub's hot `listProviders` path, the tray — then resolves capabilities **synchronously and offline**, without importing an external package.

- `GET /api/v1/providers` lists built-ins and plugins alike, each row carrying its descriptor.
- The hub's readiness, credential and bake logic reads the descriptor; `PROVIDER_CRED_KEYS` is gone. The credentials/prepare routes accept plugin ids.
- The tray and the hub's settings card build their credential forms from `credentials.fields` and pace progress bars from `bake.*ProgressSteps`, instead of from hardcoded tables.
- `agentbox code`, `open`, `prune`, `checkpoint set-default` and `fork` gate on declared capabilities rather than name lists.

## Capabilities are declared, not derived

The original design inferred capabilities from optional-method presence. Probing the real modules showed that does not work: `createCloudProvider` defines `setInbound`, `enableDirectGit` and `checkpoint` on **every** cloud provider, so their presence signals which scaffold was used, not what the provider supports — and `sandbox-docker` has no `provider.checkpoint` at all despite `docker commit` checkpoints being the oldest feature in the repo.

The honest line is which object the method hangs off: `CloudBackend` methods are author-written, `Provider` methods are scaffold-supplied. So `prune`, `inbound` and `timeoutModel` are cross-checked against the backend by a guard test; everything else is declared.

## Nothing breaks for existing plugins

`descriptor` is optional and `SDK_API_VERSION` is unchanged, so a plugin built against an older SDK loads exactly as before. When one is missing, AgentBox derives what it can and defaults the rest to **reproduce pre-descriptor behavior** rather than to "safe = false" — `vnc`/`dind` stay `true` (the scaffold wires both; `false` would delete working UI), `pauseSemantics` stays `freeze`, and `bake.required` defaults **false** so a create that works today is never newly blocked. Loading a plugin module back-fills the derived descriptor, so an existing `plugins.json` migrates with no user action. Pinned by `provider-descriptor.test.ts`.

## Verified against a real third-party plugin

Live-tested with the published `agentbox-provider-sprites` (SDK v2, declares no descriptor) — the plugin from #306:

- Lists as `configured`, creatable, nothing blocked.
- Derivation gets `prune: true` and `timeoutModel: "inactivity"` right from its backend, the latter matching Sprites actually hibernating when idle.
- Its credential status comes from its own `readCredStatus()` (`label: "sprite CLI"`), not a built-in key table — #306's "without requiring built-in credential-key tables".
- `agentbox prune --provider sprites --dry-run` enumerated real orphan sandboxes; that command was rejected outright before.
- The tray's own `Codable` decodes all rows including the plugin.

Two things only a *declared* descriptor can fix for Sprites, worth an upstream PR to `philippgerard/agentbox-provider-sprites`: the fallback guesses an `apiKey` credential field (it wants `SPRITE_TOKEN`), and it inherits `vnc: true` though Sprites ships no VNC stack. Neither is a regression — both match pre-descriptor behavior.

## Behavior changes worth calling out

- **DigitalOcean gains `agentbox code` / `open`.** It is a VPS with the same per-box identity file as Hetzner; the old arrays omitted it while listing it in the direct-box-ssh set.
- **`checkpoint set-default --provider <plugin>` now warns** that a plugin has no per-provider config key, so the write lands on the cross-provider default docker boxes also read. Previously that would have been silent.
- `pauseSemantics: 'freeze' | 'stop'` instead of a boolean: Hetzner and DO are literally `pause ≡ stop`, and a boolean would have hidden a pause control that usefully stops billing. It is a labelling hint, never a reason to hide.

## Notes for the reviewer

- The tray half is a separate commit in `madarco/agentbox-tray` (`3db893a`, on `nightly`).
- `@madarco/agentbox-provider-sdk` is bumped to `2.8.0` here but **not published** — that stays a manual step.
- Plan and rationale: `docs/provider-descriptor-plan.md`.

https://claude.ai/code/session_01SKLmAbYKtGVKNzKG3j9eqp

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared relay/hub port binding, plugin registry snapshots, and hub VNC redirect auth—areas where misconfiguration or stale state affects every box, though changes are heavily tested and mostly fail-closed with clearer errors.
> 
> **Overview**
> **Community provider plugins** now surface in create flows and credential UIs via a shared **`ProviderDescriptor`** (built-ins in config, plugins on `ProviderModule.descriptor` and snapshotted in `plugins.json`). The CLI stops using hardcoded provider name lists for **`code`**, **`open`**, **`prune`**, **`checkpoint set-default`**, and **`fork`**, and instead gates on declared capabilities (e.g. DigitalOcean gets SSH/`open` behavior it was missing before).
> 
> **Relay and hub behavior** is tightened: **`relay.port`** is applied at CLI startup and threaded through loopback URLs; **`agentbox doctor`** warns when docker boxes still dial an old baked-in relay URL; **`relay start`** re-probes `/healthz` and fails loudly on a bad bind. Hub/tray-oriented fixes from the changelog (hub vs relay on 8787, stale bundle warning) ride along in the same release notes.
> 
> **VNC access** for expiring cloud URLs moves to **mint-at-click**: new hub routes **`GET /api/v1/boxes/:id/vnc`** and **`/boxes/:id/vnc`**, **`agentbox screen`** prefers the owning hub, and **`agentbox list`** builds `(VNC)` links through the hub when the payload has no static `vncUrl`.
> 
> Smaller but user-visible changes: **GitHub Enterprise / SSH `Host` aliases** for hub git token and direct-push creds; **size ignored** notes on `config set` and queued `-i` creates; **unknown subcommand** errors on groups with default actions; **wrapped attach chrome** gated on escape-sequence boundaries (fixes garbled footers on fine-grained PTY transports).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1616940b4574a7bdace832004b806e150e0dcab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->