### PR TITLE
fix: unblock a clean install (hub token) and stop silently dropping the attach footer

### DIFF
--- a/apps/cli/src/commands/control-plane.ts
+++ b/apps/cli/src/commands/control-plane.ts
@@ -1180,6 +1180,29 @@ async function autostartLocalHub(): Promise<boolean> {
 }
 
 /**
+ * Stop then start the local hub so it re-mints `~/.agentbox/hub/token`, returning
+ * true on success. The recovery behind {@link resolveHubApiTarget} for a live hub
+ * whose token file was deleted underneath it.
+ */
+async function restartLocalHubForToken(): Promise<boolean> {
+  const { ensureHub, stopHub } = await import('@agentbox/sandbox-core');
+  const { rehydrateFromState } = await import('./relay.js');
+  const s = spinner();
+  s.start('hub token missing — restarting local hub');
+  try {
+    await stopHub();
+    const ep = await ensureHub({ onLog: (line) => s.message(line) });
+    await rehydrateFromState();
+    s.stop(`local hub restarted on ${ep.hostUrl}`);
+    return true;
+  } catch (err) {
+    s.stop('local hub failed to restart');
+    log.error(err instanceof Error ? err.message : String(err));
+    return false;
+  }
+}
+
+/**
  * Resolve the hub's public REST API target — its URL + the Bearer that authorizes
  * `/api/v1` — for BOTH modes. Delegates the local⇄remote decision to
  * {@link resolveHubTarget} (the same seam `agentbox hub target` and the tray
@@ -1213,10 +1236,19 @@ export async function resolveHubApiTarget(
   // autostart is safe to trigger in both cases. Skipped under `quiet` (a probe
   // must not spawn a daemon); `getHubStatus` is local-only, so irrelevant remote.
   if (target.mode === 'local' && !opts.quiet) {
-    const { getHubStatus } = await import('@agentbox/sandbox-core');
+    const { getHubStatus, readHubToken } = await import('@agentbox/sandbox-core');
     const st = await getHubStatus();
     if (!(st.running && st.ui)) {
       if (!(await autostartLocalHub())) return null;
+      target = await resolveHubTarget(urlFlag, { preferLocal: opts.preferLocal });
+    } else if (!(await readHubToken())) {
+      // Live hub, but `~/.agentbox/hub/token` is gone — the usual cause is
+      // wiping ~/.agentbox while the daemon kept running. The hub only ever
+      // reads that file at boot and then serves from the in-memory value, so
+      // the secret is unrecoverable and no amount of `agentbox hub` (a no-op
+      // against a live daemon) rewrites it. Restarting is the only recovery:
+      // `ensureHubToken` mints a fresh one on the next boot.
+      if (!(await restartLocalHubForToken())) return null;
       target = await resolveHubTarget(urlFlag, { preferLocal: opts.preferLocal });
     }
   }

--- a/apps/cli/src/wrapped-pty/run.ts
+++ b/apps/cli/src/wrapped-pty/run.ts
@@ -206,6 +206,17 @@ function buildAgentboxAttachArgv(
 }
 
 /**
+ * Shown when the optional native pty backend can't be loaded — the one gate that
+ * silently costs the user the footer and the permission prompts.
+ */
+const PTY_UNAVAILABLE_NOTICE =
+  'agentbox: footer + permission prompts disabled — the optional native backend\n' +
+  "  '@homebridge/node-pty-prebuilt-multiarch' could not be loaded.\n" +
+  '  Most often `agentbox` is installed under a different Node than the one on\n' +
+  '  PATH. Compare `node -v` with the Node that owns `command -v agentbox`, then\n' +
+  '  reinstall with that Node: npm i -g @madarco/agentbox\n';
+
+/**
  * Replace `spawnSync('docker', argv, { stdio: 'inherit' })` with a
  * node-pty wrapper that reserves the bottom row for a permission-prompt
  * footer. Falls back transparently to today's spawnSync behavior when
@@ -255,9 +266,16 @@ export async function runWrappedAttach(opts: WrappedAttachOptions): Promise<numb
   }
   const backend = await loadPtyBackend();
   if (!backend) {
-    // One-line stderr notice; preserves current behavior bit-for-bit.
-    process.stderr.write('agentbox: permission prompts disabled (node-pty backend unavailable)\n');
-    return runFallback(command, opts.dockerArgv, opts.env);
+    // The agent's full-screen TUI paints over anything written here, so the
+    // pre-attach notice alone reads as "the footer just isn't there". Repeat it
+    // after the session ends, where it survives in the scrollback, and name the
+    // optional dep so the cause is actionable — the usual one is `agentbox`
+    // installed under a different Node than the one on PATH, leaving the
+    // prebuilt native binding unloadable.
+    process.stderr.write(PTY_UNAVAILABLE_NOTICE);
+    const code = runFallback(command, opts.dockerArgv, opts.env);
+    process.stderr.write(PTY_UNAVAILABLE_NOTICE);
+    return code;
   }
 
   const cols = process.stdout.columns ?? 80;


### PR DESCRIPTION
Two clean-install bugs found while running the docker/hetzner/daytona regression pass on a wiped `~/.agentbox`.

## 1. A live hub whose token file was deleted is a permanent dead end

Wiping `~/.agentbox` while the hub daemon keeps running leaves the daemon serving from its in-memory token with no token file on disk. The CLI can't authenticate to `/api/v1`, so every `agentbox prepare` — and the install wizard's bake — fails with:

```
The local hub reports no API token. Start it with `agentbox hub` and retry.
prepare failed: could not reach a hub to run the bake
```

The advice is a dead end: `agentbox hub` is a no-op against a live daemon and never rewrites the file. The hub only reads it at boot, so the secret is unrecoverable.

`resolveHubApiTarget` now detects the live-hub/no-token case and restarts the hub, which re-mints the token via `ensureHubToken` on the next boot.

Verified: `hub token missing — restarting local hub` → `local hub restarted` → `prepared docker on the hub`.

## 2. A missing native pty silently costs you the footer

`@homebridge/node-pty-prebuilt-multiarch` is an `optionalDependency`, and npm swallows an optional dep that fails to install — so `npm i -g @madarco/agentbox` can succeed with the native backend absent. `loadPtyBackend()` returns null, `runWrappedAttach` falls back to a plain `spawnSync` attach, and the box works but the footer and permission prompts are gone with no visible reason.

Reproduced on a clean Mac mini: the installed package declared the optional dep, it was present nowhere (not hoisted, not nested), `@xterm/headless` was fine, and there was no `.npmrc` or `omit` config asking for it to be skipped. Installing it standalone worked first try — npm had just dropped it.

The old one-line notice was printed immediately before the agent's full-screen TUI painted over it, so the symptom read as "the footer just isn't there". The notice now names the missing package, points at the usual cause (agentbox installed under a different Node than the one on PATH), and is repeated after the session exits where it survives in the scrollback.

Note this is npm's optional-dependency behavior, so it can recur on any fresh install. Making it impossible would mean a loud postinstall check or promoting node-pty to a regular dependency — the latter trades silent degradation for a hard install failure where no prebuild exists. Left as a separate product call.

## Testing

- docker: create → attach → footer → real turn → `Ctrl+a d` → re-attach, all green
- hetzner: fresh bake → create → attach → footer → real turn, all green
- `pnpm typecheck` and `pnpm lint` green

https://claude.ai/code/session_01WPLZGvivtiV6XWboTo8ziv

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Hub restart is invoked automatically during hub API resolution and briefly disrupts a running local hub; behavior is limited to the detected missing-token case but touches core CLI↔hub auth paths.
> 
> **Overview**
> Fixes two **clean-install / wiped `~/.agentbox`** failure modes.
> 
> **Hub API auth:** When the local hub is up but `~/.agentbox/hub/token` is gone (e.g. data wiped while the daemon keeps running), `resolveHubApiTarget` now **stops and restarts** the hub via new `restartLocalHubForToken()` so a fresh token is minted on boot—instead of failing with advice to run `agentbox hub`, which cannot rewrite the file on a live process.
> 
> **Attach footer:** If the optional `@homebridge/node-pty-prebuilt-multiarch` backend fails to load, attach still falls back to plain `spawnSync`, but stderr now prints a **multi-line, actionable** notice (package name, Node mismatch hint) **before and after** the session so it is not hidden by the agent’s full-screen TUI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d626dbf02ef8e8356c1ec85d5166fd8f3beb9f4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->