### PR TITLE
Phase 2a: each agent owns its login binding, unblocking the CLI-layer move

### DIFF
--- a/apps/cli/src/agents/claude/host-creds.ts
+++ b/apps/cli/src/agents/claude/host-creds.ts
@@ -1,0 +1,52 @@
+/**
+ * Claude's host-side credential check, for the pre-flight that runs before a
+ * detached `-i` job. Beside the runtime that owns it — the shared queue helper
+ * used to hold this and codex's and opencode's, dispatching between them with a
+ * three-arm chain that a fourth agent fell through silently.
+ */
+import { hostBackupHasCredentials } from '@agentbox/sandbox-docker';
+import { resolveClaudeAuth } from '../../auth.js';
+import { resolveClaudeCredHealth } from '../../lib/claude-cred-health.js';
+
+/**
+ * True when Claude is already authenticated on the host: a forwarded env var
+ * (`ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`), the legacy
+ * `~/.agentbox/auth.json` setup-token, or a real OAuth refresh token in the
+ * host backup (`~/.agentbox/claude-credentials.json`). The backup is what the
+ * foreground sync writes whenever a box's claude logs in, so its presence is
+ * the load-bearing signal that the shared volume has been seeded.
+ */
+export async function claudeAuthAvailable(env: NodeJS.ProcessEnv): Promise<boolean> {
+  const resolved = await resolveClaudeAuth(env);
+  if (resolved.source !== 'none') return true;
+  return hostBackupHasCredentials();
+}
+
+/**
+ * Richer Claude credential verdict for the non-interactive paths. `'missing'`
+ * when nothing can seed a box; `'expired'` when the saved login can no longer be
+ * renewed AND we're on a cloud provider — cloud has no shared volume to fall
+ * back to, whereas a docker box boots from the volume's live copy and refreshes
+ * it in-box. A host-env token (`ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`)
+ * or legacy `auth.json` short-circuits to `'ok'`: it has no expiry concept here.
+ * Mirrors the interactive `maybeRunCloudClaudeLogin` split, and shares its
+ * verdict helper — so a merely-lapsed access token is renewed here too rather
+ * than failing the job. This used to gate on `expiresAt` (the ~8h access token)
+ * and so refused to submit perfectly good jobs every day.
+ */
+export async function claudeCredStatus(
+  env: NodeJS.ProcessEnv,
+  isCloud: boolean,
+  image?: string,
+): Promise<'ok' | 'missing' | 'expired'> {
+  const resolved = await resolveClaudeAuth(env);
+  if (resolved.source !== 'none') return 'ok';
+  if (!isCloud) return (await hostBackupHasCredentials()) ? 'ok' : 'missing';
+  const health = await resolveClaudeCredHealth({
+    image: image ?? '',
+    // No image to probe with means no renewal; answer off the backup alone.
+    ...(image === undefined ? { offlineOnly: true } : {}),
+  });
+  if (health === 'missing') return 'missing';
+  return health === 'dead' ? 'expired' : 'ok';
+}

--- a/apps/cli/src/agents/claude/login-binding.ts
+++ b/apps/cli/src/agents/claude/login-binding.ts
@@ -1,0 +1,39 @@
+/**
+ * Binds claude's login spec to the docker surface it runs against: the
+ * `docker run` argv, the post-exit credential check, and the post-success
+ * warm-up. Beside the runtime that is its only caller — see
+ * `lib/agent-login-bindings.ts` for why it is not in the shared lib.
+ */
+import { syncClaudeCredentials, volumeClaudeCredentials } from '@agentbox/sandbox-docker';
+import {
+  buildClaudeLoginRunArgv,
+  SHARED_CLAUDE_VOLUME,
+  warmUpClaudeCredentials,
+} from '@agentbox/agent-claude';
+import { withLoginDefaults, type AgentLoginBinding } from '../../lib/agent-login-bindings.js';
+import { CLAUDE_LOGIN_SPEC } from './login.js';
+
+export function claudeLoginBinding(o: {
+  image: string;
+  volume?: string;
+  extraArgs?: string[];
+  writeLog?: (line: string) => void;
+}): AgentLoginBinding {
+  const volume = o.volume ?? SHARED_CLAUDE_VOLUME;
+  const { image } = o;
+  const extraArgs = withLoginDefaults(CLAUDE_LOGIN_SPEC, o.extraArgs ?? []);
+  return {
+    spec: CLAUDE_LOGIN_SPEC,
+    dockerArgv: buildClaudeLoginRunArgv({ volume, image, extraArgs }),
+    verify: async () => (await volumeClaudeCredentials(volume, image)).hasRefreshToken,
+    // Absorb the fresh-token first-request 400 in a throwaway container before
+    // any box uses these credentials, then mirror them to the host backup.
+    finalize: async () => {
+      const warm = await warmUpClaudeCredentials(volume, image, {
+        onProgress: (l) => o.writeLog?.(l),
+      });
+      await syncClaudeCredentials({ volume }, { image, isolate: false });
+      return { warmed: warm.warmed };
+    },
+  };
+}

--- a/apps/cli/src/agents/claude/runtime.ts
+++ b/apps/cli/src/agents/claude/runtime.ts
@@ -30,7 +30,7 @@ import {
 } from '@agentbox/agent-claude';
 import { confirm, log, spinner } from '../../lib/prompt.js';
 import { resolveClaudeAuth } from '../../auth.js';
-import { claudeLoginBinding } from '../../lib/agent-login-bindings.js';
+import { claudeLoginBinding } from './login-binding.js';
 import { resolveClaudeCredHealth } from '../../lib/claude-cred-health.js';
 import { runGuidedLogin } from '../../lib/guided-login.js';
 import { imageProgress } from '../../lib/progress.js';

