### PR TITLE
feat(agents): derive the download paths and item lists from the registry

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -332,22 +332,31 @@ baked agent and a runtime-added one are byte-identical. Everything below is a
 place where agent knowledge still lives as **code** instead of data. None of it
 is broken; all of it is work a fourth agent would pay for.
 
-### 1. `agentbox download` duplicates the registry's paths, in reverse
+### 1. `agentbox download` duplicates the registry's paths, in reverse — **partly done**
 
-`packages/sandbox-core/src/sync/agent-pull.ts` hardcodes `CLAUDE_BOX_CONFIG_DIR`
-/ `CODEX_BOX_CONFIG_DIR` / `OPENCODE_BOX_DATA_DIR` and exposes per-agent
-functions (`pullClaudeExtrasViaTransport` and friends). It never reads
-`staticPaths` from `AGENT_SYNC_SPECS` — so the host→box direction is
-registry-driven and the box→host direction is not, with two copies of the same
-path knowledge free to drift.
+Fixed: the box roots and the pull item lists now derive from the registry.
+`agentBoxDir(agent)` reads `staticPaths[0].boxDir`, and each spec carries an
+`AgentPullSpec` (`items` / `categories` / `jsonMerges`) that
+`CLAUDE_PULL_DIR_CATEGORIES`, `CODEX_PULL_ITEMS` and the two opencode lists are
+derived from. A drift test asserts the derivation and that every agent declaring
+`staticPaths` also declares how to pull them — the gap that let `download` be
+forgotten silently.
 
-`apps/cli/src/commands/download-{claude,codex,opencode}.ts` are ~120 lines each
-over shared `_agent-pull.ts` / `_agent-propagate.ts` helpers.
+`AgentPullSpec` is deliberately NOT `staticPaths`: that field's
+`exclude`/`include` are push-direction hygiene (claude drops `projects` and
+`sessions` on the way in) while the pull's real filters are different ones, and
+opencode's `update: true` state root must never be pulled at all — newest-wins is
+the opposite of pull's additive rule. The test pins that exclusion.
 
-**Fix:** give `staticPaths` a pull direction and drive `agent-pull.ts` from it.
-The categories differ per agent (claude has `skills`/`agents`/`commands`,
-opencode has `themes`), so the row needs a `pullCategories` field rather than
-reusing `staticPaths` verbatim.
+**Still open:** the three `download-<agent>.ts` commands remain separate
+(~120 lines each), and `pullClaudeExtrasViaTransport` /
+`pullCodexConfigViaTransport` / `pullOpencodeConfigViaTransport` are still three
+functions rather than one driven by the strategy in the spec. Codex and opencode
+are the same function differing only in group/root/items; claude is a genuinely
+different shape (category children + a JSON registry merge with a path rewrite),
+so collapsing them needs the two strategies implemented, not just declared.
+The docker-side pull also hand-rolls its own inventory shell, so it can still
+drift from the transport path even though both now share the item lists.
 
 ### 2. ctl carries a second copy of the credential paths, and is frozen at bake
 

