### PR TITLE
feat(agents): ctl pulls its watch list from the host over RPC

### DIFF
--- a/packages/ctl/src/agent-registry.ts
+++ b/packages/ctl/src/agent-registry.ts
@@ -1,0 +1,102 @@
+import { postRpcAwait } from './relay-rpc.js';
+import { WATCHED_CREDENTIALS, type WatchedCredential } from './credentials-watcher.js';
+
+/**
+ * The agent watch list, pulled from the host over `agents.list`.
+ *
+ * Why this exists: `agentbox-ctl` is BAKED INTO THE BOX IMAGE, so its compiled-in
+ * list is frozen at bake time. A box built from a snapshot taken before an agent
+ * existed never watches that agent's files. A plugin-supplied agent is
+ * `ondemand`-only and can never be baked at all, so without this it would be
+ * permanently invisible to ctl.
+ *
+ * Pulled rather than pushed as a file: a file has to be written by the PROVIDER
+ * (cloud bootstrap, docker box-env, and a hand-written equivalent in every
+ * community provider), which makes its shape a contract each of them implements.
+ * Over RPC the shape stays host-side and providers stay uninvolved.
+ *
+ * Reconciled ONCE at daemon start, never polled — on a control box a poll would
+ * be a WAN round trip per box per minute (the reason `ToolLinksWatcher` stopped
+ * polling too). That covers a new box, a restarted box and a resumed box.
+ *
+ * NOT yet covered: a box already running when the host's agent list changes; it
+ * picks the change up on the next ctl restart. `ToolLinksWatcher` solves the
+ * equivalent with `agentbox-ctl tool relink` over `Provider.exec`, but that works
+ * because tool links are on-disk state a separate process can rewrite — this list
+ * lives in the daemon's memory, so the same push needs a ctl socket op. Left for
+ * a follow-up; the startup reconcile is what turns adding an agent from
+ * "re-bake every base" into "restart ctl".
+ *
+ * FAILURE IS SILENT AND KEEPS THE BAKED LIST. An unreachable relay, an older
+ * host with no `agents.list`, or a malformed payload must all leave the box
+ * watching what it already watched — never nothing. Losing the credential
+ * watcher would silently break login fan-out for the whole fleet.
+ */
+
+interface WireWatch {
+  path?: unknown;
+  sync?: unknown;
+  shape?: unknown;
+  hostDest?: unknown;
+}
+interface WireAgent {
+  id?: unknown;
+  watch?: unknown;
+}
+
+/**
+ * Narrow the wire payload, dropping anything malformed rather than throwing.
+ *
+ * Unknown fields are IGNORED, not rejected: a newer host must never break an
+ * older box. Same posture as the in-box `agentbox.yaml` parser, which warns on
+ * unknown keys instead of failing.
+ */
+export function parseAgentDescriptors(stdout: string): WatchedCredential[] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== 'object') return null;
+  const agents = (parsed as { agents?: unknown }).agents;
+  if (!Array.isArray(agents)) return null;
+
+  const out: WatchedCredential[] = [];
+  for (const raw of agents as WireAgent[]) {
+    const id = typeof raw?.id === 'string' ? raw.id : null;
+    if (!id) continue;
+    const watches = Array.isArray(raw.watch) ? (raw.watch as WireWatch[]) : [];
+    for (const w of watches) {
+      if (typeof w?.path !== 'string' || w.path.length === 0) continue;
+      const sync = w.sync === 'fanout' ? 'fanout' : 'backup';
+      // Only a `fanout` watch posts a credential blob, and only a known shape is
+      // validatable — anything else is dropped rather than posted unvalidated.
+      if (sync !== 'fanout') continue;
+      if (w.shape !== 'claude-oauth' && w.shape !== 'nonempty-json') continue;
+      out.push({ agent: id as WatchedCredential['agent'], path: w.path, shape: w.shape });
+    }
+  }
+  // An empty list is a malformed answer, not a valid "watch nothing" — refuse it
+  // so the caller keeps the baked list.
+  return out.length > 0 ? out : null;
+}
+
+/**
+ * Fetch the watch list, falling back to the baked one on any failure.
+ * Never throws.
+ */
+export async function fetchWatchList(): Promise<{
+  files: readonly WatchedCredential[];
+  source: 'host' | 'baked';
+}> {
+  try {
+    const res = await postRpcAwait('agents.list', {});
+    if (res.exitCode !== 0) return { files: WATCHED_CREDENTIALS, source: 'baked' };
+    const parsed = parseAgentDescriptors(res.stdout);
+    if (!parsed) return { files: WATCHED_CREDENTIALS, source: 'baked' };
+    return { files: parsed, source: 'host' };
+  } catch {
+    return { files: WATCHED_CREDENTIALS, source: 'baked' };
+  }
+}

