### PR TITLE
Cloud B2 (part 1): agentless base + per-agent artifacts for e2b and daytona

### DIFF
--- a/apps/web/content/docs/daytona.mdx
+++ b/apps/web/content/docs/daytona.mdx
@@ -46,7 +46,7 @@ The easiest path is the interactive wizard — it takes your API key and bakes t
 agentbox install        # then select daytona
 ```
 
-Paste a **`DAYTONA_API_KEY`** when prompted; the wizard offers to open [the keys page](https://app.daytona.io/dashboard/keys) in your browser first so you can generate one. (There's no browser sign-in — the key is the whole auth. If you paste a **JWT** instead of an API key, you'll also be asked for a `DAYTONA_ORGANIZATION_ID`, which an API key doesn't need: the SDK derives the org from it.) Credentials persist to `~/.agentbox/secrets.env`; project `.env` files are never harvested. `install` also bakes the base snapshot (a one-time `agentbox prepare --provider daytona` under the hood) with the AgentBox runtime — `agentbox-ctl`, the agents, tmux — so every new box boots in seconds instead of eating a ~7-minute cold Dockerfile build.
+Paste a **`DAYTONA_API_KEY`** when prompted; the wizard offers to open [the keys page](https://app.daytona.io/dashboard/keys) in your browser first so you can generate one. (There's no browser sign-in — the key is the whole auth. If you paste a **JWT** instead of an API key, you'll also be asked for a `DAYTONA_ORGANIZATION_ID`, which an API key doesn't need: the SDK derives the org from it.) Credentials persist to `~/.agentbox/secrets.env`; project `.env` files are never harvested. `install` also bakes the base snapshot (a one-time `agentbox prepare --provider daytona` under the hood) with the AgentBox runtime — `agentbox-ctl`, tmux, the browser stack — so every new box boots in seconds instead of eating a ~7-minute cold Dockerfile build.
 
 For CI or scripted setup, run the explicit equivalents:
 
@@ -76,6 +76,23 @@ A `linux-vm` base is baked from the prebuilt box image AgentBox publishes, so it
 
 - **`box.claudeInstall: npm`** — only the default (native) image is published.
 - **A locally modified `Dockerfile.box`** — i.e. you're developing on the AgentBox repo itself. Point `box.daytonaVmBaseImage` at an image you've published to bake a VM anyway. It's also the knob for a private registry mirror.
+
+### Agents are a separate tier
+
+The base carries **no agent**. Add one as its own snapshot on top of it:
+
+```bash
+agentbox prepare --provider daytona --agents claude
+```
+
+How that derives depends on the class the base was baked as — a snapshot's class is immutable, so the variant always matches its base rather than `box.daytonaClass`:
+
+- **container** — the agent recipe is appended to the same Dockerfile build. Daytona's builder serves every layer below it from cache, so a variant takes about a minute against the base's several.
+- **linux-vm** — the base snapshot is booted, the agent installed, and the result cold-snapshotted.
+
+Each agent set gets its own record, so baking `--agents codex` later does not invalidate the claude one, and each rebake deletes only the snapshot it replaces.
+
+Skipping this is fine: a box whose agent isn't baked installs it on first use (~30–60s), and the result is identical — the bake and the on-demand install run the same recipe.
 
 When you upgrade AgentBox, `create --provider daytona` notices if the new install would bake a different snapshot (the comparison is checksum-based on the baked files — CLI version strings on their own don't count) and offers to rebake inline; with `-y` or non-TTY it instead warns loudly and boots on the existing snapshot. `agentbox daytona login` also nudges you toward `agentbox prepare --provider daytona` on the first successful login.
 

--- a/apps/web/content/docs/e2b.mdx
+++ b/apps/web/content/docs/e2b.mdx
@@ -17,7 +17,7 @@ The easiest path is the interactive wizard — it signs you in and bakes the bas
 agentbox install        # then select e2b
 ```
 
