### PR TITLE
fix(daytona): run a linux-vm box as vscode, not root

### DIFF
--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -323,6 +323,36 @@ docker run --rm --privileged -v /:/host alpine \
 The fix persists into the snapshot, so every box booted from that base has working
 sudo from the start.
 
+#### A `linux-vm` execs as `root`, so AgentBox drops it to `vscode`
+
+Same root cause as the stripped setuid bits and the vanished `ENV`: a VM keeps the
+rootfs and loses the image *metadata*, and `USER vscode` is metadata. A `container`
+honours it and execs as the box user; a `linux-vm` execs as **root** with
+`HOME=/root`, while every credential and config file is seeded into `/home/vscode`.
+Left alone, the agent starts in root's empty home and sits at an interactive login
+prompt on a box that otherwise reports healthy.
+
+The SDK offers no lever — `executeCommand(command, cwd, env, timeout)` has no user,
+`createSshAccess` has no user, and the create-time `user` field is not honoured here
+(a VM box reports `user: "daytona"` while actually running as root). So AgentBox
+wraps, the way vercel does:
+
+- **`exec`** defaults to `vscode` and wraps in `sudo -n -u vscode -H bash -lc …`
+  (`buildDaytonaExec`). `cwd`/`env` move *inside* the wrap — the SDK's own arguments
+  apply to the outer root shell and would never reach the dropped user.
+- **attach** declares `attachRunAs`, and `buildAttach` wraps the whole inner command
+  the same way — the tmux *server* included, so the session, its panes and the in-box
+  ctl client share one identity. A root tmux server owning a `vscode` agent could not
+  reach the ctl socket (0660, in a user-owned dir).
+- **`{ user: 'root' }` opts out**, which the bake depends on: `sudo` is not setuid
+  until the repair above runs and refuses to run at all before then, even for root,
+  so the dockerd wait and the repair itself must stay unwrapped.
+- The **container class is untouched** — it already lands on the box user.
+
+Because the ownership of `/home/vscode` is baked into the snapshot, picking this up
+needs `agentbox prepare --provider daytona --force`, and existing `linux-vm` boxes
+should be destroyed and recreated.
+
 #### Snapshot names are never reused
 
 Recreating a snapshot under a **recently deleted name** yields one that reports

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -268,8 +268,8 @@ A regression checklist that an AI (or human) can drive end-to-end to declare Age
 - [ ] **CREATE-002** `create --provider daytona` provisions a cloud sandbox.
   - **Providers:** [daytona]
   - **Run:** `node apps/cli/dist/index.js create --provider daytona -y -n cloud-smoke &` and tail the log.
-  - **Signal:** exit 0; box reachable via `agentbox shell cloud-smoke -- pwd` returning `/workspace`; preview URL minted (`url --print` returns a `*.proxy.daytona.work` URL).
-  - **Note:** End-to-end create on Daytona using bundle + stash + untracked seeding.
+  - **Signal:** exit 0; box reachable via `agentbox shell cloud-smoke -- pwd` returning `/workspace`; `agentbox shell cloud-smoke -- 'id -un'` returning **`vscode`**; preview URL minted (`url --print` returns a `*.proxy.daytona.work` URL).
+  - **Note:** End-to-end create on Daytona using bundle + stash + untracked seeding. The box-user check is not cosmetic: a `linux-vm` execs as root unless AgentBox drops it, and this check answered only `pwd` while the agent sat at a login prompt for weeks.
 
 - [ ] **CREATE-003** `create --provider hetzner` provisions a VPS.
   - **Providers:** [hetzner]