--- a/packages/ctl/src/commands/daemon.ts
+++ b/packages/ctl/src/commands/daemon.ts
@@ -6,6 +6,7 @@ import { selectInBoxTransport } from './in-box-transport.js';
 import { startCodexScraper, type CodexScraperHandle } from '../codex-scraper.js';
 import { startClaudeScraper, type ClaudeScraperHandle } from '../claude-scraper.js';
 import { Supervisor } from '../supervisor.js';
+import { fetchWatchList } from '../agent-registry.js';
 import { startServer } from '../socket.js';
 import { StatusReporter } from '../status-reporter.js';
 import { CredentialsWatcher } from '../credentials-watcher.js';
@@ -75,7 +76,17 @@ export const daemonCommand = new Command('daemon')
     // AGENTBOX_CREDENTIAL_SYNC=0 is the wire form of box.credentialSync=false.
     let credentialsWatcher: CredentialsWatcher | null = null;
     if (process.env.AGENTBOX_CREDENTIAL_SYNC !== '0') {
-      credentialsWatcher = new CredentialsWatcher({ relay: sup.relayClient });
+      // Ask the host which files to watch instead of trusting the list compiled
+      // into this binary: ctl is baked into the image, so a box built before an
+      // agent existed would otherwise never watch it — and a plugin agent, which
+      // can never be baked, would be invisible forever. Falls back to the baked
+      // list on any failure, so an unreachable relay or an older host leaves the
+      // box watching exactly what it watches today.
+      const watch = await fetchWatchList();
+      if (watch.source === 'baked') {
+        process.stderr.write('agentbox-ctl: agents.list unavailable; using the baked watch list\n');
+      }
+      credentialsWatcher = new CredentialsWatcher({ relay: sup.relayClient, files: watch.files });
       credentialsWatcher.start();
     }
 

