### PR TITLE
feat(sdk): export the per-agent variant helpers

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -369,27 +369,17 @@ posting the fresh blob to the relay is what keeps the fleet logged in, so a box
 whose ctl doesn't watch a credential silently degrades the whole fleet's login
 for that agent, not just its own.
 
-### 3. Community provider plugins cannot support per-agent variants
+### 3. Community provider plugins cannot support per-agent variants — **done**
 
-`@madarco/agentbox-provider-sdk` re-exports `claudeInstallFingerprint` but none
-of the helpers the per-agent tier is built on:
+Fixed: the SDK now re-exports `variantFingerprint`, `normalizeAgentSet`,
+`agentSetArg`, `resolveAgentSpec`, `resolveAgentInstall`, `renderInstallRecipe`
+and `renderPackageInstall`, and `docs/provider-plugins.md` documents the opt-in
+with a worked example. Purely additive — `agents` was already optional on
+`PrepareOptions` and `CloudProvisionRequest`, so a plugin that ignores it still
+degrades gracefully and `SDK_API_VERSION` stays at 2.
 
-```
-variantFingerprint · normalizeAgentSet · agentSetArg
-resolveAgentSpec · resolveAgentInstall · renderInstallRecipe · renderPackageInstall
-```
-
-Nothing is *broken*: `agents` is optional on both `PrepareOptions` and
-`CloudProvisionRequest`, so an existing plugin compiles and runs unchanged — it
-just always boots its base and lets `ensureAgentInstalled` add the agent at
-create, which is the intended graceful degradation. `SDK_API_VERSION` stays at
-2 for the same reason.
-
-But a plugin that *wants* the tier can't compute a variant key, render an
-agent's install recipe, or fingerprint a variant. Exporting those is additive
-(no version bump) — it does need a rebuild + republish, since the SDK inlines
-the `@agentbox/*` packages. See
-[`provider-plugins.md`](./provider-plugins.md) → "Publishing the SDK".
+The published surface is pinned by `pack:test`, which installs a real packed
+tarball in isolation and fails naming any missing export.
 
 ### 4. The per-agent command tail
 

--- a/docs/provider-plugins.md
+++ b/docs/provider-plugins.md
@@ -275,6 +275,77 @@ the helpers each needs, so it's all buildable on `@madarco/agentbox-provider-sdk
   `currentCloudBaseFingerprint`. If your snapshots are name-addressed, just
   implement `backend.createSnapshot`/`deleteSnapshot` and skip the override.
 