--- a/packages/core/src/cloud-backend.ts
+++ b/packages/core/src/cloud-backend.ts
@@ -259,10 +259,40 @@ export interface CloudBackend {
    * Declared by the backend rather than matched on `name` so an out-of-tree
    * provider plugin can opt in. Ownership stays correct under root because the
    * chown resolves the box user from `--reference=$BOX_HOME`, not a hardcoded
-   * uid. Backends whose non-root path already works (hetzner, daytona — whose
-   * S3-backed FUSE volumes reject a root chown anyway) leave this unset.
+   * uid. Backends whose non-root path already works (hetzner, daytona) leave
+   * this unset. (Daytona's reason used to be given as "its S3-backed FUSE
+   * volumes reject a root chown" — that holds only for the container class. A
+   * `linux-vm` mounts no volume at all; it stays unset because its exec now
+   * drops to the box user like everyone else's.)
    */
   readonly stageFilesAsRoot?: boolean;
+
+  /**
+   * Box user an attach must drop to, for backends whose interactive session
+   * lands as root.
+   *
+   * Only Daytona's `linux-vm` needs it: its SSH gateway takes an opaque access
+   * token rather than a unix user (`createSshAccess` has no user parameter), so
+   * the session lands as whatever the sandbox execs as — root on a VM, because
+   * the rootfs conversion drops the image's `USER` metadata. Left unset, the
+   * tmux server and the agent inside it run as root with `HOME=/root` and never
+   * see the credentials seeded into `/home/vscode`.
+   *
+   * When set, `buildAttach` wraps the rendered inner command in
+   * `sudo -n -u <user> -H bash -lc …` so the whole session — tmux server
+   * included — belongs to the box user. Backends that already land on the right
+   * user (hetzner/digitalocean ssh as `vscode`, vercel/e2b select it in their
+   * own attach builders, docker passes `--user`) leave it unset.
+   *
+   * Must agree with what `exec` does: the in-box ctl daemon is started through
+   * `exec` and its socket is 0660 in a user-owned dir, so a tmux client of a
+   * different user could not talk to it.
+   *
+   * A method rather than a flag because it is per-box, not per-backend: Daytona
+   * needs it for `linux-vm` and must NOT wrap its `container` class, which
+   * already lands as the box user. Return undefined to leave the session alone.
+   */
+  attachRunAs?(h: CloudHandle): string | undefined;
 
   provision(req: CloudProvisionRequest): Promise<CloudHandle>;
   /** Resolve an existing sandbox by id; null when it no longer exists. */

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -65,7 +65,11 @@ import {
   registerBoxWithRelay,
   TERM_FALLBACK_SNIPPET,
 } from '@agentbox/sandbox-docker';
-import { ensureAgentVolumesForCloud, reconcileAgentCredentials } from './sync/agent-credentials.js';
+import {
+  cloudVolumesUsable,
+  ensureAgentVolumesForCloud,
+  reconcileAgentCredentials,
+} from './sync/agent-credentials.js';
 import {
   cloudSnapshotName,
   currentCloudBaseFingerprint,
@@ -818,7 +822,7 @@ export function createCloudProvider(
         onLog: log,
         // Daytona's linux-vm class accepts volume mounts and never honors them
         // (see ensureAgentVolumesForCloud) — take the per-create upload path.
-        volumesUsable: sandboxClass !== 'linux-vm',
+        volumesUsable: cloudVolumesUsable(sandboxClass),
       });
 
       // Read the `expose:` service ports up front so port-capped backends
@@ -1647,7 +1651,7 @@ export function createCloudProvider(
       }
       const handle = handleFor(box);
       const baseArgv = await backend.attachArgv(handle);
-      const inner = renderInnerCommand(kind, opts);
+      const inner = wrapAttachAsUser(renderInnerCommand(kind, opts), backend.attachRunAs?.(handle));
       // -t forces TTY allocation on the remote side (the SSH default of
       // skipping TTY when a command is provided would break tmux + readline).
       // A `detached` build only creates the session (no `exec tmux attach`), so
@@ -1983,6 +1987,23 @@ export function hostTermForCloud(): string {
 export function attachScriptPath(sessionName: string): string {
   const safe = sessionName.replace(/[^A-Za-z0-9._-]/g, '_').slice(0, 40) || 'attach';
   return `/tmp/agentbox-attach-${safe}.sh`;
+}
+
+/**
+ * Drop an attach's inner command to the box user, for backends whose session
+ * lands as root (see `CloudBackend.attachRunAs`). Wrapping the WHOLE inner
+ * command — not just the agent — is deliberate: it puts the tmux *server* on
+ * the box user's socket, so the session, its panes and the in-box ctl client
+ * all share one identity. Wrapping only the launch command would leave a root
+ * tmux server owning a vscode agent, which is how the ctl socket (0660, in a
+ * user-owned dir) becomes unreachable.
+ *
+ * `-n` fails loudly rather than hanging on a password prompt; `-H` sets HOME,
+ * which is the entire point — the credentials live in the box user's home.
+ */
+export function wrapAttachAsUser(inner: string, user: string | undefined): string {
+  if (!user) return inner;
+  return `exec sudo -n -u ${user} -H bash -lc ${shellSingle(inner)}`;
 }
 
 export function renderInnerCommand(kind: AttachKind, opts?: BuildAttachOptions): string {

--- a/packages/sandbox-cloud/src/sync/agent-credentials.ts
+++ b/packages/sandbox-cloud/src/sync/agent-credentials.ts
@@ -141,6 +141,20 @@ export interface EnsureAgentVolumesResult {
  * Idempotent: every call is a fast lookup for the already-created volume.
  * Safe to call on every `create`.
  */
+/**
+ * Whether a box of this sandbox class can actually USE a mounted volume.
+ *
+ * Daytona's `linux-vm` accepts a volume mount and even echoes it back in the
+ * sandbox DTO — the path simply never appears in the guest. So the provision-time
+ * reservation and the credential seed must answer this the same way; when they
+ * disagreed, a VM box reserved no volume and then seeded as though it had one.
+ *
+ * One definition, used by both, so they cannot drift apart again.
+ */
+export function cloudVolumesUsable(sandboxClass: string | undefined): boolean {
+  return sandboxClass !== 'linux-vm';
+}
+
 export async function ensureAgentVolumesForCloud(
   backend: CloudBackend,
   opts: { onLog?: (line: string) => void; volumesUsable?: boolean } = {},
@@ -337,7 +351,14 @@ async function seedCredentialsOne(
   // tokens are renewable, so we just push fresh every create. Volume backends
   // (daytona) keep the marker-based idempotency so they don't re-upload into
   // a volume already carrying credentials from a previous box.
-  const hasVolume = typeof backend.ensureVolume === 'function';
+  //
+  // "Has a volume API" is NOT the same question as "this box has a volume":
+  // Daytona's linux-vm has the API and no mount, and answering the capability
+  // question sent VM boxes down the volume branch — which extracts as root with
+  // no `--no-same-owner` and then `cp -r`, landing root:root 0600 credentials
+  // the box user cannot read.
+  const hasVolume =
+    typeof backend.ensureVolume === 'function' && cloudVolumesUsable(handle.sandboxClass);
 
   if (hasVolume && !opts.force) {
     const probe = await backend.exec(handle, `test -f ${spec.credentialsMountPath}/${SEED_MARKER}`);

--- a/packages/sandbox-cloud/src/sync/claude-json-overlay.ts
+++ b/packages/sandbox-cloud/src/sync/claude-json-overlay.ts
@@ -51,8 +51,14 @@ export async function seedClaudeJsonAtCreate(
     await backend.uploadFile(handle, staged.tarballPath, REMOTE_TAR);
     const extract = await backend.exec(
       handle,
+      // `--no-same-owner --no-same-permissions -m`: the host tarball records the
+      // HOST's uid/gid and mode, and GNU tar restores both when it runs as root.
+      // That is how `/home/vscode/.claude` ended up owned by uid 501 (a macOS
+      // uid that means nothing in the box) mode 0700 — unreadable by the agent.
+      // Harmless when the extract already runs unprivileged; load-bearing when
+      // it doesn't.
       `set -e; mkdir -p ${BOX_CLAUDE_DIR}; ` +
-        `tar -xzf ${REMOTE_TAR} -C ${BOX_CLAUDE_DIR}; ` +
+        `tar -xzf ${REMOTE_TAR} -C ${BOX_CLAUDE_DIR} --no-same-permissions --no-same-owner -m; ` +
         `rm -f ${REMOTE_TAR}`,
     );
     if (extract.exitCode !== 0) {

--- a/packages/sandbox-cloud/src/sync/dynamic-sync.ts
+++ b/packages/sandbox-cloud/src/sync/dynamic-sync.ts
@@ -61,7 +61,10 @@ export async function seedDynamicConfig(
     // 1. Read the manifest the box already carries (absent on a fresh box).
     let boxManifest: DynamicSyncManifest | null = null;
     try {
-      const res = await backend.exec(handle, `cat ${BOX_DYNAMIC_SYNC_MANIFEST} 2>/dev/null || true`);
+      const res = await backend.exec(
+        handle,
+        `cat ${BOX_DYNAMIC_SYNC_MANIFEST} 2>/dev/null || true`,
+      );
       const out = res.stdout.trim();
       if (res.exitCode === 0 && out.length > 0) {
         boxManifest = JSON.parse(out) as DynamicSyncManifest;
@@ -95,7 +98,10 @@ export async function seedDynamicConfig(
         steps.push(
           `rm -rf ${BOX_STAGE}`,
           `mkdir -p ${BOX_STAGE}`,
-          `tar -xzf ${REMOTE_TAR} -C ${BOX_STAGE}`,
+          // See claude-json-overlay: the host tarball carries the host's uid/gid,
+          // which a root extract would restore verbatim and `cp -a` below would
+          // then propagate into the box user's home.
+          `tar -xzf ${REMOTE_TAR} -C ${BOX_STAGE} --no-same-permissions --no-same-owner -m`,
           `if [ -d ${BOX_STAGE}/workflows ]; then cp -a ${BOX_STAGE}/workflows/. ${BOX_WORKFLOWS_DIR}/; fi`,
           `if [ -d ${BOX_STAGE}/memory ]; then cp -a ${BOX_STAGE}/memory/. ${BOX_MEMORY_DIR}/; fi`,
           `rm -rf ${BOX_STAGE} ${REMOTE_TAR}`,

--- a/packages/sandbox-cloud/test/agent-credentials.test.ts
+++ b/packages/sandbox-cloud/test/agent-credentials.test.ts
@@ -87,7 +87,14 @@ function makeMockBackend(opts: {
     },
   };
 
-  return { backend, execCalls, uploadCalls, get destroyed() { return state.destroyed; } } as never;
+  return {
+    backend,
+    execCalls,
+    uploadCalls,
+    get destroyed() {
+      return state.destroyed;
+    },
+  } as never;
 }
 
 describe('ensureAgentVolumesForCloud', () => {
@@ -152,15 +159,19 @@ describe('seedAgentVolumesIfFresh (credentials-only)', () => {
       ]),
     });
     const logs: string[] = [];
-    await seedAgentVolumesIfFresh(backend, { sandboxId: 's' }, {
-      onLog: (l) => logs.push(l),
-    });
+    await seedAgentVolumesIfFresh(
+      backend,
+      { sandboxId: 's' },
+      {
+        onLog: (l) => logs.push(l),
+      },
+    );
     expect(uploadCalls).toEqual([]);
     expect(execCalls.filter((c) => c.cmd.startsWith('test -f ')).length).toBe(3);
     expect(execCalls.some((c) => c.cmd.includes('tar -xzf'))).toBe(false);
-    expect(
-      logs.every((l) => l.includes('already seeded') || l.includes('mounting only')),
-    ).toBe(true);
+    expect(logs.every((l) => l.includes('already seeded') || l.includes('mounting only'))).toBe(
+      true,
+    );
   });
 
   // Tests below pass `agents: ['codex', 'opencode']` to exclude claude — the
@@ -171,9 +182,13 @@ describe('seedAgentVolumesIfFresh (credentials-only)', () => {
 
   it('does not upload when host has no credentials to stage (codex/opencode)', async () => {
     const { backend, uploadCalls } = makeMockBackend({});
-    await seedAgentVolumesIfFresh(backend, { sandboxId: 's' }, {
-      agents: ['codex', 'opencode'],
-    });
+    await seedAgentVolumesIfFresh(
+      backend,
+      { sandboxId: 's' },
+      {
+        agents: ['codex', 'opencode'],
+      },
+    );
     expect(uploadCalls).toEqual([]);
   });
 
@@ -185,17 +200,19 @@ describe('seedAgentVolumesIfFresh (credentials-only)', () => {
     await writeFile(join(codexDir, 'config.toml'), 'model = "gpt-5"\n');
 
     const { backend, uploadCalls, execCalls } = makeMockBackend({});
-    await seedAgentVolumesIfFresh(backend, { sandboxId: 's' }, {
-      agents: ['codex', 'opencode'],
-    });
+    await seedAgentVolumesIfFresh(
+      backend,
+      { sandboxId: 's' },
+      {
+        agents: ['codex', 'opencode'],
+      },
+    );
 
     expect(uploadCalls).toHaveLength(1);
     expect(uploadCalls[0]!.remotePath).toBe('/tmp/agentbox-codex-creds.tar.gz');
     expect(
       execCalls.some(
-        (c) =>
-          c.cmd.includes('tar -xzf') &&
-          c.cmd.includes('/home/vscode/.agentbox-creds/codex'),
+        (c) => c.cmd.includes('tar -xzf') && c.cmd.includes('/home/vscode/.agentbox-creds/codex'),
       ),
     ).toBe(true);
     expect(uploadCalls.some((c) => c.remotePath.includes('opencode'))).toBe(false);
@@ -228,6 +245,55 @@ describe('seedAgentVolumesIfFresh (credentials-only)', () => {
     await rm(codexDir, { recursive: true, force: true });
   });
 
+  it('takes the ephemeral path on a linux-vm box even though the backend has a volume API', async () => {
+    // Daytona's linux-vm accepts a volume mount, echoes it back in the DTO, and
+    // never surfaces it in the guest. Answering "does the backend have volumes?"
+    // instead of "does THIS box have one?" sent VM boxes down the volume branch,
+    // which extracts as root with no --no-same-owner and then `cp -r` — landing
+    // root:root 0600 credentials the vscode agent cannot read, which is exactly
+    // how the box ended up at an interactive login prompt.
+    const codexDir = join(fakeHome, '.codex');
+    await mkdir(codexDir, { recursive: true });
+    await writeFile(join(codexDir, 'auth.json'), '{"token":"redacted"}\n');
+
+    const { backend, execCalls } = makeMockBackend({});
+    // Volume primitive present — only the sandbox class says otherwise.
+    expect(typeof backend.ensureVolume).toBe('function');
+    await seedAgentVolumesIfFresh(
+      backend,
+      { sandboxId: 's', sandboxClass: 'linux-vm' },
+      { agents: ['codex'] },
+    );
+
+    const extractCall = execCalls.find(
+      (c) => c.cmd.includes('tar -xzf') && c.cmd.includes('/home/vscode/.agentbox-creds/codex'),
+    );
+    expect(extractCall).toBeDefined();
+    expect(extractCall!.user).toBe('vscode');
+    expect(extractCall!.cmd).toContain('--no-same-owner');
+    // The volume branch's giveaway: a staging dir + cp instead of a direct extract.
+    expect(execCalls.some((c) => c.cmd.includes('agentbox-creds-stage-'))).toBe(false);
+
+    await rm(codexDir, { recursive: true, force: true });
+  });
+
+  it('keeps the volume path for a container-class box', async () => {
+    const codexDir = join(fakeHome, '.codex');
+    await mkdir(codexDir, { recursive: true });
+    await writeFile(join(codexDir, 'auth.json'), '{"token":"redacted"}\n');
+
+    const { backend, execCalls } = makeMockBackend({});
+    await seedAgentVolumesIfFresh(
+      backend,
+      { sandboxId: 's', sandboxClass: 'container' },
+      { agents: ['codex'] },
+    );
+
+    expect(execCalls.some((c) => c.cmd.includes('agentbox-creds-stage-'))).toBe(true);
+
+    await rm(codexDir, { recursive: true, force: true });
+  });
+
   it('warns + skips codex when ~/.codex exists but auth.json is missing (Keychain landmine)', async () => {
     const codexDir = join(fakeHome, '.codex');
     await mkdir(codexDir, { recursive: true });
@@ -236,14 +302,16 @@ describe('seedAgentVolumesIfFresh (credentials-only)', () => {
 
     const { backend, uploadCalls } = makeMockBackend({});
     const logs: string[] = [];
-    await seedAgentVolumesIfFresh(backend, { sandboxId: 's' }, {
-      agents: ['codex', 'opencode'],
-      onLog: (l) => logs.push(l),
-    });
+    await seedAgentVolumesIfFresh(
+      backend,
+      { sandboxId: 's' },
+      {
+        agents: ['codex', 'opencode'],
+        onLog: (l) => logs.push(l),
+      },
+    );
     expect(uploadCalls.some((c) => c.remotePath.includes('codex'))).toBe(false);
-    expect(
-      logs.some((l) => /auth\.json missing|cli_auth_credentials_store/i.test(l)),
-    ).toBe(true);
+    expect(logs.some((l) => /auth\.json missing|cli_auth_credentials_store/i.test(l))).toBe(true);
 
     await rm(codexDir, { recursive: true, force: true });
   });
@@ -264,11 +332,20 @@ describe('extractCloudAgentCredentials', () => {
   function backendCatting(files: Record<string, string | undefined>): CloudBackend {
     return {
       name: 'mock',
-      async provision(): Promise<CloudHandle> { return { sandboxId: 's' }; },
-      async get(): Promise<CloudHandle | null> { return { sandboxId: 's' }; },
-      async start() {}, async stop() {}, async pause() {}, async resume() {},
+      async provision(): Promise<CloudHandle> {
+        return { sandboxId: 's' };
+      },
+      async get(): Promise<CloudHandle | null> {
+        return { sandboxId: 's' };
+      },
+      async start() {},
+      async stop() {},
+      async pause() {},
+      async resume() {},
       async destroy() {},
-      async state(): Promise<CloudState> { return 'running'; },
+      async state(): Promise<CloudState> {
+        return 'running';
+      },
       async exec(_h, cmd: string): Promise<CloudExecResult> {
         const m = /^cat (\S+) 2>\/dev\/null$/.exec(cmd);
         if (m) {
@@ -279,9 +356,14 @@ describe('extractCloudAgentCredentials', () => {
         }
         return { exitCode: 0, stdout: '', stderr: '' };
       },
-      async uploadFile() {}, async downloadFile() {},
-      async listFiles(): Promise<CloudFileEntry[]> { return []; },
-      async previewUrl(): Promise<CloudPreviewUrl> { return { url: 'https://mock/' }; },
+      async uploadFile() {},
+      async downloadFile() {},
+      async listFiles(): Promise<CloudFileEntry[]> {
+        return [];
+      },
+      async previewUrl(): Promise<CloudPreviewUrl> {
+        return { url: 'https://mock/' };
+      },
     };
   }
 
@@ -321,7 +403,9 @@ describe('extractCloudAgentCredentials', () => {
   it('swallows a failing exec and returns []', async () => {
     const backend: CloudBackend = {
       ...backendCatting({}),
-      async exec(): Promise<CloudExecResult> { throw new Error('transient'); },
+      async exec(): Promise<CloudExecResult> {
+        throw new Error('transient');
+      },
     };
     const logs: string[] = [];
     const extracted = await extractCloudAgentCredentials(
@@ -333,4 +417,3 @@ describe('extractCloudAgentCredentials', () => {
     expect(logs.some((l) => l.includes('extract failed'))).toBe(true);
   });
 });
-

--- a/packages/sandbox-cloud/test/attach-no-tty.test.ts
+++ b/packages/sandbox-cloud/test/attach-no-tty.test.ts
@@ -60,10 +60,9 @@ describe('buildAttach on a backend whose exec sessions get no TTY', () => {
     // editor mangles it into a `>` continuation prompt.
     expect(execs).toHaveLength(1);
     expect(execs[0]).toMatch(/base64 -d > \/tmp\/agentbox-attach-claude\.sh/);
-    const staged = Buffer.from(
-      /printf %s '([^']+)'/.exec(execs[0]!)![1]!,
-      'base64',
-    ).toString('utf8');
+    const staged = Buffer.from(/printf %s '([^']+)'/.exec(execs[0]!)![1]!, 'base64').toString(
+      'utf8',
+    );
     expect(staged).toMatch(/tmux attach -t 'claude'/);
 
     // ...and only a short line is typed, newline-terminated so it actually runs.
@@ -88,5 +87,58 @@ describe('buildAttach on a backend whose exec sessions get no TTY', () => {
     expect(spec.argv).toContain('-t');
     expect(spec.argv.some((a) => a.includes('tmux attach'))).toBe(true);
     expect(spec.initialInput).toBeUndefined();
+  });
+});
+
+/**
+ * A backend whose interactive session lands as root (daytona's linux-vm: its SSH
+ * gateway takes an opaque token and offers no unix user) must drop the WHOLE
+ * inner command to the box user — tmux server included, so the session, its
+ * panes and the in-box ctl client share one identity.
+ */
+describe('buildAttach drops to the box user when the backend asks', () => {
+  it('wraps the staged script in sudo -u for the declared user', async () => {
+    const execs: string[] = [];
+    const provider = createCloudProvider(
+      makeBackend({
+        attachExecLacksTty: true,
+        attachRunAs: () => 'vscode',
+        exec: async (_h, cmd: string) => {
+          execs.push(cmd);
+          return { exitCode: 0, stdout: '', stderr: '' };
+        },
+      } as Partial<CloudBackend>),
+    );
+    await provider.buildAttach!(record, 'agent', { sessionName: 'claude' });
+
+    const staged = Buffer.from(/printf %s '([^']+)'/.exec(execs[0]!)![1]!, 'base64').toString(
+      'utf8',
+    );
+    expect(staged).toMatch(/^exec sudo -n -u vscode -H bash -lc /);
+    // The tmux commands must be INSIDE the wrap, not beside it — a root tmux
+    // server owning a vscode agent cannot reach the 0660 ctl socket.
+    expect(staged).toContain('tmux attach');
+  });
+
+  it('leaves the command alone when the backend returns undefined', async () => {
+    // Daytona's container class already lands on the box user; wrapping it would
+    // add a needless sudo dependency.
+    const execs: string[] = [];
+    const provider = createCloudProvider(
+      makeBackend({
+        attachExecLacksTty: true,
+        attachRunAs: () => undefined,
+        exec: async (_h, cmd: string) => {
+          execs.push(cmd);
+          return { exitCode: 0, stdout: '', stderr: '' };
+        },
+      } as Partial<CloudBackend>),
+    );
+    await provider.buildAttach!(record, 'agent', { sessionName: 'claude' });
+
+    const staged = Buffer.from(/printf %s '([^']+)'/.exec(execs[0]!)![1]!, 'base64').toString(
+      'utf8',
+    );
+    expect(staged).not.toContain('sudo');
   });
 });

--- a/packages/sandbox-daytona/src/backend.ts
+++ b/packages/sandbox-daytona/src/backend.ts
@@ -79,6 +79,77 @@ export const DAYTONA_DEFAULT_RESOURCES = { cpu: 2, memory: 4, disk: 8 } as const
  */
 const clients = new Map<string, Daytona>();
 
+/**
+ * The unprivileged user a box's work runs as, matching every other provider
+ * (vercel/e2b `BOX_USER`, hetzner/digitalocean `VPS_USER`, docker
+ * `CONTAINER_USER`).
+ */
+export const BOX_USER = 'vscode';
+
+/** Single-quote for /bin/sh. */
+function shq(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Decide what Daytona actually runs, honouring `opts.user`.
+ *
+ * The SDK has NO per-exec user — `executeCommand(command, cwd, env, timeout)`
+ * and nothing on sessions or PTYs — so the only lever is an in-shell `sudo -u`,
+ * the same one vercel uses (`packages/sandbox-vercel/src/backend.ts`).
+ *
+ * It is needed because the two sandbox classes land as different users. A
+ * `container` honours the image's `USER vscode` metadata and already execs as
+ * the box user. A `linux-vm` has no image metadata — the rootfs conversion
+ * drops it, which is also why the bake has to hand-repair sudo's setuid bit and
+ * re-inject the image's `ENV` — so it execs as **root**, with `HOME=/root`,
+ * while every credential and config file is seeded into `/home/vscode`. That
+ * mismatch is what left the in-box agent staring at a login prompt.
+ *
+ * `h.sandboxClass !== 'container'` mirrors `pause()` below: the class is absent
+ * on records written before it existed and on the keepalive loop's synthetic
+ * handles, and the VM side is the one that needs the wrap, so `undefined` falls
+ * there.
+ *
+ * cwd/env move INSIDE the wrap when we drop: the SDK applies its own arguments
+ * to the outer root shell, so a `cd`/`export` passed that way would never reach
+ * the dropped user's shell.
+ */
+export function buildDaytonaExec(
+  cmd: string,
+  h: Pick<CloudHandle, 'sandboxClass'>,
+  opts?: CloudExecOptions,
+): { cmd: string; cwd?: string; env?: Record<string, string> } {
+  const user = opts?.user ?? BOX_USER;
+  const isVm = h.sandboxClass !== 'container';
+  // Already the right user: hand the SDK the command untouched. Covers the
+  // container class (execs as vscode) and every explicit `user: 'root'` — which
+  // the bake relies on, since `sudo` is not setuid until the repair runs and
+  // refuses to work at all before then, even for root.
+  if (!isVm || user === 'root') {
+    return {
+      cmd,
+      ...(opts?.cwd ? { cwd: opts.cwd } : {}),
+      ...(opts?.env ? { env: opts.env } : {}),
+    };
+  }
+  const prelude: string[] = [];
+  if (opts?.cwd) prelude.push(`cd ${shq(opts.cwd)}`);
+  for (const [k, v] of Object.entries(opts?.env ?? {})) {
+    // The value is quoted, but the key is interpolated bare into a shell string
+    // that runs as root — reject anything that isn't a POSIX env-var name so a
+    // key like `x;rm -rf /` can't inject a command.
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(k)) {
+      throw new Error(`daytona exec: invalid env var name ${JSON.stringify(k)}`);
+    }
+    prelude.push(`export ${k}=${shq(v)}`);
+  }
+  const inner = [...prelude, cmd].join('\n');
+  // `-n` so a sudoers misconfiguration fails loudly instead of hanging on a
+  // password prompt; `-H` so HOME is the target user's.
+  return { cmd: `sudo -n -u ${user} -H bash -lc ${shq(inner)}` };
+}
+
 export function getClient(target = ''): Daytona {
   const cached = clients.get(target);
   if (cached) return cached;
@@ -179,8 +250,8 @@ function resolveImage(ref: string): string | Image {
   const ctx = resolveDockerfileContext();
   if (!ctx) {
     throw new Error(
-      "could not locate the AgentBox Dockerfile.box build context for the Daytona snapshot. " +
-        "Set AGENTBOX_DOCKER_CONTEXT to a directory containing Dockerfile.box, or pass --image <ref> with a Daytona-compatible image.",
+      'could not locate the AgentBox Dockerfile.box build context for the Daytona snapshot. ' +
+        'Set AGENTBOX_DOCKER_CONTEXT to a directory containing Dockerfile.box, or pass --image <ref> with a Daytona-compatible image.',
     );
   }
   // Image.fromDockerfile bundles the directory the Dockerfile lives in and
@@ -553,6 +624,17 @@ export const daytonaBackend: CloudBackend = {
   attachExecLacksTty: true,
 
   /**
+   * See `CloudBackend.attachRunAs`. The SSH gateway authenticates with an
+   * opaque token and offers no unix user, so a `linux-vm` session lands as root
+   * — the class that has no image metadata to say otherwise. Drop it to the box
+   * user so the tmux server, the agent and the ctl client are all `vscode`,
+   * matching what `exec` now does. `container` already lands there.
+   */
+  attachRunAs(h: CloudHandle): string | undefined {
+    return h.sandboxClass === 'container' ? undefined : BOX_USER;
+  },
+
+  /**
    * Hold off Daytona's auto-stop while the in-box agent is working.
    *
    * Daytona's timeout is an INACTIVITY window, not an absolute deadline like
@@ -610,11 +692,8 @@ export const daytonaBackend: CloudBackend = {
     });
   },
 
-  async exec(
-    h: CloudHandle,
-    cmd: string,
-    opts?: CloudExecOptions,
-  ): Promise<CloudExecResult> {
+  async exec(h: CloudHandle, cmd: string, opts?: CloudExecOptions): Promise<CloudExecResult> {
+    const plan = buildDaytonaExec(cmd, h, opts);
     return retry(
       'exec',
       async () => {
@@ -622,7 +701,11 @@ export const daytonaBackend: CloudBackend = {
         // Daytona's ExecuteResponse returns combined output in `result` with no
         // separate stderr stream. Surface it as stdout and leave stderr empty —
         // callers that need split streams must redirect inside `cmd` itself.
-        const r = await sb.process.executeCommand(cmd, opts?.cwd, opts?.env);
+        //
+        // cwd/env go through the SDK only when we are NOT dropping privileges;
+        // the wrapped form folds them into the inner shell instead (see
+        // buildDaytonaExec).
+        const r = await sb.process.executeCommand(plan.cmd, plan.cwd, plan.env);
         return { exitCode: r.exitCode, stdout: r.result, stderr: '' };
       },
       { attemptTimeoutMs: opts?.attemptTimeoutMs ?? 120_000, noRetry: opts?.noRetry },
@@ -635,6 +718,22 @@ export const daytonaBackend: CloudBackend = {
       async () => {
         const sb = await getSandbox(h.sandboxId);
         await sb.fs.uploadFile(localPath, remotePath);
+        // The toolbox writes as its own identity — root on a linux-vm — while
+        // `exec` now drops to the box user. Every caller that uploads a tarball
+        // then extracts and `rm`s it would break on the mismatch: /tmp is
+        // sticky, so a non-owner cannot unlink a root-owned file there, and the
+        // seed died on exactly that ("rm: cannot remove … Operation not
+        // permitted"). Hand the file to the box user, as e2b's uploadFile does.
+        //
+        // Best-effort: the file is present and readable either way, and the
+        // container class already writes as the box user.
+        if (h.sandboxClass !== 'container') {
+          try {
+            await sb.process.executeCommand(`chown ${BOX_USER}: ${shq(remotePath)}`);
+          } catch {
+            // ignore — an unchowned upload is still readable
+          }
+        }
       },
       { attemptTimeoutMs: 300_000 },
     );
@@ -696,7 +795,8 @@ export const daytonaBackend: CloudBackend = {
         'ssh',
         // First-connect to a never-seen host fingerprint should be silent in a
         // PTY — the user already authenticated via Daytona's API.
-        '-o', 'StrictHostKeyChecking=accept-new',
+        '-o',
+        'StrictHostKeyChecking=accept-new',
         // Daytona's SSH gateway terminates per-token; no key file, no port.
         `${ssh.token}@ssh.app.daytona.io`,
       ];

--- a/packages/sandbox-daytona/src/prepare-vm.ts
+++ b/packages/sandbox-daytona/src/prepare-vm.ts
@@ -291,7 +291,13 @@ export async function bakeDaytonaVmBase(opts: VmBaseBakeOptions): Promise<VmBase
   }
   const handle: CloudHandle = { sandboxId: sandbox.id, sandboxClass: 'linux-vm' };
   try {
-    const wait = await opts.backend.exec(handle, buildDockerWaitCommand());
+    // These two run BEFORE the repair, so they must stay as root. `exec`
+    // otherwise drops to the box user via `sudo -n -u vscode`, and sudo is
+    // exactly what is broken here: the rootfs conversion left it non-setuid, so
+    // it refuses to run at all — even for root — until the repair below. Asking
+    // sudo to fix sudo would deadlock the bake.
+    const asRoot = { user: 'root' } as const;
+    const wait = await opts.backend.exec(handle, buildDockerWaitCommand(), asRoot);
     if (wait.exitCode !== 0) {
       throw new Error(
         'dockerd never came up in the VM base, so sudo cannot be repaired ' +
@@ -299,7 +305,7 @@ export async function bakeDaytonaVmBase(opts: VmBaseBakeOptions): Promise<VmBase
       );
     }
     log('repairing sudo (the VM rootfs conversion strips setuid bits)…');
-    const repair = await opts.backend.exec(handle, buildSudoRepairCommand());
+    const repair = await opts.backend.exec(handle, buildSudoRepairCommand(), asRoot);
     if (repair.exitCode !== 0) {
       throw new Error(
         `failed to restore sudo in the VM base (exit ${String(repair.exitCode)}): ` +

--- a/packages/sandbox-daytona/test/exec-user.test.ts
+++ b/packages/sandbox-daytona/test/exec-user.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { BOX_USER, buildDaytonaExec } from '../src/backend.js';
+
+/**
+ * Daytona's SDK has no per-exec user, so `opts.user` is honoured with an
+ * in-shell `sudo -u` (vercel's pattern). It matters because the two sandbox
+ * classes land as different users: a `container` honours the image's
+ * `USER vscode`, while a `linux-vm` — whose rootfs conversion drops image
+ * metadata — execs as root with `HOME=/root`, where none of the seeded
+ * credentials live.
+ */
+const VM = { sandboxClass: 'linux-vm' } as const;
+const CONTAINER = { sandboxClass: 'container' } as const;
+
+/**
+ * Undo one level of POSIX single-quoting — the inner script is quoted twice
+ * (each prelude value, then the whole inner for `bash -lc`), so asserting on the
+ * escaped literal tests the escaping of the escaping. Decode instead and assert
+ * on the script a shell would actually run.
+ */
+function innerScript(cmd: string): string {
+  const m = /^sudo -n -u \S+ -H bash -lc '(.*)'$/s.exec(cmd);
+  if (!m) throw new Error(`not a wrapped command: ${cmd}`);
+  return m[1]!.replace(/'\\''/g, `'`);
+}
+
+describe('buildDaytonaExec — linux-vm drops to the box user', () => {
+  it('defaults to the box user', () => {
+    const p = buildDaytonaExec('echo hi', VM);
+    expect(p.cmd).toMatch(/^sudo -n -u vscode -H bash -lc /);
+    expect(BOX_USER).toBe('vscode');
+  });
+
+  it('folds cwd and env INSIDE the wrap, not into the SDK arguments', () => {
+    const p = buildDaytonaExec('echo hi', VM, { cwd: '/workspace', env: { FOO: 'bar' } });
+    // The SDK's own cwd/env would apply to the outer root shell and never reach
+    // the dropped user — that is the whole reason they move inside.
+    expect(p.cwd).toBeUndefined();
+    expect(p.env).toBeUndefined();
+    expect(innerScript(p.cmd)).toBe("cd '/workspace'\nexport FOO='bar'\necho hi");
+  });
+
+  it('quotes a cwd and env value containing a single quote', () => {
+    const p = buildDaytonaExec('true', VM, { cwd: "/tmp/it's", env: { A: "x'y" } });
+    expect(innerScript(p.cmd)).toBe("cd '/tmp/it'\\''s'\nexport A='x'\\''y'\ntrue");
+  });
+
+  // The key is interpolated bare into a string that runs as root.
+  it('rejects an env name that could inject a command', () => {
+    expect(() => buildDaytonaExec('true', VM, { env: { 'x;rm -rf /': '1' } })).toThrow(
+      /invalid env var name/,
+    );
+  });
+});
+
+describe('buildDaytonaExec — cases that must NOT be wrapped', () => {
+  it('leaves an explicit root request alone', () => {
+    // Load-bearing for the bake: sudo is not setuid until the repair runs, so a
+    // wrapped pre-repair step would deadlock (sudo cannot fix sudo).
+    const p = buildDaytonaExec('docker info', VM, { user: 'root' });
+    expect(p.cmd).toBe('docker info');
+    expect(p.cmd).not.toContain('sudo');
+  });
+
+  it('passes cwd/env through to the SDK when not dropping', () => {
+    const p = buildDaytonaExec('true', VM, { user: 'root', cwd: '/tmp', env: { A: 'b' } });
+    expect(p.cwd).toBe('/tmp');
+    expect(p.env).toEqual({ A: 'b' });
+  });
+
+  it('leaves the container class alone — it already execs as the box user', () => {
+    const p = buildDaytonaExec('echo hi', CONTAINER);
+    expect(p.cmd).toBe('echo hi');
+  });
+
+  it('treats an unknown class as a VM, matching pause()', () => {
+    // The class is absent on records written before it existed and on the
+    // keepalive loop's synthetic handles; the VM side is the one needing the
+    // wrap, so undefined must fall there.
+    expect(buildDaytonaExec('echo hi', {}).cmd).toMatch(/^sudo -n -u vscode -H/);
+  });
+});


### PR DESCRIPTION
A Daytona `linux-vm` box ran **everything as root** — exec, the SSH attach, and therefore tmux and the agent — while every credential and config file is seeded into `/home/vscode`. The box reached "ready" and its Claude sat at the first-run theme picker, then the login picker, because root's `/root/.claude` is empty.

`backend.exec` accepted `CloudExecOptions` and never read `opts.user`, so every `{ user: 'vscode' }` in the shared cloud layer was silently dropped.

## Not a regression

`exec` has never honored `opts.user`; `linux-vm` became the default on 2026-07-12 and `prepare-vm.ts` is unchanged since 2026-07-13. It went unnoticed because bakes kept degrading to the **container** class (the GHCR image for a locally-modified build context isn't published), and a container honors the image's `USER vscode` metadata. A VM rootfs has no metadata — the same reason the bake already hand-repairs `sudo`'s setuid bit and re-injects `ENV`.

## Approach

The SDK offers no lever: `executeCommand(command, cwd, env, timeout)` has no user, `createSshAccess` has no user, and the create-time `user` field is not honored here (a VM reports `user: "daytona"` while actually running as root). So wrap, the way vercel already does.

- **`exec`** defaults to `vscode` and wraps in `sudo -n -u vscode -H bash -lc`, folding `cwd`/`env` *inside* the wrap — the SDK's own arguments apply to the outer root shell and would never reach the dropped user.
- **attach** declares a new `CloudBackend.attachRunAs`, and `buildAttach` wraps the whole inner command — the tmux *server* included, so the session and the in-box ctl client share one identity. A root tmux server owning a `vscode` agent cannot reach the ctl socket (0660, in a user-owned dir), so the two halves must ship together.
- **`{ user: 'root' }` opts out**, which the bake depends on: `sudo` is not setuid until the repair runs and refuses to run at all before then, even for root. Asking sudo to fix sudo would deadlock the bake.
- **`uploadFile` now chowns to the box user**, as e2b's already does. The toolbox writes as root and `/tmp` is sticky, so the seed's `rm` of its own uploaded tarball failed with `Operation not permitted`. Caught by a live bake, not by a unit test.
- **Credential seeding** keyed off "does the backend have volumes" rather than "does this box have one". A `linux-vm` mounts none (verified: `/home/vscode/.agentbox-creds` is plain ext4, same device as `/`), so VM boxes took the volume branch — extract as root with no `--no-same-owner`, then `cp -r` — landing `root:root 0600` credentials. One `cloudVolumesUsable` now answers it for both the provision-time reservation and the seed, so they cannot drift apart again.
- `claude-json-overlay` / `dynamic-sync` extracted host tarballs without `--no-same-owner`, restoring the **host's** uid (501) into `/home/vscode`.

The **container class is untouched** throughout.

## Upgrade note

Needs `agentbox prepare --provider daytona --force` — ownership is baked into the snapshot. Existing `linux-vm` boxes should be destroyed and recreated.

## Testing

New `packages/sandbox-daytona/test/exec-user.test.ts` (8 cases) plus coverage for the linux-vm credential branch and the attach wrap. `pnpm typecheck`, `pnpm lint` and the full suite are green.

Verified end-to-end on a **fresh** box (the earlier diagnostic box had been hand-chowned, so it was destroyed first):

- `id -un` → `vscode`, `HOME=/home/vscode`
- `claude`, `agentbox-ctl`, `tmux` all running as `vscode`
- `/home/vscode`, `.claude`, `.credentials.json` all `vscode:vscode` — no uid 501
- attach shows **"Welcome back Marco!"** — no theme picker, no login picker — and completes a real turn

Docker and hetzner boxes re-checked unaffected (they share the changed shared-layer code).

`docs/cloud-providers.md` documents the behavior; `docs/test-plan.md` CREATE-002 now asserts the box user — its signal was only `pwd` → `/workspace`, which is why this shipped unnoticed.

https://claude.ai/code/session_01WPLZGvivtiV6XWboTo8ziv

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared cloud attach/credential seeding and Daytona exec for all VM boxes; container class is explicitly exempt but misclassification of sandbox class could break bake or attach.
> 
> **Overview**
> **Daytona `linux-vm` boxes no longer run AgentBox work as root.** The VM rootfs drops image `USER` metadata, so exec and SSH attach landed as root with `HOME=/root` while credentials and config live under `/home/vscode` — boxes looked healthy but agents stalled at login prompts.
> 
> **Exec** now defaults to the box user via `buildDaytonaExec`: `linux-vm` commands wrap in `sudo -n -u vscode -H bash -lc …`, with `cwd`/`env` folded inside the wrap. Explicit `{ user: 'root' }` skips wrapping so VM bake steps can repair `sudo` before setuid works. **Container** class behavior is unchanged.
> 
> **Interactive attach** adds optional `CloudBackend.attachRunAs` (Daytona returns `vscode` for VMs only); `wrapAttachAsUser` wraps the full inner command including the tmux server so ctl sockets stay same-user. **Uploads** on VMs `chown` to `vscode` so sticky `/tmp` does not block seed cleanup.
> 
> **Credential and sync paths** treat `linux-vm` as volume-less via shared `cloudVolumesUsable`, fixing VM boxes that wrongly took the volume branch and root-owned extracts. Tar extracts for Claude overlay and dynamic sync add `--no-same-owner` / `--no-same-permissions` when root would restore host uids.
> 
> Docs and **CREATE-002** now assert `id -un` → `vscode`. Existing VM boxes need recreate; bases may need `prepare --provider daytona --force`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d06c7d4988f2de94cb96deee1fd0d6a4bfbe650. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->