--- a/packages/ctl/test/agent-registry.test.ts
+++ b/packages/ctl/test/agent-registry.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { parseAgentDescriptors } from '../src/agent-registry.js';
+
+/**
+ * ctl is baked into the box image, so its compiled-in watch list is frozen at
+ * bake time. These cover the parse half of pulling it from the host instead —
+ * and above all the cases where the answer must be REFUSED so the caller keeps
+ * the baked list. Watching nothing would silently break credential fan-out for
+ * the whole fleet, which is far worse than watching a slightly stale list.
+ */
+describe('parseAgentDescriptors', () => {
+  const good = JSON.stringify({
+    schema: 1,
+    agents: [
+      {
+        id: 'claude',
+        watch: [
+          { path: '/home/vscode/.claude/.credentials.json', sync: 'fanout', shape: 'claude-oauth' },
+        ],
+      },
+    ],
+  });
+
+  it('parses a well-formed payload', () => {
+    expect(parseAgentDescriptors(good)).toEqual([
+      { agent: 'claude', path: '/home/vscode/.claude/.credentials.json', shape: 'claude-oauth' },
+    ]);
+  });
+
+  it('ignores unknown fields so a NEWER host cannot break an older box', () => {
+    const withExtras = JSON.stringify({
+      schema: 99,
+      somethingFromTheFuture: { nested: true },
+      agents: [
+        {
+          id: 'claude',
+          tomorrowsField: 42,
+          watch: [
+            {
+              path: '/home/vscode/.claude/.credentials.json',
+              sync: 'fanout',
+              shape: 'claude-oauth',
+              futureKnob: 'x',
+            },
+          ],
+        },
+      ],
+    });
+    expect(parseAgentDescriptors(withExtras)).toHaveLength(1);
+  });
+
+  it('refuses malformed JSON, non-objects and a missing agents array', () => {
+    // null means "keep the baked list", never "watch nothing".
+    expect(parseAgentDescriptors('not json')).toBeNull();
+    expect(parseAgentDescriptors('"a string"')).toBeNull();
+    expect(parseAgentDescriptors('null')).toBeNull();
+    expect(parseAgentDescriptors(JSON.stringify({ schema: 1 }))).toBeNull();
+  });
+
+  it('refuses an EMPTY list rather than watching nothing', () => {
+    // A host that answers `{agents: []}` is malformed, not authoritative. Taking
+    // it literally would stop the credential watcher dead and kill login
+    // fan-out across the fleet with no error anywhere.
+    expect(parseAgentDescriptors(JSON.stringify({ schema: 1, agents: [] }))).toBeNull();
+  });
+
+  it('drops a fanout watch with no validatable shape', () => {
+    // Only `fanout` posts a blob to the relay, and only a known shape can be
+    // validated before posting. An unvalidatable one is dropped, not posted.
+    const bad = JSON.stringify({
+      schema: 1,
+      agents: [{ id: 'x', watch: [{ path: '/tmp/a', sync: 'fanout' }] }],
+    });
+    expect(parseAgentDescriptors(bad)).toBeNull();
+  });
+
+  it('does not treat a backup watch as a credential', () => {
+    // `backup` watches route through cp.toHost, not the credential event — they
+    // must never reach the credential watcher's post path.
+    const mixed = JSON.stringify({
+      schema: 1,
+      agents: [
+        {
+          id: 'claude',
+          watch: [
+            {
+              path: '/home/vscode/.claude/.credentials.json',
+              sync: 'fanout',
+              shape: 'claude-oauth',
+            },
+            { path: '/home/vscode/.claude/projects', sync: 'backup', hostDest: 'logs' },
+          ],
+        },
+      ],
+    });
+    const got = parseAgentDescriptors(mixed);
+    expect(got).toHaveLength(1);
+    expect(got?.[0]?.path).toBe('/home/vscode/.claude/.credentials.json');
+  });
+
+  it('skips entries with no id or no path instead of failing the whole payload', () => {
+    const partial = JSON.stringify({
+      schema: 1,
+      agents: [
+        { watch: [{ path: '/tmp/x', sync: 'fanout', shape: 'nonempty-json' }] },
+        { id: 'codex', watch: [{ sync: 'fanout', shape: 'nonempty-json' }] },
+        { id: 'codex', watch: [{ path: '/tmp/ok', sync: 'fanout', shape: 'nonempty-json' }] },
+      ],
+    });
+    expect(parseAgentDescriptors(partial)).toEqual([
+      { agent: 'codex', path: '/tmp/ok', shape: 'nonempty-json' },
+    ]);
+  });
+});

