### PR TITLE
Ship the agent plugin example, beside the provider one

### DIFF
--- a/apps/cli/test/example-agent-plugin.test.ts
+++ b/apps/cli/test/example-agent-plugin.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { agentSpecProblem, BUILTIN_AGENT_SPECS } from '@agentbox/agent-registry';
+
+/**
+ * The shipped example agent plugin must stay loadable and valid.
+ *
+ * It is the artifact behind the claim "adding an agent costs nothing in this
+ * repo", and a doc example that has rotted proves the opposite. This loads the
+ * real file the way `agentbox agent add` does — a dynamic import of the entry
+ * resolved from its `package.json` — and validates the spec with the same
+ * function the command uses.
+ */
+const PKG_DIR = join(__dirname, '..', '..', '..', 'examples', 'agentbox-agent-example');
+
+describe('examples/agentbox-agent-example', () => {
+  it('exports a spec that `agent add` would accept', async () => {
+    const pkg = JSON.parse(readFileSync(join(PKG_DIR, 'package.json'), 'utf8')) as {
+      exports: { '.': { import: string } };
+      agentbox?: { agentApiVersion?: number };
+    };
+    const entry = join(PKG_DIR, pkg.exports['.'].import);
+    const mod = (await import(pathToFileURL(entry).href)) as {
+      agentSpec?: unknown;
+      agentSyncModule?: { id: string; resolveVolume: (o: unknown) => { volume: string } };
+      AGENT_API_VERSION?: number;
+    };
+
+    expect(agentSpecProblem(mod.agentSpec)).toBeNull();
+    expect(mod.AGENT_API_VERSION ?? pkg.agentbox?.agentApiVersion).toBe(1);
+  });
+
+  it('claims no built-in agent id or alias', async () => {
+    // `agent add` refuses this, so an example that violated it could never be
+    // registered — and would teach the wrong thing.
+    const { agentSpec } = (await import(pathToFileURL(join(PKG_DIR, 'src/index.js')).href)) as {
+      agentSpec: { id: string; aliases: string[] };
+    };
+    const taken = new Set(BUILTIN_AGENT_SPECS.flatMap((s) => [s.id, ...s.aliases]));
+    for (const name of [agentSpec.id, ...agentSpec.aliases]) {
+      expect(taken.has(name), `example claims built-in name "${name}"`).toBe(false);
+    }
+  });
+
+  it('its docker module answers for the agent it declares', async () => {
+    const mod = (await import(pathToFileURL(join(PKG_DIR, 'src/index.js')).href)) as {
+      agentSpec: { id: string; dockerVolume: string };
+      agentSyncModule: {
+        id: string;
+        resolveVolume: (o: { isolate: boolean; boxId: string }) => { volume: string };
+      };
+    };
+    // The loader refuses a module whose id the package did not register, so a
+    // mismatch here would make the example unusable rather than merely wrong.
+    expect(mod.agentSyncModule.id).toBe(mod.agentSpec.id);
+    expect(mod.agentSyncModule.resolveVolume({ isolate: false, boxId: 'b' }).volume).toBe(
+      mod.agentSpec.dockerVolume,
+    );
+    expect(mod.agentSyncModule.resolveVolume({ isolate: true, boxId: 'b1' }).volume).toContain(
+      'b1',
+    );
+  });
+});