+## Per-agent variants (optional)
+
+A box is created **for an agent set** (`agentbox claude --provider yours`), and
+the built-in providers bake one artifact per set on top of an agentless base:
+`agentbox prepare --provider yours --agents claude` boots the base, runs just
+that agent's install recipe, and re-snapshots. A matching box then starts with
+the agent already present instead of installing it at create.
+
+**This is opt-in and costs nothing to skip.** `agents` is optional on both
+`PrepareOptions` and `CloudProvisionRequest`, so a provider that ignores it keeps
+working exactly as before — it always boots its base, and `ensureAgentInstalled`
+puts the agent in at create. That is why supporting variants needs **no
+`SDK_API_VERSION` bump**.
+
+To opt in:
+
+```ts
+import {
+  agentSetArg, normalizeAgentSet, variantFingerprint,
+  resolveAgentSpec, resolveAgentInstall, renderInstallRecipe, renderPackageInstall,
+} from '@madarco/agentbox-provider-sdk';
+
+// 1. Identity for this bake. '' is the agentless base; the set is normalised,
+//    so ['codex','claude'] and ['claude','codex'] are the SAME artifact.
+const agents = normalizeAgentSet(opts.agents);
+const variantKey = agentSetArg(agents);
+
+// 2. Fingerprint. Use this instead of `claudeInstallFingerprint` — it folds the
+//    agent set in, and is the IDENTITY for the empty set, so an existing base
+//    record keeps its hash and does not spuriously re-bake.
+const contextSha = variantFingerprint(baseSha, { claudeInstall, agents });
+
+// 3. Render the install into your bake. Same data the built-ins and the runtime
+//    installer use, so a baked agent and a runtime-added one are identical.
+for (const id of agents) {
+  const spec = resolveAgentSpec(id);
+  const install = resolveAgentInstall(spec.install, claudeInstall);
+  const steps: string[] = [];
+  if (install.packages?.length) {
+    const line = renderPackageInstall(install.packages);
+    // An OPTIONAL prerequisite must not fail the bake.
+    steps.push(install.packagesOptional ? `{ ${line} } || true` : line);
+  }
+  // `runAs: 'box-user'` is load-bearing: native installers write to the INVOKING
+  // user's ~/.local/bin, so running them as root hides the binary in /root.
+  const recipe = renderInstallRecipe(install.recipe);
+  steps.push(install.runAs === 'box-user' ? `sudo -u vscode -H bash -lc '${recipe}'` : recipe);
+  if (install.postInstall) steps.push(install.postInstall);
+  // Verify on the BOX USER's PATH, not just that the build exited 0.
+  steps.push(`sudo -u vscode -H bash -lc 'command -v ${spec.binary} >/dev/null'`);
+}
+```
+
+`renderPackageInstall` dispatches on the package manager the box actually has
+(`apt-get` | `dnf` | `microdnf`) instead of assuming Debian — Vercel's sandboxes
+are Amazon Linux, where a hardcoded `apt-get` exits 127.
+
+Three rules the built-in providers each learned the hard way:
+
+- **Always fall back to the base.** After a base-only `prepare` — the documented
+  first-run flow — no variant exists yet. Resolving must return the base, not
+  throw, or *every* create fails for a new user.
+- **Never pin a variant** into `box.image<Provider>` or a shared custody record.
+  Those are single-slot: a variant written there makes every box on your provider
+  boot one agent's artifact.
+- **Keep your `base` record meaning the agentless base.** Provider-generic readers
+  (freshness, bake sharing) read `base.contextSha256` and assume exactly that;
+  pointing it at the newest bake reports a permanent false "stale".
+
+---
+
 ## Credentials & config
 
 - Persist your API token however you like; the convention is a 0600

--- a/packages/provider-sdk/package.json
+++ b/packages/provider-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madarco/agentbox-provider-sdk",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "Public SDK for building AgentBox sandbox providers as installable community packages",
   "license": "MIT",
   "author": "Marco D'Alia",

