### PR TITLE
feat(agents): ctl pulls its watch list from the host over RPC

### DIFF
--- a/packages/ctl/src/agent-registry.ts
+++ b/packages/ctl/src/agent-registry.ts
@@ -1,0 +1,102 @@
+import { postRpcAwait } from './relay-rpc.js';
+import { WATCHED_CREDENTIALS, type WatchedCredential } from './credentials-watcher.js';
+
+/**
+ * The agent watch list, pulled from the host over `agents.list`.
+ *
+ * Why this exists: `agentbox-ctl` is BAKED INTO THE BOX IMAGE, so its compiled-in
+ * list is frozen at bake time. A box built from a snapshot taken before an agent
+ * existed never watches that agent's files. A plugin-supplied agent is
+ * `ondemand`-only and can never be baked at all, so without this it would be
+ * permanently invisible to ctl.
+ *
+ * Pulled rather than pushed as a file: a file has to be written by the PROVIDER
+ * (cloud bootstrap, docker box-env, and a hand-written equivalent in every
+ * community provider), which makes its shape a contract each of them implements.
+ * Over RPC the shape stays host-side and providers stay uninvolved.
+ *
+ * Reconciled ONCE at daemon start, never polled — on a control box a poll would
+ * be a WAN round trip per box per minute (the reason `ToolLinksWatcher` stopped
+ * polling too). That covers a new box, a restarted box and a resumed box.
+ *
+ * NOT yet covered: a box already running when the host's agent list changes; it
+ * picks the change up on the next ctl restart. `ToolLinksWatcher` solves the
+ * equivalent with `agentbox-ctl tool relink` over `Provider.exec`, but that works
+ * because tool links are on-disk state a separate process can rewrite — this list
+ * lives in the daemon's memory, so the same push needs a ctl socket op. Left for
+ * a follow-up; the startup reconcile is what turns adding an agent from
+ * "re-bake every base" into "restart ctl".
+ *
+ * FAILURE IS SILENT AND KEEPS THE BAKED LIST. An unreachable relay, an older
+ * host with no `agents.list`, or a malformed payload must all leave the box
+ * watching what it already watched — never nothing. Losing the credential
+ * watcher would silently break login fan-out for the whole fleet.
+ */
+
+interface WireWatch {
+  path?: unknown;
+  sync?: unknown;
+  shape?: unknown;
+  hostDest?: unknown;
+}
+interface WireAgent {
+  id?: unknown;
+  watch?: unknown;
+}
+
+/**
+ * Narrow the wire payload, dropping anything malformed rather than throwing.
+ *
+ * Unknown fields are IGNORED, not rejected: a newer host must never break an
+ * older box. Same posture as the in-box `agentbox.yaml` parser, which warns on
+ * unknown keys instead of failing.
+ */
+export function parseAgentDescriptors(stdout: string): WatchedCredential[] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== 'object') return null;
+  const agents = (parsed as { agents?: unknown }).agents;
+  if (!Array.isArray(agents)) return null;
+
+  const out: WatchedCredential[] = [];
+  for (const raw of agents as WireAgent[]) {
+    const id = typeof raw?.id === 'string' ? raw.id : null;
+    if (!id) continue;
+    const watches = Array.isArray(raw.watch) ? (raw.watch as WireWatch[]) : [];
+    for (const w of watches) {
+      if (typeof w?.path !== 'string' || w.path.length === 0) continue;
+      const sync = w.sync === 'fanout' ? 'fanout' : 'backup';
+      // Only a `fanout` watch posts a credential blob, and only a known shape is
+      // validatable — anything else is dropped rather than posted unvalidated.
+      if (sync !== 'fanout') continue;
+      if (w.shape !== 'claude-oauth' && w.shape !== 'nonempty-json') continue;
+      out.push({ agent: id as WatchedCredential['agent'], path: w.path, shape: w.shape });
+    }
+  }
+  // An empty list is a malformed answer, not a valid "watch nothing" — refuse it
+  // so the caller keeps the baked list.
+  return out.length > 0 ? out : null;
+}
+
+/**
+ * Fetch the watch list, falling back to the baked one on any failure.
+ * Never throws.
+ */
+export async function fetchWatchList(): Promise<{
+  files: readonly WatchedCredential[];
+  source: 'host' | 'baked';
+}> {
+  try {
+    const res = await postRpcAwait('agents.list', {});
+    if (res.exitCode !== 0) return { files: WATCHED_CREDENTIALS, source: 'baked' };
+    const parsed = parseAgentDescriptors(res.stdout);
+    if (!parsed) return { files: WATCHED_CREDENTIALS, source: 'baked' };
+    return { files: parsed, source: 'host' };
+  } catch {
+    return { files: WATCHED_CREDENTIALS, source: 'baked' };
+  }
+}

--- a/packages/ctl/src/agent-registry.ts
+++ b/packages/ctl/src/agent-registry.ts
@@ -31,6 +31,11 @@ import { WATCHED_CREDENTIALS, type WatchedCredential } from './credentials-watch
  * host with no `agents.list`, or a malformed payload must all leave the box
  * watching what it already watched — never nothing. Losing the credential
  * watcher would silently break login fan-out for the whole fleet.