--- a/apps/web/content/docs/run-an-agent.mdx
+++ b/apps/web/content/docs/run-an-agent.mdx
@@ -177,6 +177,11 @@ export const agentSpec = {
 };
 ```
 
+A complete, working example ships in the repo at
+[`examples/agentbox-agent-example`](https://github.com/madarco/agentbox/tree/main/examples/agentbox-agent-example)
+— one dependency-free file. Register it with
+`agentbox agent add ./examples/agentbox-agent-example` to see the whole flow.
+
 `agentbox agent add` loads the package once, checks the spec, and snapshots it
 into `~/.agentbox/agents.json`. Everything afterwards reads the snapshot, so no
 part of AgentBox has to import your package to know the agent exists — and your

--- a/docs/agents-as-packages-plan.md
+++ b/docs/agents-as-packages-plan.md
@@ -567,6 +567,19 @@ uses. A doc example that has rotted proves the opposite of what it claims, so th
 test mutation-checks three ways: claiming a built-in alias, dropping a required
 spec field, and declaring a module for an agent the package did not register.
 
+Bugbot found two real bugs in the first version of that example, and the second
+mattered more than the file: `install: { kind: 'none' }` is not an
+`AgentInstall`, and `agentSpecProblem` only checked that the field was PRESENT —
+so `agent add` accepted it and the failure surfaced at bake time, reading
+`recipe.kind` off undefined, where the package author is long gone. Validation
+now checks the SHAPE of everything load-bearing: the recipe kind and its
+per-kind required field, `runAs` (an installer that drops a binary in the
+invoking user's `~/.local/bin` puts it in /root when run as root),
+`credential.hostBackup` being an absolute path (the fan-out WRITES there, so an
+empty one drops a temp file in the process cwd and loses the login), and each
+`staticPaths` entry. Every built-in spec still passes; both halves
+mutation-checked.
+
 ## What adding an agent costs today — measured, after phase 3b
 
 | step | needed? |

--- a/docs/agents-as-packages-plan.md
+++ b/docs/agents-as-packages-plan.md
@@ -580,6 +580,20 @@ empty one drops a temp file in the process cwd and loses the login), and each
 `staticPaths` entry. Every built-in spec still passes; both halves
 mutation-checked.
 
+A SECOND Bugbot pass then found two holes in that validation itself, and one was
+the worst bug of the series: `hostHomeRel` was checked for being an array but
+not for being NON-EMPTY, and staging does `join(homedir(), ...hostHomeRel)` — so
+`[]` or `['']` resolves to the user's HOME, and cloud staging would rsync their
+entire home tree into a snapshot every box made from it shares. The other:
+`boxAbsPath` was only required to be non-empty while its siblings had to be
+absolute, and the credential push derives the directory with
+`slice(0, lastIndexOf('/'))`, so a relative `auth.json` gives an empty dir and a
+copy that silently never lands. Both fixed and mutation-checked.
+
+The lesson worth keeping: each round of validation I wrote was itself too weak,
+and only an adversarial reader found it. "The example registered successfully"
+never proved the spec was correct — it proved the checks were loose.
+
 ## What adding an agent costs today — measured, after phase 3b
 
 | step | needed? |

--- a/docs/agents-as-packages-plan.md
+++ b/docs/agents-as-packages-plan.md
@@ -559,6 +559,14 @@ dynamic `import()` under test is the real one.
 The measurement the plan asked for is recorded in `docs/agents.md` →
 "What a new agent actually costs, measured".
 
+**The example is committed, not a transcript claim.**
+`examples/agentbox-agent-example` is a real, dependency-free agent plugin beside
+the existing `agentbox-provider-example`, with a README and a test that loads it
+the way `agent add` does and validates it with the same function the command
+uses. A doc example that has rotted proves the opposite of what it claims, so the
+test mutation-checks three ways: claiming a built-in alias, dropping a required
+spec field, and declaring a module for an agent the package did not register.
+
 ## What adding an agent costs today — measured, after phase 3b
 
 | step | needed? |

--- a/examples/agentbox-agent-example/README.md
+++ b/examples/agentbox-agent-example/README.md
@@ -1,0 +1,54 @@
+# agentbox-agent-example
+
+A complete AgentBox **agent plugin**, in one dependency-free file — the reference
+for `agentbox agent add`, and the agent counterpart to
+[`agentbox-provider-example`](../agentbox-provider-example).
+
+## Try it
+
+```console
+$ agentbox agent add ./examples/agentbox-agent-example
+registered example-agent from agentbox-agent-example@0.1.0
+
+$ agentbox agent list
+claude               built-in
+codex                built-in
+opencode             built-in
+example-agent        agentbox-agent-example@0.1.0 (agent API v1)
+
+$ agentbox agent remove agentbox-agent-example
+```
+
+## What a package has to export
+
+**`agentSpec`** — the data. Where the agent's config lives on the host and in a
+box, how it installs, what it can do. Every field is a string, array or plain
+object, because the spec is shipped into boxes whose baked `agentbox-ctl` may
+predate the agent entirely (it arrives over the `agents.list` RPC). That same
+property is what lets `agent add` snapshot it into `~/.agentbox/agents.json`,
+where every reader resolves it **synchronously and offline** — nothing has to
+import your package to know your agent exists.
+
+**`agentSyncModule`** — optional. Only needed to create a **docker** box, which
+requires knowing how to mount the agent's config volume. Everything declarative
+— listing, resolving by id or alias, and staging your host config into every
+cloud provider's baked snapshot — works from `agentSpec` alone. A data-only
+package is valid, not a failure.
+
+**`AGENT_API_VERSION`** (or `agentbox.agentApiVersion` in `package.json`) — the
+compat gate. A package targeting a version this build does not support is
+skipped, never fatal.
+
+## Why this file imports nothing
+
+An agent package never enters AgentBox's build graph. Its data is a snapshot in
+a file; its code is reached through a *variable* `import()` of the entry path
+recorded at add time. That is what makes a plugin agent structurally exempt from
+the package cycle that forces AgentBox's own agents to keep data
+(`packages/agent-registry`) and behaviour (`packages/agent-<id>`) in separate
+packages — see [`docs/agents-as-packages-plan.md`](../../docs/agents-as-packages-plan.md).
+
+## What you cannot do
+
+Claim a built-in agent's id **or one of its aliases**. `agent add` refuses it, so
+nothing can quietly take over `agentbox claude`.

--- a/examples/agentbox-agent-example/package.json
+++ b/examples/agentbox-agent-example/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "agentbox-agent-example",
+  "version": "0.1.0",
+  "description": "A working AgentBox agent plugin — the reference example for `agentbox agent add`. Depends on nothing: an agent package is data plus, optionally, one docker module. Internal example, not published.",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.js",
+  "exports": {
+    ".": {
+      "import": "./src/index.js"
+    }
+  },
+  "agentbox": {
+    "agentApiVersion": 1
+  },
+  "files": [
+    "src",
+    "README.md"
+  ]
+}

--- a/examples/agentbox-agent-example/src/index.js
+++ b/examples/agentbox-agent-example/src/index.js
@@ -1,0 +1,113 @@
+/**
+ * A complete AgentBox agent plugin, in one file.
+ *
+ * Deliberately plain JavaScript with NO dependencies — not even an
+ * `@agentbox/*` one. That is the claim this example exists to prove: an agent
+ * package never enters AgentBox's build graph. Its data is a plain object that
+ * `agentbox agent add` snapshots into `~/.agentbox/agents.json`, and its code is
+ * reached through a variable `import()` of the entry path recorded there. A
+ * plugin agent is therefore structurally exempt from the package cycle that
+ * forces AgentBox's own agents to split data from behaviour.
+ *
+ * Register it with:
+ *
+ *     agentbox agent add ./examples/agentbox-agent-example
+ *     agentbox agent list
+ *
+ * and remove it with `agentbox agent remove agentbox-agent-example`.
+ */
+
+/** The agent API version this package targets. Gated at `agent add`. */
+export const AGENT_API_VERSION = 1;
+
+/** Where this agent keeps its config inside a box. */
+const BOX_DIR = '/home/vscode/.agentbox-example-agent';
+
+/**
+ * THE DATA. Every field here is a string, array or plain object — the spec has
+ * to stay JSON-serializable, because it is shipped into boxes whose baked
+ * `agentbox-ctl` may predate the agent entirely (it arrives over the
+ * `agents.list` RPC). That same property is what lets `agent add` snapshot it.
+ *
+ * This one runs a login shell, so it needs no network and cannot rot.
+ */
+export const agentSpec = {
+  id: 'example-agent',
+  /** Alternative spellings `agentbox <name>` should accept. */
+  aliases: ['exagent'],
+  /** tmux session name inside the box. */
+  sessionName: 'example-agent',
+  binary: 'bash',
+  install: { kind: 'none' },
+  /** Shared docker volume holding this agent's static config. */
+  dockerVolume: 'agentbox-example-agent-config',
+  /**
+   * Host → box config sources. This is all the cloud providers need: every one
+   * of them stages an agent's static config from these rows alone, so declaring
+   * them is what gets this agent into every baked snapshot.
+   */
+  staticPaths: [{ hostHomeRel: ['.agentbox-example-agent'], boxDir: BOX_DIR }],
+  credential: {
+    boxRelPath: 'auth.json',
+    boxAbsPath: `${BOX_DIR}/auth.json`,
+    hostBackup: '',
+    cloudMountPath: '/home/vscode/.agentbox-creds/example-agent',
+    cloudSubpath: 'auth.json',
+    realShape: 'nonempty-json',
+  },
+  /** Host env keys forwarded into the box so an env-authed agent finds creds. */
+  forwardedEnvKeys: [],
+  /** Extra env for the in-box process. */
+  boxRunEnv: {},
+  caps: {
+    resume: false,
+    teleport: 'stub',
+    teleportStubReason: 'the example agent has no session to carry over.',
+    /** Empty: ctl then skips probing rather than reporting a permanent `unknown`. */
+    activitySource: [],
+  },
+  /**
+   * Required once `staticPaths` is declared: an agent that can be pushed INTO a
+   * box must say how it comes back out, or `agentbox download` silently does
+   * nothing. Data, not code.
+   */
+  pull: { items: [{ group: 'data', names: ['auth.json'] }] },
+};
+
+/**
+ * THE BEHAVIOUR, and it is optional — a data-only package is perfectly valid,
+ * and everything declarative (listing, resolving, cloud staging) works without
+ * this. It is only needed to create a DOCKER box for the agent, because that
+ * requires knowing how to mount its config volume.
+ */
+export const agentSyncModule = {
+  id: agentSpec.id,
+
+  /** Which volume this box gets: shared, or per-box under `--isolate-*-config`. */
+  resolveVolume: ({ isolate, boxId }) => ({
+    volume: isolate ? `${agentSpec.dockerVolume}-${boxId}` : agentSpec.dockerVolume,
+  }),
+
+  /** How that volume is mounted into the container. */
+  buildMounts: (spec) => ({
+    extraVolumes: [`${spec.volume}:${BOX_DIR}`],
+    env: {},
+    volumeName: spec.volume,
+  }),
+
+  /**
+   * Create/seed the volume. A real agent would rsync the host's config in here;
+   * this one has nothing to copy, so it just reports what it did. `notes` is
+   * how an agent says more than created/synced without the shared contract
+   * growing a field only one agent can fill.
+   */
+  ensureVolume: () =>
+    Promise.resolve({ created: true, synced: false, notes: ['example agent volume ready'] }),
+
+  /** Is this agent's tmux session up? Probed by `agentbox list` / `status`. */
+  sessionInfo: () =>
+    Promise.resolve({ running: false, sessionName: agentSpec.sessionName, startedAt: null }),
+
+  /** Optional post-sync step. Runs for EVERY agent, not just the built-in ones. */
+  afterVolumeSync: () => Promise.resolve({ notes: ['example agent post-sync ran'] }),
+};