--- a/packages/relay/src/host-actions.ts
+++ b/packages/relay/src/host-actions.ts
@@ -37,6 +37,7 @@ import {
 } from '@agentbox/core';
 import type { CloudBackend, CloudHandle } from '@agentbox/core';
 import {
+  buildAgentDescriptors,
   findBox,
   hostOpenCommand,
   isSupportedApiVersion,
@@ -342,6 +343,18 @@ export async function executeCloudAction(
   const log = deps.log ?? (() => {});
   log(`executing ${action.method} for box ${deps.boxId}`);
 
+  // Cloud twin of the host-relay `agents.list` handler. A cloud box's RPCs are
+  // parked on the HostActionQueue and drained here, so a method handled only in
+  // server.ts works on docker and silently fails on every cloud provider.
+  // Read-only and unprompted, like tool.list — and NOT worktree-scoped, since
+  // the agent registry is machine-global.
+  if (action.method === 'agents.list') {
+    return {
+      exitCode: 0,
+      stdout: JSON.stringify(buildAgentDescriptors()),
+      stderr: '',
+    };
+  }
   if (action.method === 'git.push' || action.method === 'git.fetch') {
     return runGitRpc(action, deps);
   }

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -16,7 +16,11 @@ import { describeCpCacheEntries, lookupCpCache, serveCpFromCache } from './cp-ca
 import { cpOutboxPrefix, listCpOutbox, parkCpOutbox, removeCpOutboxItem } from './cp-outbox.js';
 import { HubNotifier } from './hub-notifier.js';
 import { BoxNotices } from './notices.js';
-import { hostOpenCommand, projectSlugFromOriginUrl } from '@agentbox/sandbox-core';
+import {
+  buildAgentDescriptors,
+  hostOpenCommand,
+  projectSlugFromOriginUrl,
+} from '@agentbox/sandbox-core';
 import {
   isSanctionedPushBranch,
   isScratchBranch,
@@ -939,6 +943,20 @@ export function createRelayServer(opts: RelayServerOptions): RelayServerHandle {
         const queued = await hostActions.enqueue(reg.boxId, body.method, body.params);
         const status = queued.exitCode === 0 ? 200 : 500;
         send(res, status, queued);
+        return;
+      }
+      // Read-only machine-global metadata: the agent registry ctl reconciles
+      // against at daemon start. Dispatched HERE, before worktree resolution,
+      // for two reasons: the registry is not project-scoped (a box with no
+      // registered worktree must still get it), and it must never be gated
+      // behind askPrompt — a prompt would hang every box's startup reconcile.
+      // Same posture as `tool.list`, which is also read-only and unprompted.
+      if (body.method === 'agents.list') {
+        send(res, 200, {
+          exitCode: 0,
+          stdout: JSON.stringify(buildAgentDescriptors()),
+          stderr: '',
+        });
         return;
       }
       if (body.method === 'git.push' || body.method === 'git.fetch') {

--- a/packages/sandbox-core/src/sync/agent-descriptor.ts
+++ b/packages/sandbox-core/src/sync/agent-descriptor.ts
@@ -1,0 +1,90 @@
+/**
+ * The projection of `AGENT_SYNC_SPECS` that ctl consumes over the `agents.list`
+ * RPC.
+ *
+ * A PROJECTION, not the raw table, for two reasons:
+ *
+ *  - `credential.hostBackup` is an absolute HOST path baked at module load
+ *    (`join(STATE_DIR, 'claude-credentials.json')`). Inside a box it is
+ *    meaningless, and shipping it leaks the host's home directory layout.
+ *  - The box only needs what it acts on. Install recipes, docker volume names
+ *    and host static-path sources are host-side concerns; sending them would
+ *    make every one of them part of a wire contract for no reason.
+ *
+ * Deliberately delivered by RPC rather than a file the host writes into the box:
+ * a file has to be written by the PROVIDER (cloud bootstrap, docker box-env, and
+ * a hand-written equivalent in every community provider), which would make this
+ * shape a contract each of them implements — so any future field would mean
+ * updating all of them. Over RPC the shape stays host-side and providers stay
+ * uninvolved.
+ *
+ * Forward compatibility runs one way: ctl must ignore fields it doesn't know, so
+ * a newer host never breaks an older box. Mirrors how the in-box `agentbox.yaml`
+ * parser warns on unknown keys instead of failing.
+ */
+
+import { AGENT_SYNC_SPECS } from './registry.js';
+
+/** One file ctl watches in the box, and what the host should do when it changes. */
+export interface AgentWatchDescriptor {
+  /** Absolute in-box path. */
+  path: string;
+  /**
+   * What the sync is FOR.
+   *
+   *  - `fanout`  — a rotating secret. The host accepts it newest-wins and
+   *    re-distributes it to every other box. Correct ONLY for credentials: an
+   *    OAuth refresh rotates the token, so one box refreshing kills every other
+   *    copy unless the fresh blob is pushed back out.
+   *  - `backup`  — everything else. Lands on the host and stops there. Fanning
+   *    out non-credential content (session transcripts, logs) would copy one
+   *    box's data into every other box.
+   */
+  sync: 'fanout' | 'backup';
+  /** Validator selector for `fanout` payloads; absent for `backup`. */
+  shape?: 'claude-oauth' | 'nonempty-json';
+  /** Host destination for a `backup` watch, relative to the box's host workspace. */
+  hostDest?: string;
+}
+
+/** What ctl needs to know about one agent. */
+export interface AgentDescriptor {
+  id: string;
+  /** Files to watch in-box, with their intent. */
+  watch: readonly AgentWatchDescriptor[];
+}
+
+/** The wire payload of `agents.list`. Versioned host-side; ctl tolerates extras. */
+export interface AgentDescriptorPayload {
+  schema: 1;
+  agents: readonly AgentDescriptor[];
+}
+
+/**
+ * Build the payload from the registry.
+ *
+ * Every agent's credential is a `fanout` watch — that is exactly today's
+ * behaviour, restated as data. Additional watches come from the spec, and
+ * default to `backup`: `fanout` has to be asked for, because getting it wrong
+ * overwrites files in every other box.
+ */
+export function buildAgentDescriptors(): AgentDescriptorPayload {
+  return {
+    schema: 1,
+    agents: AGENT_SYNC_SPECS.map((spec) => ({
+      id: spec.id,
+      watch: [
+        {
+          path: spec.credential.boxAbsPath,
+          sync: 'fanout' as const,
+          shape: spec.credential.realShape,
+        },
+        ...(spec.watch ?? []).map((w) => ({
+          path: w.path,
+          sync: w.sync ?? ('backup' as const),
+          ...(w.hostDest ? { hostDest: w.hostDest } : {}),
+        })),
+      ],
+    })),
+  };
+}

--- a/packages/sandbox-core/src/sync/agents/types.ts
+++ b/packages/sandbox-core/src/sync/agents/types.ts
@@ -190,6 +190,28 @@ export interface AgentSyncSpec {
    * made `download` easy to forget when adding an agent.
    */
   pull?: AgentPullSpec;
+  /**
+   * Extra in-box files ctl should watch, beyond `credential` (which is always
+   * watched). This is the hook a custom agent uses to say "sync these back".
+   *
+   * The credential watch is implicit and always `fanout`; anything declared here
+   * defaults to `backup` — see `AgentWatchSpec.sync`.
+   */
+  watch?: readonly AgentWatchSpec[];
+}
+
+/** One extra file an agent asks ctl to watch. */
+export interface AgentWatchSpec {
+  /** Absolute in-box path. */
+  path: string;
+  /**
+   * `backup` (default) lands the file on the host and stops. `fanout` also
+   * re-distributes it to every other box, which is correct ONLY for a rotating
+   * secret — an agent's own logs or transcripts must never fan out.
+   */
+  sync?: 'fanout' | 'backup';
+  /** Host destination, relative to the box's host workspace. */
+  hostDest?: string;
 }
 
 /**
@@ -207,6 +229,28 @@ export interface AgentPullSpec {
    * value is that dir plus the matching entry's `relocToSubpath`.
    */
   items?: readonly { group: string; names: readonly string[] }[];
+  /**
+   * Roots that exist ONLY in the pull direction, named directly rather than
+   * resolved through `staticPaths`.
+   *
+   * Session logs are the motivating case and are genuinely pull-only: you would
+   * never PUSH transcripts into a box, and every agent's `staticPaths.exclude`
+   * already drops them on the way in (claude: `projects`/`sessions`/
+   * `history.jsonl`; codex: `sessions`/`archived_sessions`/`log`; opencode:
+   * `storage`/`log`/`snapshot`). With groups resolving only through
+   * `staticPaths`, such a location had nowhere to be declared.
+   *
+   * Roots that exist in BOTH directions keep deriving from `staticPaths` — this
+   * is an alternative, not a replacement.
+   */
+  roots?: readonly {
+    /** Group name referenced by `items[].group`. */
+    group: string;
+    /** Absolute in-box directory. */
+    boxDir: string;
+    /** Host destination, as path segments under `os.homedir()`. */
+    hostHomeRel: readonly string[];
+  }[];
   /**
    * Directories whose CHILDREN are the unit — claude's `skills`/`agents`/
    * `commands`. Each child dir is one item.

--- a/packages/sandbox-core/src/sync/index.ts
+++ b/packages/sandbox-core/src/sync/index.ts
@@ -49,6 +49,12 @@ export {
   type FlatInventoryEntry,
 } from './agent-pull.js';
 export {
+  buildAgentDescriptors,
+  type AgentDescriptor,
+  type AgentDescriptorPayload,
+  type AgentWatchDescriptor,
+} from './agent-descriptor.js';
+export {
   agentBoxConfigDir,
   claudeStagedItems,
   codexStagedItems,

--- a/packages/sandbox-core/test/agent-descriptor.test.ts
+++ b/packages/sandbox-core/test/agent-descriptor.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { buildAgentDescriptors } from '../src/sync/agent-descriptor.js';
+import { AGENT_SYNC_SPECS } from '../src/sync/registry.js';
+
+describe('buildAgentDescriptors', () => {
+  it('reproduces the credential watch list ctl has baked in today', () => {
+    // The whole point of shipping this over RPC is that a box's behaviour does
+    // not change on day one. Every agent's credential must still be watched,
+    // with the same path and the same validator.
+    const { agents } = buildAgentDescriptors();
+    expect(agents).toHaveLength(AGENT_SYNC_SPECS.length);
+    for (const spec of AGENT_SYNC_SPECS) {
+      const got = agents.find((a) => a.id === spec.id);
+      const cred = got?.watch.find((w) => w.path === spec.credential.boxAbsPath);
+      expect(cred, spec.id).toBeDefined();
+      expect(cred?.sync).toBe('fanout');
+      expect(cred?.shape).toBe(spec.credential.realShape);
+    }
+  });
+
+  it('never ships a host path into the box', () => {
+    // `credential.hostBackup` is an absolute HOST path baked at module load. In
+    // a box it is meaningless, and sending it leaks the host's home layout.
+    const json = JSON.stringify(buildAgentDescriptors());
+    for (const spec of AGENT_SYNC_SPECS) {
+      expect(json, spec.id).not.toContain(spec.credential.hostBackup);
+    }
+    expect(json).not.toContain('/Users/');
+    expect(json).not.toContain('.agentbox/');
+  });
+
+  it('is JSON round-trippable — it crosses a wire', () => {
+    const built = buildAgentDescriptors();
+    expect(JSON.parse(JSON.stringify(built))).toEqual(built);
+  });
+
+  it('defaults a declared watch to backup, never fanout', () => {
+    // fanout re-distributes to EVERY other box. A spec that forgets to say what
+    // a watch is for must get the safe one; fanout has to be asked for.
+    const spec = AGENT_SYNC_SPECS[0]!;
+    const withWatch = {
+      ...spec,
+      watch: [{ path: '/home/vscode/.someagent/session.jsonl' }],
+    };
+    // Exercise the same mapping the builder uses.
+    const mapped = (withWatch.watch ?? []).map((w) => ({
+      path: w.path,
+      sync: (w as { sync?: string }).sync ?? 'backup',
+    }));
+    expect(mapped[0]?.sync).toBe('backup');
+  });
+});


### PR DESCRIPTION
Phase 3 of the agent data plane, and the first half of backlog item 2 from #336. **Stacked on #338** (base is `feat/agent-data-plane-pull`).

## The problem

`agentbox-ctl` is baked into the box image, so its watch list is frozen at bake time. A box built from a snapshot taken before an agent existed never watches that agent's credential — and a plugin-supplied agent, which is `ondemand`-only and can *never* be baked, would be invisible to ctl forever.

## RPC, not a pushed file

ctl now reconciles against an `agents.list` RPC at daemon start, modelled on `tool.list`: read-only, unprompted, and dispatched **before worktree resolution** since the agent registry is machine-global rather than project-scoped.

I originally planned to push `/etc/agentbox/agents.json` at create. Marco pushed back, correctly: a file has to be *written by someone*, and that someone is the **provider** — cloud bootstrap, docker box-env, and a hand-written equivalent in every community provider. The file's shape then becomes a contract each of them implements, so any future field means updating all of them, third-party ones included. Over RPC the shape stays host-side and providers stay entirely uninvolved.

## Both dispatch sites

Handled in `server.ts` (docker) **and** `host-actions.ts` (cloud). A cloud box's RPCs are parked on the `HostActionQueue` and drained by a separate executor, so a method wired only in `server.ts` works on docker and silently fails on every cloud provider.

## Safety posture

- **Ships a projection, not the raw table.** `credential.hostBackup` is an absolute *host* path baked at module load — meaningless inside a box and a leak of the host's home layout. Pinned by a test.
- **Every failure keeps the baked list.** Unreachable relay, older host with no `agents.list`, malformed JSON, and an **empty `agents` array** are all refused. Taking an empty list literally would stop the credential watcher dead and kill login fan-out across the fleet with no error anywhere — so "watch nothing" is treated as malformed, never as authoritative.
- **Unknown fields are ignored**, so a newer host never breaks an older box — the same posture as the in-box `agentbox.yaml` parser.
- **A `fanout` watch with no validatable shape is dropped**, not posted unvalidated.

## The hooks a custom agent declares

- `watch` — extra in-box files, with **`backup` the default and `fanout` opt-in**. Fanout re-distributes to *every other box*, which is correct only for a rotating secret; doing it to session transcripts would be a privacy leak.
- `roots` on `AgentPullSpec` — pull-only locations. Session logs are genuinely pull-only: you'd never *push* transcripts into a box, and every agent's `staticPaths.exclude` already drops them (claude `projects`/`sessions`/`history.jsonl`, codex `sessions`/`archived_sessions`/`log`, opencode `storage`/`log`/`snapshot`). With groups resolving only through `staticPaths` there was nowhere to declare them — the gap Marco identified in #338.

## Verification

Live on docker, the full loop:

```
agentbox-hub: rpc box=bd40b86a5 method=agents.list
agentbox-hub: credentials-updated box=bd40b86a5 accepted=false (unchanged)
```

ctl pulled the list over RPC and the watcher then ran off it, with the newest-wins gate correctly rejecting unchanged content. I also queried `agents.list` directly from inside the box and got the full payload.

Unit coverage for the refusal cases, and I confirmed the two safety-critical ones **fail when the guard is removed** — the empty-list refusal and the host-path leak.

## Not in this PR

- **Refreshing an already-running box.** `ToolLinksWatcher` solves the equivalent with `agentbox-ctl tool relink` over `Provider.exec`, but that works because tool links are on-disk state a separate process can rewrite; this list lives in the daemon's memory, so the same push needs a ctl socket op. A running box picks up changes on the next ctl restart — which is still the win: adding an agent goes from "re-bake every base" to "restart ctl".
- Consuming the `watch`/`roots` hooks end-to-end (the `cp.toHost` backup route, `box.agentFileSync`) — declared and shipped here, wired next.
- `boxRunEnv` is still declared-and-unconsumed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes credential watcher startup and fleet-wide login fan-out behavior; failures are designed to fall back to the baked list, but a bad host payload that parses incorrectly could still alter which paths are watched until restart.
> 
> **Overview**
> **agentbox-ctl** no longer relies solely on the credential paths compiled into the box image. At daemon startup it calls a new read-only **`agents.list`** RPC, uses the returned **fanout** credential watches for **`CredentialsWatcher`**, and on any failure (unreachable relay, bad JSON, empty list, older host) keeps the existing baked list so credential fan-out never goes silent.
> 
> The host exposes **`buildAgentDescriptors()`** — a projection of **`AGENT_SYNC_SPECS`** without host-only paths — from **`server.ts`** (docker) and **`host-actions.ts`** (cloud queue). In-box **`parseAgentDescriptors`** tolerates unknown fields and only admits validated **fanout** shapes for the watcher.
> 
> Agent sync types gain optional **`watch`** (extra in-box files, default **backup**) and **`pull.roots`** for pull-only locations; those hooks are declared and shipped on the wire but not fully consumed in ctl yet. Running boxes pick up registry changes on the next ctl restart, not live.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c21b96132a59fdbc5514c401a5ed51b6e0b765bf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->