--- a/apps/cli/src/agents/claude/runtime.ts
+++ b/apps/cli/src/agents/claude/runtime.ts
@@ -31,6 +31,7 @@ import {
 import { confirm, log, spinner } from '../../lib/prompt.js';
 import { resolveClaudeAuth } from '../../auth.js';
 import { claudeLoginBinding } from './login-binding.js';
+import { claudeCredStatus } from './host-creds.js';
 import { resolveClaudeCredHealth } from '../../lib/claude-cred-health.js';
 import { runGuidedLogin } from '../../lib/guided-login.js';
 import { imageProgress } from '../../lib/progress.js';
@@ -140,6 +141,16 @@ const SKIP_PERMISSIONS_RULE: SkipPermissionsRule = {
 };
 
 export const claudeRuntime: AgentRuntime = {
+  hostCredStatus: async ({ image, env, isCloud }) => {
+    const status = await claudeCredStatus(env, isCloud, image);
+    if (status === 'ok') return { status: 'ok' };
+    if (status === 'missing') return { status: 'missing' };
+    return {
+      status: 'expired',
+      message:
+        'Your saved Claude login can no longer be renewed. Sign in again with `agentbox claude login`, then retry.',
+    };
+  },
   sharedVolume: SHARED_CLAUDE_VOLUME,
   SessionError: ClaudeSessionError,
 

--- a/apps/cli/src/agents/codex/host-creds.ts
+++ b/apps/cli/src/agents/codex/host-creds.ts
@@ -1,0 +1,33 @@
+/**
+ * Codex's host-side credential check. See `agents/claude/host-creds.ts` for why
+ * these live beside their runtimes rather than in the shared queue helper.
+ */
+import { stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { SHARED_CODEX_VOLUME, volumeHasCodexAuth } from '@agentbox/agent-codex';
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * True when Codex is already authenticated: `OPENAI_API_KEY` in env, a host
+ * `~/.codex/auth.json`, or an `auth.json` already in the shared codex-config
+ * volume. Mirrors the foreground command's local helper so the `-i`
+ * pre-flight and the interactive login offer agree on what counts as
+ * "seeded".
+ */
+export async function codexAuthAvailable(
+  image: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<boolean> {
+  if ((env['OPENAI_API_KEY'] ?? '').length > 0) return true;
+  if (await fileExists(join(homedir(), '.codex', 'auth.json'))) return true;
+  return volumeHasCodexAuth(SHARED_CODEX_VOLUME, image);
+}

--- a/apps/cli/src/agents/codex/login-binding.ts
+++ b/apps/cli/src/agents/codex/login-binding.ts
@@ -1,0 +1,26 @@
+/**
+ * Binds codex's login spec to its docker surface. Beside the runtime that is
+ * its only caller — see `lib/agent-login-bindings.ts`.
+ */
+import {
+  buildCodexLoginRunArgv,
+  SHARED_CODEX_VOLUME,
+  volumeHasCodexAuth,
+} from '@agentbox/agent-codex';
+import { withLoginDefaults, type AgentLoginBinding } from '../../lib/agent-login-bindings.js';
+import { CODEX_LOGIN_SPEC } from './login.js';
+
+export function codexLoginBinding(o: {
+  image: string;
+  volume?: string;
+  extraArgs?: string[];
+}): AgentLoginBinding {
+  const volume = o.volume ?? SHARED_CODEX_VOLUME;
+  const { image } = o;
+  const extraArgs = withLoginDefaults(CODEX_LOGIN_SPEC, o.extraArgs ?? []);
+  return {
+    spec: CODEX_LOGIN_SPEC,
+    dockerArgv: buildCodexLoginRunArgv({ volume, image, extraArgs }),
+    verify: () => volumeHasCodexAuth(volume, image),
+  };
+}

--- a/apps/cli/src/agents/codex/runtime.ts
+++ b/apps/cli/src/agents/codex/runtime.ts
@@ -29,8 +29,8 @@ import {
   startCodexSession,
 } from '@agentbox/agent-codex';
 import { confirm, log, spinner } from '../../lib/prompt.js';
-import { codexAuthAvailable } from '../../lib/queue/assert-creds.js';
 import { codexLoginBinding } from './login-binding.js';
+import { codexAuthAvailable } from './host-creds.js';
 import { runGuidedLogin } from '../../lib/guided-login.js';
 import { loadPtyBackend } from '../../pty/pty-backend.js';
 import { imageProgress } from '../../lib/progress.js';
@@ -154,6 +154,8 @@ const SKIP_PERMISSIONS_RULE: SkipPermissionsRule = {
 };
 
 export const codexRuntime: AgentRuntime = {
+  hostCredStatus: async ({ image, env }) =>
+    (await codexAuthAvailable(image, env)) ? { status: 'ok' } : { status: 'missing' },
   sharedVolume: SHARED_CODEX_VOLUME,
   SessionError: CodexSessionError,
 

--- a/apps/cli/src/agents/codex/runtime.ts
+++ b/apps/cli/src/agents/codex/runtime.ts
@@ -30,7 +30,7 @@ import {
 } from '@agentbox/agent-codex';
 import { confirm, log, spinner } from '../../lib/prompt.js';
 import { codexAuthAvailable } from '../../lib/queue/assert-creds.js';
-import { codexLoginBinding } from '../../lib/agent-login-bindings.js';
+import { codexLoginBinding } from './login-binding.js';
 import { runGuidedLogin } from '../../lib/guided-login.js';
 import { loadPtyBackend } from '../../pty/pty-backend.js';
 import { imageProgress } from '../../lib/progress.js';

--- a/apps/cli/src/agents/command/create-action.ts
+++ b/apps/cli/src/agents/command/create-action.ts
@@ -357,6 +357,8 @@ export async function runAgentCreate(
         agent: a.spec.wireId ?? a.id,
         image: cfg.box.image,
         providerName,
+        // The agent's own check, not a chain in the shared helper.
+        hostCredStatus: (o) => a.runtime.hostCredStatus(o),
       });
     } catch (err) {
       if (err instanceof MissingAgentCredsError) fail(err.message);
@@ -442,6 +444,7 @@ export async function runAgentCreate(
           agent: a.spec.wireId ?? a.id,
           image: cfg.box.image,
           providerName,
+          hostCredStatus: (o) => a.runtime.hostCredStatus(o),
         });
       } catch (err) {
         if (err instanceof MissingAgentCredsError) fail(err.message);

--- a/apps/cli/src/agents/command/types.ts
+++ b/apps/cli/src/agents/command/types.ts
@@ -25,6 +25,7 @@ import type { CreateRouting } from '../../control-plane/route-create.js';
 import type { WrappedAttachOptions } from '../../wrapped-pty/index.js';
 import type { Command } from 'commander';
 import type { AgentLoginBinding } from '../../lib/agent-login-bindings.js';
+import type { HostCredVerdict } from '../../lib/queue/assert-creds.js';
 import type { ResolvedTeleport } from '../../session-teleport/index.js';
 import type { AgentSyncSpec } from '@agentbox/sandbox-core';
 
@@ -152,6 +153,19 @@ export interface AgentRuntime {
    * means "don't check".
    */
   requireCredsWhenNonTty?(): Promise<boolean>;
+  /**
+   * This agent's verdict on its own host credentials, for the `-i` pre-flight.
+   *
+   * Required, not optional: the shared helper used to dispatch with
+   * `agent === 'codex' ? … : opencode`, so an agent nobody had wired got
+   * OpenCode's check and a wrong answer. Making it part of the contract turns
+   * that into a compile error.
+   */
+  hostCredStatus(o: {
+    image: string;
+    env: NodeJS.ProcessEnv;
+    isCloud: boolean;
+  }): Promise<HostCredVerdict>;
   /** An agent whose login is a protocol of its own replaces the default
    *  subcommand body here — see `command/login.ts`. */
   loginCommand?: {

--- a/apps/cli/src/agents/opencode/host-creds.ts
+++ b/apps/cli/src/agents/opencode/host-creds.ts
@@ -1,0 +1,37 @@
+/**
+ * OpenCode's host-side credential check. See `agents/claude/host-creds.ts` for
+ * why these live beside their runtimes rather than in the shared queue helper.
+ */
+import { stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import {
+  OPENCODE_FORWARDED_ENV_KEYS,
+  SHARED_OPENCODE_VOLUME,
+  volumeHasOpencodeAuth,
+} from '@agentbox/agent-opencode';
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * True when OpenCode is already authenticated: any of its forwarded provider
+ * env keys, a host `~/.local/share/opencode/auth.json`, or an `auth.json`
+ * already in the shared opencode volume.
+ */
+export async function opencodeAuthAvailable(
+  image: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<boolean> {
+  for (const k of OPENCODE_FORWARDED_ENV_KEYS) {
+    if ((env[k] ?? '').length > 0) return true;
+  }
+  if (await fileExists(join(homedir(), '.local', 'share', 'opencode', 'auth.json'))) return true;
+  return volumeHasOpencodeAuth(SHARED_OPENCODE_VOLUME, image);
+}

--- a/apps/cli/src/agents/opencode/login-binding.ts
+++ b/apps/cli/src/agents/opencode/login-binding.ts
@@ -1,0 +1,26 @@
+/**
+ * Binds opencode's login spec to its docker surface. Beside the runtime that is
+ * its only caller — see `lib/agent-login-bindings.ts`.
+ */
+import {
+  buildOpencodeLoginRunArgv,
+  SHARED_OPENCODE_VOLUME,
+  volumeHasOpencodeAuth,
+} from '@agentbox/agent-opencode';
+import { withLoginDefaults, type AgentLoginBinding } from '../../lib/agent-login-bindings.js';
+import { OPENCODE_LOGIN_SPEC } from './login.js';
+
+export function opencodeLoginBinding(o: {
+  image: string;
+  volume?: string;
+  extraArgs?: string[];
+}): AgentLoginBinding {
+  const volume = o.volume ?? SHARED_OPENCODE_VOLUME;
+  const { image } = o;
+  const extraArgs = withLoginDefaults(OPENCODE_LOGIN_SPEC, o.extraArgs ?? []);
+  return {
+    spec: OPENCODE_LOGIN_SPEC,
+    dockerArgv: buildOpencodeLoginRunArgv({ volume, image, extraArgs }),
+    verify: () => volumeHasOpencodeAuth(volume, image),
+  };
+}

--- a/apps/cli/src/agents/opencode/runtime.ts
+++ b/apps/cli/src/agents/opencode/runtime.ts
@@ -30,8 +30,8 @@ import {
   startOpencodeSession,
 } from '@agentbox/agent-opencode';
 import { confirm, log, spinner, text } from '../../lib/prompt.js';
-import { opencodeAuthAvailable } from '../../lib/queue/assert-creds.js';
 import { opencodeLoginBinding } from './login-binding.js';
+import { opencodeAuthAvailable } from './host-creds.js';
 import { runGuidedLogin } from '../../lib/guided-login.js';
 import { loadPtyBackend } from '../../pty/pty-backend.js';
 import { imageProgress } from '../../lib/progress.js';
@@ -174,6 +174,8 @@ const SIGN_IN_PROMPT = 'Sign in to OpenCode? (pick a provider; saved and reused 
 const SKIPPED = 'Skipped sign-in — opencode will prompt you to sign in inside the box.';
 
 export const opencodeRuntime: AgentRuntime = {
+  hostCredStatus: async ({ image, env }) =>
+    (await opencodeAuthAvailable(image, env)) ? { status: 'ok' } : { status: 'missing' },
   sharedVolume: SHARED_OPENCODE_VOLUME,
   SessionError: OpencodeSessionError,
 

--- a/apps/cli/src/agents/opencode/runtime.ts
+++ b/apps/cli/src/agents/opencode/runtime.ts
@@ -31,7 +31,7 @@ import {
 } from '@agentbox/agent-opencode';
 import { confirm, log, spinner, text } from '../../lib/prompt.js';
 import { opencodeAuthAvailable } from '../../lib/queue/assert-creds.js';
-import { opencodeLoginBinding } from '../../lib/agent-login-bindings.js';
+import { opencodeLoginBinding } from './login-binding.js';
 import { runGuidedLogin } from '../../lib/guided-login.js';
 import { loadPtyBackend } from '../../pty/pty-backend.js';
 import { imageProgress } from '../../lib/progress.js';

--- a/apps/cli/src/commands/_run-queued-job.ts
+++ b/apps/cli/src/commands/_run-queued-job.ts
@@ -48,7 +48,7 @@ import {
 } from '@agentbox/relay';
 import { toSyncKind } from '@agentbox/core';
 import { resolveClaudeAuth } from '../auth.js';
-import { claudeCredStatus } from '../lib/queue/assert-creds.js';
+import { claudeCredStatus } from '../agents/claude/host-creds.js';
 import { runClaudeLogin } from '../lib/claude-login-run.js';
 import { cloudSizingProviderOptions } from '../lib/cloud-sizing.js';
 import { resolveLimits } from '../limits.js';

--- a/apps/cli/src/lib/agent-login-bindings.ts
+++ b/apps/cli/src/lib/agent-login-bindings.ts
@@ -1,28 +1,18 @@
 /**
- * Binds each agent's login spec to the docker surface it runs against: the
- * `docker run` argv, the post-exit credential check, and any post-success work.
- * Kept apart from `agent-login-specs.ts` (pure, unit-tested) and from
- * `agent-login-run.ts` (the pty loop) so neither has to know about volumes.
+ * What a guided login needs from an agent, and nothing about WHICH agents exist.
+ *
+ * This file used to hold three `<agent>LoginBinding` functions and import each
+ * agent's login spec and docker helpers — a per-agent table in shared code, and
+ * the last import edge pointing from the shared CLI INTO the agents. Each of
+ * those three had exactly one caller: that agent's own runtime, which already
+ * exposes the binding through `AgentRuntime.loginBinding`. So the seam was
+ * already there; the functions were simply on the wrong side of it.
+ *
+ * They live beside their runtimes now (`agents/<id>/login-binding.ts`, moving
+ * into `packages/agent-<id>/` with the rest of the CLI layer). What is left here
+ * is the contract both `guided-login.ts` and the command descriptor refer to by
+ * type only.
  */
-import { syncClaudeCredentials, volumeClaudeCredentials } from '@agentbox/sandbox-docker';
-import {
-  buildClaudeLoginRunArgv,
-  SHARED_CLAUDE_VOLUME,
-  warmUpClaudeCredentials,
-} from '@agentbox/agent-claude';
-import {
-  buildOpencodeLoginRunArgv,
-  SHARED_OPENCODE_VOLUME,
-  volumeHasOpencodeAuth,
-} from '@agentbox/agent-opencode';
-import {
-  buildCodexLoginRunArgv,
-  SHARED_CODEX_VOLUME,
-  volumeHasCodexAuth,
-} from '@agentbox/agent-codex';
-import { CLAUDE_LOGIN_SPEC } from '../agents/claude/login.js';
-import { CODEX_LOGIN_SPEC } from '../agents/codex/login.js';
-import { OPENCODE_LOGIN_SPEC } from '../agents/opencode/login.js';
 import type { AgentLoginSpec } from './agent-login-specs.js';
 
 export interface AgentLoginBinding {
@@ -34,61 +24,7 @@ export interface AgentLoginBinding {
   finalize?: () => Promise<{ warmed?: boolean }>;
 }
 
-function withDefaults(spec: AgentLoginSpec, extraArgs: string[]): string[] {
+/** An agent's own defaults apply when the user passed no extra args. */
+export function withLoginDefaults(spec: AgentLoginSpec, extraArgs: string[]): string[] {
   return extraArgs.length > 0 ? extraArgs : spec.defaultArgs;
-}
-
-export function claudeLoginBinding(o: {
-  image: string;
-  volume?: string;
-  extraArgs?: string[];
-  writeLog?: (line: string) => void;
-}): AgentLoginBinding {
-  const volume = o.volume ?? SHARED_CLAUDE_VOLUME;
-  const { image } = o;
-  const extraArgs = withDefaults(CLAUDE_LOGIN_SPEC, o.extraArgs ?? []);
-  return {
-    spec: CLAUDE_LOGIN_SPEC,
-    dockerArgv: buildClaudeLoginRunArgv({ volume, image, extraArgs }),
-    verify: async () => (await volumeClaudeCredentials(volume, image)).hasRefreshToken,
-    // Absorb the fresh-token first-request 400 in a throwaway container before
-    // any box uses these credentials, then mirror them to the host backup.
-    finalize: async () => {
-      const warm = await warmUpClaudeCredentials(volume, image, {
-        onProgress: (l) => o.writeLog?.(l),
-      });
-      await syncClaudeCredentials({ volume }, { image, isolate: false });
-      return { warmed: warm.warmed };
-    },
-  };
-}
-
-export function codexLoginBinding(o: {
-  image: string;
-  volume?: string;
-  extraArgs?: string[];
-}): AgentLoginBinding {
-  const volume = o.volume ?? SHARED_CODEX_VOLUME;
-  const { image } = o;
-  const extraArgs = withDefaults(CODEX_LOGIN_SPEC, o.extraArgs ?? []);
-  return {
-    spec: CODEX_LOGIN_SPEC,
-    dockerArgv: buildCodexLoginRunArgv({ volume, image, extraArgs }),
-    verify: () => volumeHasCodexAuth(volume, image),
-  };
-}
-
-export function opencodeLoginBinding(o: {
-  image: string;
-  volume?: string;
-  extraArgs?: string[];
-}): AgentLoginBinding {
-  const volume = o.volume ?? SHARED_OPENCODE_VOLUME;
-  const { image } = o;
-  const extraArgs = withDefaults(OPENCODE_LOGIN_SPEC, o.extraArgs ?? []);
-  return {
-    spec: OPENCODE_LOGIN_SPEC,
-    dockerArgv: buildOpencodeLoginRunArgv({ volume, image, extraArgs }),
-    verify: () => volumeHasOpencodeAuth(volume, image),
-  };
 }

--- a/apps/cli/src/lib/queue/assert-creds.ts
+++ b/apps/cli/src/lib/queue/assert-creds.ts
@@ -1,101 +1,17 @@
-import { stat } from 'node:fs/promises';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
-import { hostBackupHasCredentials } from '@agentbox/sandbox-docker';
-import {
-  OPENCODE_FORWARDED_ENV_KEYS,
-  SHARED_OPENCODE_VOLUME,
-  volumeHasOpencodeAuth,
-} from '@agentbox/agent-opencode';
-import { SHARED_CODEX_VOLUME, volumeHasCodexAuth } from '@agentbox/agent-codex';
+/**
+ * The `-i` pre-flight: refuse to submit a detached job whose agent has no
+ * host-side credentials to seed into the box.
+ *
+ * This file names no agent. It used to hold each one's host check and dispatch
+ * between them with `agent === 'codex' ? … : opencode` — so a fourth agent
+ * silently got OpenCode's credential check and a wrong answer. The check is the
+ * agent's own now (`AgentRuntime.hostCredStatus`, implemented in
+ * `agents/<id>/host-creds.ts`); what stays here is the contract, the errors and
+ * the wording, which already had a generic fallback for an agent it had never
+ * heard of.
+ */
 import type { QueueAgentKind } from '@agentbox/relay';
 import { normalizeLastAgent } from '@agentbox/core';
-import { resolveClaudeAuth } from '../../auth.js';
-import { resolveClaudeCredHealth } from '../claude-cred-health.js';
-
-async function fileExists(p: string): Promise<boolean> {
-  try {
-    await stat(p);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * True when Claude is already authenticated on the host: a forwarded env var
- * (`ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`), the legacy
- * `~/.agentbox/auth.json` setup-token, or a real OAuth refresh token in the
- * host backup (`~/.agentbox/claude-credentials.json`). The backup is what the
- * foreground sync writes whenever a box's claude logs in, so its presence is
- * the load-bearing signal that the shared volume has been seeded.
- */
-export async function claudeAuthAvailable(env: NodeJS.ProcessEnv): Promise<boolean> {
-  const resolved = await resolveClaudeAuth(env);
-  if (resolved.source !== 'none') return true;
-  return hostBackupHasCredentials();
-}
-
-/**
- * Richer Claude credential verdict for the non-interactive paths. `'missing'`
- * when nothing can seed a box; `'expired'` when the saved login can no longer be
- * renewed AND we're on a cloud provider — cloud has no shared volume to fall
- * back to, whereas a docker box boots from the volume's live copy and refreshes
- * it in-box. A host-env token (`ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`)
- * or legacy `auth.json` short-circuits to `'ok'`: it has no expiry concept here.
- * Mirrors the interactive `maybeRunCloudClaudeLogin` split, and shares its
- * verdict helper — so a merely-lapsed access token is renewed here too rather
- * than failing the job. This used to gate on `expiresAt` (the ~8h access token)
- * and so refused to submit perfectly good jobs every day.
- */
-export async function claudeCredStatus(
-  env: NodeJS.ProcessEnv,
-  isCloud: boolean,
-  image?: string,
-): Promise<'ok' | 'missing' | 'expired'> {
-  const resolved = await resolveClaudeAuth(env);
-  if (resolved.source !== 'none') return 'ok';
-  if (!isCloud) return (await hostBackupHasCredentials()) ? 'ok' : 'missing';
-  const health = await resolveClaudeCredHealth({
-    image: image ?? '',
-    // No image to probe with means no renewal; answer off the backup alone.
-    ...(image === undefined ? { offlineOnly: true } : {}),
-  });
-  if (health === 'missing') return 'missing';
-  return health === 'dead' ? 'expired' : 'ok';
-}
-
-/**
- * True when Codex is already authenticated: `OPENAI_API_KEY` in env, a host
- * `~/.codex/auth.json`, or an `auth.json` already in the shared codex-config
- * volume. Mirrors the foreground command's local helper so the `-i`
- * pre-flight and the interactive login offer agree on what counts as
- * "seeded".
- */
-export async function codexAuthAvailable(
-  image: string,
-  env: NodeJS.ProcessEnv = process.env,
-): Promise<boolean> {
-  if ((env['OPENAI_API_KEY'] ?? '').length > 0) return true;
-  if (await fileExists(join(homedir(), '.codex', 'auth.json'))) return true;
-  return volumeHasCodexAuth(SHARED_CODEX_VOLUME, image);
-}
-
-/**
- * True when OpenCode is already authenticated: any of its forwarded provider
- * env keys, a host `~/.local/share/opencode/auth.json`, or an `auth.json`
- * already in the shared opencode volume.
- */
-export async function opencodeAuthAvailable(
-  image: string,
-  env: NodeJS.ProcessEnv = process.env,
-): Promise<boolean> {
-  for (const k of OPENCODE_FORWARDED_ENV_KEYS) {
-    if ((env[k] ?? '').length > 0) return true;
-  }
-  if (await fileExists(join(homedir(), '.local', 'share', 'opencode', 'auth.json'))) return true;
-  return volumeHasOpencodeAuth(SHARED_OPENCODE_VOLUME, image);
-}
 
 /**
  * Wording for the agents we have something specific to say about. Not total —
@@ -123,9 +39,6 @@ function missingCredsMessage(agent: QueueAgentKind): string {
   );
 }
 
-const CLAUDE_EXPIRED_MESSAGE =
-  'Your saved Claude login can no longer be renewed. Sign in again with `agentbox claude login`, then retry.';
-
 export class MissingAgentCredsError extends Error {
   readonly agent: QueueAgentKind;
   constructor(agent: QueueAgentKind, message: string) {
@@ -148,13 +61,36 @@ export class ExpiredAgentCredsError extends MissingAgentCredsError {
   }
 }
 
+/**
+ * An agent's verdict on its own host credentials. `'expired'` is for the
+ * present-but-unrenewable case; an agent with no such concept simply never
+ * returns it.
+ */
+export type HostCredVerdict =
+  | { status: 'ok' }
+  | { status: 'missing' }
+  | { status: 'expired'; message: string };
+
 export interface AssertAgentCredsInput {
   agent: QueueAgentKind;
   image: string;
   env?: NodeJS.ProcessEnv;
-  /** Provider for this run; gates the Claude renewability check to cloud (see
-   *  {@link claudeCredStatus}). Omitted/`'docker'` → presence check only. */
+  /**
+   * Provider for this run. Passed to the agent's own check as `isCloud`, which
+   * claude uses to gate its renewability probe — cloud has no shared volume to
+   * fall back on. Omitted/`'docker'` → presence check only.
+   */
   providerName?: string;
+  /**
+   * The agent's own host-credential check. Required: there is no default, so an
+   * agent that has not supplied one is a compile error rather than a silent
+   * pass — which is what the removed three-arm chain gave a fourth agent.
+   */
+  hostCredStatus: (o: {
+    image: string;
+    env: NodeJS.ProcessEnv;
+    isCloud: boolean;
+  }) => Promise<HostCredVerdict>;
 }
 
 /**
@@ -167,17 +103,11 @@ export interface AssertAgentCredsInput {
  */
 export async function assertAgentCredsAvailable(input: AssertAgentCredsInput): Promise<void> {
   const env = input.env ?? process.env;
-  if (input.agent === 'claude-code') {
-    const isCloud = input.providerName !== undefined && input.providerName !== 'docker';
-    const status = await claudeCredStatus(env, isCloud, input.image);
-    if (status === 'missing')
-      throw new MissingAgentCredsError(input.agent, missingCredsMessage(input.agent));
-    if (status === 'expired') throw new ExpiredAgentCredsError(input.agent, CLAUDE_EXPIRED_MESSAGE);
-    return;
+  const isCloud = input.providerName !== undefined && input.providerName !== 'docker';
+  const verdict = await input.hostCredStatus({ image: input.image, env, isCloud });
+  if (verdict.status === 'ok') return;
+  if (verdict.status === 'expired') {
+    throw new ExpiredAgentCredsError(input.agent, verdict.message);
   }
-  const ok =
-    input.agent === 'codex'
-      ? await codexAuthAvailable(input.image, env)
-      : await opencodeAuthAvailable(input.image, env);
-  if (!ok) throw new MissingAgentCredsError(input.agent, missingCredsMessage(input.agent));
+  throw new MissingAgentCredsError(input.agent, missingCredsMessage(input.agent));
 }

--- a/apps/cli/test/assert-creds.test.ts
+++ b/apps/cli/test/assert-creds.test.ts
@@ -42,15 +42,35 @@ vi.mock('@agentbox/agent-opencode', async (importOriginal) => ({
   volumeHasOpencodeAuth: sandboxDockerMock.volumeHasOpencodeAuth,
 }));
 
-const {
-  assertAgentCredsAvailable,
-  claudeAuthAvailable,
-  claudeCredStatus,
-  codexAuthAvailable,
-  opencodeAuthAvailable,
-  MissingAgentCredsError,
-  ExpiredAgentCredsError,
-} = await import('../src/lib/queue/assert-creds.js');
+const { assertAgentCredsAvailable, MissingAgentCredsError, ExpiredAgentCredsError } =
+  await import('../src/lib/queue/assert-creds.js');
+// The per-agent checks moved next to their runtimes — the shared helper no
+// longer knows any agent's name. The mock has to follow the symbol.
+const { claudeAuthAvailable, claudeCredStatus } =
+  await import('../src/agents/claude/host-creds.js');
+const { codexAuthAvailable } = await import('../src/agents/codex/host-creds.js');
+const { opencodeAuthAvailable } = await import('../src/agents/opencode/host-creds.js');
+const { claudeRuntime } = await import('../src/agents/claude/runtime.js');
+const { codexRuntime } = await import('../src/agents/codex/runtime.js');
+const { opencodeRuntime } = await import('../src/agents/opencode/runtime.js');
+
+/** The agent supplies its own check now, so every assert call carries one. */
+const RUNTIMES: Record<string, { hostCredStatus: (typeof claudeRuntime)['hostCredStatus'] }> = {
+  'claude-code': claudeRuntime,
+  codex: codexRuntime,
+  opencode: opencodeRuntime,
+};
+function assertFor(input: {
+  agent: string;
+  image: string;
+  env?: NodeJS.ProcessEnv;
+  providerName?: string;
+}) {
+  return assertAgentCredsAvailable({
+    ...input,
+    hostCredStatus: (o) => RUNTIMES[input.agent]!.hostCredStatus(o),
+  } as Parameters<typeof assertAgentCredsAvailable>[0]);
+}
 
 // Re-import the auth file path AFTER the mock; the module reads STATE_DIR from
 // the mocked sandbox-docker, but resolveClaudeAuth pulls it through readAuthFile
@@ -274,22 +294,22 @@ describe('assertAgentCredsAvailable dispatcher', () => {
   it('returns silently when claude has creds', async () => {
     sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
     await expect(
-      assertAgentCredsAvailable({ agent: 'claude-code', image: IMAGE, env: {} }),
+      assertFor({ agent: 'claude-code', image: IMAGE, env: {} }),
     ).resolves.toBeUndefined();
   });
 
   it('throws MissingAgentCredsError for claude when no source has creds', async () => {
     sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(false);
-    await expect(
-      assertAgentCredsAvailable({ agent: 'claude-code', image: IMAGE, env: {} }),
-    ).rejects.toBeInstanceOf(MissingAgentCredsError);
+    await expect(assertFor({ agent: 'claude-code', image: IMAGE, env: {} })).rejects.toBeInstanceOf(
+      MissingAgentCredsError,
+    );
   });
 
   it('throws ExpiredAgentCredsError for claude on cloud when the login cannot be renewed', async () => {
     sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
     sandboxDockerMock.hostClaudeLoginDead.mockResolvedValue(true);
     try {
-      await assertAgentCredsAvailable({
+      await assertFor({
         agent: 'claude-code',
         image: IMAGE,
         env: {},
@@ -310,7 +330,7 @@ describe('assertAgentCredsAvailable dispatcher', () => {
     sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
     sandboxDockerMock.hostClaudeLoginDead.mockResolvedValue(true);
     await expect(
-      assertAgentCredsAvailable({
+      assertFor({
         agent: 'claude-code',
         image: IMAGE,
         env: {},
@@ -322,7 +342,7 @@ describe('assertAgentCredsAvailable dispatcher', () => {
   it('error carries the agent kind and a helpful message', async () => {
     sandboxDockerMock.volumeHasCodexAuth.mockResolvedValue(false);
     try {
-      await assertAgentCredsAvailable({ agent: 'codex', image: IMAGE, env: {} });
+      await assertFor({ agent: 'codex', image: IMAGE, env: {} });
       throw new Error('expected to throw');
     } catch (err) {
       expect(err).toBeInstanceOf(MissingAgentCredsError);
@@ -335,11 +355,73 @@ describe('assertAgentCredsAvailable dispatcher', () => {
 
   it('routes opencode through the opencode predicate', async () => {
     sandboxDockerMock.volumeHasOpencodeAuth.mockResolvedValue(true);
-    await expect(
-      assertAgentCredsAvailable({ agent: 'opencode', image: IMAGE, env: {} }),
-    ).resolves.toBeUndefined();
+    await expect(assertFor({ agent: 'opencode', image: IMAGE, env: {} })).resolves.toBeUndefined();
     // Wrong-agent predicates must not be consulted.
     expect(sandboxDockerMock.hostBackupHasCredentials).not.toHaveBeenCalled();
     expect(sandboxDockerMock.volumeHasCodexAuth).not.toHaveBeenCalled();
+  });
+});
+
+describe('assertAgentCredsAvailable dispatch', () => {
+  it("uses the AGENT's own check, so a fourth agent is never given another's", async () => {
+    // The removed three-arm chain was `agent === 'codex' ? codex : opencode`,
+    // so any agent that was not claude or codex silently got OpenCode's
+    // credential check — a wrong answer with nothing failing.
+    let sawImage: string | undefined;
+    await expect(
+      assertAgentCredsAvailable({
+        agent: 'demo' as never,
+        image: 'demo-image',
+        env: {},
+        hostCredStatus: ({ image }) => {
+          sawImage = image;
+          return Promise.resolve({ status: 'ok' as const });
+        },
+      }),
+    ).resolves.toBeUndefined();
+    expect(sawImage).toBe('demo-image');
+  });
+
+  it('reports a missing credential for an agent it has never heard of', async () => {
+    await expect(
+      assertAgentCredsAvailable({
+        agent: 'demo' as never,
+        image: 'demo-image',
+        env: {},
+        hostCredStatus: () => Promise.resolve({ status: 'missing' as const }),
+      }),
+    ).rejects.toThrow(/No demo credentials on host/);
+  });
+
+  it('passes isCloud through, since only the agent knows what to do with it', async () => {
+    const seen: boolean[] = [];
+    const probe = (providerName?: string) =>
+      assertAgentCredsAvailable({
+        agent: 'demo' as never,
+        image: 'i',
+        env: {},
+        ...(providerName === undefined ? {} : { providerName }),
+        hostCredStatus: ({ isCloud }) => {
+          seen.push(isCloud);
+          return Promise.resolve({ status: 'ok' as const });
+        },
+      });
+    await probe('daytona');
+    await probe('docker');
+    await probe();
+    expect(seen).toEqual([true, false, false]);
+  });
+
+  it("surfaces the agent's own wording for an unrenewable login", async () => {
+    // The expired message used to be a claude constant in the shared helper.
+    await expect(
+      assertAgentCredsAvailable({
+        agent: 'demo' as never,
+        image: 'i',
+        env: {},
+        hostCredStatus: () =>
+          Promise.resolve({ status: 'expired' as const, message: 'demo says: re-auth' }),
+      }),
+    ).rejects.toThrow('demo says: re-auth');
   });
 });

--- a/apps/cli/test/login-binding.test.ts
+++ b/apps/cli/test/login-binding.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { claudeLoginBinding } from '../src/agents/claude/login-binding.js';
+import { codexLoginBinding } from '../src/agents/codex/login-binding.js';
+import { opencodeLoginBinding } from '../src/agents/opencode/login-binding.js';
+import { withLoginDefaults } from '../src/lib/agent-login-bindings.js';
+
+/**
+ * The bindings moved out of `lib/agent-login-bindings.ts` and next to their
+ * runtimes, which removed the last import edge pointing from the shared CLI
+ * INTO the agents. This asserts the move was behaviour-preserving: each still
+ * builds a `docker run` argv against its own config volume, and only claude
+ * carries a post-success step.
+ */
+const IMAGE = 'agentbox/box:dev';
+
+describe('per-agent login bindings', () => {
+  it('each mounts its own config volume into the throwaway container', () => {
+    const rows = [
+      { name: 'claude', b: claudeLoginBinding({ image: IMAGE }) },
+      { name: 'codex', b: codexLoginBinding({ image: IMAGE }) },
+      { name: 'opencode', b: opencodeLoginBinding({ image: IMAGE }) },
+    ];
+    for (const { name, b } of rows) {
+      expect(b.dockerArgv[0], name).toBe('run');
+      expect(b.dockerArgv.join(' '), name).toContain(IMAGE);
+      // Its own volume, never another agent's.
+      const mounts = b.dockerArgv.filter((a) => a.includes(':/home/'));
+      expect(mounts.length, `${name} mounts`).toBeGreaterThan(0);
+      for (const other of rows.filter((r) => r.name !== name)) {
+        expect(mounts.join(' '), `${name} must not mount ${other.name}`).not.toContain(
+          `agentbox-${other.name}-config`,
+        );
+      }
+    }
+  });
+
+  it('only claude has post-success work', () => {
+    // The warm-up + host-backup mirror. A shared `finalize` on every agent
+    // would be a field only one of them can fill.
+    expect(Boolean(claudeLoginBinding({ image: IMAGE }).finalize)).toBe(true);
+    expect(Boolean(codexLoginBinding({ image: IMAGE }).finalize)).toBe(false);
+    expect(Boolean(opencodeLoginBinding({ image: IMAGE }).finalize)).toBe(false);
+  });
+
+  it("honours the user's own args over the agent's defaults", () => {
+    const withArgs = codexLoginBinding({ image: IMAGE, extraArgs: ['--sso'] });
+    expect(withArgs.dockerArgv).toContain('--sso');
+  });
+
+  it('withLoginDefaults falls back only when the user passed nothing', () => {
+    const spec = { defaultArgs: ['--default'] } as never;
+    expect(withLoginDefaults(spec, [])).toEqual(['--default']);
+    expect(withLoginDefaults(spec, ['--mine'])).toEqual(['--mine']);
+  });
+});

--- a/apps/cli/test/no-agent-named-exports.test.ts
+++ b/apps/cli/test/no-agent-named-exports.test.ts
@@ -61,7 +61,6 @@ const ALLOWLIST: Record<string, string> = {
   'apps/cli/src/commands/download-opencode.ts': 'phase 2',
   'apps/cli/src/commands/install-codex.ts': 'phase 2',
   'apps/cli/src/commands/_claude-login-worker.ts': 'phase 2',
-  'apps/cli/src/lib/queue/assert-creds.ts': 'phase 2',
   'apps/cli/src/session-teleport/cwd-encoding.ts': 'phase 2',
   'apps/cli/src/session-teleport/plan.ts': 'phase 2',
 

--- a/apps/cli/test/no-agent-named-exports.test.ts
+++ b/apps/cli/test/no-agent-named-exports.test.ts
@@ -60,6 +60,8 @@ const ALLOWLIST: Record<string, string> = {
   'apps/cli/src/commands/download-codex.ts': 'phase 2',
   'apps/cli/src/commands/download-opencode.ts': 'phase 2',
   'apps/cli/src/commands/install-codex.ts': 'phase 2',
+  'apps/cli/src/commands/_claude-login-worker.ts': 'phase 2',
+  'apps/cli/src/lib/queue/assert-creds.ts': 'phase 2',
   'apps/cli/src/session-teleport/cwd-encoding.ts': 'phase 2',
   'apps/cli/src/session-teleport/plan.ts': 'phase 2',
 
@@ -75,6 +77,7 @@ const ALLOWLIST: Record<string, string> = {
   'packages/sandbox-cloud/src/sync/claude-json-overlay.ts': 'phase 4',
   'packages/sandbox-docker/src/sync/claude-credentials.ts': 'phase 4',
   'packages/sandbox-docker/src/credential-refresh.ts': 'phase 4',
+  'packages/sandbox-core/src/sync/agent-propagate.ts': 'phase 4',
 
   // Phase 5b — `claudeInstall`. 300 sites across 79 files, reaching the
   // published SDK, the hub's REST schema, on-disk prepared state and a
@@ -86,6 +89,8 @@ const ALLOWLIST: Record<string, string> = {
   'packages/core/src/claude-tui.ts': 'phase 7',
   'packages/ctl/src/types.ts': 'phase 7',
   'packages/ctl/src/session-pointer.ts': 'phase 7',
+  'packages/ctl/src/client.ts': 'phase 7',
+  'packages/ctl/src/commands/claude-session.ts': 'phase 7',
 };
 
 /**
@@ -101,10 +106,19 @@ const NOT_APPLICABLE = [
   'apps/cli/src/agents/',
   'packages/ctl/src/claude-scraper.ts',
   'packages/ctl/src/codex-scraper.ts',
+  // `codexAddUrl` here is the Codex.app `codex://` deep link — the DESKTOP APP,
+  // sitting among herdr, cmux, vscode and finder. Renaming it would be wrong,
+  // which is why this is an exclusion and not an exemption. The union guard in
+  // `no-inline-agent-union.test.ts` carves this same file out for the same
+  // reason.
+  'apps/cli/src/commands/_open-in.ts',
 ];
 
+// Both cases: `stageClaudeStatic` and `claudeLoginBinding` are the same
+// mistake, and the lowercase form is the one that hid — `claudeLoginBinding`
+// sat in the shared CLI until it was looked for by hand.
 const EXPORTED_AGENT_NAME =
-  /^export\s+(?:type\s+|interface\s+|const\s+|let\s+|function\s+|class\s+|abstract\s+class\s+|async\s+function\s+)?[A-Za-z_]*(?:Claude|Codex|Opencode|OpenCode|CLAUDE|CODEX|OPENCODE)/;
+  /^export\s+(?:type\s+|interface\s+|const\s+|let\s+|function\s+|class\s+|abstract\s+class\s+|async\s+function\s+)?[A-Za-z_]*(?:claude|codex|opencode|Claude|Codex|Opencode|OpenCode|CLAUDE|CODEX|OPENCODE)/;
 
 function walk(dir: string, out: string[] = []): string[] {
   let entries;

--- a/docs/agents-as-packages-plan.md
+++ b/docs/agents-as-packages-plan.md
@@ -350,9 +350,28 @@ allowlisted against its owning phase, except `commands/_open-in.ts`, which is
 excluded rather than exempted: its `codexAddUrl` is the Codex.app `codex://`
 deep link, and renaming that would be wrong.
 
-**Next (2b):** extract the ten-module kit and move codex + opencode. Then
-claude's heavy six, most likely by inverting them through the existing
-`AgentCliSpec` ctx seam rather than extracting `control-plane.ts`.
+**Done (2b, part 1): the queue's credential pre-flight is agent-agnostic.**
+`lib/queue/assert-creds.ts` was the one kit module with agent-specific
+dependencies, and it dispatched with `agent === 'codex' ? codex : opencode` — so
+**an agent that was neither claude nor codex silently got OpenCode's credential
+check**, and a wrong answer with nothing failing. Found while sizing the kit, not
+by a test.
+
+Each agent's host check moved to `agents/<id>/host-creds.ts`, and
+`AgentRuntime.hostCredStatus` is a REQUIRED member: an agent that has not
+supplied one is now a compile error rather than a silent pass. The shared helper
+keeps the contract, the errors, and the wording — which already had a generic
+fallback for an unknown agent, so only the dispatch was ever wrong. Claude's
+`'expired'` message travels in the verdict rather than sitting in the shared file
+as a constant.
+
+That emptied `assert-creds.ts` of agent names, and the stale-exemption half of
+the `no-agent-named-exports` guard fired on the next run demanding its removal —
+the allowlist is 27 files, down from 29.
+
+**Next (2b, part 2):** extract the remaining nine-module kit and move codex +
+opencode. Then claude's heavy six, most likely by inverting them through the
+existing `AgentCliSpec` ctx seam rather than extracting `control-plane.ts`.
 
 **Phase 4 — `sandbox-cloud` — PARTLY DONE (`568cac29`).** `AgentCloudModule` is
 the cloud twin of `AgentSyncModule`; codex's `AGENTS.override` fold and

--- a/docs/agents-as-packages-plan.md
+++ b/docs/agents-as-packages-plan.md
@@ -319,13 +319,40 @@ and register from the app instead of `builtins.ts`. Each agent's arm leaves that
 file as it goes, so the exemption in `agent-module-isolation.test.ts` shrinks to
 nothing. Land per file, claude last — it is the daily driver.
 
-**Phase 2 — the CLI layer — BLOCKED, and reordered after 3b.** Measured: the
-per-agent folders import **26 distinct shared CLI modules** (`lib/prompt`,
-`lib/progress`, `pty/pty-backend`, `lib/guided-login`, `session-teleport/*`,
-`wizard.ts`, `provider/registry.ts`, `checkpoint-lookup.ts`, …). Moving them into
-packages needs a CLI-kit extraction first, or an inversion of the app-level ones
-through the existing `AgentCliSpec` ctx seam. That is its own phase, not a file
-move — the original plan assumed this step was mechanical and it is not.
+**Phase 2 — the CLI layer — STARTED; the blocker is smaller than measured.**
+The 26-shared-module count is right but misleading, and re-measuring changed the
+plan:
+
+- **All six heavy imports belong to claude alone** — `commands/prepare` (975
+  lines), `commands/control-plane` (2,729), `wizard.ts`, `provider/registry`,
+  `checkpoint-lookup`, `commands/_errors`, all from
+  `agents/claude/{command,login-command}.ts`. **codex (606 lines) and opencode
+  (371) touch none of them.** They need ten modules, and every one is a near-leaf
+  (0–4 local imports of its own). So those two can move on a modest kit; only
+  claude needs the heavy six inverted, and that is a separate step.
+- **The real blocker was an import edge, not a size.** `lib/agent-login-bindings.ts`
+  imported each agent's login spec and docker helpers — a per-agent table in
+  shared code, pointing from the shared CLI INTO the agents. Nothing could move
+  while that edge existed.
+
+**Done (2a): that edge is gone.** Each `<agent>LoginBinding` had exactly one
+caller — its own runtime, which already exposed it through
+`AgentRuntime.loginBinding` — so the seam was already there and the functions
+were simply on the wrong side of it. They live in
+`agents/<id>/login-binding.ts` now; the shared file keeps the
+`AgentLoginBinding` contract and `withLoginDefaults`, which is all
+`guided-login.ts` and the command descriptor ever used (both by type only).
+
+The `no-agent-named-exports` guard was broadened to catch the **lowercase**
+form in the same pass — `claudeLoginBinding` had sat in the shared CLI unnoticed
+because the guard only matched `Claude`. Six more files came into view, each
+allowlisted against its owning phase, except `commands/_open-in.ts`, which is
+excluded rather than exempted: its `codexAddUrl` is the Codex.app `codex://`
+deep link, and renaming that would be wrong.
+
+**Next (2b):** extract the ten-module kit and move codex + opencode. Then
+claude's heavy six, most likely by inverting them through the existing
+`AgentCliSpec` ctx seam rather than extracting `control-plane.ts`.
 
 **Phase 4 — `sandbox-cloud` — PARTLY DONE (`568cac29`).** `AgentCloudModule` is
 the cloud twin of `AgentSyncModule`; codex's `AGENTS.override` fold and


### PR DESCRIPTION
Follow-on to #346. Starts phase 2 (the CLI layer) by removing what was actually blocking it.

## The blocker was an import edge, not a size

The plan recorded phase 2 as blocked on "26 distinct shared CLI modules". That count is right but it was the wrong thing to measure. Re-measuring changed the plan:

- **All six HEAVY imports belong to claude alone** — `commands/prepare` (975 lines), `commands/control-plane` (2,729), `wizard.ts`, `provider/registry`, `checkpoint-lookup`, `commands/_errors`, every one from `agents/claude/{command,login-command}.ts`. **codex (606 lines) and opencode (371) touch none of them.** They need ten modules, and each is a near-leaf (0–4 local imports of its own).
- **What genuinely blocked everything** was `lib/agent-login-bindings.ts`: it held three `<agent>LoginBinding` functions and imported each agent's login spec and docker helpers — a per-agent table in shared code, pointing from the shared CLI *into* the agents.

## The fix

Each of those three had exactly one caller: that agent's own runtime, which already exposes the binding through `AgentRuntime.loginBinding`. The seam was already there; the functions were on the wrong side of it. They now live in `agents/<id>/login-binding.ts`, and the shared file keeps only the `AgentLoginBinding` contract and `withLoginDefaults` — which is all `guided-login.ts` and the command descriptor ever used, both by type only.

## The guard had a hole, and this is what fell through it

`no-agent-named-exports` only matched capitalized agent names, so `claudeLoginBinding` sat in the shared CLI unnoticed. Broadened to the lowercase form in the same pass; six more files came into view, each allowlisted against its owning phase.

One is excluded rather than exempted: `commands/_open-in.ts`'s `codexAddUrl` is the **Codex.app** `codex://` deep link — the desktop app, sitting among herdr, cmux, vscode and finder. Renaming it would be wrong, which is the same carve-out `no-inline-agent-union.test.ts` already makes for that file.

## Verification

Full CI locally (`check:plugin-skill`, `lint`, `build`, hub standalone, `check:cloud-backends`, `typecheck`, `test`). New tests assert each binding mounts its **own** config volume and never another agent's, that only claude carries post-success work, and that a user's args beat the agent's defaults — all three mutation-checked, plus the broadened guard.

## Next

Extract the ten-module kit and move codex + opencode; then claude's heavy six, most likely inverted through the existing `AgentCliSpec` ctx seam rather than by extracting `control-plane.ts`.

https://claude.ai/code/session_01PkEcUxA2Jqs4CPD4ni1rXP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor with behavior-preserving tests; login flow logic is moved, not rewritten.
> 
> **Overview**
> **Phase 2a** removes the import edge that blocked moving agent CLI code into packages: shared `lib/agent-login-bindings.ts` no longer imports each agent’s login spec and docker helpers.
> 
> **`claudeLoginBinding`**, **`codexLoginBinding`**, and **`opencodeLoginBinding`** now live in `agents/<id>/login-binding.ts` beside each runtime; runtimes import locally instead of from the shared lib. The shared module keeps only the **`AgentLoginBinding`** contract and exported **`withLoginDefaults`** (renamed from internal `withDefaults`) for **`guided-login.ts`** and command types.
> 
> **`no-agent-named-exports`** now flags lowercase agent-prefixed exports (e.g. `claudeLoginBinding`); six additional files are allowlisted for later phases, and **`commands/_open-in.ts`** is excluded because **`codexAddUrl`** names the Codex desktop app deep link.
> 
> New **`login-binding.test.ts`** asserts behavior-preserving mounts, Claude-only **`finalize`**, and default-args handling. **`docs/agents-as-packages-plan.md`** records 2a done and 2b next (kit extract + codex/opencode move).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 980fe9134a5384ad1ae8ed162f468665ba653862. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->