--- a/packages/provider-sdk/scripts/pack-test.mjs
+++ b/packages/provider-sdk/scripts/pack-test.mjs
@@ -37,6 +37,16 @@ const REQUIRED_EXPORTS = [
   'readPreparedStateRaw',
   'writePreparedStateRaw',
   'claudeInstallFingerprint',
+  // per-agent variants — a provider that bakes one artifact per agent set needs
+  // all of these; without them a plugin can compute neither the variant key nor
+  // an agent's install recipe.
+  'variantFingerprint',
+  'normalizeAgentSet',
+  'agentSetArg',
+  'resolveAgentSpec',
+  'resolveAgentInstall',
+  'renderInstallRecipe',
+  'renderPackageInstall',
   // box-state helpers
   'recordBox',
   'readState',

--- a/packages/provider-sdk/src/index.ts
+++ b/packages/provider-sdk/src/index.ts
@@ -122,6 +122,43 @@ export {
   type CliStamp,
 } from '@agentbox/sandbox-core';
 
+// ---- per-agent variants (the "one agent per box" tier) ----
+// A box is created FOR an agent set, and a provider may bake one artifact per
+// set on top of its agentless base — `prepare --agents claude` — so an
+// `agentbox claude` box boots with the agent already in place instead of
+// installing it at create.
+//
+// OPTIONAL: `agents` is optional on both `PrepareOptions` and
+// `CloudProvisionRequest`, so a provider that ignores it keeps working — it
+// always boots its base and `ensureAgentInstalled` adds the agent at create.
+// That is the intended graceful degradation, which is why supporting variants
+// needs no `SDK_API_VERSION` bump.
+//
+// To OPT IN you need all of these:
+//   - `normalizeAgentSet` + `agentSetArg` to build the variant key (`''` is the
+//     agentless base). Order-insensitive, so ['codex','claude'] and
+//     ['claude','codex'] resolve to the same artifact.
+//   - `variantFingerprint` instead of `claudeInstallFingerprint` — it folds the
+//     agent set into the hash, and is the IDENTITY for the empty set, so
+//     existing base records stay valid.
+//   - `resolveAgentSpec` + `resolveAgentInstall` + `renderInstallRecipe` +
+//     `renderPackageInstall` to render an agent's install into your bake. These
+//     are the same data the built-in providers and the runtime installer use,
+//     so a baked agent and a runtime-added one end up identical.
+//
+// `renderPackageInstall` dispatches on the package manager the box actually has
+// (apt-get | dnf | microdnf) rather than assuming Debian — Vercel's sandboxes
+// are Amazon Linux, where `apt-get` exits 127.
+export {
+  variantFingerprint,
+  normalizeAgentSet,
+  agentSetArg,
+  resolveAgentSpec,
+  resolveAgentInstall,
+  renderInstallRecipe,
+  renderPackageInstall,
+} from '@agentbox/sandbox-core';
+
 // ---- config access ----
 export { loadEffectiveConfig, findProjectRoot, type EffectiveConfig } from '@agentbox/config';
 


### PR DESCRIPTION
Phase 1 of the agent data plane (backlog item 3 from #336). Small and self-contained so the SDK can be published independently of the rest.

## The gap

A community provider plugin could not support the per-agent tier at all. The SDK re-exports `claudeInstallFingerprint` but none of the helpers that superseded it:

`variantFingerprint` · `normalizeAgentSet` · `agentSetArg` · `resolveAgentSpec` · `resolveAgentInstall` · `renderInstallRecipe` · `renderPackageInstall`

So a plugin could compute neither a variant key nor an agent's install recipe — structurally locked out of the tier every built-in provider gained in #329–#332.

## Why this needs no version bump

`agents` is **optional** on both `PrepareOptions` and `CloudProvisionRequest`. A plugin that ignores it keeps working: it always boots its base and `ensureAgentInstalled` adds the agent at create — the intended graceful degradation. So this is purely additive and **`SDK_API_VERSION` stays 2**.

## Verification

The seven names are added to `pack:test`'s `REQUIRED_EXPORTS`, which is the meaningful check — it `npm pack`s the package, installs the tarball into a throwaway dir with plain npm, and imports it from there, so it catches a `.d.ts` or runtime export that didn't actually ship (a workspace link can't). Now reports **32 exports present**, and I confirmed it fails naming the symbol when one is removed.

I also exercised the full plugin call chain through the built surface: variant key is order-insensitive (`['codex','claude']` → `claude,codex`), the empty set is the identity fold (so existing base records keep their hash), and codex's prerequisite renders both `apt-get` and `dnf` branches.

## Docs

`provider-plugins.md` gains a worked opt-in example plus the three rules the built-in providers each learned the hard way — always fall back to the base (the base-only prepare is the documented first-run flow), never pin a variant into a single-slot key, and keep the `base` record meaning the agentless base.

Backlog item 3 in `agents.md` is ticked off.

**Not automated:** the npm publish. Version bumped 2.9.0 → 2.10.0; publishing is still the manual `cd packages/provider-sdk && npm publish` step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK re-exports and documentation; no runtime or auth changes in AgentBox itself.
> 
> **Overview**
> Community provider plugins can now opt into **per-agent bake variants** the same way built-in providers do. **`@madarco/agentbox-provider-sdk`** re-exports seven helpers from `@agentbox/sandbox-core` — `variantFingerprint`, `normalizeAgentSet`, `agentSetArg`, `resolveAgentSpec`, `resolveAgentInstall`, `renderInstallRecipe`, and `renderPackageInstall` — so plugins can compute variant keys and render install recipes during `prepare --agents`.
> 
> The change is **additive only**: optional `agents` on prepare/create is unchanged, **`SDK_API_VERSION` stays 2**, and the package version goes **2.9.0 → 2.10.0**. **`pack:test`** now requires all seven names on the packed tarball so a missing export fails publish smoke tests.
> 
> **Docs:** `provider-plugins.md` adds an opt-in section with a TypeScript example and three operational rules (base fallback, don’t pin variants in single-slot keys, keep `base` agentless). **`agents.md`** marks backlog item 3 as done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4b269945c274a14723b30bc5950794445193ca8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->