--- a/examples/agentbox-agent-example/src/index.js
+++ b/examples/agentbox-agent-example/src/index.js
@@ -1,8 +1,8 @@
 /**
  * A complete AgentBox agent plugin, in one file.
  *
- * Deliberately plain JavaScript with NO dependencies — not even an
- * `@agentbox/*` one. That is the claim this example exists to prove: an agent
+ * Deliberately plain JavaScript with no dependencies beyond node builtins —
+ * not one `@agentbox/*` import. That is the claim this example exists to prove: an agent
  * package never enters AgentBox's build graph. Its data is a plain object that
  * `agentbox agent add` snapshots into `~/.agentbox/agents.json`, and its code is
  * reached through a variable `import()` of the entry path recorded there. A
@@ -16,6 +16,9 @@
  *
  * and remove it with `agentbox agent remove agentbox-agent-example`.
  */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 
 /** The agent API version this package targets. Gated at `agent add`. */
 export const AGENT_API_VERSION = 1;
@@ -71,7 +74,7 @@ export const agentSpec = {
   credential: {
     boxRelPath: 'auth.json',
     boxAbsPath: `${BOX_DIR}/auth.json`,
-    hostBackup: `${process.env.HOME ?? ''}/.agentbox/example-agent-credentials.json`,
+    hostBackup: join(homedir(), '.agentbox', 'example-agent-credentials.json'),
     cloudMountPath: '/home/vscode/.agentbox-creds/example-agent',
     cloudSubpath: 'auth.json',
     realShape: 'nonempty-json',

--- a/examples/agentbox-agent-example/src/index.js
+++ b/examples/agentbox-agent-example/src/index.js
@@ -38,7 +38,21 @@ export const agentSpec = {
   /** tmux session name inside the box. */
   sessionName: 'example-agent',
   binary: 'bash',
-  install: { kind: 'none' },
+  /**
+   * HOW the agent gets into a box. `recipe` is the union — `npm`, `script`
+   * (fetch-then-run, never `curl | bash`, so a blocked download fails the chain)
+   * or `exec` for anything else. `runAs` is not a detail: an installer that
+   * drops a binary in the invoking user's `~/.local/bin` must run as the box
+   * user, while `npm install -g` needs root.
+   *
+   * This agent's binary is `bash`, which is already there, so the recipe is an
+   * honest no-op and `postInstall` just creates the dirs it expects.
+   */
+  install: {
+    recipe: { kind: 'exec', script: 'true' },
+    runAs: 'root',
+    postInstall: `install -d -o vscode -g vscode ${BOX_DIR}`,
+  },
   /** Shared docker volume holding this agent's static config. */
   dockerVolume: 'agentbox-example-agent-config',
   /**
@@ -47,10 +61,17 @@ export const agentSpec = {
    * them is what gets this agent into every baked snapshot.
    */
   staticPaths: [{ hostHomeRel: ['.agentbox-example-agent'], boxDir: BOX_DIR }],
+  /**
+   * Where this agent's login lives — in the box, and in the host backup that
+   * carries it between boxes. `hostBackup` must be a real absolute path under
+   * `~/.agentbox`: the credential fan-out WRITES there when a box logs in, so
+   * an empty string would drop a temp file in whatever directory the CLI
+   * happened to be run from and lose the login.
+   */
   credential: {
     boxRelPath: 'auth.json',
     boxAbsPath: `${BOX_DIR}/auth.json`,
-    hostBackup: '',
+    hostBackup: `${process.env.HOME ?? ''}/.agentbox/example-agent-credentials.json`,
     cloudMountPath: '/home/vscode/.agentbox-creds/example-agent',
     cloudSubpath: 'auth.json',
     realShape: 'nonempty-json',

--- a/packages/agent-registry/src/plugin-agents.ts
+++ b/packages/agent-registry/src/plugin-agents.ts
@@ -83,6 +83,79 @@ const REQUIRED_SPEC_FIELDS = [
   'caps',
 ] as const;
 
+const RECIPE_KINDS = ['npm', 'script', 'exec'] as const;
+const RUN_AS = ['root', 'box-user'] as const;
+
+/**
+ * The fields whose SHAPE — not just presence — is worth checking.
+ *
+ * Presence alone is not enough, and that is not hypothetical: an `install` of
+ * `{ kind: 'none' }` passed a presence check and then threw at bake time, where
+ * the author is long gone and the message is about `recipe.kind` being
+ * undefined. The whole point of validating at `agent add` is to fail at the one
+ * moment someone can still fix the package, so anything with a load-bearing
+ * shape gets checked here.
+ */
+function installProblem(raw: unknown): string | null {
+  if (raw === null || typeof raw !== 'object') return '`install` must be an object';
+  const install = raw as Record<string, unknown>;
+  const recipe = install.recipe as Record<string, unknown> | undefined;
+  if (recipe === undefined || typeof recipe !== 'object' || recipe === null) {
+    return '`install.recipe` is required (`{ kind: "npm" | "script" | "exec", … }`)';
+  }
+  const kind = recipe.kind;
+  if (typeof kind !== 'string' || !(RECIPE_KINDS as readonly string[]).includes(kind)) {
+    return `\`install.recipe.kind\` must be one of ${RECIPE_KINDS.join(', ')}`;
+  }
+  if (kind === 'npm' && typeof recipe.package !== 'string') {
+    return '`install.recipe.package` is required for the npm recipe';
+  }
+  if (kind === 'script' && typeof recipe.url !== 'string') {
+    return '`install.recipe.url` is required for the script recipe';
+  }
+  if (kind === 'exec' && typeof recipe.script !== 'string') {
+    return '`install.recipe.script` is required for the exec recipe';
+  }
+  // Not cosmetic: an installer that drops a binary in the INVOKING user's
+  // ~/.local/bin puts it in /root when run as root, and the box user never
+  // sees it.
+  if (typeof install.runAs !== 'string' || !(RUN_AS as readonly string[]).includes(install.runAs)) {
+    return `\`install.runAs\` must be one of ${RUN_AS.join(', ')}`;
+  }
+  return null;
+}
+
+function credentialProblem(raw: unknown): string | null {
+  if (raw === null || typeof raw !== 'object') return '`credential` must be an object';
+  const cred = raw as Record<string, unknown>;
+  if (typeof cred.boxAbsPath !== 'string' || cred.boxAbsPath.length === 0) {
+    return '`credential.boxAbsPath` must be a non-empty in-box path';
+  }
+  // The credential fan-out WRITES here when a box logs in. An empty or relative
+  // path drops a temp file in whatever directory the CLI was run from and loses
+  // the login silently.
+  if (typeof cred.hostBackup !== 'string' || !cred.hostBackup.startsWith('/')) {
+    return '`credential.hostBackup` must be an absolute host path (the fan-out writes to it)';
+  }
+  return null;
+}
+
+function staticPathsProblem(raw: unknown): string | null {
+  if (!Array.isArray(raw)) return '`staticPaths` must be an array';
+  for (const [i, entry] of raw.entries()) {
+    if (entry === null || typeof entry !== 'object')
+      return `\`staticPaths[${i}]\` must be an object`;
+    const path = entry as Record<string, unknown>;
+    if (!Array.isArray(path.hostHomeRel)) {
+      return `\`staticPaths[${i}].hostHomeRel\` must be an array of path segments`;
+    }
+    if (typeof path.boxDir !== 'string' || !path.boxDir.startsWith('/')) {
+      return `\`staticPaths[${i}].boxDir\` must be an absolute in-box path`;
+    }
+  }
+  return null;
+}
+
 /** Why a spec was rejected, or null when it is usable. */
 export function agentSpecProblem(raw: unknown): string | null {
   if (raw === null || typeof raw !== 'object') return 'not an object';
@@ -91,7 +164,11 @@ export function agentSpecProblem(raw: unknown): string | null {
   if (missing.length > 0) return `missing required field(s): ${missing.join(', ')}`;
   if (typeof spec.id !== 'string' || spec.id.length === 0) return '`id` must be a non-empty string';
   if (!Array.isArray(spec.aliases)) return '`aliases` must be an array';
-  if (!Array.isArray(spec.staticPaths)) return '`staticPaths` must be an array';
+  const shape =
+    installProblem(spec.install) ??
+    credentialProblem(spec.credential) ??
+    staticPathsProblem(spec.staticPaths);
+  if (shape !== null) return shape;
   // A spec that isn't JSON-round-trippable cannot reach a box: it travels to
   // `agentbox-ctl` over `agents.list` as JSON. Catching it here keeps that
   // guarantee true for plugin agents too.

--- a/packages/agent-registry/src/plugin-agents.ts
+++ b/packages/agent-registry/src/plugin-agents.ts
@@ -128,8 +128,11 @@ function installProblem(raw: unknown): string | null {
 function credentialProblem(raw: unknown): string | null {
   if (raw === null || typeof raw !== 'object') return '`credential` must be an object';
   const cred = raw as Record<string, unknown>;
-  if (typeof cred.boxAbsPath !== 'string' || cred.boxAbsPath.length === 0) {
-    return '`credential.boxAbsPath` must be a non-empty in-box path';
+  // Absolute, like `boxDir` and `hostBackup`. The credential push derives the
+  // directory with `slice(0, lastIndexOf('/'))`, so a relative `auth.json`
+  // yields an empty dir, `mkdir -p ''`, and a copy that never lands.
+  if (typeof cred.boxAbsPath !== 'string' || !cred.boxAbsPath.startsWith('/')) {
+    return '`credential.boxAbsPath` must be an absolute in-box path';
   }
   // The credential fan-out WRITES here when a box logs in. An empty or relative
   // path drops a temp file in whatever directory the CLI was run from and loses
@@ -146,8 +149,16 @@ function staticPathsProblem(raw: unknown): string | null {
     if (entry === null || typeof entry !== 'object')
       return `\`staticPaths[${i}]\` must be an object`;
     const path = entry as Record<string, unknown>;
-    if (!Array.isArray(path.hostHomeRel)) {
-      return `\`staticPaths[${i}].hostHomeRel\` must be an array of path segments`;
+    // NON-EMPTY, and every segment non-empty. Staging does
+    // `join(homedir(), ...hostHomeRel)`, so `[]` and `['']` both resolve to the
+    // user's HOME — and cloud staging would then rsync their entire home tree
+    // into a snapshot that every box made from it shares.
+    if (
+      !Array.isArray(path.hostHomeRel) ||
+      path.hostHomeRel.length === 0 ||
+      path.hostHomeRel.some((seg) => typeof seg !== 'string' || seg.length === 0)
+    ) {
+      return `\`staticPaths[${i}].hostHomeRel\` must be a non-empty array of non-empty path segments`;
     }
     if (typeof path.boxDir !== 'string' || !path.boxDir.startsWith('/')) {
       return `\`staticPaths[${i}].boxDir\` must be an absolute in-box path`;

--- a/packages/agent-registry/test/plugin-agents.test.ts
+++ b/packages/agent-registry/test/plugin-agents.test.ts
@@ -147,6 +147,32 @@ describe('agentSpecProblem', () => {
     ).toMatch(/boxDir/);
   });
 
+  it('refuses a staticPath that would stage the whole home directory', () => {
+    // `join(homedir(), ...[])` IS homedir(). A spec with an empty
+    // `hostHomeRel` — or an empty segment — would make cloud staging rsync the
+    // user's entire home into a snapshot every box then shares.
+    for (const hostHomeRel of [[], [''], ['.ok', '']]) {
+      expect(
+        agentSpecProblem({
+          ...exampleSpec,
+          staticPaths: [{ hostHomeRel, boxDir: '/home/vscode/.x' }],
+        }),
+        JSON.stringify(hostHomeRel),
+      ).toMatch(/hostHomeRel/);
+    }
+  });
+
+  it('refuses a relative credential path the push would truncate', () => {
+    // The push derives the dir with `slice(0, lastIndexOf('/'))`, so
+    // `auth.json` gives an empty dir and the copy silently never lands.
+    expect(
+      agentSpecProblem({
+        ...exampleSpec,
+        credential: { ...exampleSpec.credential, boxAbsPath: 'auth.json' },
+      }),
+    ).toMatch(/boxAbsPath/);
+  });
+
   it('rejects a non-object and an empty id', () => {
     expect(agentSpecProblem('claude')).toBe('not an object');
     expect(agentSpecProblem({ ...exampleSpec, id: '' })).toMatch(/non-empty string/);

--- a/packages/agent-registry/test/plugin-agents.test.ts
+++ b/packages/agent-registry/test/plugin-agents.test.ts
@@ -103,6 +103,50 @@ describe('agentSpecProblem', () => {
     expect(problem).toContain('credential');
   });
 
+  it('rejects a structurally wrong `install`, not merely a missing one', () => {
+    // The exact shape that slipped through a presence-only check and then threw
+    // at bake time, where the author is long gone.
+    expect(agentSpecProblem({ ...exampleSpec, install: { kind: 'none' } })).toMatch(
+      /install\.recipe/,
+    );
+    expect(
+      agentSpecProblem({ ...exampleSpec, install: { recipe: { kind: 'nope' }, runAs: 'root' } }),
+    ).toMatch(/recipe\.kind/);
+    expect(
+      agentSpecProblem({ ...exampleSpec, install: { recipe: { kind: 'npm' }, runAs: 'root' } }),
+    ).toMatch(/recipe\.package/);
+    // `runAs` decides whether the binary lands where the box user can see it.
+    expect(
+      agentSpecProblem({
+        ...exampleSpec,
+        install: { recipe: { kind: 'exec', script: 'true' } },
+      }),
+    ).toMatch(/runAs/);
+  });
+
+  it('rejects a credential backup path the fan-out cannot write to', () => {
+    // An empty or relative path drops a temp file in the process cwd and loses
+    // the login, silently.
+    for (const hostBackup of ['', 'relative/path.json']) {
+      expect(
+        agentSpecProblem({
+          ...exampleSpec,
+          credential: { ...exampleSpec.credential, hostBackup },
+        }),
+        hostBackup || '(empty)',
+      ).toMatch(/hostBackup/);
+    }
+  });
+
+  it('rejects a staticPaths entry that cannot be staged', () => {
+    expect(
+      agentSpecProblem({ ...exampleSpec, staticPaths: [{ hostHomeRel: '.x', boxDir: '/b' }] }),
+    ).toMatch(/hostHomeRel/);
+    expect(
+      agentSpecProblem({ ...exampleSpec, staticPaths: [{ hostHomeRel: ['.x'], boxDir: 'rel' }] }),
+    ).toMatch(/boxDir/);
+  });
+
   it('rejects a non-object and an empty id', () => {
     expect(agentSpecProblem('claude')).toBe('not an object');
     expect(agentSpecProblem({ ...exampleSpec, id: '' })).toMatch(/non-empty string/);


### PR DESCRIPTION
Follows #347. The plugin path was proven with a package written in a scratch directory and then deleted — nothing anyone can reproduce. `examples/` already ships [`agentbox-provider-example`](../tree/main/examples/agentbox-provider-example) for exactly that reason; agents now have the counterpart.

## `examples/agentbox-agent-example`

One dependency-free file — not even an `@agentbox/*` import, which is the claim it exists to demonstrate. An agent package never enters AgentBox's build graph: its data is a snapshot in `~/.agentbox/agents.json`, and its code is reached through a *variable* `import()` of the recorded entry path. That is what makes a plugin agent structurally exempt from the package cycle that forces AgentBox's own agents to split data from behaviour.

It carries both halves — `agentSpec` and `agentSyncModule` — with the second documented as optional, since everything declarative (listing, resolving, cloud staging) works from the spec alone.

## Verified end to end, from the committed path

```
agent add ./examples/agentbox-agent-example  → registered example-agent@0.1.0
agent list                                   → shows it beside the built-ins
AGENT_SYNC_SPECS                             → includes example-agent
resolveAgentSpec('exagent')                  → resolves by alias
registerInstalledAgentModules()              → loaded: ['example-agent']
requireAgentSyncModule(...).afterVolumeSync  → runs
stageAllAgentStatic()                        → staged /home/vscode/.agentbox-example-agent
agent remove agentbox-agent-example          → gone
```

## Rot-proofing

A doc example that has rotted proves the opposite of what it claims, so a test loads it the way `agent add` does — resolving the entry from its `package.json`, dynamically importing it — and validates the spec with the same function the command uses. Mutation-checked three ways: claiming a built-in alias, dropping a required spec field, and declaring a module for an agent the package never registered.

Full CI locally. Public docs point at it from `run-an-agent.mdx`.

https://claude.ai/code/session_01PkEcUxA2Jqs4CPD4ni1rXP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect plugin registration validation and cloud/credential staging paths; incorrect rules could block valid agents or miss bad specs, though built-in specs and mutation tests are included.
> 
> **Overview**
> Adds **`examples/agentbox-agent-example`**, a single-file, dependency-free reference plugin (mirroring `agentbox-provider-example`) with README and exports for `agentSpec` + optional `agentSyncModule`. Public docs in **`run-an-agent.mdx`** now link to it and show `agentbox agent add ./examples/agentbox-agent-example`.
> 
> **`agentSpecProblem`** no longer stops at required-field presence: it validates **`install`** (recipe kind and per-kind fields, `runAs`), **`credential`** (absolute `boxAbsPath` and `hostBackup`), and **`staticPaths`** (non-empty `hostHomeRel` segments, absolute `boxDir`) so bad specs fail at `agent add` instead of bake or staging time.
> 
> New tests load the committed example like **`agent add`** (entry from `package.json`, dynamic `import`) and assert spec validity, no built-in id/alias collision, and docker module id/volume behavior; registry unit tests mutation-check the new validation rules. **`agents-as-packages-plan.md`** records the example and the validation gaps that motivated the shape checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d4255ffb8c4db68f334235a0f034b20a4482e00. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->