### PR TITLE
fix(hub): stop the control box's identity leaking into this machine's hub

### DIFF
--- a/apps/cli/src/host-reach-env.ts
+++ b/apps/cli/src/host-reach-env.ts
@@ -1,16 +1,26 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { loadEffectiveConfig } from '@agentbox/config';
-import { loadControlPlaneEnv } from './control-plane/env-file.js';
+import { readControlPlaneEnvMap } from './control-plane/env-file.js';
 
 /**
  * Export what the relay daemon needs to be this machine's side of the
  * host-reach channel, before any command can spawn it.
  *
- * The daemon drains `cp` actions a control box parked for this machine (see
- * `docs/plans/box-cp-host-reach-plan.md`), which takes two values it cannot get
- * for itself: the control box's URL — which lives in layered config, and no
- * child re-reads that — and the admin bearer, which lives in
+ * The daemon drains the `cp` and `tool.*` actions a control box parked for this
+ * machine (see `docs/plans/box-cp-host-reach-plan.md`), which takes two values it
+ * cannot get for itself: the control box's URL — which lives in layered config,
+ * and no child re-reads that — and the admin bearer, which lives in
  * `control-plane.env`. Both ride `process.env` into the spawned relay, the same
  * idiom as `AGENTBOX_RELAY_PORT` / `AGENTBOX_CLI_VERSION`.
+ *
+ * **Exactly two keys, never the whole file.** `control-plane.env` also holds
+ * `AGENTBOX_HUB_PROFILE=hetzner` and `AGENTBOX_HUB_AUTH=on` — the identity of the
+ * REMOTE control box. Merging the file wholesale (which an earlier version of
+ * this did) leaked those into the locally spawned hub, so this machine's own hub
+ * believed it was a control box: it served its UI in password mode and, worse,
+ * declared itself the broker, which switches OFF the very poller this function
+ * exists to enable.
  *
  * An already-exported value always wins, and every failure is swallowed: a
  * missing control box (the common case) simply means no poller, and a broken
@@ -18,9 +28,14 @@ import { loadControlPlaneEnv } from './control-plane/env-file.js';
  */
 export async function applyHostReachEnvAtStartup(): Promise<void> {
   try {
-    // Brings AGENTBOX_RELAY_ADMIN_TOKEN (and the App creds) in per-key without
-    // overriding anything the shell already set.
-    loadControlPlaneEnv();
+    if (!process.env.AGENTBOX_RELAY_ADMIN_TOKEN) {
+      // Path resolved HERE, not at module load: `homedir()` is read once at
+      // import time by the module-level default, which pins the file for the
+      // life of the process even when HOME changes under it.
+      const envPath = join(homedir(), '.agentbox', 'control-plane', 'control-plane.env');
+      const token = readControlPlaneEnvMap(envPath).AGENTBOX_RELAY_ADMIN_TOKEN;
+      if (token) process.env.AGENTBOX_RELAY_ADMIN_TOKEN = token;
+    }
     if (process.env.AGENTBOX_CONTROL_PLANE_URL) return;
     const loaded = await loadEffectiveConfig(process.cwd());
     const url = (loaded.effective.relay.controlPlaneUrl ?? '').trim().replace(/\/+$/, '');

--- a/apps/cli/test/host-reach-env.test.ts
+++ b/apps/cli/test/host-reach-env.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { applyHostReachEnvAtStartup } from '../src/host-reach-env.js';
+
+/**
+ * What this exports lands in EVERY spawned daemon, including this machine's own
+ * hub. Taking the whole `control-plane.env` made that hub inherit the remote
+ * control box's identity (`AGENTBOX_HUB_PROFILE=hetzner`, `AGENTBOX_HUB_AUTH=on`)
+ * — so it served its UI in password mode and declared itself the broker, which
+ * disables the poller this function exists to enable. Seen on a live machine.
+ */
+
+const KEEP = ['HOME', 'AGENTBOX_RELAY_ADMIN_TOKEN', 'AGENTBOX_CONTROL_PLANE_URL', 'AGENTBOX_HUB_PROFILE', 'AGENTBOX_HUB_AUTH'] as const;
+const saved = new Map<string, string | undefined>();
+let home: string;
+
+beforeEach(async () => {
+  for (const k of KEEP) saved.set(k, process.env[k]);
+  home = await mkdtemp(join(tmpdir(), 'agentbox-hre-'));
+  process.env.HOME = home;
+  for (const k of KEEP.slice(1)) delete process.env[k];
+  await mkdir(join(home, '.agentbox', 'control-plane'), { recursive: true });
+  await writeFile(
+    join(home, '.agentbox', 'control-plane', 'control-plane.env'),
+    [
+      'AGENTBOX_RELAY_ADMIN_TOKEN=admin-secret',
+      'AGENTBOX_HUB_PROFILE=hetzner',
+      'AGENTBOX_HUB_AUTH=on',
+      'AGENTBOX_HUB_API_KEY=key',
+      'GH_TOKEN=ghp_x',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+  await writeFile(
+    join(home, '.agentbox', 'config.yaml'),
+    'schema: 1\nrelay:\n  controlPlaneUrl: https://cp.example/\n',
+    'utf8',
+  );
+});
+
+afterEach(async () => {
+  for (const [k, v] of saved) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  await rm(home, { recursive: true, force: true });
+});
+
+describe('applyHostReachEnvAtStartup', () => {
+  it('exports the admin token from the control-plane file', async () => {
+    // Only the token is asserted: `@agentbox/config` resolves HOME at import
+    // time, so the URL half reads this developer's real config and is not
+    // something a unit test can pin without isolating the whole loader.
+    await applyHostReachEnvAtStartup();
+    expect(process.env.AGENTBOX_RELAY_ADMIN_TOKEN).toBe('admin-secret');
+  });
+
+  it('never exports the control box IDENTITY into this machine', async () => {
+    await applyHostReachEnvAtStartup();
+    // The local hub inherits process.env; these would make it believe it is the
+    // control box — password-mode UI, and no host-action poller.
+    expect(process.env.AGENTBOX_HUB_PROFILE).toBeUndefined();
+    expect(process.env.AGENTBOX_HUB_AUTH).toBeUndefined();
+  });
+
+  it('leaves an explicitly exported token alone', async () => {
+    process.env.AGENTBOX_RELAY_ADMIN_TOKEN = 'from-the-shell';
+    await applyHostReachEnvAtStartup();
+    expect(process.env.AGENTBOX_RELAY_ADMIN_TOKEN).toBe('from-the-shell');
+  });
+});


### PR DESCRIPTION
Caught while starting everything for a manual test: this machine's own hub reported `profile: hetzner` and served its UI in password mode.

`applyHostReachEnvAtStartup` (added in #323) merged all of `control-plane.env` into `process.env`, and `spawnHub`/`spawnRelay` pass `...process.env` to the daemon. So the local hub inherited the REMOTE control box's identity — `AGENTBOX_HUB_PROFILE=hetzner`, `AGENTBOX_HUB_AUTH=on` — with two consequences:

- its web UI switched from token mode to password mode, and
- `authMode() === 'password'` made it declare itself a control box, which disables the host-reach poller — the exact thing that function exists to enable. `cp` and host tools from a hub box would have fallen back to the cache (or failed) while the user's machine sat right there.

Now it exports exactly two keys, and resolves the env file at call time instead of at module import (which also lets the test point HOME at a temp dir — `apps/cli` tests have no HOME isolation, and the first version of the test read my real control-plane.env).

Verified live: local hub back to `profile: localhost`, and `host-reach: streaming host actions (event stream)` now appears in `~/.agentbox/hub.log` — one process serves the local UI and drains for the control box.

Tests fail against the pre-fix code (2 of 3) and pass after.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what every CLI-spawned daemon inherits from startup env; the fix is narrower and safer than before, but mistakes here still affect local hub auth mode and the host-reach poller.
> 
> **Overview**
> **`applyHostReachEnvAtStartup` no longer merges all of `control-plane.env` into `process.env`.** It now sets at most **`AGENTBOX_RELAY_ADMIN_TOKEN`** (from a file read via `readControlPlaneEnvMap`) and **`AGENTBOX_CONTROL_PLANE_URL`** (from layered config), leaving keys like `AGENTBOX_HUB_PROFILE` / `AGENTBOX_HUB_AUTH` out so the locally spawned hub does not inherit the remote control box’s identity.
> 
> The control-plane env path is resolved **at call time** with `join(homedir(), …)` instead of relying on the module-level default, so tests can point `HOME` at a temp dir and the path stays correct if `HOME` changes.
> 
> New unit tests cover token export, explicit shell token precedence, and that hub identity vars stay unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d462b3cd0a42bbdced6ce9d959ee14f8d3ca7cec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->