-Paste an `E2B_API_KEY` (mint at [e2b.dev/dashboard](https://e2b.dev/dashboard?tab=keys)) when prompted. Credentials persist to `~/.agentbox/secrets.env`; project `.env` files are never harvested. `install` also bakes the base template (a one-time `agentbox prepare --provider e2b` under the hood) with the AgentBox runtime — `agentbox-ctl`, the agents, tmux — so every new box boots ready in seconds.
+Paste an `E2B_API_KEY` (mint at [e2b.dev/dashboard](https://e2b.dev/dashboard?tab=keys)) when prompted. Credentials persist to `~/.agentbox/secrets.env`; project `.env` files are never harvested. `install` also bakes the base template (a one-time `agentbox prepare --provider e2b` under the hood) with the AgentBox runtime — `agentbox-ctl`, tmux, the browser stack — so every new box boots ready in seconds. Agents are a separate, optional tier on top (see below).
 
 For CI or scripted setup, run the explicit equivalents:
 
@@ -45,7 +45,17 @@ agentbox e2b claude
   code-first build rather than a stateful provisioning run.
 </Callout>
 
-`agentbox prepare --provider e2b` drives a TypeScript-described `Template.build()` that includes everything the box needs (agentbox-ctl, the vscode user, Claude / Codex / OpenCode, tmux, VNC). The resulting `templateId:tag` is recorded under the per-provider key `box.imageE2b` and to `~/.agentbox/e2b-prepared.json`; every `create --provider e2b` boots from it.
+`agentbox prepare --provider e2b` drives a TypeScript-described `Template.build()` that includes everything the box needs (agentbox-ctl, the vscode user, tmux, VNC, the browser stack) — but **no agent**. The resulting `templateId:tag` is recorded under the per-provider key `box.imageE2b` and to `~/.agentbox/e2b-prepared.json`; every `create --provider e2b` boots from it.
+
+Add an agent as its own template, built on top of the base:
+
+```bash
+agentbox prepare --provider e2b --agents claude
+```
+
+E2B is the cheapest provider to do this on: `Template().fromTemplate(base)` derives declaratively with no sandbox boot at all, so a variant takes **well under a minute**. Each agent set gets its own record, so building `--agents codex` later does not invalidate the claude one.
+
+Skipping it is fine: a box whose agent isn't baked installs it on first use (~30–60s), and the result is identical — the bake and the on-demand install run the same recipe.
 
 ```bash
 agentbox prepare --provider e2b
@@ -82,14 +92,14 @@ agentbox e2b claude
 
 ## Limits
 
-| Limit             |                                                                                                                                             |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| Region            | SDK-chosen (transparent)                                                                                                                    |
-| Disk / RAM / vCPU | Template-level — baked at `Template.build()` time via `prepare --provider e2b --size <cpu-memory>`; per-create `--size` warns if it differs |
-| Exposed ports     | Any port via `sandbox.getHost(port)`; WebProxy runs on 8080                                                                                 |
+| Limit             |                                                                                                                                                                                                    |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Region            | SDK-chosen (transparent)                                                                                                                                                                           |
+| Disk / RAM / vCPU | Template-level — baked at `Template.build()` time via `prepare --provider e2b --size <cpu-memory>`; per-create `--size` warns if it differs                                                        |
+| Exposed ports     | Any port via `sandbox.getHost(port)`; WebProxy runs on 8080                                                                                                                                        |
 | Session length    | 1 hour (Hobby) / 24 hours (Pro) — auto-renewed while the agent is working; at the cap the box **pauses and auto-resumes**, it is not killed. The attach helper caps at **55 minutes** for headroom |
-| Nested containers | Yes — the docker engine is baked into the prepare template; `dockerd` auto-launches on create/resume                                        |
-| SSH               | none — attach is an SDK-streaming PTY bridge over `pty.create`                                                                              |
+| Nested containers | Yes — the docker engine is baked into the prepare template; `dockerd` auto-launches on create/resume                                                                                               |
+| SSH               | none — attach is an SDK-streaming PTY bridge over `pty.create`                                                                                                                                     |
 
 <Callout title="IN-BOX DOCKER">
   E2B supports [Docker-in-Docker](/docs/docker-in-docker) — the microVM grants the capabilities a

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -194,70 +194,90 @@ collapse — see the seam analysis in
 
 ## Provider status
 
-| | docker | hetzner | vercel, e2b, daytona, DO |
-|---|---|---|---|
-| agentless base | yes | yes | no — the provision scripts still install all three |
-| agents as a derived layer/snapshot | yes | yes | not yet |
-| per-box agent selection | yes | yes | not yet — cloud still mounts every agent's volume |
-| on-demand install into a live box | yes | yes | yes |
+| | docker | hetzner | e2b | daytona | vercel, DO |
+|---|---|---|---|---|---|
+| agentless base | yes | yes | yes | yes | no — the provision scripts still install all three |
+| agents as a derived layer/snapshot | yes | yes | yes | yes | not yet |
+| per-box agent selection | yes | yes | yes | yes | not yet |
+| install into a live box on demand | yes | yes | yes | yes | yes |
 
-Vercel, E2B and DigitalOcean bake from their own provision scripts, which still
-install all three agents — so their behaviour is unchanged and the create-time
-install probe is a no-op there.
-
-**Daytona is the exception.** It bakes from `Dockerfile.box` (container class,
-`sandbox-daytona/src/dockerfile-context.ts`) or from that image published to
-GHCR (linux-vm, `prepare-vm.ts`), and that Dockerfile is now agentless. A
-*fresh* `prepare --provider daytona` therefore produces a base with no agents
-and falls back to the per-box install (~30-90s on first use). Existing daytona
-bases keep their agents until re-prepared.
+Vercel and DigitalOcean still bake all three agents into their base, so their
+behaviour is unchanged and the create-time install probe is a no-op there.
 
 Every cloud box gets per-agent credential isolation at **create**: an
 `agentbox claude --provider <cloud>` box seeds only claude's credential, and the
-other agents' symlinks dangle.
+other agents' symlinks dangle. On a provider with an agentless base that now
+holds across pause/resume too — verified live on hetzner and daytona.
 
-**Known limitation on daytona:** a pause/resume re-materialises the other
-agents' credentials. This is not the host re-seeding them — verified with the
-relay stopped and with the daytona backend's `uploadFile` and `exec` both
-instrumented, neither of which is called. Daytona's archive/restore re-applies
-content from the baked base snapshot, which still contains every agent's
-credentials. The fix is an agentless daytona base, not more host-side filtering.
-Hetzner, which now has one, holds isolation across pause/resume.
+> **Resolved:** daytona used to re-materialise the other agents' credentials on
+> resume. It was never host re-seeding (proven with the relay stopped and the
+> backend's `uploadFile`/`exec` instrumented); the archive/restore re-applied
+> content from a baked base that contained every agent's credential paths. The
+> agentless base removes the source, and a resumed box now shows only its own
+> agent's credential.
 
-### Cloud: agentless base + derived snapshots (hetzner)
+### The three tiers, per provider
 
-The snapshot analogue of docker's `FROM base` layer, and the same three tiers:
+Everything below is the same idea as docker's `FROM base` layer: an agentless
+base, one artifact per agent set on top of it, and a runtime install as the
+fallback when no matching artifact exists. Only the *derive mechanism* differs —
+there is no shared `deriveAgentSnapshot` over `CloudBackend`, because
+hetzner/DO's `backend.exec` is gated on a per-box SSH key and cannot address a
+bake VPS.
 
-| tier | what it is | cost |
+| provider | how a variant is derived | measured cost |
 |---|---|---|
-| base | `prepare --provider hetzner` — Ubuntu, deps, ctl, browser, **no agents** | ~6 min, 1.87 GB |
-| variant | `prepare --provider hetzner --agents claude` — boots the base, runs one install recipe, re-snapshots | ~3.5 min |
-| runtime | no matching variant: the create-time probe installs the agent into the live box | ~30-60s per box |
+| docker | `FROM base` + recipe | seconds |
+| e2b | `Template().fromTemplate(base)` — declarative, no boot | **43s** |
+| daytona (container) | recipe appended to the same Dockerfile build; the builder's layer cache serves everything below it | **77s** (base: 3m18s) |
+| daytona (linux-vm) | boot the base snapshot, install, stop, cold-snapshot | untested live |
+| hetzner | boot the base snapshot, install over ssh, re-snapshot | ~3.5 min |
 
-The recipes are the same `AGENT_SYNC_SPECS.install` entries the docker layer and
-`ensureAgentInstalled` use, so a baked agent and a runtime-added one are byte-
-identical in layout. Only the *execution* differs per provider — there is no
-shared `deriveAgentSnapshot` over `CloudBackend`, because hetzner's
-`backend.exec` is gated on a per-box SSH key and cannot address a bake VPS.
+The recipes are the same `AGENT_SYNC_SPECS.install` entries in every row, so a
+baked agent and a runtime-added one are byte-identical in layout.
 
-Three details that are easy to get wrong:
+### Rules that cost us a live debugging cycle each
 
-- **The derived bake logs in as `vscode`, not `root`.** The base snapshot already
-  carries install-box.sh's `PermitRootLogin no`, so a root key is accepted by
-  cloud-init and then refused by sshd — the symptom is a `waitForSsh` timeout
-  with nothing in any log.
-- **`box.imageHetzner` is pinned to the base's description by every bake**, so by
-  create time the image ref usually names our own base rather than the sentinel.
-  `resolveImageId` treats that as "no explicit choice" and still consults the
-  variants map; otherwise the pin silently defeats variant selection.
-- **A variant bake must not pin, share, or adopt.** `box.image<Provider>`,
-  the custody record and base adoption are all single-slot: a variant written
-  into any of them makes every box on the provider boot one agent's snapshot.
+- **The base pin defeats variant selection.** Every bake pins
+  `box.image<Provider>` to the base's own name, so by create time the image ref
+  usually *is* our base rather than the sentinel. Hetzner and daytona both need
+  a `refIsOurBase` escape that treats it as "no explicit choice"; e2b doesn't,
+  because its backend ignores `req.image` entirely.
+- **A variant bake must not pin, share, or adopt.** `box.image<Provider>`, the
+  custody record and base adoption are all single-slot: a variant written into
+  any of them makes every box on that provider boot one agent's snapshot.
+- **`base` must stay the agentless base**, never "the most recent bake".
+  Provider-generic readers (freshness, bake sharing, `prepared-custody.ts`) read
+  `base.contextSha256` / `base.imageRef` and assume exactly that.
+- **A variant must match the base's class/shape.** On daytona a snapshot's class
+  is immutable, so the variant takes its class from the base rather than from
+  config — a `box.daytonaClass` that disagrees with what was baked would
+  otherwise produce an unbootable pairing.
+- **Derived bakes log in as the box user, not root** (hetzner): the base already
+  carries `PermitRootLogin no`, so a root key is accepted by cloud-init and then
+  refused by sshd — which looks like an unexplained `waitForSsh` timeout.
+- **Verify the binary on the BOX USER's PATH**, not just that the build exited
+  0. A native installer run as root writes into `/root` and does both.
 
-Prepared state (`~/.agentbox/hetzner-prepared.json`, schema 3) keys one record
-per agent set under `variants` (`''` = the agentless base) so baking codex does
-not invalidate the claude snapshot. Each bake deletes the snapshot it supersedes
-— only its own variant, and only after the replacement is recorded, so a failed
-bake never leaves you with no base. Snapshots carry an `agentbox.agents` label
-(`none` for the base) so an orphan sweep can tell the tiers apart without the
-local state file.
+### Per-variant records and GC
+
+Each provider keys one record per agent set under `variants` in its own
+`~/.agentbox/<provider>-prepared.json` (`''` = the agentless base), so baking
+codex never invalidates the claude artifact. Schema bumps: hetzner 3, e2b 2,
+daytona 2 — all with lossless migrations that seed `variants['']` from the
+existing `base`.
+
+GC differs by how each platform addresses artifacts:
+
+- **hetzner / daytona** — id- and name-addressed snapshots, so a rebuild orphans
+  its predecessor. Both reap it, but only for that exact variant and only after
+  the replacement is recorded, so a failed bake never leaves you with no base.
+  Hetzner had no base-snapshot GC at all before this.
+- **e2b** — templates are *named*, so rebuilding `agentbox-claude:latest` moves
+  the tag rather than orphaning an id. There is also no `Template.delete` in the
+  SDK to reap one with.
+
+Identifying a snapshot's tier from the platform side varies too: hetzner carries
+an `agentbox.agents` label (`none` for the base), while daytona's
+`snapshot.create` accepts only name/image/resources/region — so there the **name**
+is the only channel, hence `agentbox-<set>-<fp12>`.

--- a/packages/sandbox-daytona/src/backend.ts
+++ b/packages/sandbox-daytona/src/backend.ts
@@ -20,7 +20,8 @@ import type {
 } from '@agentbox/core';
 import { resolveDockerfileContext } from './dockerfile-context.js';
 import { ensureDaytonaEnvLoaded } from './env-loader.js';
-import { readPreparedDaytonaState } from './prepared-state.js';
+import { preparedEntryFor, readPreparedDaytonaState } from './prepared-state.js';
+import { agentSetArg, normalizeAgentSet } from '@agentbox/sandbox-core';
 import { waitForSnapshotActive } from './snapshot-wait.js';
 import { withDaytonaRetry } from './retry.js';
 
@@ -179,8 +180,8 @@ function resolveImage(ref: string): string | Image {
   const ctx = resolveDockerfileContext();
   if (!ctx) {
     throw new Error(
-      "could not locate the AgentBox Dockerfile.box build context for the Daytona snapshot. " +
-        "Set AGENTBOX_DOCKER_CONTEXT to a directory containing Dockerfile.box, or pass --image <ref> with a Daytona-compatible image.",
+      'could not locate the AgentBox Dockerfile.box build context for the Daytona snapshot. ' +
+        'Set AGENTBOX_DOCKER_CONTEXT to a directory containing Dockerfile.box, or pass --image <ref> with a Daytona-compatible image.',
     );
   }
   // Image.fromDockerfile bundles the directory the Dockerfile lives in and
@@ -318,6 +319,23 @@ export const daytonaBackend: CloudBackend = {
         // resolveImage (Image.fromDockerfile). Explicit `req.snapshot` always
         // wins (cloud checkpoint path).
         let snapshotName = req.snapshot;
+        // Prefer the snapshot baked for exactly this agent set. `box.imageDaytona`
+        // is pinned to the base's own NAME by every bake and adopt, so by the
+        // time we get here `req.image` normally IS our agentless base — treat
+        // that (and the default ref) as "no explicit choice", or the pin
+        // silently defeats variant selection and every box boots the agentless
+        // base. A ref naming anything else is a real choice and wins.
+        const refIsOurBase =
+          req.snapshot === undefined &&
+          (!req.image ||
+            req.image === DEFAULT_BOX_IMAGE_REF ||
+            req.image === prepared?.base?.imageRef);
+        if (refIsOurBase) {
+          const variant = preparedEntryFor(prepared, agentSetArg(normalizeAgentSet(req.agents)));
+          // Falling back to the agentless base is not a failure:
+          // `ensureAgentsInstalledForCloud` puts the agent in at create.
+          if (variant) snapshotName = variant.imageRef;
+        }
         if (!snapshotName && req.image && req.image !== DEFAULT_BOX_IMAGE_REF) {
           try {
             const snap = await client.snapshot.get(req.image);
@@ -610,11 +628,7 @@ export const daytonaBackend: CloudBackend = {
     });
   },
 
-  async exec(
-    h: CloudHandle,
-    cmd: string,
-    opts?: CloudExecOptions,
-  ): Promise<CloudExecResult> {
+  async exec(h: CloudHandle, cmd: string, opts?: CloudExecOptions): Promise<CloudExecResult> {
     return retry(
       'exec',
       async () => {
@@ -696,7 +710,8 @@ export const daytonaBackend: CloudBackend = {
         'ssh',
         // First-connect to a never-seen host fingerprint should be silent in a
         // PTY — the user already authenticated via Daytona's API.
-        '-o', 'StrictHostKeyChecking=accept-new',
+        '-o',
+        'StrictHostKeyChecking=accept-new',
         // Daytona's SSH gateway terminates per-token; no key file, no port.
         `${ssh.token}@ssh.app.daytona.io`,
       ];

--- a/packages/sandbox-daytona/src/backend.ts
+++ b/packages/sandbox-daytona/src/backend.ts
@@ -241,8 +241,35 @@ export const daytonaBackend: CloudBackend = {
         const resources = sizeResources ?? req.resources;
         const prepared = readPreparedDaytonaState();
         const baseRef = req.snapshot ?? req.image;
+        // Resolve WHICH prepared snapshot this box boots before anything reads
+        // its properties. `box.imageDaytona` is pinned to the base's own NAME by
+        // every bake and adopt, so by the time we get here `req.image` normally
+        // IS our agentless base — treat that (and the default ref, and an unset
+        // one) as "no explicit choice", or the pin silently defeats variant
+        // selection. A ref naming anything else is a real choice and wins.
+        const refIsOurBase =
+          req.snapshot === undefined &&
+          (!req.image ||
+            req.image === DEFAULT_BOX_IMAGE_REF ||
+            req.image === prepared?.base?.imageRef);
+        // Falling back to the agentless base is not a failure:
+        // `ensureAgentsInstalledForCloud` puts the agent in at create.
+        const preparedEntry = refIsOurBase
+          ? (preparedEntryFor(prepared, agentSetArg(normalizeAgentSet(req.agents))) ??
+            preparedEntryFor(prepared, ''))
+          : undefined;
+        // Class, region, size and image env must come from the entry we ACTUALLY
+        // boot, not from `req.image`. Deriving them from the request meant an
+        // unpinned create booted a prepared snapshot while taking its class and
+        // env from config — so a container snapshot could be looked up in the
+        // VM-only region, recorded as linux-vm, and come up with no DISPLAY.
         const bootingPreparedBase =
-          prepared?.base?.imageRef !== undefined && baseRef === prepared.base.imageRef;
+          preparedEntry !== undefined ||
+          (prepared?.base?.imageRef !== undefined && baseRef === prepared.base.imageRef);
+        // A variant carries its own extras (its class is fixed at bake time and
+        // it inherits the base's image env); fall back to the top-level extras,
+        // which describe the agentless base.
+        const bootedExtras = preparedEntry?.extras ?? prepared?.extras;
         // A linux-vm does NOT inherit the box image's `ENV` — the conversion keeps
         // the rootfs and drops the metadata — so the bake recorded it and we hand
         // it to the sandbox here. The bake also wrote it into the VM's /etc, but
@@ -252,7 +279,7 @@ export const daytonaBackend: CloudBackend = {
         // The box's own env (relay tokens, …) wins over the image's.
         const imageEnv: Record<string, string> = {};
         if (bootingPreparedBase) {
-          for (const kv of prepared.extras?.env ?? []) {
+          for (const kv of bootedExtras?.env ?? []) {
             const i = kv.indexOf('=');
             if (i > 0) imageEnv[kv.slice(0, i)] = kv.slice(i + 1);
           }
@@ -281,9 +308,7 @@ export const daytonaBackend: CloudBackend = {
         // successful `prepare`, with "no linux-vm base snapshot — run prepare".
         // Absent `class` on a recorded base = baked before classes existed, i.e.
         // a container.
-        const bakedClass = bootingPreparedBase
-          ? (prepared.extras?.class ?? 'container')
-          : undefined;
+        const bakedClass = bootingPreparedBase ? (bootedExtras?.class ?? 'container') : undefined;
         const sandboxClass = bakedClass ?? req.sandboxClass;
         if (bakedClass && req.sandboxClass && bakedClass !== req.sandboxClass) {
           req.onLog?.(
@@ -319,23 +344,7 @@ export const daytonaBackend: CloudBackend = {
         // resolveImage (Image.fromDockerfile). Explicit `req.snapshot` always
         // wins (cloud checkpoint path).
         let snapshotName = req.snapshot;
-        // Prefer the snapshot baked for exactly this agent set. `box.imageDaytona`
-        // is pinned to the base's own NAME by every bake and adopt, so by the
-        // time we get here `req.image` normally IS our agentless base — treat
-        // that (and the default ref) as "no explicit choice", or the pin
-        // silently defeats variant selection and every box boots the agentless
-        // base. A ref naming anything else is a real choice and wins.
-        const refIsOurBase =
-          req.snapshot === undefined &&
-          (!req.image ||
-            req.image === DEFAULT_BOX_IMAGE_REF ||
-            req.image === prepared?.base?.imageRef);
-        if (refIsOurBase) {
-          const variant = preparedEntryFor(prepared, agentSetArg(normalizeAgentSet(req.agents)));
-          // Falling back to the agentless base is not a failure:
-          // `ensureAgentsInstalledForCloud` puts the agent in at create.
-          if (variant) snapshotName = variant.imageRef;
-        }
+        if (preparedEntry) snapshotName = preparedEntry.imageRef;
         if (!snapshotName && req.image && req.image !== DEFAULT_BOX_IMAGE_REF) {
           try {
             const snap = await client.snapshot.get(req.image);
@@ -354,7 +363,7 @@ export const daytonaBackend: CloudBackend = {
         // loudly — silently ignoring `--size` would leave them wondering why the
         // box came up the old size.
         if (snapshotName && sizeResources) {
-          const bakedSize = prepared?.extras?.size;
+          const bakedSize = bootedExtras?.size;
           const requestedKey = `${String(sizeResources.cpu)}-${String(sizeResources.memory)}-${String(sizeResources.disk)}`;
           if (bakedSize !== requestedKey) {
             req.onLog?.(

--- a/packages/sandbox-daytona/src/prepare-vm.ts
+++ b/packages/sandbox-daytona/src/prepare-vm.ts
@@ -468,7 +468,7 @@ function sha12(s: string): string {
 }
 
 /** Short, monotonic, never-reused token for a snapshot name. */
-function nonce(): string {
+export function nonce(): string {
   return Math.floor(Date.now() / 1000).toString(36);
 }
 

--- a/packages/sandbox-daytona/src/prepare-vm.ts
+++ b/packages/sandbox-daytona/src/prepare-vm.ts
@@ -36,7 +36,14 @@ import type { CloudBackend, CloudHandle } from '@agentbox/core';
 import type { Daytona } from '@daytona/sdk';
 import { SandboxClass } from '@daytona/sdk';
 import { seedAgentStaticIntoCloudBox } from '@agentbox/sandbox-cloud';
-import { BOX_IMAGE_REGISTRY, registryRefForSha } from '@agentbox/sandbox-core';
+import {
+  BOX_IMAGE_REGISTRY,
+  registryRefForSha,
+  renderAptInstall,
+  renderInstallRecipe,
+  resolveAgentInstall,
+  resolveAgentSpec,
+} from '@agentbox/sandbox-core';
 import { waitForSnapshotActive } from './snapshot-wait.js';
 
 /**
@@ -237,6 +244,101 @@ export interface VmBaseBakeResult {
   env: string[];
 }
 
+/** What a derived VM bake needs on top of an existing agentless base snapshot. */
+export interface VmVariantBakeOptions {
+  client: Daytona;
+  backend: CloudBackend;
+  /** The AGENTLESS base snapshot to boot. Already provisioned, sudo-repaired, env-restored. */
+  baseSnapshot: string;
+  /** Final variant-snapshot name stem; a `nonce()` is appended. */
+  snapshotName: string;
+  /** Agents to install, normalized and sorted. */
+  agents: readonly string[];
+  /** `box.claudeInstall` — selects claude's recipe, not whether to install. */
+  claudeInstall?: 'native' | 'npm';
+  onLog?: (line: string) => void;
+}
+
+/**
+ * Bake a per-agent linux-vm snapshot on top of the agentless base.
+ *
+ * Deliberately much shorter than `bakeDaytonaVmBase`: the base already did the
+ * expensive and fiddly parts (the ~2 GB image pull, the setuid `sudo` repair,
+ * the image-ENV restore, the host static config), and all of that is in the
+ * snapshot we boot. A variant adds one thing — the agent binary — from the same
+ * `AGENT_SYNC_SPECS` recipes the docker derived layer, the hetzner derived
+ * snapshot and `ensureAgentInstalled` use, so however an agent reaches a box it
+ * is installed identically.
+ *
+ * Static agent config is NOT re-seeded here: the base carries all three agents'
+ * config already (it is config, not credentials), so a variant inherits it and a
+ * runtime-installed agent still finds its plugins.
+ */
+export async function bakeDaytonaVmVariant(
+  opts: VmVariantBakeOptions,
+): Promise<{ snapshotName: string }> {
+  const log = opts.onLog ?? (() => {});
+  log(`booting the agentless base '${opts.baseSnapshot}' to add ${opts.agents.join(', ')}…`);
+  const sandbox = await opts.client.create({ snapshot: opts.baseSnapshot }, { timeout: 900 });
+  const handle: CloudHandle = { sandboxId: sandbox.id, sandboxClass: 'linux-vm' };
+  try {
+    for (const id of opts.agents) {
+      const spec = resolveAgentSpec(id);
+      const install = resolveAgentInstall(spec.install, opts.claudeInstall);
+      log(`installing ${spec.id} into the derived snapshot…`);
+      const steps: string[] = [];
+      if (install.apt && install.apt.length > 0) {
+        steps.push(`sudo sh -c ${shellSingleQuote(renderAptInstall(install.apt))}`);
+      }
+      const recipe = renderInstallRecipe(install.recipe);
+      // `runAs: 'box-user'` is load-bearing: the native installers write into
+      // the INVOKING user's ~/.local/bin, so as root the binary lands in /root
+      // and the box user never sees it. `exec` already runs as the box user, so
+      // a box-user recipe needs no pivot — only a root one does.
+      steps.push(install.runAs === 'root' ? `sudo sh -c ${shellSingleQuote(recipe)}` : recipe);
+      if (install.postInstall) {
+        steps.push(`sudo sh -c ${shellSingleQuote(install.postInstall)}`);
+      }
+      // Prove it landed on the BOX USER's PATH. An installer that exits 0
+      // without producing a usable binary is a real failure mode, and finding
+      // out here beats a box that attaches to a session that died instantly.
+      steps.push(`command -v ${spec.binary} >/dev/null`);
+      const res = await opts.backend.exec(handle, `set -e; ${steps.join('\n')}`);
+      if (res.exitCode !== 0) {
+        throw new Error(
+          `daytona: installing ${spec.id} into the derived snapshot failed ` +
+            `(exit ${String(res.exitCode)}): ${`${res.stdout}${res.stderr}`.trim().slice(-600)}`,
+        );
+      }
+    }
+
+    // Cold snapshot: filesystem only, and Daytona requires the sandbox STOPPED.
+    // It does not stop for you.
+    log('stopping the sandbox to capture a cold snapshot…');
+    await sandbox.stop();
+    // Never reuse a name — Daytona's delete is async and a recreated name can
+    // report `active` yet fail to boot. Same rule as the base bake.
+    const finalName = `${opts.snapshotName}-${nonce()}`;
+    log(`capturing variant snapshot '${finalName}'…`);
+    await sandbox._experimental_createSnapshot(finalName, 900);
+    await waitForSnapshotActive(opts.client, finalName);
+    log(`snapshot '${finalName}' is active`);
+    return { snapshotName: finalName };
+  } finally {
+    try {
+      await sandbox.delete(120);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log(`warning: could not delete the temporary bake sandbox ${sandbox.id}: ${msg}`);
+    }
+  }
+}
+
+/** Wrap a shell snippet in single quotes for safe nesting inside `sudo sh -c`. */
+function shellSingleQuote(s: string): string {
+  return `'${s.replaceAll("'", `'\\''`)}'`;
+}
+
 /**
  * Bake the linux-vm base snapshot.
  */
@@ -312,7 +414,9 @@ export async function bakeDaytonaVmBase(opts: VmBaseBakeOptions): Promise<VmBase
     // DISPLAY, and the in-box browser dies with "Missing X server or $DISPLAY".
     imageEnv = (await fetchImageEnv(imageRef)) ?? [];
     if (imageEnv.length > 0) {
-      log(`restoring the image's ${String(imageEnv.length)} env vars (the VM conversion drops them)…`);
+      log(
+        `restoring the image's ${String(imageEnv.length)} env vars (the VM conversion drops them)…`,
+      );
       const envFix = await opts.backend.exec(handle, buildEnvRestoreCommand(imageEnv));
       if (envFix.exitCode !== 0) {
         throw new Error(

--- a/packages/sandbox-daytona/src/prepare.ts
+++ b/packages/sandbox-daytona/src/prepare.ts
@@ -27,9 +27,11 @@ import { Image } from '@daytona/sdk';
 import type { PrepareOptions, PrepareResult } from '@agentbox/core';
 import { DAYTONA_VM_REGION, type DaytonaSandboxClass } from '@agentbox/config';
 import {
-  claudeInstallFingerprint,
   stageAllAgentStatic,
   type AgentStaticStage,
+  variantFingerprint,
+  normalizeAgentSet,
+  agentSetArg,
 } from '@agentbox/sandbox-core';
 import {
   DAYTONA_DEFAULT_RESOURCES,
@@ -41,15 +43,17 @@ import { resolveDaytonaCustomClaudeMd, resolveDockerfileContext } from './docker
 import { ensureDaytonaEnvLoaded } from './env-loader.js';
 import {
   bakeDaytonaVmBase,
+  bakeDaytonaVmVariant,
   deleteSnapshotQuietly,
   VmBaseImageUnavailableError,
 } from './prepare-vm.js';
 import {
   computeDaytonaContextFingerprint,
   computeDockerBaseSha,
-  preparedMatches,
   readPreparedDaytonaState,
   writePreparedDaytonaState,
+  preparedEntryFor,
+  preparedVariantMatches,
 } from './prepared-state.js';
 
 /**
@@ -64,6 +68,7 @@ export function defaultSnapshotName(
   fingerprint: string | null,
   sizeKey?: string,
   sandboxClass?: DaytonaSandboxClass,
+  variantKey?: string,
 ): string {
   // The size suffix keeps re-sized bakes from colliding on one name, so a
   // `--size 2-4-8` snapshot doesn't overwrite the `4-8-20` one. Same for the
@@ -71,8 +76,13 @@ export function defaultSnapshotName(
   // artifacts and cannot substitute for each other. Container stays unsuffixed
   // so existing snapshot names keep resolving.
   const suffix = `${sizeKey ? `-${sizeKey}` : ''}${sandboxClass === 'linux-vm' ? '-vm' : ''}`;
-  if (fingerprint) return `agentbox-base-${fingerprint.slice(0, 12)}${suffix}`;
-  return `agentbox-base-${Math.floor(Date.now() / 1000).toString()}${suffix}`;
+  // The agent set goes in the NAME, not a label: daytona's snapshot.create
+  // accepts only name/image/resources/region, so unlike hetzner there is no
+  // label to carry it and the name is the only channel that tells a human (or
+  // an orphan sweep) which tier a snapshot belongs to.
+  const stem = variantKey ? `agentbox-${variantKey.replaceAll(',', '-')}` : 'agentbox-base';
+  if (fingerprint) return `${stem}-${fingerprint.slice(0, 12)}${suffix}`;
+  return `${stem}-${Math.floor(Date.now() / 1000).toString()}${suffix}`;
 }
 
 /**
@@ -169,27 +179,52 @@ export async function prepareDaytona(opts: PrepareOptions): Promise<PrepareResul
   // Fold the install mode into the sha so native↔npm are distinct cache
   // identities (`native` leaves the hash unchanged) — the snapshot name and the
   // prepared-state match both derive from it.
+  const agents = normalizeAgentSet(opts.agents);
+  const variantKey = agentSetArg(agents);
+  const derived = agents.length > 0;
   const fingerprint = rawFingerprint
     ? {
         ...rawFingerprint,
-        contextSha256: claudeInstallFingerprint(rawFingerprint.contextSha256, claudeInstall),
+        contextSha256: variantFingerprint(rawFingerprint.contextSha256, {
+          claudeInstall,
+          agents,
+        }),
       }
     : rawFingerprint;
   // Not const: a linux-vm bake that finds no published base image downgrades to
   // container below, and must then drop the `-vm` suffix from its name.
   let snapshotName =
-    opts.name ?? defaultSnapshotName(fingerprint?.contextSha256 ?? null, sizeKey, sandboxClass);
+    opts.name ??
+    defaultSnapshotName(fingerprint?.contextSha256 ?? null, sizeKey, sandboxClass, variantKey);
 
   const prepared = readPreparedDaytonaState();
+
+  // A derived bake boots the agentless base, so that has to exist first — and
+  // it must be a linux-vm one, since that is the only class we can boot and
+  // re-snapshot.
+  const baseEntry = preparedEntryFor(prepared, '');
+  if (derived && (!baseEntry || (baseEntry.extras?.class ?? 'container') !== 'linux-vm')) {
+    throw new Error(
+      derived && baseEntry
+        ? 'daytona --agents needs a linux-vm base to derive from (the container class has no ' +
+            'boot-and-resnapshot path yet). Run `agentbox config set box.daytonaClass linux-vm` ' +
+            'and `agentbox prepare --provider daytona` first.'
+        : 'no daytona base snapshot to derive from — run `agentbox prepare --provider daytona` ' +
+            'first, then re-run with --agents.',
+    );
+  }
+
   if (
     !opts.force &&
     fingerprint &&
-    preparedMatches(prepared, fingerprint.contextSha256, sizeKey, sandboxClass)
+    preparedVariantMatches(prepared, variantKey, fingerprint.contextSha256, sizeKey, sandboxClass)
   ) {
     // Confirm the snapshot still exists on Daytona before short-circuiting.
     // A "yes locally, no on the server" mismatch must rebuild.
     try {
-      const existing = await getClient().snapshot.get(prepared?.base?.imageRef ?? snapshotName);
+      const existing = await getClient().snapshot.get(
+        preparedEntryFor(prepared, variantKey)?.imageRef ?? snapshotName,
+      );
       if (existing?.name) {
         log(
           `daytona snapshot '${existing.name}' up to date ` +
@@ -242,6 +277,46 @@ export async function prepareDaytona(opts: PrepareOptions): Promise<PrepareResul
     );
   }
 
+  // Derived bake: boot the recorded agentless base, add one agent set,
+  // re-snapshot. Much shorter than the base bake — the expensive parts (the
+  // ~2 GB image pull, the setuid sudo repair, the image-ENV restore, the host
+  // static config) are already in the snapshot we boot.
+  if (derived) {
+    const baked = await bakeDaytonaVmVariant({
+      client: getClient(opts.location ?? DAYTONA_VM_REGION),
+      backend: daytonaBackend,
+      baseSnapshot: baseEntry!.imageRef,
+      snapshotName,
+      agents,
+      claudeInstall,
+      onLog: log,
+    });
+    if (fingerprint) {
+      writePreparedDaytonaState({
+        variant: variantKey,
+        snapshotName: baked.snapshotName,
+        contextSha256: fingerprint.contextSha256,
+        size: sizeKey,
+        effectiveSize: baseEntry!.extras?.effectiveSize,
+        class: 'linux-vm',
+        // Inherit the base's recorded image env: `create` hands it to the
+        // sandbox, and a variant boots the same rootfs.
+        env: baseEntry!.extras?.env,
+      });
+      log(
+        `recorded daytona-prepared.json (${variantKey}, fingerprint ${fingerprint.contextSha256.slice(0, 12)})`,
+      );
+    }
+    // Reap only THIS variant's predecessor, and only after the replacement is
+    // recorded — a failed bake must never leave the user with no snapshot.
+    const superseded = preparedEntryFor(prepared, variantKey)?.imageRef;
+    if (superseded && superseded !== baked.snapshotName) {
+      log(`removing superseded ${variantKey} snapshot '${superseded}'`);
+      await deleteSnapshotQuietly(getClient(opts.location ?? DAYTONA_VM_REGION), superseded);
+    }
+    return { snapshotName: baked.snapshotName };
+  }
+
   if (sandboxClass === 'linux-vm') {
     const dockerBaseSha = await computeDockerBaseSha(claudeInstall);
     if (!dockerBaseSha) {
@@ -270,6 +345,7 @@ export async function prepareDaytona(opts: PrepareOptions): Promise<PrepareResul
       });
       if (fingerprint) {
         writePreparedDaytonaState({
+          variant: '',
           snapshotName: baked.snapshotName,
           contextSha256: fingerprint.contextSha256,
           size: sizeKey,
@@ -287,7 +363,7 @@ export async function prepareDaytona(opts: PrepareOptions): Promise<PrepareResul
       // — a failed bake must never leave the user with no base at all. Never the
       // one we just made, and never a container snapshot (a user who flips the
       // class back would want it).
-      const superseded = prepared?.base?.imageRef;
+      const superseded = preparedEntryFor(prepared, '')?.imageRef;
       if (
         superseded &&
         superseded !== baked.snapshotName &&

--- a/packages/sandbox-daytona/src/prepare.ts
+++ b/packages/sandbox-daytona/src/prepare.ts
@@ -47,6 +47,7 @@ import { resolveDaytonaCustomClaudeMd, resolveDockerfileContext } from './docker
 import { ensureDaytonaEnvLoaded } from './env-loader.js';
 import {
   bakeDaytonaVmBase,
+  nonce,
   bakeDaytonaVmVariant,
   deleteSnapshotQuietly,
   VmBaseImageUnavailableError,
@@ -263,6 +264,13 @@ export async function prepareDaytona(opts: PrepareOptions): Promise<PrepareResul
     snapshotName =
       opts.name ??
       defaultSnapshotName(fingerprint?.contextSha256 ?? null, sizeKey, sandboxClass, variantKey);
+    // Never reuse a snapshot name, on EITHER class. Daytona's delete is async,
+    // so a name recreated soon after its predecessor was reaped can report
+    // `active` and still fail to boot. The linux-vm bake has always nonced for
+    // this reason; a container variant now reaps too (below), so it needs the
+    // same protection. The name doesn't have to be deterministic — prepared
+    // state records whatever we pinned, and that is what skip-fast reads.
+    if (!opts.name) snapshotName = `${snapshotName}-${nonce()}`;
   }
 
   if (
@@ -526,6 +534,19 @@ export async function prepareDaytona(opts: PrepareOptions): Promise<PrepareResul
         class: 'container',
       });
       log(`recorded daytona-prepared.json (fingerprint ${fingerprint.contextSha256.slice(0, 12)})`);
+      // Reap the snapshot this bake replaces — only this exact variant, and
+      // only after the replacement is recorded, so a failed bake never leaves
+      // the user with no snapshot. Matches the linux-vm path. Variants only:
+      // the container BASE has always overwritten by name and a user who flips
+      // `box.daytonaClass` back would want the old one.
+      if (derived) {
+        const superseded = preparedEntryFor(prepared, variantKey)?.imageRef;
+        const created = snapshot.name ?? snapshotName;
+        if (superseded && superseded !== created) {
+          log(`removing superseded ${variantKey} snapshot '${superseded}'`);
+          await deleteSnapshotQuietly(getClient(opts.location ?? ''), superseded);
+        }
+      }
     }
     return { snapshotName: snapshot.name ?? snapshotName };
   } finally {

--- a/packages/sandbox-daytona/src/prepare.ts
+++ b/packages/sandbox-daytona/src/prepare.ts
@@ -32,6 +32,10 @@ import {
   variantFingerprint,
   normalizeAgentSet,
   agentSetArg,
+  resolveAgentSpec,
+  resolveAgentInstall,
+  renderInstallRecipe,
+  renderAptInstall,
 } from '@agentbox/sandbox-core';
 import {
   DAYTONA_DEFAULT_RESOURCES,
@@ -142,6 +146,45 @@ export function buildDaytonaSeedCommands(
 }
 
 /**
+ * Dockerfile commands that install one agent set, appended after the seed
+ * layers on a container-class variant build.
+ *
+ * Daytona's container class has no `Image.fromSnapshot`, so a variant cannot
+ * boot the base and re-snapshot the way linux-vm does. Appending the recipe to
+ * the SAME Dockerfile build gets the derived-layer benefit a different way:
+ * every instruction up to this point is byte-identical across variants, so
+ * Daytona's builder layer-cache serves them and only the agent step is new.
+ *
+ * The recipes are the same `AGENT_SYNC_SPECS.install` data every other path
+ * uses, so a baked agent and one added by `ensureAgentInstalled` land the same.
+ */
+export function buildDaytonaAgentCommands(
+  agents: readonly string[],
+  claudeInstall?: 'native' | 'npm',
+): string[] {
+  const cmds: string[] = [];
+  for (const id of agents) {
+    const spec = resolveAgentSpec(id);
+    const install = resolveAgentInstall(spec.install, claudeInstall);
+    if (install.apt && install.apt.length > 0) {
+      cmds.push('USER root', `RUN ${renderAptInstall(install.apt)}`);
+    }
+    const recipe = renderInstallRecipe(install.recipe);
+    // `runAs: 'box-user'` is load-bearing: the native installers write into the
+    // INVOKING user's ~/.local/bin, so a root RUN puts the binary in /root and
+    // the box user never sees it.
+    cmds.push(install.runAs === 'box-user' ? 'USER vscode' : 'USER root', `RUN ${recipe}`);
+    if (install.postInstall) cmds.push('USER root', `RUN ${install.postInstall}`);
+    // Prove it landed on the BOX USER's PATH — an installer that exits 0
+    // without a usable binary is a real failure mode, and a build failure here
+    // beats a box that attaches to a session that died instantly.
+    cmds.push('USER vscode', `RUN command -v ${spec.binary} >/dev/null`);
+  }
+  cmds.push('USER vscode');
+  return cmds;
+}
+
+/**
  * Run `agentbox prepare --provider daytona`. Returns `{ snapshotName }` on
  * success so the CLI can pin it into the project config.
  */
@@ -203,15 +246,23 @@ export async function prepareDaytona(opts: PrepareOptions): Promise<PrepareResul
   // it must be a linux-vm one, since that is the only class we can boot and
   // re-snapshot.
   const baseEntry = preparedEntryFor(prepared, '');
-  if (derived && (!baseEntry || (baseEntry.extras?.class ?? 'container') !== 'linux-vm')) {
+  if (derived && !baseEntry) {
     throw new Error(
-      derived && baseEntry
-        ? 'daytona --agents needs a linux-vm base to derive from (the container class has no ' +
-            'boot-and-resnapshot path yet). Run `agentbox config set box.daytonaClass linux-vm` ' +
-            'and `agentbox prepare --provider daytona` first.'
-        : 'no daytona base snapshot to derive from — run `agentbox prepare --provider daytona` ' +
-            'first, then re-run with --agents.',
+      'no daytona base snapshot to derive from — run `agentbox prepare --provider daytona` ' +
+        'first, then re-run with --agents.',
     );
+  }
+  // A variant must be the SAME class as the base it derives from: a snapshot's
+  // class is immutable and one class cannot make a sandbox of the other. Take
+  // the class from the base rather than from config, so a `box.daytonaClass`
+  // that disagrees with what was actually baked can't produce an unbootable
+  // pairing. The two classes then derive by different mechanisms below.
+  const baseClass: DaytonaSandboxClass = baseEntry?.extras?.class ?? 'container';
+  if (derived) {
+    sandboxClass = baseClass;
+    snapshotName =
+      opts.name ??
+      defaultSnapshotName(fingerprint?.contextSha256 ?? null, sizeKey, sandboxClass, variantKey);
   }
 
   if (
@@ -281,7 +332,7 @@ export async function prepareDaytona(opts: PrepareOptions): Promise<PrepareResul
   // re-snapshot. Much shorter than the base bake — the expensive parts (the
   // ~2 GB image pull, the setuid sudo repair, the image-ENV restore, the host
   // static config) are already in the snapshot we boot.
-  if (derived) {
+  if (derived && baseClass === 'linux-vm') {
     const baked = await bakeDaytonaVmVariant({
       client: getClient(opts.location ?? DAYTONA_VM_REGION),
       backend: daytonaBackend,
@@ -317,7 +368,11 @@ export async function prepareDaytona(opts: PrepareOptions): Promise<PrepareResul
     return { snapshotName: baked.snapshotName };
   }
 
-  if (sandboxClass === 'linux-vm') {
+  // A container-class variant falls through to the Dockerfile build below,
+  // which appends the agent recipe as extra layers (see
+  // `buildDaytonaAgentCommands`) — there is no `Image.fromSnapshot` to boot the
+  // base from, so the builder's layer cache is what makes it cheap instead.
+  if (!derived && sandboxClass === 'linux-vm') {
     const dockerBaseSha = await computeDockerBaseSha(claudeInstall);
     if (!dockerBaseSha) {
       throw new Error(
@@ -438,6 +493,9 @@ export async function prepareDaytona(opts: PrepareOptions): Promise<PrepareResul
     }
 
     image = image.dockerfileCommands(buildDaytonaSeedCommands(usable), seedContextDir);
+    if (derived) {
+      image = image.dockerfileCommands(buildDaytonaAgentCommands(agents, claudeInstall));
+    }
 
     // Region: a container snapshot registers wherever the client points (the
     // account default unless the user pinned `box.daytonaRegion`).
@@ -457,6 +515,7 @@ export async function prepareDaytona(opts: PrepareOptions): Promise<PrepareResul
     log(`snapshot '${snapshot.name}' is ${snapshot.state ?? 'created'}`);
     if (fingerprint) {
       writePreparedDaytonaState({
+        variant: variantKey,
         snapshotName: snapshot.name ?? snapshotName,
         contextSha256: fingerprint.contextSha256,
         size: sizeKey,

--- a/packages/sandbox-daytona/src/prepare.ts
+++ b/packages/sandbox-daytona/src/prepare.ts
@@ -264,13 +264,14 @@ export async function prepareDaytona(opts: PrepareOptions): Promise<PrepareResul
     snapshotName =
       opts.name ??
       defaultSnapshotName(fingerprint?.contextSha256 ?? null, sizeKey, sandboxClass, variantKey);
-    // Never reuse a snapshot name, on EITHER class. Daytona's delete is async,
-    // so a name recreated soon after its predecessor was reaped can report
-    // `active` and still fail to boot. The linux-vm bake has always nonced for
-    // this reason; a container variant now reaps too (below), so it needs the
-    // same protection. The name doesn't have to be deterministic — prepared
-    // state records whatever we pinned, and that is what skip-fast reads.
-    if (!opts.name) snapshotName = `${snapshotName}-${nonce()}`;
+    // Never reuse a snapshot name: Daytona's delete is async, so a name
+    // recreated soon after its predecessor was reaped can report `active` and
+    // still fail to boot. Container variants reap (below) and so need this;
+    // linux-vm ones must NOT get it here, because `bakeDaytonaVmVariant` treats
+    // `snapshotName` as a stem and appends its own nonce — doing both yields a
+    // double token. The name needn't be deterministic: prepared state records
+    // whatever we pinned, and that is what skip-fast reads.
+    if (!opts.name && baseClass !== 'linux-vm') snapshotName = `${snapshotName}-${nonce()}`;
   }
 
   if (

--- a/packages/sandbox-daytona/src/prepared-state.ts
+++ b/packages/sandbox-daytona/src/prepared-state.ts
@@ -26,7 +26,7 @@ import {
 } from '@agentbox/sandbox-core';
 import { resolveDaytonaCustomClaudeMd, resolveDockerfileContext } from './dockerfile-context.js';
 
-const SCHEMA = 1 as const;
+const SCHEMA = 2 as const;
 
 /** Provider-specific extras baked into the daytona snapshot. `size` is the
  *  normalized `cpu-memory-disk` spec the snapshot was created with (absent =
@@ -61,7 +61,67 @@ export interface DaytonaPreparedExtras {
   env?: string[];
 }
 
-export type PreparedDaytonaState = PreparedBaseSnapshot<string, DaytonaPreparedExtras>;
+/**
+ * One baked snapshot for one agent set. Carries its own `extras` because a
+ * daytona snapshot's identity is (context, size, class) as well as the agent
+ * set — a claude snapshot baked as `linux-vm` cannot serve a `container` box.
+ */
+export interface DaytonaVariantRecord {
+  imageRef: string;
+  contextSha256?: string;
+  createdAt?: string;
+  extras?: DaytonaPreparedExtras;
+}
+
+export type PreparedDaytonaState = PreparedBaseSnapshot<string, DaytonaPreparedExtras> & {
+  /**
+   * One record per agent set, keyed by `agentSetArg(agents)` (`''` = the
+   * agentless base). Without this the single `base` slot means baking a codex
+   * snapshot invalidates the claude one.
+   *
+   * `base` stays the AGENTLESS base and is mirrored into `variants['']`:
+   * provider-generic readers outside this package (the freshness surface, bake
+   * sharing, and `prepared-custody.ts`, which pins `base.imageRef` into
+   * `box.imageDaytona`) all assume `base` describes the agentless context.
+   */
+  variants?: Record<string, DaytonaVariantRecord>;
+};
+
+/**
+ * The record for one variant (`''` = the agentless base), falling back to
+ * `base` + top-level `extras` for state written before variants existed.
+ */
+export function preparedEntryFor(
+  state: PreparedDaytonaState | null,
+  variant = '',
+): DaytonaVariantRecord | undefined {
+  const hit = state?.variants?.[variant];
+  if (hit) return hit;
+  if (variant !== '' || !state?.base) return undefined;
+  return {
+    imageRef: state.base.imageRef,
+    ...(state.base.contextSha256 !== undefined ? { contextSha256: state.base.contextSha256 } : {}),
+    ...(state.extras ? { extras: state.extras } : {}),
+  };
+}
+
+/**
+ * Variant-aware {@link preparedMatches}: same (context, size, class) rules, but
+ * against the record for THIS agent set rather than whatever was baked last.
+ */
+export function preparedVariantMatches(
+  state: PreparedDaytonaState | null,
+  variant: string,
+  current: string,
+  size?: string,
+  sandboxClass?: DaytonaSandboxClass,
+): boolean {
+  const entry = preparedEntryFor(state, variant);
+  if (!entry || entry.contextSha256 !== current) return false;
+  if ((entry.extras?.size ?? undefined) !== (size ?? undefined)) return false;
+  if (sandboxClass === undefined) return true;
+  return (entry.extras?.class ?? 'container') === sandboxClass;
+}
 
 /**
  * Resolve every file that influences the daytona base snapshot: the docker
@@ -182,11 +242,41 @@ export function readPreparedDaytonaState(): PreparedDaytonaState | null {
   const raw = readPreparedStateRaw('daytona');
   if (raw === null || typeof raw !== 'object') return null;
   const parsed = raw as Partial<PreparedDaytonaState>;
+  if ((parsed as { schema?: unknown }).schema === 1) {
+    // Lossless: a v1 file has exactly one bake and it is the agentless base
+    // (nothing ever baked agents into a daytona snapshot), so seed the variants
+    // map from it rather than forcing a re-bake.
+    if (!parsed.base) return { schema: SCHEMA };
+    return {
+      schema: SCHEMA,
+      base: parsed.base,
+      ...(parsed.extras ? { extras: parsed.extras } : {}),
+      variants: {
+        '': {
+          imageRef: parsed.base.imageRef,
+          ...(parsed.base.contextSha256 !== undefined
+            ? { contextSha256: parsed.base.contextSha256 }
+            : {}),
+          ...(parsed.extras ? { extras: parsed.extras } : {}),
+        },
+      },
+    };
+  }
   if (parsed.schema !== SCHEMA) return null;
-  return { schema: SCHEMA, base: parsed.base, extras: parsed.extras };
+  return {
+    schema: SCHEMA,
+    base: parsed.base,
+    extras: parsed.extras,
+    variants: parsed.variants,
+  };
 }
 
 export function writePreparedDaytonaState(opts: {
+  /**
+   * Agent set this bake is for (normalized key; `''` = the agentless base).
+   * A variant bake writes ONLY its `variants` entry and leaves `base` alone.
+   */
+  variant?: string;
   snapshotName: string;
   contextSha256: string;
   /** Normalized `cpu-memory-disk` size the snapshot was baked with (absent = default). */
@@ -205,16 +295,39 @@ export function writePreparedDaytonaState(opts: {
     ...(opts.class ? { class: opts.class } : {}),
     ...(opts.env && opts.env.length > 0 ? { env: opts.env } : {}),
   };
+  const createdAt = new Date().toISOString();
+  const variant = opts.variant ?? '';
+  const prior = readPreparedDaytonaState();
+  const entry: DaytonaVariantRecord = {
+    imageRef: opts.snapshotName,
+    contextSha256: opts.contextSha256,
+    createdAt,
+    ...(Object.keys(extras).length > 0 ? { extras } : {}),
+  };
   const state: PreparedDaytonaState = {
     schema: SCHEMA,
-    base: {
-      imageRef: opts.snapshotName,
-      contextSha256: opts.contextSha256,
-      cliVersion: stamp.cliVersion,
-      cliCommit: stamp.cliCommit,
-      createdAt: new Date().toISOString(),
-    },
-    ...(Object.keys(extras).length > 0 ? { extras } : {}),
+    // `base` (and the top-level `extras` that describe it) is the AGENTLESS
+    // base and is only rewritten by an agentless bake. A variant bake that
+    // touched it would repoint `box.imageDaytona` — which `prepared-custody.ts`
+    // pins from `base.imageRef` — at one agent's snapshot for every box.
+    ...(variant === ''
+      ? {
+          base: {
+            imageRef: opts.snapshotName,
+            contextSha256: opts.contextSha256,
+            cliVersion: stamp.cliVersion,
+            cliCommit: stamp.cliCommit,
+            createdAt,
+          },
+          ...(Object.keys(extras).length > 0 ? { extras } : {}),
+        }
+      : {
+          ...(prior?.base ? { base: prior.base } : {}),
+          ...(prior?.extras ? { extras: prior.extras } : {}),
+        }),
+    // Merge, never replace: each agent set keeps its own record, so baking a
+    // codex snapshot doesn't invalidate the claude one.
+    variants: { ...prior?.variants, [variant]: entry },
   };
   writePreparedStateRaw('daytona', state);
 }

--- a/packages/sandbox-e2b/scripts/build-template.sh
+++ b/packages/sandbox-e2b/scripts/build-template.sh
@@ -217,25 +217,18 @@ set -g escape-time 0
 TMUX
 done_ "baked config files (claude / codex / setup guide / tmux.conf)"
 
-step "credential pivot symlinks (vscode home)"
-sudo -u vscode -H mkdir -p \
-  /home/vscode/.claude \
-  /home/vscode/.claude/skills/agentbox-setup \
-  /home/vscode/.codex \
-  /home/vscode/.local/share/opencode \
-  /home/vscode/.agentbox-creds/claude \
-  /home/vscode/.agentbox-creds/codex \
-  /home/vscode/.agentbox-creds/opencode
-sudo -u vscode -H ln -sf /home/vscode/.agentbox-creds/claude/.credentials.json \
-  /home/vscode/.claude/.credentials.json
-sudo -u vscode -H ln -sf /home/vscode/.agentbox-creds/codex/auth.json \
-  /home/vscode/.codex/auth.json
-sudo -u vscode -H ln -sf /home/vscode/.agentbox-creds/opencode/auth.json \
-  /home/vscode/.local/share/opencode/auth.json
-sudo -u vscode -H ln -sf /home/vscode/.claude/_claude.json /home/vscode/.claude.json
-sudo -u vscode -H cp /usr/local/share/agentbox/setup-guide.md \
-  /home/vscode/.claude/skills/agentbox-setup/SKILL.md
-done_ "credential pivot symlinks (vscode home)"
+# NOTE: the per-agent home dirs (~/.claude, ~/.codex, ~/.local/share/opencode),
+# the ~/.agentbox-creds/<agent>/ credential pivots and their symlinks are NOT
+# created here. They belong to the agent, so they live on that agent's
+# `install.postInstall` in AGENT_SYNC_SPECS and are applied by whichever path
+# adds the agent -- a derived template, or `ensureAgentInstalled` against a live
+# box. Creating them here as well would put every agent's credential path in
+# every box and would be a second copy to keep in step.
+#
+# The `/agentbox-setup` skill moved with them, onto claude's postInstall: it is
+# claude-specific, and the file it copies from
+# (/usr/local/share/agentbox/setup-guide.md) is baked above, so it is available
+# whenever the agent lands.
 
 step "login-shell shim (/etc/profile.d/agentbox.sh)"
 cat > /etc/profile.d/agentbox.sh <<'PROFILE'
@@ -297,43 +290,26 @@ fi
 sudo -u vscode -H mkdir -p /home/vscode/.vnc
 done_ "VNC stack (TigerVNC + websockify + noVNC)"
 
-step "agent CLIs (codex + opencode + agent-browser, global npm)"
-npm install -g @openai/codex opencode-ai agent-browser 2>&1 | tail -3 || \
-  echo "build-template.sh: one or more agent npm installs failed (continuing)"
-done_ "agent CLIs (codex + opencode + agent-browser, global npm)"
+step "agent-browser (global npm)"
+# agent-browser is box runtime, not an agent -- it stays in the base.
+npm install -g agent-browser 2>&1 | tail -3 || \
+  echo "build-template.sh: agent-browser npm install failed (continuing)"
+done_ "agent-browser (global npm)"
 
-# AGENTBOX_CLAUDE_INSTALL selects how Claude Code is installed (default
-# `native`). `npm` is an opt-in fallback for hosts whose egress IP the native
-# installer's CDN 403s — see `box.claudeInstall`.
-if [ "${AGENTBOX_CLAUDE_INSTALL:-native}" = "npm" ]; then
-  step "Claude Code (npm: @anthropic-ai/claude-code)"
-  # npm-global drops `claude` at Node's prefix bin, not the
-  # /home/vscode/.local/bin/claude the rest of AgentBox hardcodes. Symlink it
-  # into that path so the box stays indistinguishable from a native install.
-  npm install -g @anthropic-ai/claude-code
-  install -d -o vscode -g vscode /home/vscode/.local/bin
-  ln -sf "$(command -v claude)" /home/vscode/.local/bin/claude
-  chown -h vscode:vscode /home/vscode/.local/bin/claude
-  command -v claude >/dev/null || { echo "build-template.sh: npm claude install produced no claude on PATH" >&2; exit 71; }
-  done_ "Claude Code (npm: @anthropic-ai/claude-code)"
-else
-  step "Claude Code (native installer, run as vscode)"
-  # Anthropic's native installer drops `claude` at /home/vscode/.local/bin/claude
-  # with installMethod=native (matching the host-seeded .claude.json, so the
-  # startup integrity check stays quiet) and ships native-only features the npm
-  # package lacks. Its CDN (claude.ai / downloads.claude.ai) sits behind
-  # Cloudflare, which intermittently 403s cloud-datacenter egress IPs under load —
-  # so retry with backoff rather than falling back to npm. A bare `curl | bash`
-  # would hide a 403 (curl -f exits non-zero but the pipe's status is bash's 0),
-  # so keep pipefail and fold the PATH check in so a "succeeded but absent" result
-  # also retries. A failed build is better than a claude-less template.
-  if ! retry_backoff 3 sudo -u vscode -H bash -lc \
-       'set -o pipefail; curl -fsSL https://claude.ai/install.sh | bash -s stable && command -v claude >/dev/null'; then
-    echo "build-template.sh: Claude native installer failed after 3 attempts (Cloudflare 403?) — aborting build" >&2
-    exit 71
-  fi
-  done_ "Claude Code (native installer, run as vscode)"
-fi
+# Agents: NONE. This template is deliberately agentless.
+#
+# An agent is added either as a derived template (`Template().fromTemplate()` on
+# this base plus one install recipe) or into an already-running box by
+# `ensureAgentInstalled` -- both driven by the same `install` recipes on
+# AGENT_SYNC_SPECS, so a baked agent and a runtime-added one are identical.
+# Baking them here instead would put every agent in every box: an
+# `agentbox claude` box would carry codex and opencode plus their credential
+# paths, and the template could never shrink to the workload.
+#
+# The per-agent home + credential dirs are NOT created here either; they belong
+# to the agent and live on its `install.postInstall`. AGENTBOX_CLAUDE_INSTALL is
+# still honoured -- it selects the RECIPE, not whether to install -- and reaches
+# the recipe via the derived build.
 
 step "Chrome runtime libs (apt)"
 # agent-browser launches Chromium at AGENT_BROWSER_EXECUTABLE_PATH

--- a/packages/sandbox-e2b/src/backend.ts
+++ b/packages/sandbox-e2b/src/backend.ts
@@ -46,7 +46,12 @@ import type { SandboxInfo, SandboxState } from './sdk.js';
 import { Sandbox, Template, resolveApiKey } from './sdk.js';
 import { withE2bRetry } from './retry.js';
 import { parseE2bSize } from './prepare.js';
-import { ensureE2bBaseTemplate, readPreparedState } from './prepared-state.js';
+import {
+  ensureE2bBaseTemplate,
+  preparedEntryFor,
+  readPreparedState,
+} from './prepared-state.js';
+import { agentSetArg, normalizeAgentSet } from '@agentbox/sandbox-core';
 
 /**
  * Sentinel image ref the cloud-provider hands us when no --image was passed.
@@ -173,7 +178,14 @@ export const e2bBackend: CloudBackend = {
     if (req.snapshot === undefined) {
       ensureE2bBaseTemplate();
     }
-    const template = req.snapshot ?? readPreparedState().base?.templateId;
+    // Prefer the template built for exactly this agent set — it already carries
+    // the agent, so the box skips the create-time install. Falling back to the
+    // agentless base is not a failure: `ensureAgentsInstalledForCloud` puts the
+    // agent in at create, which is also what an un-rebuilt older base does.
+    const template =
+      req.snapshot ??
+      preparedEntryFor(readPreparedState(), agentSetArg(normalizeAgentSet(req.agents)))
+        ?.templateId;
     if (!template) {
       throw new Error(
         'e2b provision: no template available — `agentbox prepare --provider e2b` must run first',

--- a/packages/sandbox-e2b/src/backend.ts
+++ b/packages/sandbox-e2b/src/backend.ts
@@ -50,6 +50,7 @@ import {
   ensureE2bBaseTemplate,
   preparedEntryFor,
   readPreparedState,
+  type PreparedE2bState,
 } from './prepared-state.js';
 import { agentSetArg, normalizeAgentSet } from '@agentbox/sandbox-core';
 
@@ -152,6 +153,27 @@ function safeMetadataName(name: string): string {
   return name.replace(/[\u0000-\u001f]/g, '').slice(0, 200);
 }
 
+/**
+ * Which E2B template a create boots: an explicit checkpoint snapshot, else the
+ * template built for exactly this agent set, else the agentless base.
+ *
+ * The base fallback is load-bearing, not belt-and-braces: after a base-only
+ * `prepare --provider e2b` — the documented install path — NO variant exists,
+ * and without it every create would throw. Booting the base is the correct
+ * degrade, because `ensureAgentsInstalledForCloud` puts the agent in at create;
+ * hetzner and daytona fall back the same way.
+ *
+ * Exported pure so the fallback chain is testable without the SDK.
+ */
+export function resolveE2bTemplate(
+  prepared: PreparedE2bState,
+  req: Pick<CloudProvisionRequest, 'snapshot' | 'agents'>,
+): string | undefined {
+  if (req.snapshot !== undefined) return req.snapshot;
+  const variant = preparedEntryFor(prepared, agentSetArg(normalizeAgentSet(req.agents)));
+  return variant?.templateId ?? prepared.base?.templateId;
+}
+
 export const e2bBackend: CloudBackend = {
   name: 'e2b',
 
@@ -178,14 +200,7 @@ export const e2bBackend: CloudBackend = {
     if (req.snapshot === undefined) {
       ensureE2bBaseTemplate();
     }
-    // Prefer the template built for exactly this agent set — it already carries
-    // the agent, so the box skips the create-time install. Falling back to the
-    // agentless base is not a failure: `ensureAgentsInstalledForCloud` puts the
-    // agent in at create, which is also what an un-rebuilt older base does.
-    const template =
-      req.snapshot ??
-      preparedEntryFor(readPreparedState(), agentSetArg(normalizeAgentSet(req.agents)))
-        ?.templateId;
+    const template = resolveE2bTemplate(readPreparedState(), req);
     if (!template) {
       throw new Error(
         'e2b provision: no template available — `agentbox prepare --provider e2b` must run first',

--- a/packages/sandbox-e2b/src/prepare.ts
+++ b/packages/sandbox-e2b/src/prepare.ts
@@ -35,15 +35,22 @@ import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import type { Provider } from '@agentbox/core';
 import {
-  claudeInstallFingerprint,
   computeContextManifest,
   readCliStamp,
   stageAllAgentStatic,
   type AgentStaticStage,
+  variantFingerprint,
+  normalizeAgentSet,
+  agentSetArg,
+  resolveAgentSpec,
+  resolveAgentInstall,
+  renderInstallRecipe,
+  renderAptInstall,
 } from '@agentbox/sandbox-core';
 import { ensureE2bCredentials } from './credentials.js';
 import { resolveApiKey, Template } from './sdk.js';
 import {
+  preparedEntryFor,
   preparedStatePath,
   readPreparedState,
   writePreparedState,
@@ -76,6 +83,13 @@ export interface PrepareE2bOptions {
   /** How build-template.sh installs Claude Code (`native` default | `npm`). */
   claudeInstall?: 'native' | 'npm';
   onLog?: (line: string) => void;
+  /**
+   * Agents to build into a DERIVED template on top of the agentless base.
+   * Empty/absent bakes the base itself. Not just another env var into the build
+   * script: the set picks which template we build, which record we write, and
+   * which template a later create boots from.
+   */
+  agents?: string[];
 }
 
 export interface PrepareE2bResult {
@@ -85,6 +99,15 @@ export interface PrepareE2bResult {
 /** Template name agentbox bakes under. E2B treats `name:tag` as a single addressable build. */
 const TEMPLATE_NAME = 'agentbox-base:latest';
 const DEFAULT_TAG = 'latest';
+
+/**
+ * Template name for one agent set. E2B names allow `[a-zA-Z0-9-_]`, so a
+ * multi-agent set joins with `-` rather than the `,` the variant key uses.
+ */
+function templateNameFor(variantKey: string): string {
+  if (variantKey === '') return TEMPLATE_NAME;
+  return `agentbox-${variantKey.replaceAll(',', '-')}:${DEFAULT_TAG}`;
+}
 
 const DEFAULT_CPU = 2;
 const DEFAULT_MEMORY_MB = 4096;
@@ -106,9 +129,7 @@ export function parseE2bSize(
   if (trimmed === '') return undefined;
   const parts = trimmed.split('-');
   const bad = (): never => {
-    throw new Error(
-      `invalid --size '${trimmed}' for e2b: expected 'cpu-memory' GB, e.g. '4-8'.`,
-    );
+    throw new Error(`invalid --size '${trimmed}' for e2b: expected 'cpu-memory' GB, e.g. '4-8'.`);
   };
   if (parts.length < 2 || parts.length > 3) bad();
   const nums = parts.map((p) => Number(p));
@@ -128,9 +149,12 @@ function e2bSizeKey(parsed: { cpuCount: number; memoryMB: number }): string {
   return `${String(parsed.cpuCount)}-${String(parsed.memoryMB / 1024)}`;
 }
 
-export async function prepareE2b(
-  opts: PrepareE2bOptions = {},
-): Promise<PrepareE2bResult> {
+/** Wrap a shell snippet in single quotes for safe nesting inside `bash -lc`. */
+function shellSingleQuote(s: string): string {
+  return `'${s.replaceAll("'", `'\\''`)}'`;
+}
+
+export async function prepareE2b(opts: PrepareE2bOptions = {}): Promise<PrepareE2bResult> {
   await ensureE2bCredentials();
   const apiKey = resolveApiKey();
   const log = opts.onLog ?? (() => {});
@@ -146,7 +170,11 @@ export async function prepareE2b(
   const contextManifest = await computeContextManifest(
     assets.map((a) => ({ rel: a.name, abs: a.localPath })),
   );
-  const contextSha = claudeInstallFingerprint(contextManifest.contextSha256, claudeInstall);
+  const agents = normalizeAgentSet(opts.agents);
+  const variantKey = agentSetArg(agents);
+  const derived = agents.length > 0;
+  const templateName = templateNameFor(variantKey);
+  const contextSha = variantFingerprint(contextManifest.contextSha256, { claudeInstall, agents });
 
   // Bake-time size. A `--size` / `box.sizeE2b` like `4-8` overrides the default
   // cpu/memory (E2B rejects per-create resources, so it MUST be baked). The
@@ -162,24 +190,36 @@ export async function prepareE2b(
   // 404s. `Template.exists` accepts both `name:tag` and `template-id:tag`
   // forms, so we pass the exact id we'd later hand to `provision`.
   const existing = readPreparedState();
-  if (!opts.force && existing.base) {
-    const bakedSize = existing.base.size;
-    if (existing.base.contextSha256 === contextSha && bakedSize === sizeKey) {
-      const stillThere = await templateExists(existing.base.templateId, apiKey);
+
+  // A derived build starts FROM the agentless base, so that has to exist first.
+  const baseEntry = preparedEntryFor(existing, '');
+  if (derived && !baseEntry) {
+    throw new Error(
+      'no E2B base template to derive from — run `agentbox prepare --provider e2b` first, ' +
+        'then re-run with --agents.',
+    );
+  }
+
+  const existingEntry = preparedEntryFor(existing, variantKey);
+  if (!opts.force && existingEntry) {
+    const bakedSize = existingEntry.size;
+    const label = derived ? `${variantKey} template` : 'template';
+    if (existingEntry.contextSha256 === contextSha && bakedSize === sizeKey) {
+      const stillThere = await templateExists(existingEntry.templateId, apiKey);
       if (stillThere) {
         progress(
-          `template ${existing.base.templateId} already exists (fingerprint ${contextSha.slice(0, 12)} matches); skipping (pass --force to rebuild)`,
+          `${label} ${existingEntry.templateId} already exists (fingerprint ${contextSha.slice(0, 12)} matches); skipping (pass --force to rebuild)`,
         );
-        return { snapshotName: existing.base.templateId };
+        return { snapshotName: existingEntry.templateId };
       }
-      progress(`recorded template ${existing.base.templateId} is gone on E2B; rebuilding`);
-    } else if (existing.base.contextSha256 === contextSha && bakedSize !== sizeKey) {
+      progress(`recorded ${label} ${existingEntry.templateId} is gone on E2B; rebuilding`);
+    } else if (existingEntry.contextSha256 === contextSha && bakedSize !== sizeKey) {
       progress(
         `size changed (was ${bakedSize ?? 'default'}, now ${sizeKey ?? 'default'}); rebuilding`,
       );
     } else {
       progress(
-        `build context changed (was ${existing.base.contextSha256?.slice(0, 12) ?? '<none>'}, now ${contextSha.slice(0, 12)}); rebuilding`,
+        `build context changed (was ${existingEntry.contextSha256?.slice(0, 12) ?? '<none>'}, now ${contextSha.slice(0, 12)}); rebuilding ${label}`,
       );
     }
   }
@@ -201,59 +241,125 @@ export async function prepareE2b(
     for (const s of agentStages) for (const w of s.staged.warnings) log(w);
     const usableStages = agentStages.filter((s) => s.staged.tarballPath !== null);
     for (const s of usableStages) {
-      await copyFile(s.staged.tarballPath as string, resolve(contextDir, e2bStagePaths(s.kind).contextRel));
+      await copyFile(
+        s.staged.tarballPath as string,
+        resolve(contextDir, e2bStagePaths(s.kind).contextRel),
+      );
     }
 
     // Build the Template via the SDK builder. fromBaseImage() starts from E2B's
     // own `e2bdev/base` (Debian 12 + node 20 + git + sudo), which halves the
     // install time vs starting from a vanilla Debian image.
-    progress('assembling template build (fromBaseImage + asset copy + runCmd)');
-    const template = Template({ fileContextPath: contextDir }).fromBaseImage();
-    for (const a of assets) {
-      progress(`  copy ${a.name} -> ${a.remotePath}`);
-      template.copy(a.name, a.remotePath, {
-        forceUpload: true,
-        mode: a.remoteMode,
-        user: 'root',
-      });
+    // A derived build starts FROM the recorded agentless base template and adds
+    // only the agent recipe — E2B is the one provider where deriving needs no
+    // boot at all, so a variant costs a build, not a VPS-minute.
+    //
+    // The base build stays as it was: fromBaseImage() starts from E2B's own
+    // `e2bdev/base` (Debian 12 + node 20 + git + sudo), which halves the install
+    // time vs a vanilla Debian image.
+    progress(
+      derived
+        ? `assembling derived template build (fromTemplate ${baseEntry!.templateId} + ${variantKey})`
+        : 'assembling template build (fromBaseImage + asset copy + runCmd)',
+    );
+    const template = derived
+      ? Template({ fileContextPath: contextDir }).fromTemplate(baseEntry!.templateId)
+      : Template({ fileContextPath: contextDir }).fromBaseImage();
+
+    if (derived) {
+      // Same AGENT_SYNC_SPECS recipes the docker derived layer, the hetzner
+      // derived snapshot and `ensureAgentInstalled` use, so however an agent
+      // reaches a box it is installed identically.
+      for (const id of agents) {
+        const spec = resolveAgentSpec(id);
+        const install = resolveAgentInstall(spec.install, claudeInstall);
+        progress(`  install ${spec.id}`);
+        if (install.apt && install.apt.length > 0) {
+          template.runCmd(renderAptInstall(install.apt), { user: 'root' });
+        }
+        const recipe = renderInstallRecipe(install.recipe);
+        // `runAs: 'box-user'` is load-bearing: the native installers write into
+        // the INVOKING user's ~/.local/bin, so as root the binary lands in
+        // /root and the box user never sees it. E2B's runCmd takes a `user`,
+        // but we go through `sudo -u vscode -H bash -lc` for the same reason
+        // hetzner does — a login shell, and one form across providers.
+        template.runCmd(
+          install.runAs === 'box-user'
+            ? `sudo -u vscode -H bash -lc ${shellSingleQuote(recipe)}`
+            : recipe,
+          { user: 'root' },
+        );
+        if (install.postInstall) template.runCmd(install.postInstall, { user: 'root' });
+      }
+    } else {
+      for (const a of assets) {
+        progress(`  copy ${a.name} -> ${a.remotePath}`);
+        template.copy(a.name, a.remotePath, {
+          forceUpload: true,
+          mode: a.remoteMode,
+          user: 'root',
+        });
+      }
+      template.runCmd('bash /tmp/agentbox-build-template.sh 2>&1', { user: 'root' });
     }
-    template.runCmd(`AGENTBOX_CLAUDE_INSTALL=${claudeInstall} bash /tmp/agentbox-build-template.sh 2>&1`, {
-      user: 'root',
-    });
 
     // Seed the host's static agent config ON TOP of the built box (the vscode
     // user + home dirs exist only after build-template.sh). Copy each staged
     // tarball into the build, then one root pass extracts + chowns them —
     // mirrors Vercel/Hetzner/Daytona's host-static bake.
-    for (const s of usableStages) {
+    // On a derived build, stage only THIS variant's agent config: putting
+    // codex/opencode settings into a claude-only template would ship config for
+    // agents that template will never run. `agents` (shared skills, not auth) is
+    // always staged. The agentless base still carries all three, so an agent
+    // installed at runtime still finds its plugins and settings.
+    const wantsStage = (kind: AgentStaticStage['kind']): boolean =>
+      !derived || kind === 'agents' || agents.includes(kind);
+    const stagesForBuild = usableStages.filter((s) => wantsStage(s.kind));
+    for (const s of stagesForBuild) {
       const { contextRel, remoteTar } = e2bStagePaths(s.kind);
       progress(`  seed ${s.kind} static -> ${s.extractDir}`);
       template.copy(contextRel, remoteTar, { forceUpload: true, mode: 0o644, user: 'root' });
     }
-    if (usableStages.length > 0) {
+    if (stagesForBuild.length > 0) {
       const extract =
-        usableStages
-          .map((s) => `mkdir -p ${s.extractDir} && tar -xzf ${e2bStagePaths(s.kind).remoteTar} -C ${s.extractDir} --no-same-permissions --no-same-owner -m`)
+        stagesForBuild
+          .map(
+            (s) =>
+              `mkdir -p ${s.extractDir} && tar -xzf ${e2bStagePaths(s.kind).remoteTar} -C ${s.extractDir} --no-same-permissions --no-same-owner -m`,
+          )
           .join(' && ') +
-        ' && chown -R vscode:vscode /home/vscode/.claude /home/vscode/.codex /home/vscode/.local' +
-        ' && ([ -d /home/vscode/.agents ] && chown -R vscode:vscode /home/vscode/.agents || true)' +
-        ' && rm -f /tmp/agentbox-seed-*.tar.gz';
+        // Guard each chown: with an agentless base and per-variant staging,
+        // any of these dirs can legitimately be absent (the agent that owns it
+        // was never installed here), and an unguarded chown fails the build.
+        ' && for d in /home/vscode/.claude /home/vscode/.codex /home/vscode/.local /home/vscode/.agents;' +
+        ' do [ -e "$d" ] && chown -R vscode:vscode "$d"; done' +
+        ' ; rm -f /tmp/agentbox-seed-*.tar.gz';
       template.runCmd(extract, { user: 'root' });
     }
     // setReadyCmd flips the builder into TemplateFinal — required for build().
-    // The check passes once the script's last `install` step lands the ctl bundle.
-    const finalTemplate = template.setReadyCmd(
-      'test -x /usr/local/bin/agentbox-ctl',
-    );
+    // The base checks the ctl bundle the script's last `install` step lands; a
+    // variant additionally proves its agent is on the BOX USER's PATH, which is
+    // the thing that actually breaks (a native installer that writes to /root
+    // exits 0 and leaves the box unusable).
+    const readyCmd = derived
+      ? agents
+          .map(
+            (id) =>
+              `sudo -u vscode -H bash -lc 'command -v ${resolveAgentSpec(id).binary} >/dev/null'`,
+          )
+          .concat('test -x /usr/local/bin/agentbox-ctl')
+          .join(' && ')
+      : 'test -x /usr/local/bin/agentbox-ctl';
+    const finalTemplate = template.setReadyCmd(readyCmd);
 
     // Parsed `--size` wins over the explicit cpuCount/memoryMB options, which
     // win over the built-in defaults.
     const cpuCount = parsedSize?.cpuCount ?? opts.cpuCount ?? DEFAULT_CPU;
     const memoryMB = parsedSize?.memoryMB ?? opts.memoryMB ?? DEFAULT_MEMORY_MB;
     progress(
-      `running Template.build('${TEMPLATE_NAME}', { cpuCount: ${String(cpuCount)}, memoryMB: ${String(memoryMB)} })`,
+      `running Template.build('${templateName}', { cpuCount: ${String(cpuCount)}, memoryMB: ${String(memoryMB)} })`,
     );
-    const info = await Template.build(finalTemplate, TEMPLATE_NAME, {
+    const info = await Template.build(finalTemplate, templateName, {
       apiKey,
       cpuCount,
       memoryMB,
@@ -271,25 +377,39 @@ export async function prepareE2b(
     const tag = info.tags?.[0] ?? DEFAULT_TAG;
     const cliStamp = readCliStamp();
     const taggedId = `${info.templateId}:${tag}`;
+    const entry = {
+      templateId: taggedId,
+      // info.name is the full `name:tag` pair Template.build() was called
+      // with (e.g. `agentbox-base:latest`). Earlier code re-appended `:${tag}`
+      // and produced `agentbox-base:latest:latest` in the status display.
+      templateName: info.name,
+      contextSha256: contextSha,
+      files: contextManifest.files,
+      ...(sizeKey ? { size: sizeKey } : {}),
+      cliVersion: cliStamp.cliVersion,
+      cliCommit: cliStamp.cliCommit,
+      createdAt: new Date().toISOString(),
+    };
+    const prior = readPreparedState();
     writePreparedState({
-      schema: 1,
-      base: {
-        templateId: taggedId,
-        // info.name is the full `name:tag` pair Template.build() was called
-        // with (e.g. `agentbox-base:latest`). Earlier code re-appended `:${tag}`
-        // and produced `agentbox-base:latest:latest` in the status display.
-        templateName: info.name,
-        contextSha256: contextSha,
-        files: contextManifest.files,
-        ...(sizeKey ? { size: sizeKey } : {}),
-        cliVersion: cliStamp.cliVersion,
-        cliCommit: cliStamp.cliCommit,
-        createdAt: new Date().toISOString(),
-      },
+      schema: 2,
+      // Merge, never replace: each variant keeps its own record, so building
+      // the codex template doesn't invalidate the claude one.
+      variants: { ...prior.variants, [variantKey]: entry },
+      // `base` stays the AGENTLESS base, never the newest build — the
+      // provider-generic readers (freshness, bake sharing, custody adoption)
+      // reach straight for `base.contextSha256` and assume it describes the
+      // agentless build context.
+      ...(derived ? (prior.base ? { base: prior.base } : {}) : { base: entry }),
     });
     progress(`wrote ${preparedStatePath()}`);
 
-    progress(`prepare complete — base template ${taggedId}`);
+    // No GC here, unlike hetzner. E2B templates are NAMED resources: rebuilding
+    // `agentbox-claude:latest` moves the tag, so a rebuild replaces rather than
+    // orphans, and the SDK exposes no template delete to reap an id with.
+    progress(
+      `prepare complete — ${derived ? `${variantKey} template` : 'base template'} ${taggedId}`,
+    );
     return { snapshotName: taggedId };
   } finally {
     await Promise.all(agentStages.map((s) => s.staged.cleanup())).catch(() => {
@@ -306,10 +426,7 @@ export async function prepareE2b(
  * source mode on the copy (E2B's `template.copy` also accepts a `mode`
  * override, but the on-disk mode keeps the local stage representative).
  */
-async function stageAssetsInto(
-  contextDir: string,
-  assets: ResolvedAsset[],
-): Promise<void> {
+async function stageAssetsInto(contextDir: string, assets: ResolvedAsset[]): Promise<void> {
   for (const a of assets) {
     const dest = resolve(contextDir, a.name);
     await mkdir(dirname(dest), { recursive: true });
@@ -368,5 +485,6 @@ export const prepareE2bProvider: NonNullable<Provider['prepare']> = (req) =>
     force: req.force,
     size: req.size,
     claudeInstall: req.claudeInstall,
+    ...(req.agents ? { agents: req.agents } : {}),
     onLog: req.onLog,
   });

--- a/packages/sandbox-e2b/src/prepared-state.ts
+++ b/packages/sandbox-e2b/src/prepared-state.ts
@@ -4,23 +4,34 @@
  * (`ensureE2bBaseTemplate()`) and `backend.provision` can resolve the base
  * template every box boots from.
  *
- * Single tier for now — the shared base template (Debian + agentbox-ctl +
- * agents). Templates on E2B are id+tag-addressed reusable resources, so unlike
- * Vercel snapshots we don't worry about per-box snapshot eviction; one template
- * is reused for every create.
+ * Two tiers, both E2B templates: the agentless `base` (Debian + agentbox-ctl +
+ * the box runtime) and one `variants` entry per agent set, built declaratively
+ * on top of it with `Template().fromTemplate(base)`. Templates on E2B are
+ * id+tag-addressed reusable resources, so unlike Vercel snapshots we don't worry
+ * about per-box eviction; each template is reused for every create.
  *
- * Schema versioned so future shape changes can migrate; only `schema: 1` is
- * accepted today.
+ * Schema history:
+ *   1 — single `base` template.
+ *   2 — `variants` added: one record per agent set, so building the codex
+ *       template doesn't invalidate the claude one. `base` keeps its schema-1
+ *       meaning (the agentless base) and is mirrored into `variants['']`;
+ *       provider-generic readers outside this package reach straight for
+ *       `base.contextSha256` and assume exactly that.
  */
 
-import { claudeInstallFingerprint, computeContextManifest,
-  computeContextSha256, readPreparedStateRaw, writePreparedStateRaw, preparedStatePathFor,
+import {
+  claudeInstallFingerprint,
+  computeContextManifest,
+  computeContextSha256,
+  readPreparedStateRaw,
+  writePreparedStateRaw,
+  preparedStatePathFor,
   type FileManifest,
 } from '@agentbox/sandbox-core';
 import { UserFacingError } from '@agentbox/core';
 import { findStagedCliRuntimeRoot, resolveRuntimeAssets } from './runtime-assets.js';
 
-const SCHEMA = 1 as const;
+const SCHEMA = 2 as const;
 
 export interface PreparedE2bBase {
   /** Opaque E2B template id (e.g. `tmpl_xxxx` or `name:tag`). Sandbox.create({ template }) boots from this. */
@@ -47,8 +58,29 @@ export interface PreparedE2bBase {
 
 export interface PreparedE2bState {
   schema: typeof SCHEMA;
-  /** The shared base template. Absent until first `agentbox prepare`. */
+  /**
+   * The shared AGENTLESS base template, and only ever that — a variant build
+   * leaves it alone. Absent until first `agentbox prepare`.
+   */
   base?: PreparedE2bBase;
+  /**
+   * One record per agent set, keyed by `agentSetArg(agents)` (`''` = the
+   * agentless base). Without this the single `base` slot means building a codex
+   * template invalidates the claude one, and anyone alternating agents rebuilds
+   * every time.
+   */
+  variants?: Record<string, PreparedE2bBase>;
+}
+
+/**
+ * The record for one variant (`''` = agentless base), falling back to `base`
+ * for state written before variants existed.
+ */
+export function preparedEntryFor(
+  state: PreparedE2bState | null,
+  variant = '',
+): PreparedE2bBase | undefined {
+  return state?.variants?.[variant] ?? (variant === '' ? state?.base : undefined);
 }
 
 export function preparedStatePath(): string {
@@ -59,11 +91,20 @@ export function readPreparedState(): PreparedE2bState {
   const raw = readPreparedStateRaw('e2b');
   if (raw === null || typeof raw !== 'object') return { schema: SCHEMA };
   const parsed = raw as Partial<PreparedE2bState>;
+  if ((parsed as { schema?: unknown }).schema === 1) {
+    // Lossless: a v1 file has exactly one build and it is the base, so seed the
+    // variants map from it rather than forcing a rebuild.
+    const v1 = parsed;
+    return {
+      schema: SCHEMA,
+      ...(v1.base ? { base: v1.base, variants: { '': v1.base } } : {}),
+    };
+  }
   if (parsed.schema !== SCHEMA) {
     // Unknown/missing schema: refuse to read — the next prepare overwrites it.
     return { schema: SCHEMA };
   }
-  return { schema: SCHEMA, base: parsed.base };
+  return { schema: SCHEMA, base: parsed.base, variants: parsed.variants };
 }
 
 export function writePreparedState(state: PreparedE2bState): void {
@@ -134,9 +175,8 @@ export function ensureE2bBaseTemplate(): void {
 export async function currentE2bBaseFileHashes(): Promise<FileManifest | undefined> {
   try {
     const assets = resolveRuntimeAssets({ cliRuntimeRoot: findStagedCliRuntimeRoot() });
-    return (
-      await computeContextManifest(assets.map((a) => ({ rel: a.name, abs: a.localPath })))
-    ).files;
+    return (await computeContextManifest(assets.map((a) => ({ rel: a.name, abs: a.localPath }))))
+      .files;
   } catch {
     return undefined;
   }

--- a/packages/sandbox-e2b/test/prepared-state.test.ts
+++ b/packages/sandbox-e2b/test/prepared-state.test.ts
@@ -6,6 +6,7 @@ import {
   readPreparedState,
   writePreparedState,
   ensureE2bBaseTemplate,
+  preparedEntryFor,
   preparedStatePath,
 } from '../src/prepared-state.js';
 
@@ -25,13 +26,13 @@ afterEach(() => {
 });
 
 describe('e2b prepared-state', () => {
-  it('returns an empty schema-1 state when the file is absent', () => {
-    expect(readPreparedState()).toEqual({ schema: 1 });
+  it('returns an empty schema-2 state when the file is absent', () => {
+    expect(readPreparedState()).toEqual({ schema: 2 });
   });
 
   it('round-trips a base template record', () => {
     writePreparedState({
-      schema: 1,
+      schema: 2,
       base: {
         templateId: 'tmpl_abc:latest',
         templateName: 'agentbox-base:latest',
@@ -50,7 +51,32 @@ describe('e2b prepared-state', () => {
       preparedStatePath(),
       JSON.stringify({ schema: 99, base: { templateId: 'tmpl_x:latest' } }),
     );
-    expect(readPreparedState()).toEqual({ schema: 1 });
+    expect(readPreparedState()).toEqual({ schema: 2 });
+  });
+
+  it('lifts a schema-1 file forward by seeding the variants map from base', () => {
+    // A v1 file has exactly one build and it is the agentless base, so the
+    // migration is lossless — nobody has to rebuild a template to get variants.
+    const base = { templateId: 'tmpl_v1:latest', createdAt: '2026-06-03T00:00:00Z' };
+    writeFileSync(preparedStatePath(), JSON.stringify({ schema: 1, base }));
+    const s = readPreparedState();
+    expect(s.schema).toBe(2);
+    expect(preparedEntryFor(s, '')).toEqual(base);
+    // ...and it is NOT offered as any agent's variant.
+    expect(preparedEntryFor(s, 'claude')).toBeUndefined();
+  });
+
+  it('keeps each agent set in its own slot', () => {
+    const base = { templateId: 'tmpl_base:latest', createdAt: '2026-06-03T00:00:00Z' };
+    const claude = { templateId: 'tmpl_claude:latest', createdAt: '2026-06-04T00:00:00Z' };
+    writePreparedState({ schema: 2, base, variants: { '': base, claude } });
+    const s = readPreparedState();
+    // `base` is the AGENTLESS base even when a variant was built later —
+    // provider-generic readers assume exactly that.
+    expect(s.base?.templateId).toBe('tmpl_base:latest');
+    expect(preparedEntryFor(s, '')?.templateId).toBe('tmpl_base:latest');
+    expect(preparedEntryFor(s, 'claude')?.templateId).toBe('tmpl_claude:latest');
+    expect(preparedEntryFor(s, 'codex')).toBeUndefined();
   });
 
   it('ensureE2bBaseTemplate throws with the prepare hint when no base exists', () => {
@@ -59,7 +85,7 @@ describe('e2b prepared-state', () => {
 
   it('ensureE2bBaseTemplate passes once a base is recorded', () => {
     writePreparedState({
-      schema: 1,
+      schema: 2,
       base: { templateId: 'tmpl_x:latest', createdAt: '2026-06-03T00:00:00Z' },
     });
     expect(() => ensureE2bBaseTemplate()).not.toThrow();

--- a/packages/sandbox-e2b/test/template-resolution.test.ts
+++ b/packages/sandbox-e2b/test/template-resolution.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { resolveE2bTemplate } from '../src/backend.js';
+import type { PreparedE2bState } from '../src/prepared-state.js';
+
+const base = { templateId: 'tmpl_base:latest', createdAt: '2026-06-03T00:00:00Z' };
+const claude = { templateId: 'tmpl_claude:latest', createdAt: '2026-06-04T00:00:00Z' };
+
+/** Base + a claude variant, i.e. after `prepare` and `prepare --agents claude`. */
+const withVariant: PreparedE2bState = {
+  schema: 2,
+  base,
+  variants: { '': base, claude },
+};
+
+/** Base only, i.e. after the documented `agentbox prepare --provider e2b`. */
+const baseOnly: PreparedE2bState = { schema: 2, base, variants: { '': base } };
+
+describe('resolveE2bTemplate', () => {
+  it('prefers the template built for exactly this agent set', () => {
+    expect(resolveE2bTemplate(withVariant, { agents: ['claude'] })).toBe('tmpl_claude:latest');
+  });
+
+  it('falls back to the agentless base when the agent has no variant', () => {
+    // The regression this guards: after a base-only prepare (the documented
+    // install path) NO variant exists, and throwing here made every create
+    // fail instead of booting the base and installing the agent at create.
+    expect(resolveE2bTemplate(baseOnly, { agents: ['claude'] })).toBe('tmpl_base:latest');
+    expect(resolveE2bTemplate(withVariant, { agents: ['codex'] })).toBe('tmpl_base:latest');
+  });
+
+  it('uses the base for an agentless create', () => {
+    expect(resolveE2bTemplate(withVariant, {})).toBe('tmpl_base:latest');
+    expect(resolveE2bTemplate(withVariant, { agents: [] })).toBe('tmpl_base:latest');
+  });
+
+  it('an explicit checkpoint snapshot always wins', () => {
+    expect(
+      resolveE2bTemplate(withVariant, { snapshot: 'tmpl_ckpt:latest', agents: ['claude'] }),
+    ).toBe('tmpl_ckpt:latest');
+  });
+
+  it('is undefined only when nothing is prepared at all', () => {
+    expect(resolveE2bTemplate({ schema: 2 }, { agents: ['claude'] })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Stacked on #329. Same three tiers as hetzner — agentless base, one artifact per
agent set on top, runtime install as the fallback — for the two providers whose
derive needs no VPS.

| provider | how a variant derives | measured |
|---|---|---|
| e2b | `Template().fromTemplate(base)` — declarative, no boot | **43s** |
| daytona (container) | recipe appended to the same Dockerfile build; the builder's layer cache serves everything below | **77s** (base: 3m18s) |
| daytona (linux-vm) | boot base snapshot → install → stop → cold-snapshot | see caveat |

## e2b

`build-template.sh` installs no agents and creates no per-agent home/credential
dirs. Prepared state gains a `variants` map (schema 2, lossless migration).

No GC, unlike hetzner: E2B templates are *named*, so rebuilding
`agentbox-claude:latest` moves the tag rather than orphaning an id — and the SDK
exposes no `Template.delete` to reap one with.

## daytona

`prepare --provider daytona --agents claude` previously parsed the flag and
**dropped it** — `prepareDaytona` never read `opts.agents`. Both classes now
derive, by different mechanisms, and a variant takes its class from the BASE
rather than `box.daytonaClass`: a snapshot's class is immutable, so a config key
that disagrees with what was baked would produce an unbootable pairing.

Two daytona-specific constraints shape it:

- **No labels.** `snapshot.create` accepts only name/image/resources/region, so
  unlike hetzner's `agentbox.agents` label the NAME is the only channel saying
  which tier a snapshot is. Variants are `agentbox-<set>-<fp12>`.
- **Never reuse a snapshot name** — Daytona's delete is async and a recreated
  name can report `active` yet fail to boot, so variants carry the same
  `nonce()` the base bake uses.

### The daytona regression from #328 is fixed

After pause/resume a box now has only claude's credential, with no
codex/opencode `auth.json` re-materialising. It was never host re-seeding: the
archive/restore re-applied content from a baked base that carried every agent's
credential paths, and the agentless base removes the source.

## Verified live

**e2b** — agentless base rebuilt (the `agent CLIs` and `Claude Code` build steps
are gone), `agentbox-claude:latest` derived in 43s, box boots it with claude on
the box user's PATH, no codex/opencode, only claude's credential, real
`claude -p` returns OK.

**daytona (container)** — base bakes with the expected missing-VM-image warning;
`--agents claude` derives in 77s, cache-hitting layers 1-62 and running only the
recipe, postInstall and the PATH check; a box boots the variant with no
create-time install and answers a real `claude -p`; `box.imageDaytona` names the
base and `refIsOurBase` still routes to the variant (the trap this was written
for, confirmed live); skip-fast names the claude variant; isolation holds across
pause/resume. All boxes destroyed.

## Caveat

**The daytona `linux-vm` derive is not live-tested.** It needs a published
`ghcr.io/madarco/agentbox/box:sha-<context>`, and the agentless `Dockerfile.box`
has never been published (#328 merged to `feat/custom_agents`, not `main`), so
every local bake downgrades to container:

```
local docker context sha: c79f82835a3ede35
GHCR sha-c79f82835a3ede35 -> 404   (100 tags published, none for this context)
```

Pointing `box.daytonaVmBaseImage` at an existing tag would boot an image that
still carries all three agents, defeating the point. Worth a live pass once an
agentless box image reaches GHCR.

Vercel and DigitalOcean are the second PR.

https://claude.ai/code/session_01PkEcUxA2Jqs4CPD4ni1rXP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cloud box boot paths, prepared-state schemas, and snapshot/template selection for E2B and Daytona; mistakes could boot the wrong artifact or break create after prepare, though migrations are lossless and behavior is covered by new resolution tests.
> 
> **Overview**
> **E2B and Daytona** now follow the same three-tier model as Docker/Hetzner: an **agentless base** (`agentbox prepare --provider …`), optional **per-agent-set bakes** (`--agents claude`), and **on-demand install** when no matching artifact exists.
> 
> **E2B** strips agent CLIs and per-agent credential/home setup from `build-template.sh` (only box runtime like `agent-browser` stays). `prepare` can build derived templates via `Template().fromTemplate(base)` using shared `AGENT_SYNC_SPECS` recipes. Prepared state moves to **schema 2** with a `variants` map (lossless v1 migration). **`provision`** picks the variant template through new `resolveE2bTemplate`, falling back to the agentless base when needed.
> 
> **Daytona** wires up **`--agents`** end-to-end (it was previously ignored). **Container** variants append agent install layers to the same Dockerfile build for layer-cache speed; **linux-vm** variants boot the base snapshot, install, stop, and cold-snapshot (`bakeDaytonaVmVariant`). Prepared state is also **schema 2** with per-variant records; snapshot **names** encode the agent set (no labels API). **`provision`** treats a pinned `box.imageDaytona` that points at the agentless base as “no explicit choice” (`refIsOurBase`) so variant selection still works, and class/env/size come from the snapshot actually booted.
> 
> Docs (`daytona.mdx`, `e2b.mdx`, `agents.md`) describe the split base vs agents and mark the old Daytona pause/resume credential leak as fixed with an agentless base.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 844da976d4058da35f2615d120f27f48e5c938b1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->