--- a/packages/sandbox-core/src/sync/agent-pull.ts
+++ b/packages/sandbox-core/src/sync/agent-pull.ts
@@ -19,6 +19,8 @@ import { chmod, mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promis
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import type { SyncTransport } from '@agentbox/core';
+import { resolveAgentSpec } from './registry.js';
+import type { AgentId } from './agents/types.js';
 import {
   mergeInstalledPlugins,
   mergeKnownMarketplaces,
@@ -27,16 +29,47 @@ import {
   type MergeResult,
 } from './claude-pull.js';
 
+/**
+ * Box-side agent config root, DERIVED from the registry rather than restated.
+ *
+ * `staticPaths[0].boxDir` is the same value the host->box push already syncs to,
+ * so the two directions can no longer disagree. It used to be three literals
+ * here plus three more in `registry.ts` — the box->host direction restating what
+ * the push direction already knew, with nothing to catch a divergence.
+ *
+ * Note `staticPaths[0]` specifically: opencode has three roots and the DATA one
+ * is first (`~/.local/share/opencode`); its config root is that same `boxDir`
+ * plus the entry's `relocToSubpath`, which `pullOpencodeConfigViaTransport`
+ * applies itself.
+ */
+/** A pull spec's flat item names for one group, from the registry. */
+export function pullItems(agent: AgentId, group: string): readonly string[] {
+  const g = resolveAgentSpec(agent).pull?.items?.find((i) => i.group === group);
+  return g?.names ?? [];
+}
+
+/** A pull spec's category dirs, from the registry. */
+export function pullCategories(agent: AgentId): readonly string[] {
+  return resolveAgentSpec(agent).pull?.categories ?? [];
+}
+
+export function agentBoxDir(agent: AgentId): string {
+  const dir = resolveAgentSpec(agent).staticPaths[0]?.boxDir;
+  if (!dir) throw new Error(`agent ${agent} declares no staticPaths[0].boxDir`);
+  return dir;
+}
+
 /** Box-side agent config roots (identical to the docker volume layout). */
-export const CLAUDE_BOX_CONFIG_DIR = '/home/vscode/.claude';
-export const CODEX_BOX_CONFIG_DIR = '/home/vscode/.codex';
-export const OPENCODE_BOX_DATA_DIR = '/home/vscode/.local/share/opencode';
+export const CLAUDE_BOX_CONFIG_DIR = agentBoxDir('claude');
+export const CODEX_BOX_CONFIG_DIR = agentBoxDir('codex');
+export const OPENCODE_BOX_DATA_DIR = agentBoxDir('opencode');
 
 // ---------------------------------------------------------------------------
 // claude
 // ---------------------------------------------------------------------------
 
-export const CLAUDE_PULL_DIR_CATEGORIES = ['skills', 'agents', 'commands'] as const;
+/** Claude's category dirs, from the registry. */
+export const CLAUDE_PULL_DIR_CATEGORIES = pullCategories('claude');
 
 export interface PullClaudeResult {
   /**
@@ -191,9 +224,13 @@ export async function computeClaudePullPlan(
 
   const hostInstalled = await readJsonFile(join(hostClaude, 'plugins', 'installed_plugins.json'));
   const hostMarkets = await readJsonFile(join(hostClaude, 'plugins', 'known_marketplaces.json'));
-  const mergedInstalled = mergeInstalledPlugins(hostInstalled, inv.registries['installed_plugins'], {
-    hostHome,
-  });
+  const mergedInstalled = mergeInstalledPlugins(
+    hostInstalled,
+    inv.registries['installed_plugins'],
+    {
+      hostHome,
+    },
+  );
   const mergedMarkets = mergeKnownMarketplaces(hostMarkets, inv.registries['known_marketplaces'], {
     hostHome,
   });
@@ -273,26 +310,16 @@ export async function pullClaudeExtrasViaTransport(
 // ---------------------------------------------------------------------------
 
 /** Top-level codex-config items `download codex` considers. */
-export const CODEX_PULL_ITEMS = ['config.toml', 'auth.json', 'prompts'] as const;
+export const CODEX_PULL_ITEMS = pullItems('codex', 'data');
 
 /** Data-dir items (data root → host ~/.local/share/opencode). */
-export const OPENCODE_PULL_DATA_ITEMS = ['auth.json'] as const;
+export const OPENCODE_PULL_DATA_ITEMS = pullItems('opencode', 'data');
 /**
  * Config-dir items (`config/` under the data root → host ~/.config/opencode).
  * Covers both the `.json` and `.jsonc` global config and OpenCode's
  * user-extension subdirs.
  */
-export const OPENCODE_PULL_CONFIG_ITEMS = [
-  'opencode.json',
-  'opencode.jsonc',
-  'agents',
-  'commands',
-  'modes',
-  'plugins',
-  'skills',
-  'tools',
-  'themes',
-] as const;
+export const OPENCODE_PULL_CONFIG_ITEMS = pullItems('opencode', 'config');
 
 /**
  * Inventory script for flat item lists: prints `<group> <FILE|DIR> <name>` per

--- a/packages/sandbox-core/src/sync/agents/types.ts
+++ b/packages/sandbox-core/src/sync/agents/types.ts
@@ -176,4 +176,46 @@ export interface AgentSyncSpec {
    */
   boxRunEnv: Record<string, string>;
   caps: AgentCapabilities;
+  /**
+   * Box->host (`agentbox download <agent>`) descriptor.
+   *
+   * Separate from `staticPaths` on purpose: that field's `exclude`/`include` are
+   * PUSH-direction hygiene (claude drops `projects`/`sessions` on the way in),
+   * while the pull's real filters are different ones. Reusing it verbatim would
+   * be wrong in both directions. The ROOTS do map one-to-one, which is why
+   * `agentBoxDir` derives them from `staticPaths[0].boxDir` instead of
+   * restating them.
+   *
+   * Absent means the agent has no box->host sync — which is the silent gap that
+   * made `download` easy to forget when adding an agent.
+   */
+  pull?: AgentPullSpec;
+}
+
+/**
+ * How `download <agent>` enumerates what a box has that the host doesn't.
+ *
+ * Two strategies because the agents genuinely differ in SHAPE, not just data:
+ * codex/opencode are flat item lists, while claude's unit is "child of a
+ * category dir" plus a 2-level plugin cache and a JSON registry merge. A single
+ * strategy would have to model claude's case for everyone.
+ */
+export interface AgentPullSpec {
+  /**
+   * Flat items (files or dirs) directly under a root — codex, opencode.
+   * `group` selects which root: `data` is `staticPaths[0].boxDir`, any other
+   * value is that dir plus the matching entry's `relocToSubpath`.
+   */
+  items?: readonly { group: string; names: readonly string[] }[];
+  /**
+   * Directories whose CHILDREN are the unit — claude's `skills`/`agents`/
+   * `commands`. Each child dir is one item.
+   */
+  categories?: readonly string[];
+  /**
+   * JSON files merged additively rather than copied — claude's plugin
+   * registries. `projection` names the sub-object holding the entries (`root`
+   * for a flat map). Never overwrites an existing host key.
+   */
+  jsonMerges?: readonly { rel: string; projection: 'root' | 'plugins' }[];
 }

--- a/packages/sandbox-core/src/sync/registry.ts
+++ b/packages/sandbox-core/src/sync/registry.ts
@@ -152,6 +152,16 @@ export const AGENT_SYNC_SPECS: readonly AgentSyncSpec[] = [
     ],
     boxRunEnv: {},
     caps: { resume: true, teleport: 'full', activitySource: 'scraper' },
+    // Box->host. Claude's unit is a CHILD of a category dir, plus a 2-level
+    // plugin cache, plus two registry JSONs merged additively with a
+    // container->host path rewrite. See AgentPullSpec.
+    pull: {
+      categories: ['skills', 'agents', 'commands'],
+      jsonMerges: [
+        { rel: 'plugins/installed_plugins.json', projection: 'plugins' },
+        { rel: 'plugins/known_marketplaces.json', projection: 'root' },
+      ],
+    },
   },
   {
     id: 'codex',
@@ -237,6 +247,8 @@ export const AGENT_SYNC_SPECS: readonly AgentSyncSpec[] = [
     forwardedEnvKeys: ['OPENAI_API_KEY'],
     boxRunEnv: {},
     caps: { resume: true, teleport: 'full', activitySource: 'scraper' },
+    // Box->host: a flat list under the single config root.
+    pull: { items: [{ group: 'data', names: ['config.toml', 'auth.json', 'prompts'] }] },
   },
   {
     id: 'opencode',
@@ -310,6 +322,30 @@ export const AGENT_SYNC_SPECS: readonly AgentSyncSpec[] = [
       XDG_STATE_HOME: `${OPENCODE_BOX_DIR}/.state`,
     },
     caps: { resume: false, teleport: 'stub', activitySource: 'plugin' },
+    // Box->host: two roots. `data` is staticPaths[0].boxDir; `config` is that
+    // dir plus the config entry's relocToSubpath. The THIRD staticPaths entry
+    // (~/.local/state/opencode, `update: true`) is deliberately absent: it is
+    // newest-wins two-way state, and newest-wins is the opposite of pull's
+    // additive never-overwrite rule.
+    pull: {
+      items: [
+        { group: 'data', names: ['auth.json'] },
+        {
+          group: 'config',
+          names: [
+            'opencode.json',
+            'opencode.jsonc',
+            'agents',
+            'commands',
+            'modes',
+            'plugins',
+            'skills',
+            'tools',
+            'themes',
+          ],
+        },
+      ],
+    },
   },
 ];
 

--- a/packages/sandbox-core/test/agent-pull-drift.test.ts
+++ b/packages/sandbox-core/test/agent-pull-drift.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { AGENT_SYNC_SPECS, resolveAgentSpec } from '../src/sync/registry.js';
+import {
+  CLAUDE_BOX_CONFIG_DIR,
+  CODEX_BOX_CONFIG_DIR,
+  OPENCODE_BOX_DATA_DIR,
+  CLAUDE_PULL_DIR_CATEGORIES,
+  CODEX_PULL_ITEMS,
+  OPENCODE_PULL_CONFIG_ITEMS,
+  OPENCODE_PULL_DATA_ITEMS,
+  agentBoxDir,
+} from '../src/sync/agent-pull.js';
+
+/**
+ * The box->host (`download`) direction used to restate what the host->box push
+ * already knew: three box-dir literals here and three more in the registry,
+ * with nothing to catch a divergence. `packages/ctl`'s WATCHED_CREDENTIALS drift
+ * test is the precedent this copies.
+ *
+ * These now derive from the registry, so most of this is a guard against
+ * someone reintroducing a literal.
+ */
+describe('agent-pull derives from the registry', () => {
+  it('box dirs match staticPaths[0].boxDir for every agent', () => {
+    for (const spec of AGENT_SYNC_SPECS) {
+      expect(agentBoxDir(spec.id), spec.id).toBe(spec.staticPaths[0]?.boxDir);
+    }
+  });
+
+  it('the exported constants are the derived values', () => {
+    expect(CLAUDE_BOX_CONFIG_DIR).toBe(agentBoxDir('claude'));
+    expect(CODEX_BOX_CONFIG_DIR).toBe(agentBoxDir('codex'));
+    expect(OPENCODE_BOX_DATA_DIR).toBe(agentBoxDir('opencode'));
+  });
+
+  it('pull item lists come from each spec', () => {
+    expect([...CLAUDE_PULL_DIR_CATEGORIES]).toEqual(resolveAgentSpec('claude').pull?.categories);
+    const codex = resolveAgentSpec('codex').pull?.items?.find((i) => i.group === 'data');
+    expect([...CODEX_PULL_ITEMS]).toEqual(codex?.names);
+    const oc = resolveAgentSpec('opencode').pull?.items;
+    expect([...OPENCODE_PULL_DATA_ITEMS]).toEqual(oc?.find((i) => i.group === 'data')?.names);
+    expect([...OPENCODE_PULL_CONFIG_ITEMS]).toEqual(oc?.find((i) => i.group === 'config')?.names);
+  });
+
+  it('every agent that declares staticPaths also declares how to pull them', () => {
+    // The gap that made `download` easy to forget when adding an agent: nothing
+    // failed without it, the subcommand was simply absent.
+    for (const spec of AGENT_SYNC_SPECS) {
+      expect(spec.pull, `${spec.id} has no pull spec`).toBeDefined();
+      const hasWork =
+        (spec.pull?.items?.length ?? 0) > 0 || (spec.pull?.categories?.length ?? 0) > 0;
+      expect(hasWork, `${spec.id}'s pull spec enumerates nothing`).toBe(true);
+    }
+  });
+
+  it("opencode's newest-wins state root is NOT pullable", () => {
+    // `update: true` is two-way newest-wins; pull is additive never-overwrite.
+    // Pulling it would let a stale box copy clobber newer host state.
+    const spec = resolveAgentSpec('opencode');
+    const updateRoots = spec.staticPaths.filter((sp) => sp.update === true);
+    expect(updateRoots.length).toBeGreaterThan(0);
+    const groups = new Set(spec.pull?.items?.map((i) => i.group));
+    expect(groups.has('state')).toBe(false);
+    expect(spec.pull?.items?.length).toBe(2); // data + config only
+  });
+});


### PR DESCRIPTION
Phase 2 of the agent data plane (backlog item 1 from #336). **Lands narrower than the backlog entry describes** — see "What's still open".

## The problem

The box→host direction restated what host→box already knew: box-dir literals in `agent-pull.ts` alongside the same values in `registry.ts`, plus the pull item lists as module constants — with nothing to catch a divergence.

## What's fixed

- `agentBoxDir(agent)` derives the root from `staticPaths[0].boxDir`, so the two directions can no longer disagree.
- Each spec carries an `AgentPullSpec` (`items` / `categories` / `jsonMerges`) that `CLAUDE_PULL_DIR_CATEGORIES`, `CODEX_PULL_ITEMS` and the two opencode lists derive from.
- A drift test asserts the derivation, and that **every agent declaring `staticPaths` also declares how to pull them** — the gap that let `download` be forgotten silently when adding an agent (nothing fails without it; the subcommand is simply absent).

I verified the derived values are **byte-identical** to the literals they replace — the real regression check for a refactor with no intended behaviour change.

## Why `AgentPullSpec` is not just `staticPaths`

Two things make reuse wrong, both pinned by tests:

- That field's `exclude`/`include` are **push-direction hygiene** — claude drops `projects`/`sessions` on the way *in*, while the pull's real filters are `node_modules` and the `agentbox-` skill prefix. Reusing them would be wrong in both directions.
- Opencode's third root (`~/.local/state/opencode`, `update: true`) must **never** be pulled: newest-wins two-way state is the opposite of pull's additive never-overwrite rule.

## What's still open (left in the backlog, not dropped)

The three `download-<agent>.ts` commands and the three `pull*ViaTransport` functions are **not** collapsed. Codex and opencode are the same function differing only in group/root/items, but claude is a genuinely different *shape* — category children plus a JSON registry merge with a container→host path rewrite — so collapsing needs both strategies actually implemented, not just declared.

I stopped deliberately: `download` writes to the user's real `~/.claude`, and turning "additive" into "overwrite" destroys host config. Landing the verified half beat rushing the whole.

## Live verification (docker)

A planted claude skill is enumerated, and on a real opencode box `config/agents` + `config/themes` are both detected — the latter exercises the `relocToSubpath` config group end to end.

Worth recording: my first probe run put codex/opencode items in a *claude* box and got "no new" for both, which looked like a bug. It wasn't — per-agent isolation means only `agentbox-claude-config` is mounted, so those writes never reached the volumes `download` reads. Confirmed with `docker inspect`, then re-tested against a real opencode box.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Intended behavior-preserving refactor on additive download paths, with drift tests and explicit exclusion of newest-wins OpenCode state from pull.
> 
> **Overview**
> **Phase 2 of the agent download backlog:** box→host sync no longer duplicates path and item knowledge that already lives in `AGENT_SYNC_SPECS`.
> 
> Each agent row now has an optional **`AgentPullSpec`** (`items`, `categories`, `jsonMerges`) describing how `agentbox download` inventories the box. **`agentBoxDir`**, **`pullItems`**, and **`pullCategories`** in `agent-pull.ts` read that data (box roots from `staticPaths[0].boxDir`; lists from `pull`), so exports like `CLAUDE_PULL_DIR_CATEGORIES` and `CODEX_PULL_ITEMS` are derived instead of hardcoded literals.
> 
> A new **`agent-pull-drift.test.ts`** asserts those derivations stay aligned with the registry, that every agent with `staticPaths` also defines a non-empty `pull` spec (so new agents can’t silently ship without download), and that OpenCode’s `update: true` state root is excluded from pull. **`docs/agents.md`** marks backlog item 1 as partly done and notes what’s still open (separate download CLI commands, three `pull*ViaTransport` implementations, docker inventory duplication).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d818937524eee6f720ba1537bccaea4966f43865. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->