### PR TITLE
fix(claude): stop the daily false "login expired", and never lose a rotation

### DIFF
--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -20,7 +20,6 @@ import {
   ensureImage,
   formatDetachNotice,
   hostBackupHasCredentials,
-  hostClaudeBackupExpired,
   imageExists,
   inspectBox,
   rebuildPluginNativeDeps,
@@ -80,6 +79,7 @@ import {
 } from '../session-teleport/index.js';
 import { resolvePlanTeleport } from '../session-teleport/plan.js';
 import { clampSpinnerLine } from '../spinner-line.js';
+import { resolveClaudeCredHealth } from '../lib/claude-cred-health.js';
 import { imageProgress, makeProgressReporter } from '../lib/progress.js';
 import { printLaunchRecap } from '../lib/launch-recap.js';
 import { maybeShowInstallHint } from '../lib/install-hint.js';
@@ -407,8 +407,12 @@ async function maybeRunClaudeLogin(args: {
  * a host credential the box boots unauthenticated. Capturing the login to
  * `~/.agentbox/claude-credentials.json` (via the same throwaway-container login
  * + `syncClaudeCredentials`) lets the cloud push seed it into this box and every
- * future one. Also re-offers when the saved token is *expired* — the in-box
- * refresh has proven unreliable on cloud. Skips on non-TTY / --yes / host env.
+ * future one. Skips on non-TTY / --yes / host env.
+ *
+ * The verdict comes from `resolveClaudeCredHealth`, which renews a merely-lapsed
+ * access token rather than reporting it as an expiry — see that module for why
+ * the old `expiresAt` gate nagged daily and why saying yes to it was actively
+ * destructive.
  */
 async function maybeRunCloudClaudeLogin(args: {
   image: string;
@@ -418,13 +422,26 @@ async function maybeRunCloudClaudeLogin(args: {
 }): Promise<void> {
   if (!process.stdin.isTTY || args.yes) return;
   if (args.authSource === 'host-env') return;
-  const hasCreds = await hostBackupHasCredentials();
-  const expired = hasCreds && (await hostClaudeBackupExpired());
-  if (hasCreds && !expired) return;
 
-  const message = expired
-    ? 'Your saved Claude login looks expired. Sign in again? (saved and reused by every box)'
-    : 'Sign in with your Claude subscription? (saved and reused by every box)';
+  const probe = spinner();
+  let started = false;
+  const health = await resolveClaudeCredHealth({
+    image: args.image,
+    onProgress: (line) => {
+      if (!started) {
+        started = true;
+        probe.start('checking your saved Claude login');
+      }
+      probe.message(clampSpinnerLine(line));
+    },
+  });
+  if (started) probe.stop('checked your saved Claude login');
+  if (health === 'ok') return;
+
+  const message =
+    health === 'dead'
+      ? 'Your saved Claude login can no longer be renewed. Sign in again? (saved and reused by every box)'
+      : 'Sign in with your Claude subscription? (saved and reused by every box)';
   const answer = await confirm({ message, initialValue: true });
   if (!answer) {
     log.info('Skipped sign-in — claude will prompt you to /login inside the box.');

--- a/apps/cli/src/lib/claude-cred-health.ts
+++ b/apps/cli/src/lib/claude-cred-health.ts
@@ -1,0 +1,67 @@
+/**
+ * One verdict on the saved Claude login, shared by every gate that might ask
+ * the user to sign in again.
+ *
+ * Why it exists: those gates used to read `claudeAiOauth.expiresAt`, which dates
+ * the ~8h ACCESS token. On a cloud-only workflow nothing rewrites the host
+ * backup between logins, so that field is in the past within a day of every
+ * sign-in and stays there — a guaranteed daily "your saved Claude login looks
+ * expired" on a login with weeks of life left. Worse, accepting the offer runs a
+ * login container that refreshes and ROTATES the shared refresh token before the
+ * user touches the browser; the write-back only ran on success, so a cancelled
+ * sign-in left the host backup, the control box's backup and its custody copy
+ * all holding a spent token. The false alarm made itself true.
+ *
+ * So: decide on refresh-token health, and when the access token has merely
+ * lapsed, actually renew it (`renewClaudeCredential`) instead of guessing. That
+ * both silences the nag and hands the next cloud box a fresh token, which is the
+ * other half of why the credential kept dying between sessions.
+ */
+import {
+  hostBackupHasCredentials,
+  hostClaudeAccessTokenExpired,
+  hostClaudeLoginDead,
+  imageExists,
+  renewClaudeCredential,
+} from '@agentbox/sandbox-docker';
+
+/**
+ * `ok` — usable (possibly after a silent renewal). `missing` — nothing saved to
+ * seed a box with. `dead` — saved, but it can no longer be renewed, so only a
+ * fresh sign-in helps.
+ */
+export type ClaudeCredHealth = 'ok' | 'missing' | 'dead';
+
+export interface ClaudeCredHealthOptions {
+  /** Box image the renewal probe runs in. */
+  image: string;
+  /** Progress lines from the renewal (it can take a few seconds). */
+  onProgress?: (line: string) => void;
+  /**
+   * Skip the renewal probe and answer from the backup alone. The stale-access-
+   * token case then answers `ok` — the refresh token is alive and the box can
+   * renew it in-box, so there is nothing to warn about.
+   */
+  offlineOnly?: boolean;
+}
+
+export async function resolveClaudeCredHealth(
+  opts: ClaudeCredHealthOptions,
+): Promise<ClaudeCredHealth> {
+  if (!(await hostBackupHasCredentials())) return 'missing';
+  if (await hostClaudeLoginDead()) return 'dead';
+  if (!(await hostClaudeAccessTokenExpired())) return 'ok';
+
+  // Stale access token, live refresh token. Renewing needs the image locally;
+  // don't trigger an implicit pull just to answer a question, and never nag on
+  // a host that simply can't run the probe — the refresh token is alive and the
+  // box will renew it itself.
+  if (opts.offlineOnly === true) return 'ok';
+  if (!(await imageExists(opts.image))) return 'ok';
+
+  const renewed = await renewClaudeCredential({
+    image: opts.image,
+    ...(opts.onProgress ? { onLog: opts.onProgress } : {}),
+  });
+  return renewed === 'failed' ? 'dead' : 'ok';
+}

--- a/apps/cli/src/lib/queue/assert-creds.ts
+++ b/apps/cli/src/lib/queue/assert-creds.ts
@@ -3,7 +3,6 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import {
   hostBackupHasCredentials,
-  hostClaudeBackupExpired,
   OPENCODE_FORWARDED_ENV_KEYS,
   SHARED_CODEX_VOLUME,
   SHARED_OPENCODE_VOLUME,
@@ -12,6 +11,7 @@ import {
 } from '@agentbox/sandbox-docker';
 import type { QueueAgentKind } from '@agentbox/relay';
 import { resolveClaudeAuth } from '../../auth.js';
+import { resolveClaudeCredHealth } from '../claude-cred-health.js';
 
 async function fileExists(p: string): Promise<boolean> {
   try {
@@ -38,24 +38,31 @@ export async function claudeAuthAvailable(env: NodeJS.ProcessEnv): Promise<boole
 
 /**
  * Richer Claude credential verdict for the non-interactive paths. `'missing'`
- * when nothing can seed a box; `'expired'` when the only credential is a host
- * backup whose OAuth token is known-expired AND we're on a cloud provider —
- * cloud's in-box refresh has proven unreliable, whereas docker boxes refresh the
- * access token themselves, so a stale `expiresAt` is a non-issue there (and
- * access tokens expire ~hourly, so flagging it on docker would false-fail
- * constantly). A host-env token (`ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`)
+ * when nothing can seed a box; `'expired'` when the saved login can no longer be
+ * renewed AND we're on a cloud provider — cloud has no shared volume to fall
+ * back to, whereas a docker box boots from the volume's live copy and refreshes
+ * it in-box. A host-env token (`ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`)
  * or legacy `auth.json` short-circuits to `'ok'`: it has no expiry concept here.
- * Mirrors the interactive `maybeRunCloudClaudeLogin` split.
+ * Mirrors the interactive `maybeRunCloudClaudeLogin` split, and shares its
+ * verdict helper — so a merely-lapsed access token is renewed here too rather
+ * than failing the job. This used to gate on `expiresAt` (the ~8h access token)
+ * and so refused to submit perfectly good jobs every day.
  */
 export async function claudeCredStatus(
   env: NodeJS.ProcessEnv,
   isCloud: boolean,
+  image?: string,
 ): Promise<'ok' | 'missing' | 'expired'> {
   const resolved = await resolveClaudeAuth(env);
   if (resolved.source !== 'none') return 'ok';
-  if (!(await hostBackupHasCredentials())) return 'missing';
-  if (isCloud && (await hostClaudeBackupExpired())) return 'expired';
-  return 'ok';
+  if (!isCloud) return (await hostBackupHasCredentials()) ? 'ok' : 'missing';
+  const health = await resolveClaudeCredHealth({
+    image: image ?? '',
+    // No image to probe with means no renewal; answer off the backup alone.
+    ...(image === undefined ? { offlineOnly: true } : {}),
+  });
+  if (health === 'missing') return 'missing';
+  return health === 'dead' ? 'expired' : 'ok';
 }
 
 /**
@@ -100,7 +107,7 @@ const MESSAGES: Record<QueueAgentKind, string> = {
 };
 
 const CLAUDE_EXPIRED_MESSAGE =
-  'Your saved Claude login looks expired. Refresh it with `agentbox claude login`, then retry.';
+  'Your saved Claude login can no longer be renewed. Sign in again with `agentbox claude login`, then retry.';
 
 export class MissingAgentCredsError extends Error {
   readonly agent: QueueAgentKind;
@@ -128,7 +135,7 @@ export interface AssertAgentCredsInput {
   agent: QueueAgentKind;
   image: string;
   env?: NodeJS.ProcessEnv;
-  /** Provider for this run; gates the Claude expiry check to cloud (see
+  /** Provider for this run; gates the Claude renewability check to cloud (see
    *  {@link claudeCredStatus}). Omitted/`'docker'` → presence check only. */
   providerName?: string;
 }
@@ -145,7 +152,7 @@ export async function assertAgentCredsAvailable(input: AssertAgentCredsInput): P
   const env = input.env ?? process.env;
   if (input.agent === 'claude-code') {
     const isCloud = input.providerName !== undefined && input.providerName !== 'docker';
-    const status = await claudeCredStatus(env, isCloud);
+    const status = await claudeCredStatus(env, isCloud, input.image);
     if (status === 'missing') throw new MissingAgentCredsError(input.agent, MESSAGES[input.agent]);
     if (status === 'expired') throw new ExpiredAgentCredsError(input.agent, CLAUDE_EXPIRED_MESSAGE);
     return;

--- a/apps/cli/test/assert-creds.test.ts
+++ b/apps/cli/test/assert-creds.test.ts
@@ -10,7 +10,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // which `apps/cli/src/auth.ts` reads at load time).
 const sandboxDockerMock = vi.hoisted(() => ({
   hostBackupHasCredentials: vi.fn<() => Promise<boolean>>(),
-  hostClaudeBackupExpired: vi.fn<() => Promise<boolean>>(),
+  hostClaudeAccessTokenExpired: vi.fn<() => Promise<boolean>>(),
+  hostClaudeLoginDead: vi.fn<() => Promise<boolean>>(),
+  imageExists: vi.fn<(image: string) => Promise<boolean>>(),
+  renewClaudeCredential: vi.fn<() => Promise<'renewed' | 'unchanged' | 'failed'>>(),
   volumeHasCodexAuth: vi.fn<(volume: string, image: string) => Promise<boolean>>(),
   volumeHasOpencodeAuth: vi.fn<(volume: string, image: string) => Promise<boolean>>(),
 }));
@@ -20,7 +23,10 @@ vi.mock('@agentbox/sandbox-docker', async (importOriginal) => {
   return {
     ...actual,
     hostBackupHasCredentials: sandboxDockerMock.hostBackupHasCredentials,
-    hostClaudeBackupExpired: sandboxDockerMock.hostClaudeBackupExpired,
+    hostClaudeAccessTokenExpired: sandboxDockerMock.hostClaudeAccessTokenExpired,
+    hostClaudeLoginDead: sandboxDockerMock.hostClaudeLoginDead,
+    imageExists: sandboxDockerMock.imageExists,
+    renewClaudeCredential: sandboxDockerMock.renewClaudeCredential,
     volumeHasCodexAuth: sandboxDockerMock.volumeHasCodexAuth,
     volumeHasOpencodeAuth: sandboxDockerMock.volumeHasOpencodeAuth,
   };
@@ -76,39 +82,71 @@ describe('claudeAuthAvailable', () => {
 describe('claudeCredStatus', () => {
   beforeEach(() => {
     sandboxDockerMock.hostBackupHasCredentials.mockReset();
-    sandboxDockerMock.hostClaudeBackupExpired.mockReset();
+    sandboxDockerMock.hostClaudeAccessTokenExpired.mockReset();
+    sandboxDockerMock.hostClaudeLoginDead.mockReset();
+    sandboxDockerMock.imageExists.mockReset();
+    sandboxDockerMock.renewClaudeCredential.mockReset();
+    sandboxDockerMock.hostClaudeLoginDead.mockResolvedValue(false);
+    sandboxDockerMock.imageExists.mockResolvedValue(true);
   });
 
   it('is "missing" when no env and no backup', async () => {
     sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(false);
-    expect(await claudeCredStatus({}, true)).toBe('missing');
+    expect(await claudeCredStatus({}, true, IMAGE)).toBe('missing');
   });
 
-  it('is "ok" when a host-env token is set (expiry not consulted)', async () => {
+  it('is "ok" when a host-env token is set (health not consulted)', async () => {
     sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(false);
-    sandboxDockerMock.hostClaudeBackupExpired.mockResolvedValue(true);
-    expect(await claudeCredStatus({ ANTHROPIC_API_KEY: 'sk-test' }, true)).toBe('ok');
-    expect(sandboxDockerMock.hostClaudeBackupExpired).not.toHaveBeenCalled();
+    sandboxDockerMock.hostClaudeLoginDead.mockResolvedValue(true);
+    expect(await claudeCredStatus({ ANTHROPIC_API_KEY: 'sk-test' }, true, IMAGE)).toBe('ok');
+    expect(sandboxDockerMock.hostClaudeLoginDead).not.toHaveBeenCalled();
   });
 
-  it('is "expired" on cloud when the backup token is known-expired', async () => {
+  it('is "expired" on cloud only when the login can no longer be renewed', async () => {
     sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
-    sandboxDockerMock.hostClaudeBackupExpired.mockResolvedValue(true);
-    expect(await claudeCredStatus({}, true)).toBe('expired');
+    sandboxDockerMock.hostClaudeLoginDead.mockResolvedValue(true);
+    expect(await claudeCredStatus({}, true, IMAGE)).toBe('expired');
   });
 
-  it('is "ok" on docker even when the backup token is known-expired (in-box refresh)', async () => {
+  // The false positive this whole change exists for: access tokens live ~8h, so
+  // gating on `expiresAt` failed perfectly good jobs every single day.
+  it('is "ok" on cloud when a lapsed access token renews', async () => {
     sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
-    sandboxDockerMock.hostClaudeBackupExpired.mockResolvedValue(true);
-    expect(await claudeCredStatus({}, false)).toBe('ok');
-    // The expiry probe must not even run when the provider is docker.
-    expect(sandboxDockerMock.hostClaudeBackupExpired).not.toHaveBeenCalled();
+    sandboxDockerMock.hostClaudeAccessTokenExpired.mockResolvedValue(true);
+    sandboxDockerMock.renewClaudeCredential.mockResolvedValue('renewed');
+    expect(await claudeCredStatus({}, true, IMAGE)).toBe('ok');
+    expect(sandboxDockerMock.renewClaudeCredential).toHaveBeenCalled();
   });
 
-  it('is "ok" on cloud when the backup token is present and not expired', async () => {
+  it('is "expired" on cloud when the renewal itself fails (rotated away)', async () => {
     sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
-    sandboxDockerMock.hostClaudeBackupExpired.mockResolvedValue(false);
-    expect(await claudeCredStatus({}, true)).toBe('ok');
+    sandboxDockerMock.hostClaudeAccessTokenExpired.mockResolvedValue(true);
+    sandboxDockerMock.renewClaudeCredential.mockResolvedValue('failed');
+    expect(await claudeCredStatus({}, true, IMAGE)).toBe('expired');
+  });
+
+  it('is "ok" on cloud without renewing when the access token is still valid', async () => {
+    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
+    sandboxDockerMock.hostClaudeAccessTokenExpired.mockResolvedValue(false);
+    expect(await claudeCredStatus({}, true, IMAGE)).toBe('ok');
+    expect(sandboxDockerMock.renewClaudeCredential).not.toHaveBeenCalled();
+  });
+
+  it('is "ok" on cloud when the image is not local — never pull just to answer', async () => {
+    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
+    sandboxDockerMock.hostClaudeAccessTokenExpired.mockResolvedValue(true);
+    sandboxDockerMock.imageExists.mockResolvedValue(false);
+    expect(await claudeCredStatus({}, true, IMAGE)).toBe('ok');
+    expect(sandboxDockerMock.renewClaudeCredential).not.toHaveBeenCalled();
+  });
+
+  it('is "ok" on docker whatever the token looks like (the box boots from the volume)', async () => {
+    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
+    sandboxDockerMock.hostClaudeLoginDead.mockResolvedValue(true);
+    expect(await claudeCredStatus({}, false, IMAGE)).toBe('ok');
+    // No health probe at all when the provider is docker.
+    expect(sandboxDockerMock.hostClaudeLoginDead).not.toHaveBeenCalled();
+    expect(sandboxDockerMock.renewClaudeCredential).not.toHaveBeenCalled();
   });
 });
 
@@ -181,11 +219,7 @@ describe('opencodeAuthAvailable', () => {
   it('returns true when host auth.json exists', async () => {
     sandboxDockerMock.volumeHasOpencodeAuth.mockResolvedValue(false);
     await mkdir(join(homeDir, '.local', 'share', 'opencode'), { recursive: true });
-    await writeFile(
-      join(homeDir, '.local', 'share', 'opencode', 'auth.json'),
-      '{}',
-      'utf8',
-    );
+    await writeFile(join(homeDir, '.local', 'share', 'opencode', 'auth.json'), '{}', 'utf8');
     expect(await opencodeAuthAvailable(IMAGE, {})).toBe(true);
   });
 
@@ -210,7 +244,12 @@ describe('assertAgentCredsAvailable dispatcher', () => {
 
   beforeEach(async () => {
     sandboxDockerMock.hostBackupHasCredentials.mockReset();
-    sandboxDockerMock.hostClaudeBackupExpired.mockReset();
+    sandboxDockerMock.hostClaudeAccessTokenExpired.mockReset();
+    sandboxDockerMock.hostClaudeLoginDead.mockReset();
+    sandboxDockerMock.imageExists.mockReset();
+    sandboxDockerMock.renewClaudeCredential.mockReset();
+    sandboxDockerMock.hostClaudeLoginDead.mockResolvedValue(false);
+    sandboxDockerMock.imageExists.mockResolvedValue(true);
     sandboxDockerMock.volumeHasCodexAuth.mockReset();
     sandboxDockerMock.volumeHasOpencodeAuth.mockReset();
     homeDir = await mkdtemp(join(tmpdir(), 'agentbox-dispatch-creds-'));
@@ -236,9 +275,9 @@ describe('assertAgentCredsAvailable dispatcher', () => {
     ).rejects.toBeInstanceOf(MissingAgentCredsError);
   });
 
-  it('throws ExpiredAgentCredsError for claude on cloud when the backup is expired', async () => {
+  it('throws ExpiredAgentCredsError for claude on cloud when the login cannot be renewed', async () => {
     sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
-    sandboxDockerMock.hostClaudeBackupExpired.mockResolvedValue(true);
+    sandboxDockerMock.hostClaudeLoginDead.mockResolvedValue(true);
     try {
       await assertAgentCredsAvailable({
         agent: 'claude-code',
@@ -252,14 +291,14 @@ describe('assertAgentCredsAvailable dispatcher', () => {
       // The expired subclass must still satisfy the existing catch at the call sites.
       expect(err).toBeInstanceOf(MissingAgentCredsError);
       const e = err as InstanceType<typeof ExpiredAgentCredsError>;
-      expect(e.message).toContain('expired');
+      expect(e.message).toContain('renewed');
       expect(e.message).toContain('agentbox claude login');
     }
   });
 
-  it('does NOT throw for claude on docker when the backup is expired', async () => {
+  it('does NOT throw for claude on docker when the login looks dead', async () => {
     sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
-    sandboxDockerMock.hostClaudeBackupExpired.mockResolvedValue(true);
+    sandboxDockerMock.hostClaudeLoginDead.mockResolvedValue(true);
     await expect(
       assertAgentCredsAvailable({
         agent: 'claude-code',

--- a/apps/web/content/docs/run-an-agent.mdx
+++ b/apps/web/content/docs/run-an-agent.mdx
@@ -106,6 +106,20 @@ Claude's OAuth refresh **rotates** the refresh token: the moment any box refresh
 
 This is on by default; disable it per box with `agentbox create --no-credential-sync` or globally with `agentbox config set box.credentialSync false`. A long-_running_ agent session may hold the old token in memory and ask you to `/login` once even after the file was fixed — restart the session and it picks up the fresh login.
 
+### Expired vs. dead
+
+Two different things get called "expired", and only one of them needs you:
+
+- The **access token** lives about 8 hours and renews itself from the refresh token. A saved login whose access token lapsed overnight is perfectly healthy — AgentBox renews it for you before seeding a cloud box, without asking.
+- The **refresh token** lives about 30 days, and is also what rotation kills. When it has run out (or another copy of the login spent it), nothing can renew it, and only a fresh sign-in helps:
+
+```console
+$ agentbox vercel claude
+? Your saved Claude login can no longer be renewed. Sign in again? › Yes
+```
+
+Say yes to that prompt only when you see it — signing in when you did not need to spends the shared refresh token, which is exactly what logs your other boxes out.
+
 <Callout title="TIP">
   Sign in once on the host. Install a skill or sign in there, and the next box picks it up
   automatically. See [configuration](/docs/configuration) and [sync and git](/docs/sync-and-git).

--- a/packages/ctl/src/commands/daemon.ts
+++ b/packages/ctl/src/commands/daemon.ts
@@ -237,7 +237,12 @@ export const daemonCommand = new Command('daemon')
       process.stdout.write(`agentbox-ctl: ${signal} — shutting down\n`);
       if (codexScraper) codexScraper.stop();
       if (claudeScraper) claudeScraper.stop();
-      if (credentialsWatcher) credentialsWatcher.stop();
+      if (credentialsWatcher) {
+        credentialsWatcher.stop();
+        // A credential that rotated in this box's last seconds is worth one
+        // final awaited attempt — every other copy of that login is dead.
+        await credentialsWatcher.flush();
+      }
       toolLinks.stop();
       reporter.stop();
       reporter.flush();

--- a/packages/ctl/src/credentials-watcher.ts
+++ b/packages/ctl/src/credentials-watcher.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { readFile, stat } from 'node:fs/promises';
-import type { RelayClient } from './relay-client.js';
+import type { PostOutcome, RelayClient } from './relay-client.js';
 import { CREDENTIALS_UPDATED_EVENT } from './types.js';
 
 /**
@@ -13,6 +13,14 @@ import { CREDENTIALS_UPDATED_EVENT } from './types.js';
  * atomic renames and inotify on the renamed path is unreliable. The first scan
  * posts the current blob too — the relay's newest-wins gate makes that a no-op
  * unless the box refreshed while the relay wasn't listening (self-healing).
+ *
+ * Delivery is confirmed, not assumed. The mtime/hash bookkeeping used to be
+ * committed before the fire-and-forget post was even attempted, so a post lost
+ * to a relay restart was lost forever: both gates then suppressed the resend,
+ * and since a Claude refresh ROTATES the refresh token, every other copy of
+ * that login was dead with no trace anywhere. Now nothing is recorded until the
+ * relay answers, and the next tick simply tries again — which is also why a ctl
+ * restart heals by itself (the maps start empty, the file is still on disk).
  *
  * Disabled per box via env `AGENTBOX_CREDENTIAL_SYNC=0` (the wire form of the
  * `box.credentialSync` config key / `--no-credential-sync` create flag).
@@ -63,12 +71,31 @@ export interface CredentialsWatcherOptions {
   intervalMs?: number;
   /** Override the watched file list (tests). */
   files?: readonly WatchedCredential[];
+  /** Per-post budget. Longer than the relay default: a cloud box's post travels
+   *  through the bridge, and losing this event is expensive. */
+  postTimeoutMs?: number;
+}
+
+/**
+ * Whether a failed post is worth retrying. A 4xx means this exact payload will
+ * never be accepted (malformed, unknown agent, bad token), so retrying it every
+ * tick forever is pointless noise — record it as done and move on. 408/429 are
+ * the two 4xx that explicitly mean "try again". Everything else — 5xx, and a
+ * null status (connection refused, timeout) — is transient.
+ */
+export function isRetryablePostFailure(outcome: PostOutcome): boolean {
+  if (outcome.ok) return false;
+  const { status } = outcome;
+  if (status === null) return true;
+  if (status === 408 || status === 429) return true;
+  return status < 400 || status >= 500;
 }
 
 export class CredentialsWatcher {
   private readonly relay: RelayClient;
   private readonly intervalMs: number;
   private readonly files: readonly WatchedCredential[];
+  private readonly postTimeoutMs: number;
   private readonly lastMtime = new Map<string, number>();
   private readonly lastPosted = new Map<string, string>();
   private timer: NodeJS.Timeout | null = null;
@@ -77,6 +104,7 @@ export class CredentialsWatcher {
     this.relay = opts.relay;
     this.intervalMs = opts.intervalMs ?? 15_000;
     this.files = opts.files ?? WATCHED_CREDENTIALS;
+    this.postTimeoutMs = opts.postTimeoutMs ?? 10_000;
   }
 
   start(): void {
@@ -92,6 +120,15 @@ export class CredentialsWatcher {
     }
   }
 
+  /**
+   * One last awaited pass, for shutdown — the counterpart of
+   * `StatusReporter.flush()`. Without it a rotation in a box's final 15s is
+   * dropped with no attempt at all, since `stop()` only clears the timer.
+   */
+  async flush(): Promise<void> {
+    await this.scan();
+  }
+
   /** One poll pass; exposed for tests. Never throws. */
   async scan(): Promise<void> {
     if (!this.relay.enabled) return;
@@ -99,18 +136,34 @@ export class CredentialsWatcher {
       try {
         const st = await stat(file.path);
         if (this.lastMtime.get(file.agent) === st.mtimeMs) continue;
-        this.lastMtime.set(file.agent, st.mtimeMs);
         const text = await readFile(file.path, 'utf8');
-        if (!isRealCredentialText(file.shape, text)) continue;
+        // Only now is the read known good: recording the mtime before this
+        // would permanently skip a file caught mid-write.
+        if (!isRealCredentialText(file.shape, text)) {
+          // Same mtime will still be a placeholder next tick — don't re-read it.
+          this.lastMtime.set(file.agent, st.mtimeMs);
+          continue;
+        }
         const hash = createHash('sha256').update(text).digest('hex');
-        if (this.lastPosted.get(file.agent) === hash) continue;
+        if (this.lastPosted.get(file.agent) === hash) {
+          this.lastMtime.set(file.agent, st.mtimeMs);
+          continue;
+        }
+        const outcome = await this.relay.post(
+          CREDENTIALS_UPDATED_EVENT,
+          {
+            schema: 1,
+            agent: file.agent,
+            contentBase64: Buffer.from(text, 'utf8').toString('base64'),
+            capturedAt: new Date().toISOString(),
+          },
+          { timeoutMs: this.postTimeoutMs },
+        );
+        // Leave both maps untouched on a retryable failure: the next tick re-reads
+        // the same file and tries again until the relay actually has it.
+        if (isRetryablePostFailure(outcome)) continue;
+        this.lastMtime.set(file.agent, st.mtimeMs);
         this.lastPosted.set(file.agent, hash);
-        this.relay.post(CREDENTIALS_UPDATED_EVENT, {
-          schema: 1,
-          agent: file.agent,
-          contentBase64: Buffer.from(text, 'utf8').toString('base64'),
-          capturedAt: new Date().toISOString(),
-        });
       } catch {
         // Missing file / transient read error — try again next tick.
       }

--- a/packages/ctl/src/relay-client.ts
+++ b/packages/ctl/src/relay-client.ts
@@ -4,13 +4,38 @@ import { resolveRelayEnv } from './relay-env.js';
 
 /**
  * Minimal outbound HTTP client used by the supervisor to forward events to
- * the host relay (`agentbox-relay`). Fire-and-forget — failures are silently
- * swallowed so a relay outage never blocks the supervisor.
+ * the host relay (`agentbox-relay`). A relay outage never blocks the
+ * supervisor: `post()` never rejects, it reports the outcome instead.
+ *
+ * Most callers stay fire-and-forget (`void relay.post(...)`) because their
+ * events are periodic snapshots a later tick supersedes. The credentials
+ * watcher is the exception — a Claude refresh rotates the token, so a lost post
+ * means every other copy of that login is dead with no trace. It awaits the
+ * outcome and only records the post as done once the relay has it.
  *
  * Reads AGENTBOX_RELAY_URL and AGENTBOX_RELAY_TOKEN from process.env, falling
  * back to the cloud daemon's `0600` relay-env file (see `relay-env.ts`). If
  * neither yields both, `enabled` is false and `post()` is a no-op.
  */
+
+/**
+ * What became of one `post()`. `ok` is a 2xx. `status` is null when the request
+ * never got an answer (connection error, timeout) — the retryable case; a
+ * status lets the caller tell a permanent rejection (4xx: this payload will
+ * never be accepted) from a transient one (5xx).
+ *
+ * Note a credentials event answers 202 `{ accepted: false }` when the relay's
+ * newest-wins gate judges the blob stale. That is delivery, not failure — the
+ * status is what matters here, never the body.
+ */
+export interface PostOutcome {
+  ok: boolean;
+  status: number | null;
+}
+
+/** Default per-request budget. Callers that must not lose the event pass more. */
+const DEFAULT_TIMEOUT_MS = 2000;
+
 export class RelayClient {
   private readonly url: URL | null;
   private readonly token: string;
@@ -35,38 +60,56 @@ export class RelayClient {
     return this.url !== null;
   }
 
-  post(type: string, payload: unknown): void {
-    if (!this.url) return;
+  post(type: string, payload: unknown, opts: { timeoutMs?: number } = {}): Promise<PostOutcome> {
+    if (!this.url) return Promise.resolve({ ok: false, status: null });
     const url = this.url;
     const body = JSON.stringify({ type, ts: new Date().toISOString(), payload });
     const isHttps = url.protocol === 'https:';
     const transport = isHttps ? httpsRequest : httpRequest;
     const port = url.port.length > 0 ? Number.parseInt(url.port, 10) : isHttps ? 443 : 80;
-    const req = transport(
-      {
-        host: url.hostname,
-        port,
-        method: 'POST',
-        path: `${url.pathname.replace(/\/$/, '')}/events`,
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': Buffer.byteLength(body).toString(),
-          Authorization: `Bearer ${this.token}`,
+    return new Promise<PostOutcome>((resolve) => {
+      // Exactly one settle: a request can both time out and error.
+      let settled = false;
+      const done = (outcome: PostOutcome): void => {
+        if (settled) return;
+        settled = true;
+        resolve(outcome);
+      };
+      const req = transport(
+        {
+          host: url.hostname,
+          port,
+          method: 'POST',
+          path: `${url.pathname.replace(/\/$/, '')}/events`,
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(body).toString(),
+            Authorization: `Bearer ${this.token}`,
+          },
+          timeout: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
         },
-        timeout: 2000,
-      },
-      (res) => {
-        // Drain so the socket can be reused.
-        res.resume();
-      },
-    );
-    req.on('error', () => {
-      // best-effort
+        (res) => {
+          const status = res.statusCode ?? null;
+          // Drain so the socket can be reused, and settle only once the body is
+          // gone — resolving early can leave the socket half-read.
+          res.resume();
+          res.on('end', () => {
+            done({ ok: status !== null && status >= 200 && status < 300, status });
+          });
+          res.on('error', () => {
+            done({ ok: false, status: null });
+          });
+        },
+      );
+      req.on('error', () => {
+        done({ ok: false, status: null });
+      });
+      req.on('timeout', () => {
+        req.destroy();
+        done({ ok: false, status: null });
+      });
+      req.write(body);
+      req.end();
     });
-    req.on('timeout', () => {
-      req.destroy();
-    });
-    req.write(body);
-    req.end();
   }
 }

--- a/packages/ctl/src/status-reporter.ts
+++ b/packages/ctl/src/status-reporter.ts
@@ -187,7 +187,7 @@ export class StatusReporter {
     if (!this.relay.enabled) return;
     try {
       const snapshot = await this.snapshot();
-      this.relay.post(BOX_STATUS_EVENT, snapshot);
+      void this.relay.post(BOX_STATUS_EVENT, snapshot);
     } catch {
       // Best-effort, exactly like the relay client itself — a status push
       // failure must never disturb the supervisor.

--- a/packages/ctl/src/supervisor.ts
+++ b/packages/ctl/src/supervisor.ts
@@ -1008,7 +1008,7 @@ export class Supervisor extends EventEmitter<SupervisorEvents> {
       this.schedule();
     }
     if (this.relay.enabled && PUSHED_TASK_STATES.has(state)) {
-      this.relay.post('task-state', { task: name, state });
+      void this.relay.post('task-state', { task: name, state });
     }
     this.emitChange();
   }
@@ -1029,7 +1029,7 @@ export class Supervisor extends EventEmitter<SupervisorEvents> {
       this.schedule();
     }
     if (this.relay.enabled && PUSHED_SERVICE_STATES.has(state)) {
-      this.relay.post('service-state', { service: name, state });
+      void this.relay.post('service-state', { service: name, state });
     }
     this.emitChange();
   }

--- a/packages/ctl/test/credentials-watcher.test.ts
+++ b/packages/ctl/test/credentials-watcher.test.ts
@@ -3,10 +3,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AGENT_SYNC_SPECS, isRealAgentCredential } from '@agentbox/sandbox-core';
-import type { RelayClient } from '../src/relay-client.js';
+import type { PostOutcome, RelayClient } from '../src/relay-client.js';
 import {
   CredentialsWatcher,
   isRealCredentialText,
+  isRetryablePostFailure,
   WATCHED_CREDENTIALS,
 } from '../src/credentials-watcher.js';
 import { CREDENTIALS_UPDATED_EVENT } from '../src/types.js';
@@ -15,8 +16,15 @@ const CLAUDE_BLOB = JSON.stringify({
   claudeAiOauth: { accessToken: 'a', refreshToken: 'r', expiresAt: 123 },
 });
 
-function fakeRelay(): { relay: RelayClient; post: ReturnType<typeof vi.fn> } {
-  const post = vi.fn();
+const DELIVERED: PostOutcome = { ok: true, status: 202 };
+
+/** `outcomes` is consumed one per call; once exhausted every post is delivered. */
+function fakeRelay(outcomes: PostOutcome[] = []): {
+  relay: RelayClient;
+  post: ReturnType<typeof vi.fn>;
+} {
+  const queue = [...outcomes];
+  const post = vi.fn(() => Promise.resolve(queue.shift() ?? DELIVERED));
   return { relay: { enabled: true, post } as unknown as RelayClient, post };
 }
 
@@ -118,5 +126,80 @@ describe('CredentialsWatcher', () => {
     const relay = { enabled: false, post } as unknown as RelayClient;
     await watcher(relay).scan();
     expect(post).not.toHaveBeenCalled();
+  });
+
+  // The bug this guards: bookkeeping used to be committed before the
+  // fire-and-forget post was even attempted, so an update lost to a relay
+  // restart was lost forever — and since a Claude refresh rotates the token,
+  // that silently killed every other copy of the login.
+  it('retries on the next scan when the post never reached the relay', async () => {
+    await writeFile(path, CLAUDE_BLOB);
+    const { relay, post } = fakeRelay([{ ok: false, status: null }]);
+    const w = watcher(relay);
+    await w.scan();
+    expect(post).toHaveBeenCalledTimes(1);
+    await w.scan();
+    expect(post).toHaveBeenCalledTimes(2);
+    // Delivered on the retry — now it stops.
+    await w.scan();
+    expect(post).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries a 5xx and stops once delivered', async () => {
+    await writeFile(path, CLAUDE_BLOB);
+    const { relay, post } = fakeRelay([{ ok: false, status: 503 }]);
+    const w = watcher(relay);
+    await w.scan();
+    await w.scan();
+    await w.scan();
+    expect(post).toHaveBeenCalledTimes(2);
+  });
+
+  // A 202 with `accepted: false` (the relay judged the blob stale) is delivery,
+  // not failure — resending it every 15s forever would be pure noise.
+  it('treats any 2xx as delivered', async () => {
+    await writeFile(path, CLAUDE_BLOB);
+    const { relay, post } = fakeRelay([{ ok: true, status: 202 }]);
+    const w = watcher(relay);
+    await w.scan();
+    await w.scan();
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry a 4xx — that payload will never be accepted', async () => {
+    await writeFile(path, CLAUDE_BLOB);
+    const { relay, post } = fakeRelay([{ ok: false, status: 400 }]);
+    const w = watcher(relay);
+    await w.scan();
+    await w.scan();
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+
+  it('flush() makes one final attempt, for shutdown', async () => {
+    await writeFile(path, CLAUDE_BLOB);
+    const { relay, post } = fakeRelay();
+    await watcher(relay).flush();
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes a longer timeout than the relay default', async () => {
+    await writeFile(path, CLAUDE_BLOB);
+    const { relay, post } = fakeRelay();
+    await watcher(relay).scan();
+    const [, , opts] = post.mock.calls[0] as [string, unknown, { timeoutMs?: number }];
+    expect(opts.timeoutMs).toBeGreaterThan(2000);
+  });
+});
+
+describe('isRetryablePostFailure', () => {
+  it('retries transport failures and 5xx, gives up on 4xx except 408/429', () => {
+    expect(isRetryablePostFailure({ ok: false, status: null })).toBe(true);
+    expect(isRetryablePostFailure({ ok: false, status: 500 })).toBe(true);
+    expect(isRetryablePostFailure({ ok: false, status: 503 })).toBe(true);
+    expect(isRetryablePostFailure({ ok: false, status: 408 })).toBe(true);
+    expect(isRetryablePostFailure({ ok: false, status: 429 })).toBe(true);
+    expect(isRetryablePostFailure({ ok: false, status: 400 })).toBe(false);
+    expect(isRetryablePostFailure({ ok: false, status: 401 })).toBe(false);
+    expect(isRetryablePostFailure({ ok: true, status: 202 })).toBe(false);
   });
 });

--- a/packages/ctl/test/relay-client.test.ts
+++ b/packages/ctl/test/relay-client.test.ts
@@ -1,0 +1,99 @@
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it } from 'vitest';
+import { RelayClient } from '../src/relay-client.js';
+
+/**
+ * `RelayClient.post` had no coverage at all while it was fire-and-forget. It now
+ * reports delivery, and the credentials watcher decides whether to retry from
+ * that outcome — so the status handling here is load-bearing: read it wrong and
+ * a rotated Claude token is either lost or resent every 15s forever.
+ */
+describe('RelayClient.post', () => {
+  let server: Server | null = null;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()));
+      server = null;
+    }
+  });
+
+  /** Start a relay stand-in that answers every POST with `status`. */
+  async function listen(
+    status: number,
+    opts: { body?: string; hang?: boolean } = {},
+  ): Promise<{ client: RelayClient; received: Array<Record<string, unknown>> }> {
+    const received: Array<Record<string, unknown>> = [];
+    server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
+      req.on('end', () => {
+        try {
+          received.push(
+            JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>,
+          );
+        } catch {
+          /* the malformed-body cases don't need to record */
+        }
+        if (opts.hang === true) return; // never answers — exercises the timeout
+        res.writeHead(status, { 'Content-Type': 'application/json' });
+        res.end(opts.body ?? '{}');
+      });
+    });
+    await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as AddressInfo).port;
+    const client = new RelayClient({
+      AGENTBOX_RELAY_URL: `http://127.0.0.1:${String(port)}`,
+      AGENTBOX_RELAY_TOKEN: 'tok',
+    });
+    return { client, received };
+  }
+
+  it('reports 202 as delivered and sends the typed envelope', async () => {
+    const { client, received } = await listen(202, { body: '{"ok":true,"accepted":true}' });
+    expect(await client.post('credentials-updated', { agent: 'claude' })).toEqual({
+      ok: true,
+      status: 202,
+    });
+    expect(received[0]?.['type']).toBe('credentials-updated');
+    expect(received[0]?.['payload']).toEqual({ agent: 'claude' });
+  });
+
+  // The relay answers 202 `{accepted:false}` when its newest-wins gate judges the
+  // blob stale. That is delivery — only the status may decide.
+  it('reports a 202 with accepted:false as delivered', async () => {
+    const { client } = await listen(202, { body: '{"ok":true,"accepted":false}' });
+    expect(await client.post('credentials-updated', {})).toEqual({ ok: true, status: 202 });
+  });
+
+  it('surfaces a 4xx status so the caller can stop retrying', async () => {
+    const { client } = await listen(400, { body: '{"error":"missing type"}' });
+    expect(await client.post('x', {})).toEqual({ ok: false, status: 400 });
+  });
+
+  it('surfaces a 5xx status so the caller retries', async () => {
+    const { client } = await listen(500);
+    expect(await client.post('x', {})).toEqual({ ok: false, status: 500 });
+  });
+
+  it('reports a null status when nothing is listening, and never rejects', async () => {
+    // Port 1 on loopback: reliably refused, no listener to clean up.
+    const client = new RelayClient({
+      AGENTBOX_RELAY_URL: 'http://127.0.0.1:1',
+      AGENTBOX_RELAY_TOKEN: 'tok',
+    });
+    await expect(client.post('x', {})).resolves.toEqual({ ok: false, status: null });
+  });
+
+  it('times out a hung relay rather than hanging the supervisor', async () => {
+    const { client } = await listen(202, { hang: true });
+    expect(await client.post('x', {}, { timeoutMs: 150 })).toEqual({ ok: false, status: null });
+  });
+
+  it('is a disabled no-op without a url + token', async () => {
+    const client = new RelayClient({});
+    expect(client.enabled).toBe(false);
+    expect(await client.post('x', {})).toEqual({ ok: false, status: null });
+  });
+});

--- a/packages/sandbox-core/src/sync/concerns/credentials.ts
+++ b/packages/sandbox-core/src/sync/concerns/credentials.ts
@@ -5,7 +5,7 @@
  * snapshot.
  *
  * What lives here is the provider-neutral core of the concern:
- *  - the pure host-side guards (`isRealAgentCredential`, `hostClaudeBackupExpired`,
+ *  - the pure host-side guards (`isRealAgentCredential`, `hostClaudeAccessTokenExpired`,
  *    `hostBackupHasCredentials`) — the "is this blob real / expired?" decisions,
  *    driven by the registry's `credential.realShape` so the per-agent switch has
  *    one home;
@@ -66,21 +66,25 @@ export function isRealAgentCredential(agent: CredentialAgentKind, text: string):
   if (typeof parsed !== 'object' || parsed === null) return false;
   const spec = AGENT_SYNC_SPECS.find((s) => s.id === agent);
   if (spec?.credential.realShape === 'claude-oauth') {
-    const rt = (parsed as { claudeAiOauth?: { refreshToken?: unknown } }).claudeAiOauth?.refreshToken;
+    const rt = (parsed as { claudeAiOauth?: { refreshToken?: unknown } }).claudeAiOauth
+      ?.refreshToken;
     return typeof rt === 'string' && rt.length > 0;
   }
   return Object.keys(parsed as Record<string, unknown>).length > 0;
 }
 
 /**
- * True iff the claude host backup holds an OAuth blob whose access token is
- * already expired (`claudeAiOauth.expiresAt`, ms epoch, < now). A missing
- * `expiresAt` (or unreadable file) → false: we only report a *known* expiry, so
- * callers don't nag when the box could still refresh the token itself. `now` is
- * injectable for tests. Claude is the only agent with a token-expiry gate (codex
- * / opencode auth files carry no comparable field).
+ * True iff the claude host backup's *access* token has lapsed
+ * (`claudeAiOauth.expiresAt`, ms epoch, < now). Access tokens live ~8h, so this
+ * is true of a perfectly healthy login most of the time — it answers "is this
+ * blob worth renewing before we hand it to a box?", NOT "is this login dead?".
+ * For that, see {@link hostClaudeLoginDead}.
+ *
+ * A missing `expiresAt` (or unreadable file) → false: we only report a *known*
+ * lapse. `now` is injectable for tests. Claude is the only agent with a
+ * token-expiry field (codex / opencode auth files carry no comparable one).
  */
-export async function hostClaudeBackupExpired(
+export async function hostClaudeAccessTokenExpired(
   path: string = CLAUDE_HOST_BACKUP,
   now: number = Date.now(),
 ): Promise<boolean> {
@@ -93,6 +97,39 @@ export async function hostClaudeBackupExpired(
   } catch {
     return false;
   }
+}
+
+/**
+ * True iff the saved claude login can no longer be renewed: no usable refresh
+ * token at all, or the refresh token's own ~30-day life
+ * (`claudeAiOauth.refreshTokenExpiresAt`) has run out.
+ *
+ * This is the question every "should we ask the user to sign in again?" gate
+ * actually wants. Gating those on the access token instead produced a daily
+ * false alarm — and accepting that alarm runs a login container that refreshes
+ * and ROTATES the shared token before the user types anything, so a cancelled
+ * sign-in left every copy of the login (host backup, custody, other boxes)
+ * holding a spent token. A merely-lapsed access token renews itself.
+ *
+ * A missing `refreshTokenExpiresAt` → not dead, matching the "only report a
+ * *known* death" convention of {@link hostClaudeAccessTokenExpired}: an older
+ * blob that predates the field must not be declared dead on a guess. Note this
+ * cannot see a token that was rotated away by another copy — that is only
+ * observable by trying to use it.
+ */
+export async function hostClaudeLoginDead(
+  path: string = CLAUDE_HOST_BACKUP,
+  now: number = Date.now(),
+): Promise<boolean> {
+  let text: string;
+  try {
+    text = await readFile(path, 'utf8');
+  } catch {
+    return false;
+  }
+  if (!isRealAgentCredential('claude', text)) return true;
+  const exp = claudeRefreshExpiresAt(text);
+  return exp !== null && exp < now;
 }
 
 /**
@@ -202,6 +239,21 @@ export function claudeExpiresAt(text: string): number | null {
   try {
     const parsed = JSON.parse(text) as { claudeAiOauth?: { expiresAt?: unknown } };
     const exp = parsed?.claudeAiOauth?.expiresAt;
+    return typeof exp === 'number' && Number.isFinite(exp) ? exp : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `claudeAiOauth.refreshTokenExpiresAt` (ms epoch) of a claude blob, or null.
+ * The refresh token's own life (~30 days from the original sign-in) — the field
+ * that says whether the login is still renewable, unlike `expiresAt`.
+ */
+export function claudeRefreshExpiresAt(text: string): number | null {
+  try {
+    const parsed = JSON.parse(text) as { claudeAiOauth?: { refreshTokenExpiresAt?: unknown } };
+    const exp = parsed?.claudeAiOauth?.refreshTokenExpiresAt;
     return typeof exp === 'number' && Number.isFinite(exp) ? exp : null;
   } catch {
     return null;

--- a/packages/sandbox-core/src/sync/index.ts
+++ b/packages/sandbox-core/src/sync/index.ts
@@ -102,11 +102,13 @@ export {
 } from './concerns/skills.js';
 export {
   isRealAgentCredential,
-  hostClaudeBackupExpired,
+  hostClaudeAccessTokenExpired,
+  hostClaudeLoginDead,
   hostBackupHasCredentials,
   extractCredentials,
   parseCredentialsUpdate,
   claudeExpiresAt,
+  claudeRefreshExpiresAt,
   shouldAcceptCredentialUpdate,
   writeCredentialBackup,
   readCredentialBackup,

--- a/packages/sandbox-core/test/credentials-concern.test.ts
+++ b/packages/sandbox-core/test/credentials-concern.test.ts
@@ -6,8 +6,10 @@ import { makeRecordingTransport } from '../src/sync/recording-transport.js';
 import {
   SEED_MARKER,
   extractCredentials,
+  claudeRefreshExpiresAt,
   hostBackupHasCredentials,
-  hostClaudeBackupExpired,
+  hostClaudeAccessTokenExpired,
+  hostClaudeLoginDead,
   isRealAgentCredential,
 } from '../src/sync/concerns/credentials.js';
 
@@ -17,8 +19,12 @@ import {
 describe('credentials concern — guards', () => {
   describe('isRealAgentCredential (registry realShape)', () => {
     it('claude requires a non-empty claudeAiOauth.refreshToken', () => {
-      expect(isRealAgentCredential('claude', JSON.stringify({ claudeAiOauth: { refreshToken: 'x' } }))).toBe(true);
-      expect(isRealAgentCredential('claude', JSON.stringify({ claudeAiOauth: { refreshToken: '' } }))).toBe(false);
+      expect(
+        isRealAgentCredential('claude', JSON.stringify({ claudeAiOauth: { refreshToken: 'x' } })),
+      ).toBe(true);
+      expect(
+        isRealAgentCredential('claude', JSON.stringify({ claudeAiOauth: { refreshToken: '' } })),
+      ).toBe(false);
       expect(isRealAgentCredential('claude', JSON.stringify({ claudeAiOauth: {} }))).toBe(false);
       expect(isRealAgentCredential('claude', '{}')).toBe(false);
     });
@@ -37,7 +43,7 @@ describe('credentials concern — guards', () => {
     });
   });
 
-  describe('hostClaudeBackupExpired', () => {
+  describe('hostClaudeAccessTokenExpired', () => {
     let dir: string;
     beforeEach(async () => {
       dir = await mkdtemp(join(tmpdir(), 'abx-core-exp-'));
@@ -54,18 +60,82 @@ describe('credentials concern — guards', () => {
 
     it('true when expiresAt is in the past', async () => {
       const p = await write({ claudeAiOauth: { refreshToken: 'rt', expiresAt: 1000 } });
-      expect(await hostClaudeBackupExpired(p, 2000)).toBe(true);
+      expect(await hostClaudeAccessTokenExpired(p, 2000)).toBe(true);
     });
     it('false when expiresAt is in the future', async () => {
       const p = await write({ claudeAiOauth: { refreshToken: 'rt', expiresAt: 5000 } });
-      expect(await hostClaudeBackupExpired(p, 2000)).toBe(false);
+      expect(await hostClaudeAccessTokenExpired(p, 2000)).toBe(false);
     });
     it('false when expiresAt is absent (do not nag)', async () => {
       const p = await write({ claudeAiOauth: { refreshToken: 'rt' } });
-      expect(await hostClaudeBackupExpired(p, 2000)).toBe(false);
+      expect(await hostClaudeAccessTokenExpired(p, 2000)).toBe(false);
     });
     it('false on a missing/garbage file', async () => {
-      expect(await hostClaudeBackupExpired(join(dir, 'nope.json'), 2000)).toBe(false);
+      expect(await hostClaudeAccessTokenExpired(join(dir, 'nope.json'), 2000)).toBe(false);
+    });
+  });
+
+  describe('claudeRefreshExpiresAt', () => {
+    it('reads refreshTokenExpiresAt, null when absent or unparseable', () => {
+      expect(
+        claudeRefreshExpiresAt(JSON.stringify({ claudeAiOauth: { refreshTokenExpiresAt: 42 } })),
+      ).toBe(42);
+      expect(claudeRefreshExpiresAt(JSON.stringify({ claudeAiOauth: { expiresAt: 42 } }))).toBe(
+        null,
+      );
+      expect(
+        claudeRefreshExpiresAt(JSON.stringify({ claudeAiOauth: { refreshTokenExpiresAt: 'no' } })),
+      ).toBe(null);
+      expect(claudeRefreshExpiresAt('not json')).toBe(null);
+    });
+  });
+
+  // The distinction this whole gate exists for: a lapsed ACCESS token is a
+  // healthy login that renews itself, and reporting it as expired produced a
+  // daily false alarm whose "fix" (a login container) rotated the shared token.
+  describe('hostClaudeLoginDead', () => {
+    let dir: string;
+    beforeEach(async () => {
+      dir = await mkdtemp(join(tmpdir(), 'abx-core-dead-'));
+    });
+    afterEach(async () => {
+      await rm(dir, { recursive: true, force: true });
+    });
+
+    const write = async (obj: unknown) => {
+      const p = join(dir, 'creds.json');
+      await writeFile(p, JSON.stringify(obj));
+      return p;
+    };
+
+    it('false when the access token lapsed but the refresh token is alive', async () => {
+      const p = await write({
+        claudeAiOauth: { refreshToken: 'rt', expiresAt: 1000, refreshTokenExpiresAt: 9000 },
+      });
+      expect(await hostClaudeLoginDead(p, 2000)).toBe(false);
+      expect(await hostClaudeAccessTokenExpired(p, 2000)).toBe(true);
+    });
+    it('true when the refresh token itself has expired', async () => {
+      const p = await write({
+        claudeAiOauth: { refreshToken: 'rt', expiresAt: 5000, refreshTokenExpiresAt: 1000 },
+      });
+      expect(await hostClaudeLoginDead(p, 2000)).toBe(true);
+    });
+    it('true when the refresh token is blank (claude blanks it on a rejected refresh)', async () => {
+      const p = await write({ claudeAiOauth: { refreshToken: '', refreshTokenExpiresAt: 9000 } });
+      expect(await hostClaudeLoginDead(p, 2000)).toBe(true);
+    });
+    it('false when refreshTokenExpiresAt is absent (never declare death on a guess)', async () => {
+      const p = await write({ claudeAiOauth: { refreshToken: 'rt', expiresAt: 1000 } });
+      expect(await hostClaudeLoginDead(p, 2000)).toBe(false);
+    });
+    it('false on a missing file (nothing saved is "missing", not "dead")', async () => {
+      expect(await hostClaudeLoginDead(join(dir, 'nope.json'), 2000)).toBe(false);
+    });
+    it('true on a garbage file that exists', async () => {
+      const p = join(dir, 'creds.json');
+      await writeFile(p, 'not json');
+      expect(await hostClaudeLoginDead(p, 2000)).toBe(true);
     });
   });
 
@@ -157,7 +227,8 @@ describe('credentials concern — extractCredentials', () => {
     const t = makeRecordingTransport({
       readText: (p) => {
         if (p === '/home/vscode/.codex/auth.json') return '{"OPENAI_API_KEY":"sk-x"}';
-        if (p === '/home/vscode/.local/share/opencode/auth.json') return '{"anthropic":{"type":"oauth"}}';
+        if (p === '/home/vscode/.local/share/opencode/auth.json')
+          return '{"anthropic":{"type":"oauth"}}';
         return null;
       },
     });
@@ -172,7 +243,10 @@ describe('credentials concern — extractCredentials', () => {
       },
     });
     const logs: string[] = [];
-    const extracted = await extractCredentials(t, { backups: backups(), onLog: (l) => logs.push(l) });
+    const extracted = await extractCredentials(t, {
+      backups: backups(),
+      onLog: (l) => logs.push(l),
+    });
     expect(extracted).toEqual([]);
     expect(logs.some((l) => l.includes('extract failed'))).toBe(true);
   });

--- a/packages/sandbox-docker/src/credential-refresh.ts
+++ b/packages/sandbox-docker/src/credential-refresh.ts
@@ -18,14 +18,16 @@
  * helper swallows its own failures (no docker, missing volume) and returns a
  * noop result.
  *
- * Gated on `hostClaudeBackupExpired`: when the claude backup's `expiresAt` is in
- * the future we skip the docker round-trip entirely (`docker run` against the
- * shared volume is ~1-2s and almost always a noop on fresh tokens).
+ * Gated on `hostClaudeAccessTokenExpired`: when the claude backup's access token
+ * is still valid we skip the docker round-trip entirely (`docker run` against
+ * the shared volume is ~1-2s and almost always a noop on fresh tokens). That is
+ * the one place the access-token check belongs — it asks "is this blob worth
+ * refreshing?", not "is this login dead?".
  */
-import { hostClaudeBackupExpired } from '@agentbox/sandbox-core';
+import { hostClaudeAccessTokenExpired } from '@agentbox/sandbox-core';
 import type { DockerCredentialRefresher } from '@agentbox/sandbox-core';
 import { DEFAULT_BOX_IMAGE } from './image.js';
-import { SHARED_CLAUDE_VOLUME } from './sync/agents/claude.js';
+import { SHARED_CLAUDE_VOLUME, warmUpClaudeCredentials } from './sync/agents/claude.js';
 import { SHARED_CODEX_VOLUME } from './sync/agents/codex.js';
 import { SHARED_OPENCODE_VOLUME } from './sync/agents/opencode.js';
 import {
@@ -36,7 +38,7 @@ import {
 
 export const dockerCredentialRefresh: DockerCredentialRefresher = async (opts) => {
   const log = opts.onLog ?? (() => {});
-  if (!(await hostClaudeBackupExpired())) {
+  if (!(await hostClaudeAccessTokenExpired())) {
     return;
   }
   log('claude: host credentials backup expired — refreshing from docker shared volume');
@@ -68,3 +70,61 @@ export const dockerCredentialRefresh: DockerCredentialRefresher = async (opts) =
     /* best-effort */
   }
 };
+
+/** Outcome of {@link renewClaudeCredential}. */
+export type RenewClaudeResult = 'renewed' | 'unchanged' | 'failed';
+
+/**
+ * Actively renew the saved claude login through the shared docker volume, and
+ * report whether it still works.
+ *
+ * A credential's health is not readable off disk: `expiresAt` only dates the
+ * ~8h access token, and a refresh token that was rotated away by another copy
+ * looks perfectly valid until you try it. The only honest test is to use it —
+ * so drive the same pair the successful-login path runs in its `finalize`:
+ *
+ *  1. `syncClaudeCredentials` — converge volume and backup on the newer blob,
+ *     so we renew from the freshest copy rather than whichever the volume holds.
+ *  2. `warmUpClaudeCredentials` — a headless `claude -p` forces a real OAuth
+ *     refresh, minting a fresh access token into the volume.
+ *  3. `syncClaudeCredentials` again — extract that fresh blob to the host backup
+ *     so the cloud seed (and every later box) gets a live credential.
+ *
+ * This is what keeps the fleet logged in without nagging: a lapsed access token
+ * is renewed silently, and only a genuine failure — `'failed'` — is worth
+ * asking the user to sign in again for.
+ *
+ * `attempts` is deliberately small (2 by default): the login path's 6 exist to
+ * outwait the fresh-token first-request 400, but on the create path every extra
+ * attempt costs the user 5s + a container start before we can say "dead".
+ *
+ * Best-effort: any docker failure resolves to `'failed'`, never throws.
+ */
+export async function renewClaudeCredential(opts: {
+  image?: string;
+  attempts?: number;
+  onLog?: (msg: string) => void;
+}): Promise<RenewClaudeResult> {
+  const log = opts.onLog ?? (() => {});
+  const image = opts.image ?? DEFAULT_BOX_IMAGE;
+  try {
+    await syncClaudeCredentials({ volume: SHARED_CLAUDE_VOLUME }, { image, isolate: false });
+    const warm = await warmUpClaudeCredentials(SHARED_CLAUDE_VOLUME, image, {
+      attempts: opts.attempts ?? 2,
+      onProgress: (line) => {
+        log(line);
+      },
+    });
+    if (!warm.warmed) {
+      log('claude: saved login did not renew — it may have been rotated away by another box');
+      return 'failed';
+    }
+    const synced = await syncClaudeCredentials(
+      { volume: SHARED_CLAUDE_VOLUME },
+      { image, isolate: false },
+    );
+    return synced.direction === 'extracted' ? 'renewed' : 'unchanged';
+  } catch {
+    return 'failed';
+  }
+}

--- a/packages/sandbox-docker/src/index.ts
+++ b/packages/sandbox-docker/src/index.ts
@@ -48,7 +48,8 @@ export {
   CODEX_CREDENTIALS_BACKUP_FILE,
   OPENCODE_CREDENTIALS_BACKUP_FILE,
   hostBackupHasCredentials,
-  hostClaudeBackupExpired,
+  hostClaudeAccessTokenExpired,
+  hostClaudeLoginDead,
   isRealAgentCredential,
   parseSyncResult,
   parseExtractResult,
@@ -224,7 +225,11 @@ export {
 // there now. This package only supplies the docker-side Portless hooks the CLI
 // installs into the hub seam.
 export { dockerHubPortlessHooks } from './hub-portless.js';
-export { dockerCredentialRefresh } from './credential-refresh.js';
+export {
+  dockerCredentialRefresh,
+  renewClaudeCredential,
+  type RenewClaudeResult,
+} from './credential-refresh.js';
 // The host-config stage producers now live in the provider-neutral sync layer
 // (`@agentbox/sandbox-core`); cloud consumers import them from there. The claude
 // per-project path helpers + Stage types stay re-exported here (from core) for

--- a/packages/sandbox-docker/src/sync/agents/claude.ts
+++ b/packages/sandbox-docker/src/sync/agents/claude.ts
@@ -134,7 +134,6 @@ async function volumeHasClaudeJson(volume: string, image: string): Promise<boole
   return res.exitCode === 0;
 }
 
-
 /**
  * Ensure the named volume exists, then (when {@link EnsureClaudeVolumeOptions.syncFromHost}
  * is true and the host has a `~/.claude` directory) rsync host -> volume via a throwaway
@@ -1066,10 +1065,7 @@ export function buildClaudeAttachArgv(container: string, sessionName?: string): 
  * under the shared TERM guard ({@link buildTermSafeTmuxExec}) for the same
  * reason the direct attach builders do.
  */
-export function buildDashboardAttachArgv(
-  container: string,
-  sessionName?: string,
-): string[] {
+export function buildDashboardAttachArgv(container: string, sessionName?: string): string[] {
   const name = sessionName ?? DEFAULT_CLAUDE_SESSION;
   // The grouped sibling session name ("<name>-dash") is derived in-shell from
   // $1, so the session name stays a single positional that sh never re-parses.
@@ -1100,7 +1096,17 @@ export async function waitForTmuxPaneContent(
   while (Date.now() < deadline) {
     const res = await execa(
       'docker',
-      ['exec', '--user', CONTAINER_USER, container, 'tmux', 'capture-pane', '-p', '-t', sessionName],
+      [
+        'exec',
+        '--user',
+        CONTAINER_USER,
+        container,
+        'tmux',
+        'capture-pane',
+        '-p',
+        '-t',
+        sessionName,
+      ],
       { reject: false },
     );
     if (res.exitCode === 0 && (res.stdout ?? '').trim().length > 0) return;
@@ -1265,13 +1271,19 @@ export interface WarmUpClaudeResult {
  * Best-effort and time-boxed: if it never succeeds we return `warmed: false`
  * and the caller proceeds anyway — the box then behaves exactly as it did
  * before this warm-up existed.
+ *
+ * Because a successful run forces claude to refresh a lapsed access token, this
+ * doubles as the only true liveness check we have for a saved login — a
+ * credential's health is not readable off disk. `attempts` exists for that use:
+ * the default 6 is the patience the post-login 400 needs, whereas a liveness
+ * probe on the create path must not cost ~30s (see `renewClaudeCredential`).
  */
 export async function warmUpClaudeCredentials(
   volume: string,
   image: string,
-  opts: { onProgress?: (line: string) => void } = {},
+  opts: { onProgress?: (line: string) => void; attempts?: number } = {},
 ): Promise<WarmUpClaudeResult> {
-  const MAX_ATTEMPTS = 6;
+  const MAX_ATTEMPTS = Math.max(1, opts.attempts ?? 6);
   const SLEEP_MS = 5000;
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     opts.onProgress?.(`checking credentials... ${attempt}/${MAX_ATTEMPTS}`);
@@ -1408,7 +1420,18 @@ export async function pullClaudeExtras(
   // container. `--user 0` so root can read files claude wrote as uid 1000.
   const inv = await execa(
     'docker',
-    ['run', '--rm', '--user', '0', '-v', `${spec.volume}:/src:ro`, opts.image, 'sh', '-c', claudeInventoryScript('/src')],
+    [
+      'run',
+      '--rm',
+      '--user',
+      '0',
+      '-v',
+      `${spec.volume}:/src:ro`,
+      opts.image,
+      'sh',
+      '-c',
+      claudeInventoryScript('/src'),
+    ],
     { reject: false },
   );
   if (inv.exitCode !== 0) {

--- a/packages/sandbox-docker/src/sync/claude-credentials.ts
+++ b/packages/sandbox-docker/src/sync/claude-credentials.ts
@@ -4,15 +4,16 @@ import { execa } from 'execa';
 import type { ClaudeConfigSpec } from './agents/claude.js';
 import { STATE_DIR } from '../state.js';
 
-// The pure credential guards (`isRealAgentCredential`, `hostClaudeBackupExpired`,
-// `hostBackupHasCredentials`) + `CredentialAgentKind` moved to the provider-
+// The pure credential guards (`isRealAgentCredential`, `hostClaudeAccessTokenExpired`,
+// `hostClaudeLoginDead`, `hostBackupHasCredentials`) + `CredentialAgentKind` moved to the provider-
 // neutral credentials concern in @agentbox/sandbox-core (the per-agent
 // real-credential shape is now registry data, `credential.realShape`, shared
 // with cloud). Re-exported here so existing docker importers/tests — and the
 // `@agentbox/sandbox-docker` barrel — are untouched.
 export {
   isRealAgentCredential,
-  hostClaudeBackupExpired,
+  hostClaudeAccessTokenExpired,
+  hostClaudeLoginDead,
   hostBackupHasCredentials,
   type CredentialAgentKind,
 } from '@agentbox/sandbox-core';
@@ -100,12 +101,18 @@ export async function extractVolumeAuthToBackup(opts: {
 }
 
 /** Extract codex `auth.json` from its shared volume to `~/.agentbox/codex-credentials.json`. */
-export function extractCodexCredentials(volume: string, image: string): Promise<{ copied: boolean }> {
+export function extractCodexCredentials(
+  volume: string,
+  image: string,
+): Promise<{ copied: boolean }> {
   return extractVolumeAuthToBackup({ volume, image, backupFile: CODEX_CREDENTIALS_BACKUP_FILE });
 }
 
 /** Extract opencode `auth.json` from its shared volume to `~/.agentbox/opencode-credentials.json`. */
-export function extractOpencodeCredentials(volume: string, image: string): Promise<{ copied: boolean }> {
+export function extractOpencodeCredentials(
+  volume: string,
+  image: string,
+): Promise<{ copied: boolean }> {
   return extractVolumeAuthToBackup({ volume, image, backupFile: OPENCODE_CREDENTIALS_BACKUP_FILE });
 }
 
@@ -205,35 +212,51 @@ export function parseSyncResult(stdout: string): SyncClaudeCredentialsResult {
   return { direction: 'noop', volumeHasCredentials };
 }
 
-// Bidirectional, best-effort. `jq` ships in the box image. A credentials blob
-// only counts as "real" when `claudeAiOauth.refreshToken` is a non-empty
-// string — a setup-token blob has an accessToken but no refreshToken, and
-// seeding/extracting it would just reproduce the "Claude API" label. The
+// Bidirectional, best-effort, NEWEST-WINS. `jq` ships in the box image. A
+// credentials blob only counts as "real" when `claudeAiOauth.refreshToken` is a
+// non-empty string — a setup-token blob has an accessToken but no refreshToken,
+// and seeding/extracting it would just reproduce the "Claude API" label. The
 // final `echo` always runs so the caller can read the outcome; a failed `cp`
 // leaves the flag at `no` and the whole thing still exits 0.
-const SYNC_SCRIPT = `
+//
+// The direction is decided by `claudeAiOauth.expiresAt`, which strictly
+// increases on every OAuth refresh — the same ordering key the relay's
+// `shouldAcceptCredentialUpdate` fan-out gate uses. This used to extract
+// volume→host unconditionally whenever the volume held any refresh token, which
+// let a stale volume overwrite a fresher backup. Since a refresh ROTATES the
+// refresh token, the older blob isn't merely expired, it is dead — so a
+// downgrade here logs the whole fleet out. It also never seeded a volume that
+// already had *some* credential, so a volume left holding a rotated-dead blob
+// could never be repaired from a good backup.
+export const SYNC_SCRIPT = `
 EXTRACTED=no
 SEEDED=no
 VOL=/dst/.credentials.json
 HOST=/host-state/claude-credentials.json
+num() { case "$1" in ''|*[!0-9]*) echo 0;; *) echo "$1";; esac; }
 if [ -f "$VOL" ] && jq -e '(.claudeAiOauth.refreshToken // "") | length > 0' "$VOL" >/dev/null 2>&1; then VOL_REAL=yes; else VOL_REAL=no; fi
 if [ -f "$HOST" ] && jq -e '(.claudeAiOauth.refreshToken // "") | length > 0' "$HOST" >/dev/null 2>&1; then HOST_REAL=yes; else HOST_REAL=no; fi
-if [ "$VOL_REAL" = yes ] && [ "$ISOLATE" != yes ]; then
+VOL_EXP=$(num "$(jq -r '(.claudeAiOauth.expiresAt // 0) | floor' "$VOL" 2>/dev/null)")
+HOST_EXP=$(num "$(jq -r '(.claudeAiOauth.expiresAt // 0) | floor' "$HOST" 2>/dev/null)")
+if [ "$VOL_REAL" = yes ] && [ "$ISOLATE" != yes ] && { [ "$HOST_REAL" = no ] || [ "$VOL_EXP" -gt "$HOST_EXP" ]; }; then
   cp -a "$VOL" "$HOST" && chmod 600 "$HOST" && EXTRACTED=yes
-elif [ "$VOL_REAL" = no ] && [ "$HOST_REAL" = yes ]; then
+elif [ "$HOST_REAL" = yes ] && { [ "$VOL_REAL" = no ] || [ "$HOST_EXP" -gt "$VOL_EXP" ]; }; then
   cp -a "$HOST" "$VOL" && chown 1000:1000 "$VOL" && chmod 600 "$VOL" && SEEDED=yes && VOL_REAL=yes
 fi
 echo "EXTRACTED=$EXTRACTED SEEDED=$SEEDED VOLREAL=$VOL_REAL"
 `;
 
 /**
- * Bidirectionally sync the box's `.credentials.json` with the host backup:
+ * Bidirectionally sync the box's `.credentials.json` with the host backup,
+ * newest `claudeAiOauth.expiresAt` wins:
  *
- *  - volume has a real OAuth blob and the box is **not** isolate → copy it OUT
- *    to {@link CREDENTIALS_BACKUP_FILE} (the volume is authoritative — it is
- *    the live copy the in-box claude refreshes).
- *  - volume has no `.credentials.json` and the host backup is real → copy it
- *    IN (seeds a fresh isolate box, or a recreated shared volume).
+ *  - volume blob is real, newer than the backup (or the backup isn't real), and
+ *    the box is **not** isolate → copy it OUT to {@link CREDENTIALS_BACKUP_FILE}
+ *    (the usual case: the volume is the live copy the in-box claude refreshes).
+ *  - host backup is real and newer than the volume's (or the volume has no
+ *    credentials at all) → copy it IN. Seeds a fresh isolate box or a recreated
+ *    shared volume, and repairs a volume whose copy was rotated dead by another
+ *    box while this one sat idle.
  *  - otherwise → noop.
  *
  * Isolate boxes are read-seed only — never extract — so N isolate boxes can't

--- a/packages/sandbox-docker/test/claude-credentials.test.ts
+++ b/packages/sandbox-docker/test/claude-credentials.test.ts
@@ -1,14 +1,17 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { execa } from 'execa';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   hostBackupHasCredentials,
-  hostClaudeBackupExpired,
+  hostClaudeAccessTokenExpired,
+  hostClaudeLoginDead,
   isRealAgentCredential,
   parseExtractResult,
   parseSyncResult,
   parseVolumeClaudeCredentials,
+  SYNC_SCRIPT,
 } from '../src/sync/claude-credentials.js';
 
 describe('parseExtractResult', () => {
@@ -53,7 +56,7 @@ describe('parseVolumeClaudeCredentials', () => {
   });
 });
 
-describe('hostClaudeBackupExpired', () => {
+describe('hostClaudeAccessTokenExpired', () => {
   let dir: string;
   beforeEach(async () => {
     dir = await mkdtemp(join(tmpdir(), 'abx-exp-'));
@@ -70,25 +73,44 @@ describe('hostClaudeBackupExpired', () => {
 
   it('true when expiresAt is in the past', async () => {
     const p = await write({ claudeAiOauth: { refreshToken: 'rt', expiresAt: 1000 } });
-    expect(await hostClaudeBackupExpired(p, 2000)).toBe(true);
+    expect(await hostClaudeAccessTokenExpired(p, 2000)).toBe(true);
   });
   it('false when expiresAt is in the future', async () => {
     const p = await write({ claudeAiOauth: { refreshToken: 'rt', expiresAt: 5000 } });
-    expect(await hostClaudeBackupExpired(p, 2000)).toBe(false);
+    expect(await hostClaudeAccessTokenExpired(p, 2000)).toBe(false);
   });
   it('false when expiresAt is absent (do not nag)', async () => {
     const p = await write({ claudeAiOauth: { refreshToken: 'rt' } });
-    expect(await hostClaudeBackupExpired(p, 2000)).toBe(false);
+    expect(await hostClaudeAccessTokenExpired(p, 2000)).toBe(false);
   });
   it('false on a missing/garbage file', async () => {
-    expect(await hostClaudeBackupExpired(join(dir, 'nope.json'), 2000)).toBe(false);
+    expect(await hostClaudeAccessTokenExpired(join(dir, 'nope.json'), 2000)).toBe(false);
+  });
+
+  // The two predicates must stay distinguishable through the docker re-export:
+  // a lapsed access token is a healthy login, only a spent refresh token is dead.
+  it('is not the same question as hostClaudeLoginDead', async () => {
+    const p = await write({
+      claudeAiOauth: { refreshToken: 'rt', expiresAt: 1000, refreshTokenExpiresAt: 9000 },
+    });
+    expect(await hostClaudeAccessTokenExpired(p, 2000)).toBe(true);
+    expect(await hostClaudeLoginDead(p, 2000)).toBe(false);
+
+    const spent = await write({
+      claudeAiOauth: { refreshToken: 'rt', expiresAt: 5000, refreshTokenExpiresAt: 1000 },
+    });
+    expect(await hostClaudeLoginDead(spent, 2000)).toBe(true);
   });
 });
 
 describe('isRealAgentCredential', () => {
   it('claude requires a non-empty claudeAiOauth.refreshToken', () => {
-    expect(isRealAgentCredential('claude', JSON.stringify({ claudeAiOauth: { refreshToken: 'x' } }))).toBe(true);
-    expect(isRealAgentCredential('claude', JSON.stringify({ claudeAiOauth: { refreshToken: '' } }))).toBe(false);
+    expect(
+      isRealAgentCredential('claude', JSON.stringify({ claudeAiOauth: { refreshToken: 'x' } })),
+    ).toBe(true);
+    expect(
+      isRealAgentCredential('claude', JSON.stringify({ claudeAiOauth: { refreshToken: '' } })),
+    ).toBe(false);
     expect(isRealAgentCredential('claude', JSON.stringify({ claudeAiOauth: {} }))).toBe(false);
     expect(isRealAgentCredential('claude', '{}')).toBe(false);
   });
@@ -179,5 +201,137 @@ describe('hostBackupHasCredentials', () => {
   it('returns false for garbage JSON', async () => {
     await writeFile(path, '{not json');
     expect(await hostBackupHasCredentials(path)).toBe(false);
+  });
+});
+
+/**
+ * SYNC_SCRIPT is the shell that decides which way a credential moves between the
+ * shared volume and the host backup, and getting that direction wrong logs the
+ * whole fleet out (a Claude refresh rotates the token, so the older blob is dead,
+ * not merely stale). It is plain POSIX sh + jq, so run the real thing here rather
+ * than restating its logic in a mock.
+ *
+ * In production the container runs as root; as a test user the seed branch's
+ * `chown 1000:1000` would fail and mask the outcome, so shim `chown` on PATH.
+ */
+describe('SYNC_SCRIPT direction (newest expiresAt wins)', () => {
+  let dir: string;
+  let binDir: string;
+  let hasJq = true;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'abx-sync-script-'));
+    binDir = join(dir, 'bin');
+    await mkdir(binDir, { recursive: true });
+    await mkdir(join(dir, 'dst'), { recursive: true });
+    await mkdir(join(dir, 'host-state'), { recursive: true });
+    const shim = join(binDir, 'chown');
+    await writeFile(shim, '#!/bin/sh\nexit 0\n');
+    await chmod(shim, 0o755);
+    try {
+      await execa('jq', ['--version']);
+    } catch {
+      hasJq = false;
+    }
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const blob = (expiresAt: number, refreshToken = 'rt'): string =>
+    JSON.stringify({ claudeAiOauth: { refreshToken, expiresAt, refreshTokenExpiresAt: 9e12 } });
+
+  const volPath = () => join(dir, 'dst', '.credentials.json');
+  const hostPath = () => join(dir, 'host-state', 'claude-credentials.json');
+
+  /** Run the real script with /dst and /host-state rebound to temp dirs. */
+  const run = async (isolate = false): Promise<string> => {
+    const script = SYNC_SCRIPT.replaceAll('/dst/', `${join(dir, 'dst')}/`).replaceAll(
+      '/host-state/',
+      `${join(dir, 'host-state')}/`,
+    );
+    const { stdout } = await execa('sh', ['-c', script], {
+      env: { ISOLATE: isolate ? 'yes' : 'no', PATH: `${binDir}:${process.env['PATH'] ?? ''}` },
+      extendEnv: false,
+    });
+    return stdout;
+  };
+
+  it('extracts when the volume blob is newer than the backup', async () => {
+    await writeFile(volPath(), blob(2000));
+    await writeFile(hostPath(), blob(1000));
+    if (!hasJq) return;
+    expect(parseSyncResult(await run())).toEqual({
+      direction: 'extracted',
+      volumeHasCredentials: true,
+    });
+    expect(JSON.parse(await readFile(hostPath(), 'utf8')).claudeAiOauth.expiresAt).toBe(2000);
+  });
+
+  // The regression that started this: a stale volume used to overwrite a fresher
+  // backup, replacing a live token with one that had already been rotated away.
+  it('does NOT extract when the volume blob is older — it seeds the volume instead', async () => {
+    await writeFile(volPath(), blob(1000));
+    await writeFile(hostPath(), blob(2000));
+    if (!hasJq) return;
+    expect(parseSyncResult(await run())).toEqual({
+      direction: 'seeded',
+      volumeHasCredentials: true,
+    });
+    expect(JSON.parse(await readFile(hostPath(), 'utf8')).claudeAiOauth.expiresAt).toBe(2000);
+    expect(JSON.parse(await readFile(volPath(), 'utf8')).claudeAiOauth.expiresAt).toBe(2000);
+  });
+
+  it('is a noop when both sides carry the same blob', async () => {
+    await writeFile(volPath(), blob(2000));
+    await writeFile(hostPath(), blob(2000));
+    if (!hasJq) return;
+    expect(parseSyncResult(await run())).toEqual({
+      direction: 'noop',
+      volumeHasCredentials: true,
+    });
+  });
+
+  it('seeds an empty volume from the backup', async () => {
+    await writeFile(hostPath(), blob(2000));
+    if (!hasJq) return;
+    expect(parseSyncResult(await run())).toEqual({
+      direction: 'seeded',
+      volumeHasCredentials: true,
+    });
+  });
+
+  it('extracts to an absent backup regardless of expiry', async () => {
+    await writeFile(volPath(), blob(1000));
+    if (!hasJq) return;
+    expect(parseSyncResult(await run())).toEqual({
+      direction: 'extracted',
+      volumeHasCredentials: true,
+    });
+  });
+
+  it('repairs a volume whose refresh token was blanked by a rejected refresh', async () => {
+    await writeFile(volPath(), blob(3000, ''));
+    await writeFile(hostPath(), blob(1000));
+    if (!hasJq) return;
+    expect(parseSyncResult(await run())).toEqual({
+      direction: 'seeded',
+      volumeHasCredentials: true,
+    });
+  });
+
+  it('never extracts under ISOLATE, but still seeds a newer backup in', async () => {
+    await writeFile(volPath(), blob(2000));
+    await writeFile(hostPath(), blob(1000));
+    if (!hasJq) return;
+    expect(parseSyncResult(await run(true))).toEqual({
+      direction: 'noop',
+      volumeHasCredentials: true,
+    });
+    await writeFile(hostPath(), blob(3000));
+    expect(parseSyncResult(await run(true))).toEqual({
+      direction: 'seeded',
+      volumeHasCredentials: true,
+    });
   });
 });


### PR DESCRIPTION
## Why

Two defects made the saved Claude login expire "all the time".

**The expiry check read the wrong field.** `hostClaudeBackupExpired` reported expiry from `claudeAiOauth.expiresAt` — the ~8h **access** token — while a login is alive as long as its **refresh** token is (~30 days, `refreshTokenExpiresAt`, a field nothing in the repo read). On a cloud-only workflow nothing rewrites the host backup between logins, so that field is in the past within a day of every sign-in and stays there: a guaranteed daily nag on a perfectly healthy login.

Worse, accepting the nag is destructive. It launches a `claude auth login` container that refreshes and **rotates** the shared refresh token before you touch the browser, and the write-back only ran on success — so cancelling left the host backup, the control box's backup and its custody copy all holding a spent token. The false alarm made itself true.

Session forensics: the blob AgentBox called expired at 09:18:15Z was handed to the login container at 09:19:15Z and **successfully refreshed**. It was alive the whole time.

**The fan-out had no delivery guarantee.** `CredentialsWatcher` committed its mtime/hash bookkeeping *before* the fire-and-forget `post()` was even attempted. A post lost to a hub restart was lost forever — both gates then suppressed the resend, and since a refresh rotates the token, that silently killed every other copy of the login. On the reporter's machine the fan-out had accepted a claude update **zero** times across 34 posts.

## What changed

- **Split the predicate.** `hostClaudeAccessTokenExpired` (unchanged body, honest name — still the right gate for "is this worth refreshing?", which is what `dockerCredentialRefresh` always meant) and new `hostClaudeLoginDead` (no usable refresh token, or `refreshTokenExpiresAt` past). A missing `refreshTokenExpiresAt` is *not* death — same "only report a known expiry" convention as before.
- **Verify instead of guessing.** Both user-facing gates (the interactive cloud offer in `maybeRunCloudClaudeLogin`, and `claudeCredStatus` for the `-i` pre-flight) now share one `resolveClaudeCredHealth`. On a lapsed access token it *renews* the credential — `renewClaudeCredential` drives the same warm-up + sync pair the successful-login path already runs in its `finalize` — and only asks you to sign in if that fails. A stale token is fixed silently, and the cloud seed gets a fresh one.
- **`SYNC_SCRIPT` is newest-wins.** Required by the above: it used to extract volume → backup unconditionally, letting a stale volume overwrite a fresher backup. Since a refresh rotates, the older blob is *dead*, not stale — that downgrade logs the fleet out. Now ordered by `expiresAt` in both directions (the same key the relay's fan-out gate uses), which also lets a good backup repair a volume whose copy was rotated away.
- **Confirmed delivery.** `RelayClient.post` returns a `PostOutcome` instead of `void`. The watcher commits bookkeeping only once the relay has the event, otherwise retries on its next 15s tick; a 4xx is terminal (that payload will never be accepted); a 202 with `accepted:false` is delivery, not failure. Adds `flush()`, awaited by the daemon on shutdown, so a rotation in a box's last seconds still lands. The other three `post()` callers stay fire-and-forget — their events are snapshots a later tick supersedes.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm test` all green (ctl 384, sandbox-docker 329, sandbox-core 324, cli 1368).

New coverage: `hostClaudeLoginDead` cases incl. the lapsed-access/live-refresh split; `SYNC_SCRIPT`'s direction tested by running the real shell against temp dirs (with a `chown` shim, since production runs it as root); watcher retry/terminal-4xx/flush; and a first-ever HTTP test for `RelayClient`, whose status handling is now load-bearing.

Live, against a real box image and real credentials:
- the exact blob that nagged now reads `accessExpired=true / loginDead=false` → silent, no prompt;
- a genuinely lapsed access token renewed end-to-end: refresh token rotated, the new blob landed in the host backup, the shared volume and the control box's custody store.

## Flagged, not fixed here

`packages/relay/src/core/handler.ts` (the hosted control-plane handler, distinct from `server.ts`) has its own `POST /events` path that does **not** special-case `CREDENTIALS_UPDATED_EVENT` — a credential blob arriving there would land in the plain event ring buffer and never be fanned out. Worth its own change; the two paths in `server.ts` are correct and agree.

https://claude.ai/code/session_01YHZ6wSPJACdtQLDN9WMehu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication gating, OAuth renewal/rotation, and credential fan-out delivery—bugs here can log users out fleet-wide or miss rotated tokens.
> 
> **Overview**
> Fixes Claude login gates that treated a lapsed **access** token (~8h `expiresAt`) as “expired,” which caused daily cloud sign-in prompts and could **rotate** the shared refresh token if the user accepted. Credential health now keys off refresh-token viability (`hostClaudeLoginDead` / `refreshTokenExpiresAt`) and shared **`resolveClaudeCredHealth`**, which **silently renews** stale access tokens via **`renewClaudeCredential`** before cloud create or queued jobs run.
> 
> **`maybeRunCloudClaudeLogin`** and **`claudeCredStatus`** / **`assertAgentCredsAvailable`** use that helper; user-facing copy now says the login “can no longer be renewed” only when renewal actually fails. **`SYNC_SCRIPT`** syncs host backup and docker volume **newest-wins** on `expiresAt` so a stale volume cannot overwrite a fresher backup after rotation.
> 
> In **`packages/ctl`**, **`RelayClient.post`** returns **`PostOutcome`**; **`CredentialsWatcher`** records delivery only after a successful post, retries transient failures, and **`flush()`** on daemon shutdown so rotated tokens are not dropped. Docs add an “expired vs. dead” section for when to re-sign in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb57208d84afb28b8c00d039544bb409cb62312f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->