+ *
+ * OFF THE CRITICAL PATH, for the same reason. The watcher starts on the baked
+ * list first and this only ever upgrades it, so no failure mode here can cost a
+ * box its fan-out. Awaiting it instead did exactly that: see
+ * {@link AGENTS_LIST_TIMEOUT_MS}.
  */
 
 interface WireWatch {
@@ -83,15 +88,39 @@ export function parseAgentDescriptors(stdout: string): WatchedCredential[] | nul
 }
 
 /**
- * Fetch the watch list, falling back to the baked one on any failure.
- * Never throws.
+ * How long to wait for `agents.list` before giving up and keeping the baked list.
+ *
+ * There is NO other bound on this call. On a cloud box the in-sandbox relay parks
+ * every RPC on `HostActionQueue`, whose `enqueue` is deliberately timeout-free,
+ * and whose expiry sweep runs only inside `drain()` — which only runs when the
+ * host's `CloudBoxPoller` polls. Host off, poller down, or box resumed with the
+ * PC asleep and the promise simply never settles, holding a socket and a queue
+ * slot open for the life of the daemon.
+ *
+ * Generous, because the cost of being slow here is nil (the watcher is already
+ * running on the baked list) while a premature give-up on a merely-sluggish host
+ * leaves a post-bake agent unwatched until the next ctl restart.
+ */
+const AGENTS_LIST_TIMEOUT_MS = 30_000;
+
+/**
+ * Fetch the watch list, falling back to the baked one on any failure or if the
+ * host does not answer within {@link AGENTS_LIST_TIMEOUT_MS}. Never throws.
+ *
+ * MUST NOT be awaited on the daemon's critical path — see the call site in
+ * `commands/daemon.ts`.
  */
 export async function fetchWatchList(): Promise<{
   files: readonly WatchedCredential[];
-  source: 'host' | 'baked';
+  source: 'host' | 'baked' | 'timeout';
 }> {
   try {
-    const res = await postRpcAwait('agents.list', {});
+    const timeout = new Promise<'timeout'>((resolve) => {
+      // unref: a pending timer must never be the reason the daemon stays alive.
+      setTimeout(() => resolve('timeout'), AGENTS_LIST_TIMEOUT_MS).unref();
+    });
+    const res = await Promise.race([postRpcAwait('agents.list', {}), timeout]);
+    if (res === 'timeout') return { files: WATCHED_CREDENTIALS, source: 'timeout' };
     if (res.exitCode !== 0) return { files: WATCHED_CREDENTIALS, source: 'baked' };
     const parsed = parseAgentDescriptors(res.stdout);
     if (!parsed) return { files: WATCHED_CREDENTIALS, source: 'baked' };

--- a/packages/ctl/src/commands/daemon.ts
+++ b/packages/ctl/src/commands/daemon.ts
@@ -6,6 +6,7 @@ import { selectInBoxTransport } from './in-box-transport.js';
 import { startCodexScraper, type CodexScraperHandle } from '../codex-scraper.js';
 import { startClaudeScraper, type ClaudeScraperHandle } from '../claude-scraper.js';
 import { Supervisor } from '../supervisor.js';
+import { fetchWatchList } from '../agent-registry.js';
 import { startServer } from '../socket.js';
 import { StatusReporter } from '../status-reporter.js';
 import { CredentialsWatcher } from '../credentials-watcher.js';
@@ -75,7 +76,17 @@ export const daemonCommand = new Command('daemon')
     // AGENTBOX_CREDENTIAL_SYNC=0 is the wire form of box.credentialSync=false.
     let credentialsWatcher: CredentialsWatcher | null = null;
     if (process.env.AGENTBOX_CREDENTIAL_SYNC !== '0') {
-      credentialsWatcher = new CredentialsWatcher({ relay: sup.relayClient });
+      // Ask the host which files to watch instead of trusting the list compiled
+      // into this binary: ctl is baked into the image, so a box built before an
+      // agent existed would otherwise never watch it — and a plugin agent, which
+      // can never be baked, would be invisible forever. Falls back to the baked
+      // list on any failure, so an unreachable relay or an older host leaves the
+      // box watching exactly what it watches today.
+      const watch = await fetchWatchList();
+      if (watch.source === 'baked') {
+        process.stderr.write('agentbox-ctl: agents.list unavailable; using the baked watch list\n');
+      }
+      credentialsWatcher = new CredentialsWatcher({ relay: sup.relayClient, files: watch.files });
       credentialsWatcher.start();
     }
 

--- a/packages/ctl/src/commands/daemon.ts
+++ b/packages/ctl/src/commands/daemon.ts
@@ -231,29 +231,36 @@ export const daemonCommand = new Command('daemon')
     // reconcile a minute later.
     toolLinks.start();
 
-    // Also AFTER the forwarder, and for the same reason: `agents.list` is an RPC
-    // through :8788. Fetched earlier it is a guaranteed ECONNREFUSED on a fresh
-    // box — and because the fallback is silent BY DESIGN, that failure is
-    // invisible: the box quietly keeps its baked list forever and a post-bake or
-    // plugin agent is never watched at all.
-    //
-    // Ask the host rather than trusting the list compiled into this binary: ctl is
-    // baked into the image, so a box built before an agent existed would otherwise
-    // never watch it. Falling back leaves the box watching exactly what it watches
-    // today, never nothing.
     if (process.env.AGENTBOX_CREDENTIAL_SYNC !== '0') {
-      // Ask the host which files to watch instead of trusting the list compiled
+      // Start on the BAKED list immediately, then upgrade. Never await the fetch:
+      // on a cloud box `agents.list` is parked on the in-sandbox relay's
+      // HostActionQueue, which has no timeout and only expires entries when the
+      // host's poller drains it — so with the host off (a resumed independent
+      // box) the await never returns. That cost the box its credential fan-out
+      // entirely, and left SIGTERM/SIGINT unregistered so it could not even shut
+      // down cleanly. `toolLinks.start()` above already has this shape.
+      credentialsWatcher = new CredentialsWatcher({ relay: sup.relayClient });
+      credentialsWatcher.start();
+
+      // Ask the host which files to watch rather than trusting the list compiled
       // into this binary: ctl is baked into the image, so a box built before an
       // agent existed would otherwise never watch it — and a plugin agent, which
-      // can never be baked, would be invisible forever. Falls back to the baked
-      // list on any failure, so an unreachable relay or an older host leaves the
-      // box watching exactly what it watches today.
-      const watch = await fetchWatchList();
-      if (watch.source === 'baked') {
-        process.stderr.write('agentbox-ctl: agents.list unavailable; using the baked watch list\n');
-      }
-      credentialsWatcher = new CredentialsWatcher({ relay: sup.relayClient, files: watch.files });
-      credentialsWatcher.start();
+      // can never be baked, would be invisible forever. Any failure leaves the
+      // watcher on the baked list it is already running.
+      //
+      // Fired AFTER the forwarder is listening, like `toolLinks.start()`:
+      // `agents.list` is an RPC through :8788, and earlier it is a guaranteed
+      // ECONNREFUSED on a fresh box.
+      const watcher = credentialsWatcher;
+      void fetchWatchList().then((watch) => {
+        if (watch.source === 'host') {
+          watcher.setFiles(watch.files);
+          return;
+        }
+        process.stderr.write(
+          `agentbox-ctl: agents.list ${watch.source === 'timeout' ? 'timed out' : 'unavailable'}; keeping the baked watch list\n`,
+        );
+      });
     }
 
     const shutdown = async (signal: string): Promise<void> => {

--- a/packages/ctl/src/commands/daemon.ts
+++ b/packages/ctl/src/commands/daemon.ts
@@ -74,21 +74,8 @@ export const daemonCommand = new Command('daemon')
     // Fan refreshed agent credentials out through the host relay (claude's
     // OAuth refresh rotates the refresh token, invalidating every other copy).
     // AGENTBOX_CREDENTIAL_SYNC=0 is the wire form of box.credentialSync=false.
+    // Constructed AFTER the forwarder is listening — see below.
     let credentialsWatcher: CredentialsWatcher | null = null;
-    if (process.env.AGENTBOX_CREDENTIAL_SYNC !== '0') {
-      // Ask the host which files to watch instead of trusting the list compiled
-      // into this binary: ctl is baked into the image, so a box built before an
-      // agent existed would otherwise never watch it — and a plugin agent, which
-      // can never be baked, would be invisible forever. Falls back to the baked
-      // list on any failure, so an unreachable relay or an older host leaves the
-      // box watching exactly what it watches today.
-      const watch = await fetchWatchList();
-      if (watch.source === 'baked') {
-        process.stderr.write('agentbox-ctl: agents.list unavailable; using the baked watch list\n');
-      }
-      credentialsWatcher = new CredentialsWatcher({ relay: sup.relayClient, files: watch.files });
-      credentialsWatcher.start();
-    }
 
     // Reconcile the per-tool shim symlinks with the host's grants ONCE at
     // startup — the case a push cannot cover (this box was paused, or did not
@@ -243,6 +230,31 @@ export const daemonCommand = new Command('daemon')
     // on a fresh box, leaving already-granted tools unlinked until the next
     // reconcile a minute later.
     toolLinks.start();
+
+    // Also AFTER the forwarder, and for the same reason: `agents.list` is an RPC
+    // through :8788. Fetched earlier it is a guaranteed ECONNREFUSED on a fresh
+    // box — and because the fallback is silent BY DESIGN, that failure is
+    // invisible: the box quietly keeps its baked list forever and a post-bake or
+    // plugin agent is never watched at all.
+    //
+    // Ask the host rather than trusting the list compiled into this binary: ctl is
+    // baked into the image, so a box built before an agent existed would otherwise
+    // never watch it. Falling back leaves the box watching exactly what it watches
+    // today, never nothing.
+    if (process.env.AGENTBOX_CREDENTIAL_SYNC !== '0') {
+      // Ask the host which files to watch instead of trusting the list compiled
+      // into this binary: ctl is baked into the image, so a box built before an
+      // agent existed would otherwise never watch it — and a plugin agent, which
+      // can never be baked, would be invisible forever. Falls back to the baked
+      // list on any failure, so an unreachable relay or an older host leaves the
+      // box watching exactly what it watches today.
+      const watch = await fetchWatchList();
+      if (watch.source === 'baked') {
+        process.stderr.write('agentbox-ctl: agents.list unavailable; using the baked watch list\n');
+      }
+      credentialsWatcher = new CredentialsWatcher({ relay: sup.relayClient, files: watch.files });
+      credentialsWatcher.start();
+    }
 
     const shutdown = async (signal: string): Promise<void> => {
       process.stdout.write(`agentbox-ctl: ${signal} — shutting down\n`);

--- a/packages/ctl/src/credentials-watcher.ts
+++ b/packages/ctl/src/credentials-watcher.ts
@@ -94,7 +94,7 @@ export function isRetryablePostFailure(outcome: PostOutcome): boolean {
 export class CredentialsWatcher {
   private readonly relay: RelayClient;
   private readonly intervalMs: number;
-  private readonly files: readonly WatchedCredential[];
+  private files: readonly WatchedCredential[];
   private readonly postTimeoutMs: number;
   private readonly lastMtime = new Map<string, number>();
   private readonly lastPosted = new Map<string, string>();
@@ -118,6 +118,21 @@ export class CredentialsWatcher {
       clearInterval(this.timer);
       this.timer = null;
     }
+  }
+
+  /**
+   * Swap the watched list while running — the daemon starts this watcher with
+   * the BAKED list so credential fan-out is never off, then calls this once the
+   * host answers `agents.list`. Waiting for that answer before constructing the
+   * watcher is what made a cloud box with no host poller lose fan-out entirely.
+   *
+   * Safe mid-flight: `lastMtime` / `lastPosted` are keyed by `file.agent`, so a
+   * carried-over agent keeps its de-dup state and a dropped one just leaves an
+   * unread key behind.
+   */
+  setFiles(files: readonly WatchedCredential[]): void {
+    this.files = files;
+    if (this.timer) void this.scan();
   }
 
   /**

--- a/packages/ctl/test/agent-registry-fetch.test.ts
+++ b/packages/ctl/test/agent-registry-fetch.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const postRpcAwait = vi.fn();
+vi.mock('../src/relay-rpc.js', () => ({ postRpcAwait }));
+
+const { fetchWatchList } = await import('../src/agent-registry.js');
+const { WATCHED_CREDENTIALS } = await import('../src/credentials-watcher.js');
+
+/**
+ * The failure this guards, found by review on PR #340:
+ *
+ * On a cloud box the in-sandbox relay parks EVERY rpc on `HostActionQueue`,
+ * whose `enqueue` is deliberately timeout-free and whose expiry sweep runs only
+ * inside `drain()` — which only runs when the host's `CloudBoxPoller` polls. With
+ * the host off (a resumed independent box) the promise never settles at all, and
+ * `relay-rpc`'s own 10-minute bound belongs to the 202/poll shape, not this one.
+ *
+ * So `fetchWatchList` must bound itself. It is also no longer awaited on the
+ * daemon's critical path (see daemon-startup-order.test.ts) — belt and braces,
+ * since an unbounded pending request still holds a socket and a queue slot for
+ * the life of the daemon.
+ */
+describe('fetchWatchList', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    postRpcAwait.mockReset();
+  });
+
+  it('falls back to the baked list when the host never answers', async () => {
+    vi.useFakeTimers();
+    // Never settles — a parked action on a box whose host poller is down.
+    postRpcAwait.mockReturnValue(new Promise(() => {}));
+
+    const pending = fetchWatchList();
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await expect(pending).resolves.toEqual({
+      files: WATCHED_CREDENTIALS,
+      source: 'timeout',
+    });
+  });
+
+  it('returns the host list when the host answers in time', async () => {
+    postRpcAwait.mockResolvedValue({
+      exitCode: 0,
+      stdout: JSON.stringify({
+        schema: 1,
+        agents: [
+          { id: 'codex', watch: [{ path: '/tmp/c', sync: 'fanout', shape: 'nonempty-json' }] },
+        ],
+      }),
+      stderr: '',
+    });
+    await expect(fetchWatchList()).resolves.toEqual({
+      files: [{ agent: 'codex', path: '/tmp/c', shape: 'nonempty-json' }],
+      source: 'host',
+    });
+  });
+
+  it('keeps the baked list when the rpc fails or the payload is junk', async () => {
+    postRpcAwait.mockResolvedValue({ exitCode: 126, stdout: '', stderr: 'refused' });
+    expect((await fetchWatchList()).source).toBe('baked');
+
+    postRpcAwait.mockResolvedValue({ exitCode: 0, stdout: 'not json', stderr: '' });
+    expect((await fetchWatchList()).source).toBe('baked');
+
+    postRpcAwait.mockRejectedValue(new Error('boom'));
+    expect((await fetchWatchList()).source).toBe('baked');
+  });
+});

--- a/packages/ctl/test/agent-registry.test.ts
+++ b/packages/ctl/test/agent-registry.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { parseAgentDescriptors } from '../src/agent-registry.js';
+
+/**
+ * ctl is baked into the box image, so its compiled-in watch list is frozen at
+ * bake time. These cover the parse half of pulling it from the host instead —
+ * and above all the cases where the answer must be REFUSED so the caller keeps
+ * the baked list. Watching nothing would silently break credential fan-out for
+ * the whole fleet, which is far worse than watching a slightly stale list.
+ */
+describe('parseAgentDescriptors', () => {
+  const good = JSON.stringify({
+    schema: 1,
+    agents: [
+      {
+        id: 'claude',
+        watch: [
+          { path: '/home/vscode/.claude/.credentials.json', sync: 'fanout', shape: 'claude-oauth' },
+        ],
+      },
+    ],
+  });
+
+  it('parses a well-formed payload', () => {
+    expect(parseAgentDescriptors(good)).toEqual([
+      { agent: 'claude', path: '/home/vscode/.claude/.credentials.json', shape: 'claude-oauth' },
+    ]);
+  });
+
+  it('ignores unknown fields so a NEWER host cannot break an older box', () => {
+    const withExtras = JSON.stringify({
+      schema: 99,
+      somethingFromTheFuture: { nested: true },
+      agents: [
+        {
+          id: 'claude',
+          tomorrowsField: 42,
+          watch: [
+            {
+              path: '/home/vscode/.claude/.credentials.json',
+              sync: 'fanout',
+              shape: 'claude-oauth',
+              futureKnob: 'x',
+            },
+          ],
+        },
+      ],
+    });
+    expect(parseAgentDescriptors(withExtras)).toHaveLength(1);
+  });
+
+  it('refuses malformed JSON, non-objects and a missing agents array', () => {
+    // null means "keep the baked list", never "watch nothing".
+    expect(parseAgentDescriptors('not json')).toBeNull();
+    expect(parseAgentDescriptors('"a string"')).toBeNull();
+    expect(parseAgentDescriptors('null')).toBeNull();
+    expect(parseAgentDescriptors(JSON.stringify({ schema: 1 }))).toBeNull();
+  });
+
+  it('refuses an EMPTY list rather than watching nothing', () => {
+    // A host that answers `{agents: []}` is malformed, not authoritative. Taking
+    // it literally would stop the credential watcher dead and kill login
+    // fan-out across the fleet with no error anywhere.
+    expect(parseAgentDescriptors(JSON.stringify({ schema: 1, agents: [] }))).toBeNull();
+  });
+
+  it('drops a fanout watch with no validatable shape', () => {
+    // Only `fanout` posts a blob to the relay, and only a known shape can be
+    // validated before posting. An unvalidatable one is dropped, not posted.
+    const bad = JSON.stringify({
+      schema: 1,
+      agents: [{ id: 'x', watch: [{ path: '/tmp/a', sync: 'fanout' }] }],
+    });
+    expect(parseAgentDescriptors(bad)).toBeNull();
+  });
+
+  it('does not treat a backup watch as a credential', () => {
+    // `backup` watches route through cp.toHost, not the credential event — they
+    // must never reach the credential watcher's post path.
+    const mixed = JSON.stringify({
+      schema: 1,
+      agents: [
+        {
+          id: 'claude',
+          watch: [
+            {
+              path: '/home/vscode/.claude/.credentials.json',
+              sync: 'fanout',
+              shape: 'claude-oauth',
+            },
+            { path: '/home/vscode/.claude/projects', sync: 'backup', hostDest: 'logs' },
+          ],
+        },
+      ],
+    });
+    const got = parseAgentDescriptors(mixed);
+    expect(got).toHaveLength(1);
+    expect(got?.[0]?.path).toBe('/home/vscode/.claude/.credentials.json');
+  });
+
+  it('skips entries with no id or no path instead of failing the whole payload', () => {
+    const partial = JSON.stringify({
+      schema: 1,
+      agents: [
+        { watch: [{ path: '/tmp/x', sync: 'fanout', shape: 'nonempty-json' }] },
+        { id: 'codex', watch: [{ sync: 'fanout', shape: 'nonempty-json' }] },
+        { id: 'codex', watch: [{ path: '/tmp/ok', sync: 'fanout', shape: 'nonempty-json' }] },
+      ],
+    });
+    expect(parseAgentDescriptors(partial)).toEqual([
+      { agent: 'codex', path: '/tmp/ok', shape: 'nonempty-json' },
+    ]);
+  });
+});

--- a/packages/ctl/test/credentials-watcher.test.ts
+++ b/packages/ctl/test/credentials-watcher.test.ts
@@ -189,6 +189,43 @@ describe('CredentialsWatcher', () => {
     const [, , opts] = post.mock.calls[0] as [string, unknown, { timeoutMs?: number }];
     expect(opts.timeoutMs).toBeGreaterThan(2000);
   });
+  describe('setFiles', () => {
+    // The daemon starts this watcher on the BAKED list so credential fan-out is
+    // never off, then upgrades it once the host answers `agents.list`. Awaiting
+    // that answer first is what let a cloud box with no host poller lose fan-out
+    // outright (PR #340 review).
+    it('picks up an agent that was not in the starting list', async () => {
+      const extra = join(dir, 'auth.json');
+      await writeFile(extra, JSON.stringify({ some: 'auth' }));
+      const { relay, post } = fakeRelay();
+      const w = watcher(relay);
+      await w.scan();
+      expect(post).not.toHaveBeenCalled();
+
+      w.setFiles([{ agent: 'codex', path: extra, shape: 'nonempty-json' }]);
+      await w.scan();
+      expect(post).toHaveBeenCalledTimes(1);
+      const [, payload] = post.mock.calls[0] as [string, Record<string, unknown>];
+      expect(payload['agent']).toBe('codex');
+    });
+
+    // `lastMtime` / `lastPosted` are keyed by agent, so a carried-over agent must
+    // keep its de-dup state across the swap rather than re-post an unchanged blob.
+    it('does not repost a carried-over agent whose file did not change', async () => {
+      await writeFile(path, CLAUDE_BLOB);
+      const { relay, post } = fakeRelay();
+      const w = watcher(relay);
+      await w.scan();
+      expect(post).toHaveBeenCalledTimes(1);
+
+      w.setFiles([
+        { agent: 'claude', path, shape: 'claude-oauth' },
+        { agent: 'codex', path: join(dir, 'absent.json'), shape: 'nonempty-json' },
+      ]);
+      await w.scan();
+      expect(post).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 describe('isRetryablePostFailure', () => {

--- a/packages/ctl/test/daemon-startup-order.test.ts
+++ b/packages/ctl/test/daemon-startup-order.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Source-level guard on daemon startup ordering.
+ *
+ * `agents.list` is an RPC through the in-box relay on :8788. Fetched before the
+ * forwarder binds it is a guaranteed ECONNREFUSED on a fresh box — and because
+ * the fallback to the baked watch list is SILENT BY DESIGN, that failure is
+ * invisible: the box quietly keeps its compiled-in list forever, so a post-bake
+ * or plugin-supplied agent is never watched at all and nothing anywhere errors.
+ *
+ * The daemon already had this exact rule for `toolLinks.start()` with the
+ * reason in a comment; the fetch was added above it anyway. Hence a test rather
+ * than another comment.
+ */
+describe('daemon startup order', () => {
+  const src = readFileSync(join(__dirname, '..', 'src', 'commands', 'daemon.ts'), 'utf8');
+
+  it('fetches the watch list AFTER the relay forwarder is listening', () => {
+    const forwarderAt = src.indexOf('toolLinks.start()');
+    const fetchAt = src.indexOf('fetchWatchList(');
+    expect(forwarderAt, 'toolLinks.start() marks the post-forwarder point').toBeGreaterThan(-1);
+    expect(fetchAt, 'daemon must fetch the watch list').toBeGreaterThan(-1);
+    expect(fetchAt).toBeGreaterThan(forwarderAt);
+  });
+
+  it('starts the credentials watcher after that fetch, not before', () => {
+    // Starting it earlier with the baked list would work, but then the pulled
+    // list would never reach it — the watcher reads `files` once, at construction.
+    const fetchAt = src.indexOf('fetchWatchList(');
+    const startAt = src.indexOf('credentialsWatcher = new CredentialsWatcher(');
+    expect(startAt).toBeGreaterThan(fetchAt);
+  });
+});

--- a/packages/ctl/test/daemon-startup-order.test.ts
+++ b/packages/ctl/test/daemon-startup-order.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 /**
- * Source-level guard on daemon startup ordering.
+ * Source-level guards on daemon startup ordering.
  *
  * `agents.list` is an RPC through the in-box relay on :8788. Fetched before the
  * forwarder binds it is a guaranteed ECONNREFUSED on a fresh box — and because
@@ -26,11 +26,22 @@ describe('daemon startup order', () => {
     expect(fetchAt).toBeGreaterThan(forwarderAt);
   });
 
-  it('starts the credentials watcher after that fetch, not before', () => {
-    // Starting it earlier with the baked list would work, but then the pulled
-    // list would never reach it — the watcher reads `files` once, at construction.
-    const fetchAt = src.indexOf('fetchWatchList(');
+  it('starts the credentials watcher BEFORE the fetch, on the baked list', () => {
+    // The fetch must never gate the watcher. On a cloud box `agents.list` parks
+    // on a HostActionQueue that has no timeout and only expires on a host drain,
+    // so with the host off it never settles: awaiting it cost the box credential
+    // fan-out outright. Start baked, upgrade later via setFiles().
     const startAt = src.indexOf('credentialsWatcher = new CredentialsWatcher(');
-    expect(startAt).toBeGreaterThan(fetchAt);
+    const fetchAt = src.indexOf('fetchWatchList(');
+    expect(startAt).toBeGreaterThan(-1);
+    expect(startAt).toBeLessThan(fetchAt);
+  });
+
+  it('does not await the fetch on the critical path', () => {
+    // `await fetchWatchList()` anywhere here also delays the SIGTERM/SIGINT
+    // handlers registered below it, so a stop during the hang skips the whole
+    // graceful path (credential flush, stopAll, relay close).
+    expect(src).not.toMatch(/await\s+fetchWatchList\(/);
+    expect(src).toMatch(/void\s+fetchWatchList\(/);
   });
 });

--- a/packages/relay/src/host-actions.ts
+++ b/packages/relay/src/host-actions.ts
@@ -37,6 +37,7 @@ import {
 } from '@agentbox/core';
 import type { CloudBackend, CloudHandle } from '@agentbox/core';
 import {
+  buildAgentDescriptors,
   findBox,
   hostOpenCommand,
   isSupportedApiVersion,
@@ -342,6 +343,18 @@ export async function executeCloudAction(
   const log = deps.log ?? (() => {});
   log(`executing ${action.method} for box ${deps.boxId}`);
 
+  // Cloud twin of the host-relay `agents.list` handler. A cloud box's RPCs are
+  // parked on the HostActionQueue and drained here, so a method handled only in
+  // server.ts works on docker and silently fails on every cloud provider.
+  // Read-only and unprompted, like tool.list — and NOT worktree-scoped, since
+  // the agent registry is machine-global.
+  if (action.method === 'agents.list') {
+    return {
+      exitCode: 0,
+      stdout: JSON.stringify(buildAgentDescriptors()),
+      stderr: '',
+    };
+  }
   if (action.method === 'git.push' || action.method === 'git.fetch') {
     return runGitRpc(action, deps);
   }

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -16,7 +16,11 @@ import { describeCpCacheEntries, lookupCpCache, serveCpFromCache } from './cp-ca
 import { cpOutboxPrefix, listCpOutbox, parkCpOutbox, removeCpOutboxItem } from './cp-outbox.js';
 import { HubNotifier } from './hub-notifier.js';
 import { BoxNotices } from './notices.js';
-import { hostOpenCommand, projectSlugFromOriginUrl } from '@agentbox/sandbox-core';
+import {
+  buildAgentDescriptors,
+  hostOpenCommand,
+  projectSlugFromOriginUrl,
+} from '@agentbox/sandbox-core';
 import {
   isSanctionedPushBranch,
   isScratchBranch,
@@ -939,6 +943,20 @@ export function createRelayServer(opts: RelayServerOptions): RelayServerHandle {
         const queued = await hostActions.enqueue(reg.boxId, body.method, body.params);
         const status = queued.exitCode === 0 ? 200 : 500;
         send(res, status, queued);
+        return;
+      }
+      // Read-only machine-global metadata: the agent registry ctl reconciles
+      // against at daemon start. Dispatched HERE, before worktree resolution,
+      // for two reasons: the registry is not project-scoped (a box with no
+      // registered worktree must still get it), and it must never be gated
+      // behind askPrompt — a prompt would hang every box's startup reconcile.
+      // Same posture as `tool.list`, which is also read-only and unprompted.
+      if (body.method === 'agents.list') {
+        send(res, 200, {
+          exitCode: 0,
+          stdout: JSON.stringify(buildAgentDescriptors()),
+          stderr: '',
+        });
         return;
       }
       if (body.method === 'git.push' || body.method === 'git.fetch') {

--- a/packages/sandbox-core/src/sync/agent-descriptor.ts
+++ b/packages/sandbox-core/src/sync/agent-descriptor.ts
@@ -1,0 +1,90 @@
+/**
+ * The projection of `AGENT_SYNC_SPECS` that ctl consumes over the `agents.list`
+ * RPC.
+ *
+ * A PROJECTION, not the raw table, for two reasons:
+ *
+ *  - `credential.hostBackup` is an absolute HOST path baked at module load
+ *    (`join(STATE_DIR, 'claude-credentials.json')`). Inside a box it is
+ *    meaningless, and shipping it leaks the host's home directory layout.
+ *  - The box only needs what it acts on. Install recipes, docker volume names
+ *    and host static-path sources are host-side concerns; sending them would
+ *    make every one of them part of a wire contract for no reason.
+ *
+ * Deliberately delivered by RPC rather than a file the host writes into the box:
+ * a file has to be written by the PROVIDER (cloud bootstrap, docker box-env, and
+ * a hand-written equivalent in every community provider), which would make this
+ * shape a contract each of them implements — so any future field would mean
+ * updating all of them. Over RPC the shape stays host-side and providers stay
+ * uninvolved.
+ *
+ * Forward compatibility runs one way: ctl must ignore fields it doesn't know, so
+ * a newer host never breaks an older box. Mirrors how the in-box `agentbox.yaml`
+ * parser warns on unknown keys instead of failing.
+ */
+
+import { AGENT_SYNC_SPECS } from './registry.js';
+
+/** One file ctl watches in the box, and what the host should do when it changes. */
+export interface AgentWatchDescriptor {
+  /** Absolute in-box path. */
+  path: string;
+  /**
+   * What the sync is FOR.
+   *
+   *  - `fanout`  — a rotating secret. The host accepts it newest-wins and
+   *    re-distributes it to every other box. Correct ONLY for credentials: an
+   *    OAuth refresh rotates the token, so one box refreshing kills every other
+   *    copy unless the fresh blob is pushed back out.
+   *  - `backup`  — everything else. Lands on the host and stops there. Fanning
+   *    out non-credential content (session transcripts, logs) would copy one
+   *    box's data into every other box.
+   */
+  sync: 'fanout' | 'backup';
+  /** Validator selector for `fanout` payloads; absent for `backup`. */
+  shape?: 'claude-oauth' | 'nonempty-json';
+  /** Host destination for a `backup` watch, relative to the box's host workspace. */
+  hostDest?: string;
+}
+
+/** What ctl needs to know about one agent. */
+export interface AgentDescriptor {
+  id: string;
+  /** Files to watch in-box, with their intent. */
+  watch: readonly AgentWatchDescriptor[];
+}
+
+/** The wire payload of `agents.list`. Versioned host-side; ctl tolerates extras. */
+export interface AgentDescriptorPayload {
+  schema: 1;
+  agents: readonly AgentDescriptor[];
+}
+
+/**
+ * Build the payload from the registry.
+ *
+ * Every agent's credential is a `fanout` watch — that is exactly today's
+ * behaviour, restated as data. Additional watches come from the spec, and
+ * default to `backup`: `fanout` has to be asked for, because getting it wrong
+ * overwrites files in every other box.
+ */
+export function buildAgentDescriptors(): AgentDescriptorPayload {
+  return {
+    schema: 1,
+    agents: AGENT_SYNC_SPECS.map((spec) => ({
+      id: spec.id,
+      watch: [
+        {
+          path: spec.credential.boxAbsPath,
+          sync: 'fanout' as const,
+          shape: spec.credential.realShape,
+        },
+        ...(spec.watch ?? []).map((w) => ({
+          path: w.path,
+          sync: w.sync ?? ('backup' as const),
+          ...(w.hostDest ? { hostDest: w.hostDest } : {}),
+        })),
+      ],
+    })),
+  };
+}

--- a/packages/sandbox-core/src/sync/agents/types.ts
+++ b/packages/sandbox-core/src/sync/agents/types.ts
@@ -190,6 +190,28 @@ export interface AgentSyncSpec {
    * made `download` easy to forget when adding an agent.
    */
   pull?: AgentPullSpec;
+  /**
+   * Extra in-box files ctl should watch, beyond `credential` (which is always
+   * watched). This is the hook a custom agent uses to say "sync these back".
+   *
+   * The credential watch is implicit and always `fanout`; anything declared here
+   * defaults to `backup` — see `AgentWatchSpec.sync`.
+   */
+  watch?: readonly AgentWatchSpec[];
+}
+
+/** One extra file an agent asks ctl to watch. */
+export interface AgentWatchSpec {
+  /** Absolute in-box path. */
+  path: string;
+  /**
+   * `backup` (default) lands the file on the host and stops. `fanout` also
+   * re-distributes it to every other box, which is correct ONLY for a rotating
+   * secret — an agent's own logs or transcripts must never fan out.
+   */
+  sync?: 'fanout' | 'backup';
+  /** Host destination, relative to the box's host workspace. */
+  hostDest?: string;
 }
 
 /**
@@ -207,6 +229,28 @@ export interface AgentPullSpec {
    * value is that dir plus the matching entry's `relocToSubpath`.
    */
   items?: readonly { group: string; names: readonly string[] }[];
+  /**
+   * Roots that exist ONLY in the pull direction, named directly rather than
+   * resolved through `staticPaths`.
+   *
+   * Session logs are the motivating case and are genuinely pull-only: you would
+   * never PUSH transcripts into a box, and every agent's `staticPaths.exclude`
+   * already drops them on the way in (claude: `projects`/`sessions`/
+   * `history.jsonl`; codex: `sessions`/`archived_sessions`/`log`; opencode:
+   * `storage`/`log`/`snapshot`). With groups resolving only through
+   * `staticPaths`, such a location had nowhere to be declared.
+   *
+   * Roots that exist in BOTH directions keep deriving from `staticPaths` — this
+   * is an alternative, not a replacement.
+   */
+  roots?: readonly {
+    /** Group name referenced by `items[].group`. */
+    group: string;
+    /** Absolute in-box directory. */
+    boxDir: string;
+    /** Host destination, as path segments under `os.homedir()`. */
+    hostHomeRel: readonly string[];
+  }[];
   /**
    * Directories whose CHILDREN are the unit — claude's `skills`/`agents`/
    * `commands`. Each child dir is one item.

--- a/packages/sandbox-core/src/sync/index.ts
+++ b/packages/sandbox-core/src/sync/index.ts
@@ -49,6 +49,12 @@ export {
   type FlatInventoryEntry,
 } from './agent-pull.js';
 export {
+  buildAgentDescriptors,
+  type AgentDescriptor,
+  type AgentDescriptorPayload,
+  type AgentWatchDescriptor,
+} from './agent-descriptor.js';
+export {
   agentBoxConfigDir,
   claudeStagedItems,
   codexStagedItems,

--- a/packages/sandbox-core/test/agent-descriptor.test.ts
+++ b/packages/sandbox-core/test/agent-descriptor.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { buildAgentDescriptors } from '../src/sync/agent-descriptor.js';
+import { AGENT_SYNC_SPECS } from '../src/sync/registry.js';
+
+describe('buildAgentDescriptors', () => {
+  it('reproduces the credential watch list ctl has baked in today', () => {
+    // The whole point of shipping this over RPC is that a box's behaviour does
+    // not change on day one. Every agent's credential must still be watched,
+    // with the same path and the same validator.
+    const { agents } = buildAgentDescriptors();
+    expect(agents).toHaveLength(AGENT_SYNC_SPECS.length);
+    for (const spec of AGENT_SYNC_SPECS) {
+      const got = agents.find((a) => a.id === spec.id);
+      const cred = got?.watch.find((w) => w.path === spec.credential.boxAbsPath);
+      expect(cred, spec.id).toBeDefined();
+      expect(cred?.sync).toBe('fanout');
+      expect(cred?.shape).toBe(spec.credential.realShape);
+    }
+  });
+
+  it('never ships a host path into the box', () => {
+    // `credential.hostBackup` is an absolute HOST path baked at module load. In
+    // a box it is meaningless, and sending it leaks the host's home layout.
+    const json = JSON.stringify(buildAgentDescriptors());
+    for (const spec of AGENT_SYNC_SPECS) {
+      expect(json, spec.id).not.toContain(spec.credential.hostBackup);
+    }
+    expect(json).not.toContain('/Users/');
+    expect(json).not.toContain('.agentbox/');
+  });
+
+  it('is JSON round-trippable — it crosses a wire', () => {
+    const built = buildAgentDescriptors();
+    expect(JSON.parse(JSON.stringify(built))).toEqual(built);
+  });
+
+  it('defaults a declared watch to backup, never fanout', () => {
+    // fanout re-distributes to EVERY other box. A spec that forgets to say what
+    // a watch is for must get the safe one; fanout has to be asked for.
+    const spec = AGENT_SYNC_SPECS[0]!;
+    const withWatch = {
+      ...spec,
+      watch: [{ path: '/home/vscode/.someagent/session.jsonl' }],
+    };
+    // Exercise the same mapping the builder uses.
+    const mapped = (withWatch.watch ?? []).map((w) => ({
+      path: w.path,
+      sync: (w as { sync?: string }).sync ?? 'backup',
+    }));
+    expect(mapped[0]?.sync).toBe('backup');
+  });
+});


### PR DESCRIPTION
Phase 3 of the agent data plane. **Replaces #339**, which GitHub auto-closed when I merged #338 with `--delete-branch` — that deleted #339's base branch. Same commits, rebased onto `feat/custom_agents`; the review history is on #339.

Backlog item 2 from #336.

## The problem

`agentbox-ctl` is baked into the box image, so its watch list is frozen at bake time. A box built from a snapshot taken before an agent existed never watches that agent's credential — and a plugin-supplied agent, which is `ondemand`-only and can *never* be baked, would be invisible to ctl forever.

## RPC, not a pushed file

ctl reconciles against an `agents.list` RPC at daemon start, modelled on `tool.list`: read-only, unprompted, dispatched **before worktree resolution** since the registry is machine-global.

I originally planned to push `/etc/agentbox/agents.json`. Marco pushed back, correctly: a file has to be *written by someone*, and that someone is the **provider** — cloud bootstrap, docker box-env, and a hand-written equivalent in every community provider. Its shape becomes a contract each of them implements, so any future field means updating all of them. Over RPC the shape stays host-side and providers stay uninvolved.

## Both dispatch sites

`server.ts` (docker) **and** `host-actions.ts` (cloud). Cloud RPCs are parked on the `HostActionQueue` and drained by a separate executor, so a method wired only in `server.ts` works on docker and silently fails on every cloud provider.

## Safety posture

- **A projection, not the raw table.** `credential.hostBackup` is an absolute *host* path baked at module load — meaningless in a box and a leak of the host's home layout. Pinned by a test.
- **Every failure keeps the baked list.** Unreachable relay, older host, malformed JSON, and an **empty `agents` array** are all refused. Taking an empty list literally would stop the credential watcher dead and kill login fan-out across the fleet with no error anywhere.
- **Unknown fields ignored**, so a newer host never breaks an older box.
- **A `fanout` watch with no validatable shape is dropped**, not posted unvalidated.

## The hooks a custom agent declares

- `watch` — extra in-box files, **`backup` default, `fanout` opt-in**. Fanout re-distributes to every other box; correct only for a rotating secret, never for transcripts.
- `roots` on `AgentPullSpec` — pull-only locations. Session logs are genuinely pull-only: every agent's `staticPaths.exclude` already drops them, so there was nowhere to declare them.

## The bug Bugbot caught on #339 (fixed here)

**High severity, and the feature was inert.** I had placed `fetchWatchList()` *before* the relay forwarder binds :8788, so the RPC was a guaranteed `ECONNREFUSED` on a fresh box. Because the fallback is silent **by design**, that failure was invisible — the box quietly kept its baked list forever.

The daemon already had this exact rule for `toolLinks.start()`, with the reason in a comment three lines from where I put the fetch. So this adds a **source-level ordering test** rather than another comment, and I confirmed it fails when the fetch is moved back.

**My earlier "live verified" claim on #339 was also wrong** — the `agents.list` line I saw in the hub log came from a manual `curl` I ran inside the box, not from ctl. Re-verified properly: snapshot the hub log, create a box, run no curl, and confirm one `agents.list` from ctl's own startup reconcile. That's what's in the log now.

## Not in this PR

- **Refreshing an already-running box.** `ToolLinksWatcher` does this with `tool relink` over `Provider.exec`, but that works because tool links are on-disk state; this list lives in daemon memory, so it needs a ctl socket op. A running box picks changes up on the next ctl restart — still the win: "re-bake every base" becomes "restart ctl".
- Consuming the `watch`/`roots` hooks end-to-end (`cp.toHost` backup route, `box.agentFileSync`).
- `boxRunEnv` and `caps` remain declared-and-unconsumed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes credential fan-out startup and new relay paths; regressions could leave post-bake or plugin agents unwatched, though baked-list fallbacks, timeouts, and ordering tests reduce that risk.
> 
> **Overview**
> **In-box ctl** no longer depends only on the image-baked credential paths: at daemon start it calls **`agents.list`** over the in-box relay, parses fanout watches, and upgrades **`CredentialsWatcher`** via **`setFiles`**. The watcher still **starts immediately on the baked list**; the fetch is **`void`** (not awaited), **30s-bounded**, and runs **only after** the relay forwarder listens—fixing the silent ECONNREFUSED case where reconcile never ran. Any timeout, RPC failure, malformed JSON, or empty agent list **keeps the baked list** (never “watch nothing”).
> 
> The **host** adds a read-only **`agents.list`** handler in both **docker relay** (`server.ts`) and **cloud action executor** (`host-actions.ts`), returning **`buildAgentDescriptors()`**—a wire-safe projection of **`AGENT_SYNC_SPECS`** (no host backup paths). Agent sync types gain declarative **`watch`** and pull-only **`roots`** hooks for custom agents; end-to-end backup/fanout beyond credentials is left for follow-ups.
> 
> Tests cover payload parsing, fetch timeout/fallback, **`setFiles`** behavior, and **source-level daemon startup ordering** (watcher before fetch, no `await fetchWatchList`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6776d020b0e02b7c98793c65b79cbe0919e309fb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->