### PR TITLE
Phase 4b: claude's credential guards, the renewal, and the staged-item mappers

### DIFF
--- a/apps/cli/src/commands/download-claude.ts
+++ b/apps/cli/src/commands/download-claude.ts
@@ -8,7 +8,6 @@ import {
 } from '@agentbox/agent-claude';
 import {
   agentBoxConfigDir,
-  claudeStagedItems,
   pullClaudeExtrasViaTransport,
   stageItemsViaTransport,
   type PullClaudeResult,
@@ -18,6 +17,7 @@ import { resolveBoxOrExit } from '../box-ref.js';
 import { cloudTransportForPull } from './_agent-pull.js';
 import { parsePropagateFlag, runPropagateStep } from './_agent-propagate.js';
 import { handleLifecycleError } from './_errors.js';
+import { claudeStagedItems } from '@agentbox/agent-claude';
 
 interface DownloadClaudeOpts {
   yes?: boolean;

--- a/apps/cli/src/commands/download-codex.ts
+++ b/apps/cli/src/commands/download-codex.ts
@@ -4,7 +4,6 @@ import { DEFAULT_BOX_IMAGE, stageItemsFromVolume } from '@agentbox/sandbox-docke
 import { pullCodexConfig, resolveCodexVolume, SHARED_CODEX_VOLUME } from '@agentbox/agent-codex';
 import {
   agentBoxConfigDir,
-  codexStagedItems,
   pullCodexConfigViaTransport,
   stageItemsViaTransport,
 } from '@agentbox/sandbox-core';
@@ -13,6 +12,7 @@ import { resolveBoxOrExit } from '../box-ref.js';
 import { cloudTransportForPull } from './_agent-pull.js';
 import { parsePropagateFlag, runPropagateStep } from './_agent-propagate.js';
 import { handleLifecycleError } from './_errors.js';
+import { codexStagedItems } from '@agentbox/agent-codex';
 
 interface DownloadCodexOpts {
   yes?: boolean;

--- a/apps/cli/src/commands/download-opencode.ts
+++ b/apps/cli/src/commands/download-opencode.ts
@@ -8,7 +8,6 @@ import {
 } from '@agentbox/agent-opencode';
 import {
   agentBoxConfigDir,
-  opencodeStagedItems,
   pullOpencodeConfigViaTransport,
   stageItemsViaTransport,
 } from '@agentbox/sandbox-core';
@@ -17,6 +16,7 @@ import { resolveBoxOrExit } from '../box-ref.js';
 import { cloudTransportForPull } from './_agent-pull.js';
 import { parsePropagateFlag, runPropagateStep } from './_agent-propagate.js';
 import { handleLifecycleError } from './_errors.js';
+import { opencodeStagedItems } from '@agentbox/agent-opencode';
 
 interface DownloadOpencodeOpts {
   yes?: boolean;

--- a/apps/cli/test/assert-creds.test.ts
+++ b/apps/cli/test/assert-creds.test.ts
@@ -10,10 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // which `apps/cli/src/auth.ts` reads at load time).
 const sandboxDockerMock = vi.hoisted(() => ({
   hostBackupHasCredentials: vi.fn<() => Promise<boolean>>(),
-  hostClaudeAccessTokenExpired: vi.fn<() => Promise<boolean>>(),
-  hostClaudeLoginDead: vi.fn<() => Promise<boolean>>(),
   imageExists: vi.fn<(image: string) => Promise<boolean>>(),
-  renewClaudeCredential: vi.fn<() => Promise<'renewed' | 'unchanged' | 'failed'>>(),
   volumeHasCodexAuth: vi.fn<(volume: string, image: string) => Promise<boolean>>(),
   volumeHasOpencodeAuth: vi.fn<(volume: string, image: string) => Promise<boolean>>(),
 }));
@@ -23,10 +20,7 @@ vi.mock('@agentbox/sandbox-docker', async (importOriginal) => {
   return {
     ...actual,
     hostBackupHasCredentials: sandboxDockerMock.hostBackupHasCredentials,
-    hostClaudeAccessTokenExpired: sandboxDockerMock.hostClaudeAccessTokenExpired,
-    hostClaudeLoginDead: sandboxDockerMock.hostClaudeLoginDead,
     imageExists: sandboxDockerMock.imageExists,
-    renewClaudeCredential: sandboxDockerMock.renewClaudeCredential,
   };
 });
 
@@ -46,8 +40,7 @@ const { assertAgentCredsAvailable, MissingAgentCredsError, ExpiredAgentCredsErro
   await import('../src/lib/queue/assert-creds.js');
 // The per-agent checks moved next to their runtimes — the shared helper no
 // longer knows any agent's name. The mock has to follow the symbol.
-const { claudeAuthAvailable, claudeCredStatus } =
-  await import('@agentbox/agent-claude/cli');
+const { claudeAuthAvailable, claudeCredStatus } = await import('@agentbox/agent-claude/cli');
 const { claudeRuntime } = await import('@agentbox/agent-claude/cli');
 const { codexRuntime } = await import('@agentbox/agent-codex/cli');
 const { opencodeRuntime } = await import('@agentbox/agent-opencode/cli');
@@ -58,6 +51,26 @@ const RUNTIMES: Record<string, { hostCredStatus: (typeof claudeRuntime)['hostCre
   codex: codexRuntime,
   opencode: opencodeRuntime,
 };
+// `hostClaudeLoginDead`, `hostClaudeAccessTokenExpired` and
+// `renewClaudeCredential` live in `@agentbox/agent-claude` now — they only mean
+// anything for a claude-oauth blob. They were mockable before only because they
+// crossed a package boundary; inside their own package that stops working, so
+// `resolveClaudeCredHealth` takes them as an explicit `probes` seam and these
+// tests hand it stubs instead of depending on where a symbol is re-exported.
+const probeMock = vi.hoisted(() => ({
+  hostBackupHasCredentials: vi.fn<() => Promise<boolean>>(),
+  accessTokenExpired: vi.fn<() => Promise<boolean>>(),
+  loginDead: vi.fn<() => Promise<boolean>>(),
+  imageExists: vi.fn<(image: string) => Promise<boolean>>(),
+  renew: vi.fn<() => Promise<'renewed' | 'unchanged' | 'failed'>>(),
+}));
+
+function resetProbes(): void {
+  for (const fn of Object.values(probeMock)) fn.mockReset();
+  probeMock.loginDead.mockResolvedValue(false);
+  probeMock.imageExists.mockResolvedValue(true);
+}
+
 function assertFor(input: {
   agent: string;
   image: string;
@@ -66,7 +79,20 @@ function assertFor(input: {
 }) {
   return assertAgentCredsAvailable({
     ...input,
-    hostCredStatus: (o) => RUNTIMES[input.agent]!.hostCredStatus(o),
+    hostCredStatus: async (o) => {
+      if (input.agent !== 'claude-code') return RUNTIMES[input.agent]!.hostCredStatus(o);
+      // Claude's runtime maps its three-way status onto the verdict; mirror that
+      // here so the stubs reach `claudeCredStatus` while the dispatcher still
+      // sees exactly the shape a runtime returns.
+      const status = await claudeCredStatus(o.env, o.isCloud, o.image, probeMock);
+      if (status === 'ok') return { status: 'ok' };
+      if (status === 'missing') return { status: 'missing' };
+      return {
+        status: 'expired',
+        message:
+          'Your saved Claude login can no longer be renewed. Sign in again with `agentbox claude login`, then retry.',
+      };
+    },
   } as Parameters<typeof assertAgentCredsAvailable>[0]);
 }
 
@@ -108,73 +134,67 @@ describe('claudeAuthAvailable', () => {
 });
 
 describe('claudeCredStatus', () => {
-  beforeEach(() => {
-    sandboxDockerMock.hostBackupHasCredentials.mockReset();
-    sandboxDockerMock.hostClaudeAccessTokenExpired.mockReset();
-    sandboxDockerMock.hostClaudeLoginDead.mockReset();
-    sandboxDockerMock.imageExists.mockReset();
-    sandboxDockerMock.renewClaudeCredential.mockReset();
-    sandboxDockerMock.hostClaudeLoginDead.mockResolvedValue(false);
-    sandboxDockerMock.imageExists.mockResolvedValue(true);
-  });
+  beforeEach(resetProbes);
 
   it('is "missing" when no env and no backup', async () => {
-    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(false);
-    expect(await claudeCredStatus({}, true, IMAGE)).toBe('missing');
+    probeMock.hostBackupHasCredentials.mockResolvedValue(false);
+    expect(await claudeCredStatus({}, true, IMAGE, probeMock)).toBe('missing');
   });
 
   it('is "ok" when a host-env token is set (health not consulted)', async () => {
-    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(false);
-    sandboxDockerMock.hostClaudeLoginDead.mockResolvedValue(true);
-    expect(await claudeCredStatus({ ANTHROPIC_API_KEY: 'sk-test' }, true, IMAGE)).toBe('ok');
-    expect(sandboxDockerMock.hostClaudeLoginDead).not.toHaveBeenCalled();
+    probeMock.hostBackupHasCredentials.mockResolvedValue(false);
+    probeMock.loginDead.mockResolvedValue(true);
+    expect(await claudeCredStatus({ ANTHROPIC_API_KEY: 'sk-test' }, true, IMAGE, probeMock)).toBe(
+      'ok',
+    );
+    expect(probeMock.loginDead).not.toHaveBeenCalled();
   });
 
   it('is "expired" on cloud only when the login can no longer be renewed', async () => {
-    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
-    sandboxDockerMock.hostClaudeLoginDead.mockResolvedValue(true);
-    expect(await claudeCredStatus({}, true, IMAGE)).toBe('expired');
+    probeMock.hostBackupHasCredentials.mockResolvedValue(true);
+    probeMock.loginDead.mockResolvedValue(true);
+    expect(await claudeCredStatus({}, true, IMAGE, probeMock)).toBe('expired');
   });
 
   // The false positive this whole change exists for: access tokens live ~8h, so
   // gating on `expiresAt` failed perfectly good jobs every single day.
   it('is "ok" on cloud when a lapsed access token renews', async () => {
-    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
-    sandboxDockerMock.hostClaudeAccessTokenExpired.mockResolvedValue(true);
-    sandboxDockerMock.renewClaudeCredential.mockResolvedValue('renewed');
-    expect(await claudeCredStatus({}, true, IMAGE)).toBe('ok');
-    expect(sandboxDockerMock.renewClaudeCredential).toHaveBeenCalled();
+    probeMock.hostBackupHasCredentials.mockResolvedValue(true);
+    probeMock.accessTokenExpired.mockResolvedValue(true);
+    probeMock.renew.mockResolvedValue('renewed');
+    expect(await claudeCredStatus({}, true, IMAGE, probeMock)).toBe('ok');
+    expect(probeMock.renew).toHaveBeenCalled();
   });
 
   it('is "expired" on cloud when the renewal itself fails (rotated away)', async () => {
-    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
-    sandboxDockerMock.hostClaudeAccessTokenExpired.mockResolvedValue(true);
-    sandboxDockerMock.renewClaudeCredential.mockResolvedValue('failed');
-    expect(await claudeCredStatus({}, true, IMAGE)).toBe('expired');
+    probeMock.hostBackupHasCredentials.mockResolvedValue(true);
+    probeMock.accessTokenExpired.mockResolvedValue(true);
+    probeMock.renew.mockResolvedValue('failed');
+    expect(await claudeCredStatus({}, true, IMAGE, probeMock)).toBe('expired');
   });
 
   it('is "ok" on cloud without renewing when the access token is still valid', async () => {
-    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
-    sandboxDockerMock.hostClaudeAccessTokenExpired.mockResolvedValue(false);
-    expect(await claudeCredStatus({}, true, IMAGE)).toBe('ok');
-    expect(sandboxDockerMock.renewClaudeCredential).not.toHaveBeenCalled();
+    probeMock.hostBackupHasCredentials.mockResolvedValue(true);
+    probeMock.accessTokenExpired.mockResolvedValue(false);
+    expect(await claudeCredStatus({}, true, IMAGE, probeMock)).toBe('ok');
+    expect(probeMock.renew).not.toHaveBeenCalled();
   });
 
   it('is "ok" on cloud when the image is not local — never pull just to answer', async () => {
-    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
-    sandboxDockerMock.hostClaudeAccessTokenExpired.mockResolvedValue(true);
-    sandboxDockerMock.imageExists.mockResolvedValue(false);
-    expect(await claudeCredStatus({}, true, IMAGE)).toBe('ok');
-    expect(sandboxDockerMock.renewClaudeCredential).not.toHaveBeenCalled();
+    probeMock.hostBackupHasCredentials.mockResolvedValue(true);
+    probeMock.accessTokenExpired.mockResolvedValue(true);
+    probeMock.imageExists.mockResolvedValue(false);
+    expect(await claudeCredStatus({}, true, IMAGE, probeMock)).toBe('ok');
+    expect(probeMock.renew).not.toHaveBeenCalled();
   });
 
   it('is "ok" on docker whatever the token looks like (the box boots from the volume)', async () => {
-    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
-    sandboxDockerMock.hostClaudeLoginDead.mockResolvedValue(true);
-    expect(await claudeCredStatus({}, false, IMAGE)).toBe('ok');
+    probeMock.hostBackupHasCredentials.mockResolvedValue(true);
+    probeMock.loginDead.mockResolvedValue(true);
+    expect(await claudeCredStatus({}, false, IMAGE, probeMock)).toBe('ok');
     // No health probe at all when the provider is docker.
-    expect(sandboxDockerMock.hostClaudeLoginDead).not.toHaveBeenCalled();
-    expect(sandboxDockerMock.renewClaudeCredential).not.toHaveBeenCalled();
+    expect(probeMock.loginDead).not.toHaveBeenCalled();
+    expect(probeMock.renew).not.toHaveBeenCalled();
   });
 });
 
@@ -183,13 +203,9 @@ describe('assertAgentCredsAvailable dispatcher', () => {
   const origHome = process.env['HOME'];
 
   beforeEach(async () => {
+    resetProbes();
     sandboxDockerMock.hostBackupHasCredentials.mockReset();
-    sandboxDockerMock.hostClaudeAccessTokenExpired.mockReset();
-    sandboxDockerMock.hostClaudeLoginDead.mockReset();
     sandboxDockerMock.imageExists.mockReset();
-    sandboxDockerMock.renewClaudeCredential.mockReset();
-    sandboxDockerMock.hostClaudeLoginDead.mockResolvedValue(false);
-    sandboxDockerMock.imageExists.mockResolvedValue(true);
     sandboxDockerMock.volumeHasCodexAuth.mockReset();
     sandboxDockerMock.volumeHasOpencodeAuth.mockReset();
     homeDir = await mkdtemp(join(tmpdir(), 'agentbox-dispatch-creds-'));
@@ -202,22 +218,22 @@ describe('assertAgentCredsAvailable dispatcher', () => {
   });
 
   it('returns silently when claude has creds', async () => {
-    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
+    probeMock.hostBackupHasCredentials.mockResolvedValue(true);
     await expect(
       assertFor({ agent: 'claude-code', image: IMAGE, env: {} }),
     ).resolves.toBeUndefined();
   });
 
   it('throws MissingAgentCredsError for claude when no source has creds', async () => {
-    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(false);
+    probeMock.hostBackupHasCredentials.mockResolvedValue(false);
     await expect(assertFor({ agent: 'claude-code', image: IMAGE, env: {} })).rejects.toBeInstanceOf(
       MissingAgentCredsError,
     );
   });
 
   it('throws ExpiredAgentCredsError for claude on cloud when the login cannot be renewed', async () => {
-    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
-    sandboxDockerMock.hostClaudeLoginDead.mockResolvedValue(true);
+    probeMock.hostBackupHasCredentials.mockResolvedValue(true);
+    probeMock.loginDead.mockResolvedValue(true);
     try {
       await assertFor({
         agent: 'claude-code',
@@ -237,8 +253,8 @@ describe('assertAgentCredsAvailable dispatcher', () => {
   });
 
   it('does NOT throw for claude on docker when the login looks dead', async () => {
-    sandboxDockerMock.hostBackupHasCredentials.mockResolvedValue(true);
-    sandboxDockerMock.hostClaudeLoginDead.mockResolvedValue(true);
+    probeMock.hostBackupHasCredentials.mockResolvedValue(true);
+    probeMock.loginDead.mockResolvedValue(true);
     await expect(
       assertFor({
         agent: 'claude-code',

--- a/apps/cli/test/no-agent-named-exports.test.ts
+++ b/apps/cli/test/no-agent-named-exports.test.ts
@@ -74,7 +74,6 @@ const ALLOWLIST: Record<string, string> = {
   'packages/sandbox-core/src/sync/agents/claude/paths.ts': 'phase 4',
   'packages/sandbox-core/src/claude-app-config.ts': 'phase 4',
   'packages/sandbox-docker/src/sync/claude-credentials.ts': 'phase 4',
-  'packages/sandbox-core/src/sync/agent-propagate.ts': 'phase 4',
 
   // Phase 5b — `claudeInstall`. 300 sites across 79 files, reaching the
   // published SDK, the hub's REST schema, on-disk prepared state and a

--- a/apps/cli/test/no-agent-named-exports.test.ts
+++ b/apps/cli/test/no-agent-named-exports.test.ts
@@ -71,11 +71,9 @@ const ALLOWLIST: Record<string, string> = {
   // imports the first two, and ITS exports are published SDK surface, so the
   // move is an SDK_API_VERSION bump rather than a refactor.
   'packages/sandbox-core/src/sync/agent-pull.ts': 'phase 4',
-  'packages/sandbox-core/src/sync/concerns/credentials.ts': 'phase 4',
   'packages/sandbox-core/src/sync/agents/claude/paths.ts': 'phase 4',
   'packages/sandbox-core/src/claude-app-config.ts': 'phase 4',
   'packages/sandbox-docker/src/sync/claude-credentials.ts': 'phase 4',
-  'packages/sandbox-docker/src/credential-refresh.ts': 'phase 4',
   'packages/sandbox-core/src/sync/agent-propagate.ts': 'phase 4',
 
   // Phase 5b — `claudeInstall`. 300 sites across 79 files, reaching the

--- a/packages/agent-claude/src/cli/cred-health.ts
+++ b/packages/agent-claude/src/cli/cred-health.ts
@@ -17,13 +17,9 @@
  * both silences the nag and hands the next cloud box a fresh token, which is the
  * other half of why the credential kept dying between sessions.
  */
-import {
-  hostBackupHasCredentials,
-  hostClaudeAccessTokenExpired,
-  hostClaudeLoginDead,
-  imageExists,
-  renewClaudeCredential,
-} from '@agentbox/sandbox-docker';
+import { hostBackupHasCredentials, imageExists } from '@agentbox/sandbox-docker';
+import { hostClaudeAccessTokenExpired, hostClaudeLoginDead } from './host-cred-guards.js';
+import { renewClaudeCredential, type RenewClaudeResult } from './credential-renew.js';
 
 /**
  * `ok` — usable (possibly after a silent renewal). `missing` — nothing saved to
@@ -43,23 +39,52 @@ export interface ClaudeCredHealthOptions {
    * renew it in-box, so there is nothing to warn about.
    */
   offlineOnly?: boolean;
+  /**
+   * The IO this verdict is built from, injectable.
+   *
+   * Every one of these reads a file or starts a container, so a caller that
+   * wants to assert on the DECISION — which combination of "saved?", "dead?",
+   * "lapsed?" and "renewable?" yields which verdict — otherwise has to reach
+   * into another package's internals to do it. They used to be mockable by
+   * accident, because they were imported across a package boundary; they are
+   * this package's own now, so the seam is explicit instead.
+   */
+  probes?: Partial<CredHealthProbes>;
 }
+
+/** The four IO probes {@link resolveClaudeCredHealth} decides from. */
+export interface CredHealthProbes {
+  hostBackupHasCredentials(): Promise<boolean>;
+  loginDead(): Promise<boolean>;
+  accessTokenExpired(): Promise<boolean>;
+  imageExists(image: string): Promise<boolean>;
+  renew(opts: { image: string; onLog?: (msg: string) => void }): Promise<RenewClaudeResult>;
+}
+
+const REAL_PROBES: CredHealthProbes = {
+  hostBackupHasCredentials,
+  loginDead: hostClaudeLoginDead,
+  accessTokenExpired: hostClaudeAccessTokenExpired,
+  imageExists,
+  renew: renewClaudeCredential,
+};
 
 export async function resolveClaudeCredHealth(
   opts: ClaudeCredHealthOptions,
 ): Promise<ClaudeCredHealth> {
-  if (!(await hostBackupHasCredentials())) return 'missing';
-  if (await hostClaudeLoginDead()) return 'dead';
-  if (!(await hostClaudeAccessTokenExpired())) return 'ok';
+  const p: CredHealthProbes = { ...REAL_PROBES, ...opts.probes };
+  if (!(await p.hostBackupHasCredentials())) return 'missing';
+  if (await p.loginDead()) return 'dead';
+  if (!(await p.accessTokenExpired())) return 'ok';
 
   // Stale access token, live refresh token. Renewing needs the image locally;
   // don't trigger an implicit pull just to answer a question, and never nag on
   // a host that simply can't run the probe — the refresh token is alive and the
   // box will renew it itself.
   if (opts.offlineOnly === true) return 'ok';
-  if (!(await imageExists(opts.image))) return 'ok';
+  if (!(await p.imageExists(opts.image))) return 'ok';
 
-  const renewed = await renewClaudeCredential({
+  const renewed = await p.renew({
     image: opts.image,
     ...(opts.onProgress ? { onLog: opts.onProgress } : {}),
   });

--- a/packages/agent-claude/src/cli/credential-renew.ts
+++ b/packages/agent-claude/src/cli/credential-renew.ts
@@ -1,0 +1,72 @@
+/**
+ * Actively renew claude's saved host login.
+ *
+ * Moved out of `sandbox-docker/src/credential-refresh.ts`. Living there meant it
+ * had to reach claude's own warm-up through `requireAgentSyncModule('claude')` —
+ * an inversion that existed only because the code was on the wrong side of the
+ * boundary. Here it calls `warmUpClaudeCredentials` directly, and the registry
+ * lookup is gone.
+ *
+ * The generic `dockerCredentialRefresh` stays in `sandbox-docker`: that one is
+ * the provider-neutral refresher hook, not claude's behaviour.
+ */
+
+import { DEFAULT_BOX_IMAGE, syncClaudeCredentials } from '@agentbox/sandbox-docker';
+import { resolveAgentSpec } from '@agentbox/sandbox-core';
+import { warmUpClaudeCredentials } from '../docker-sync.js';
+
+/** Outcome of {@link renewClaudeCredential}. */
+export type RenewClaudeResult = 'renewed' | 'unchanged' | 'failed';
+
+/**
+ * Renew the saved claude login through the shared docker volume, and report
+ * whether it still works.
+ *
+ * A credential's health is not readable off disk: `expiresAt` only dates the
+ * ~8h access token, and a refresh token that was rotated away by another copy
+ * looks perfectly valid until you try it. The only honest test is to use it —
+ * so drive the same pair the successful-login path runs in its `finalize`:
+ *
+ *  1. `syncClaudeCredentials` — converge volume and backup on the newer blob,
+ *     so we renew from the freshest copy rather than whichever the volume holds.
+ *  2. `warmUpClaudeCredentials` — a headless `claude -p` forces a real OAuth
+ *     refresh, minting a fresh access token into the volume.
+ *  3. `syncClaudeCredentials` again — extract that fresh blob to the host backup
+ *     so the cloud seed (and every later box) gets a live credential.
+ *
+ * This is what keeps the fleet logged in without nagging: a lapsed access token
+ * is renewed silently, and only a genuine failure — `'failed'` — is worth
+ * asking the user to sign in again for.
+ *
+ * `attempts` is deliberately small (2 by default): the login path's 6 exist to
+ * outwait the fresh-token first-request 400, but on the create path every extra
+ * attempt costs the user 5s + a container start before we can say "dead".
+ *
+ * Best-effort: any docker failure resolves to `'failed'`, never throws.
+ */
+export async function renewClaudeCredential(opts: {
+  image?: string;
+  attempts?: number;
+  onLog?: (msg: string) => void;
+}): Promise<RenewClaudeResult> {
+  const log = opts.onLog ?? (() => {});
+  const image = opts.image ?? DEFAULT_BOX_IMAGE;
+  const volume = resolveAgentSpec('claude').dockerVolume;
+  try {
+    await syncClaudeCredentials({ volume }, { image, isolate: false });
+    const warm = await warmUpClaudeCredentials(volume, image, {
+      attempts: opts.attempts ?? 2,
+      onProgress: (line: string) => {
+        log(line);
+      },
+    });
+    if (!warm.warmed) {
+      log('claude: saved login did not renew — it may have been rotated away by another box');
+      return 'failed';
+    }
+    const synced = await syncClaudeCredentials({ volume }, { image, isolate: false });
+    return synced.direction === 'extracted' ? 'renewed' : 'unchanged';
+  } catch {
+    return 'failed';
+  }
+}

--- a/packages/agent-claude/src/cli/host-cred-guards.ts
+++ b/packages/agent-claude/src/cli/host-cred-guards.ts
@@ -1,0 +1,81 @@
+/**
+ * Claude's host-backup health guards.
+ *
+ * These read `~/.agentbox/claude-credentials.json` and answer two different
+ * questions about it — "worth renewing?" and "dead?" — both of which are only
+ * meaningful for a `claude-oauth` blob. They lived in
+ * `sandbox-core/src/sync/concerns/credentials.ts`, a layer that must not know
+ * about a specific agent; their only consumer was already in this package.
+ *
+ * The OAuth field PARSERS stayed behind, renamed for the shape rather than the
+ * agent (`oauthRefreshExpiresAt`): the generic credential-accept gate needs them
+ * too, and it reaches them by dispatching on `credential.realShape`.
+ */
+
+import { readFile } from 'node:fs/promises';
+import {
+  isRealAgentCredential,
+  oauthRefreshExpiresAt,
+  resolveAgentSpec,
+} from '@agentbox/sandbox-core';
+
+const CLAUDE_HOST_BACKUP = resolveAgentSpec('claude').credential.hostBackup;
+
+/**
+ * True iff the claude host backup's *access* token has lapsed
+ * (`claudeAiOauth.expiresAt`, ms epoch, < now). Access tokens live ~8h, so this
+ * is true of a perfectly healthy login most of the time — it answers "is this
+ * blob worth renewing before we hand it to a box?", NOT "is this login dead?".
+ * For that, see {@link hostClaudeLoginDead}.
+ *
+ * A missing `expiresAt` (or unreadable file) → false: we only report a *known*
+ * lapse. `now` is injectable for tests. Claude is the only agent with a
+ * token-expiry field (codex / opencode auth files carry no comparable one).
+ */
+export async function hostClaudeAccessTokenExpired(
+  path: string = CLAUDE_HOST_BACKUP,
+  now: number = Date.now(),
+): Promise<boolean> {
+  try {
+    const parsed = JSON.parse(await readFile(path, 'utf8')) as {
+      claudeAiOauth?: { expiresAt?: unknown };
+    };
+    const exp = parsed?.claudeAiOauth?.expiresAt;
+    return typeof exp === 'number' && Number.isFinite(exp) && exp < now;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * True iff the saved claude login can no longer be renewed: no usable refresh
+ * token at all, or the refresh token's own ~30-day life
+ * (`claudeAiOauth.refreshTokenExpiresAt`) has run out.
+ *
+ * This is the question every "should we ask the user to sign in again?" gate
+ * actually wants. Gating those on the access token instead produced a daily
+ * false alarm — and accepting that alarm runs a login container that refreshes
+ * and ROTATES the shared token before the user types anything, so a cancelled
+ * sign-in left every copy of the login (host backup, custody, other boxes)
+ * holding a spent token. A merely-lapsed access token renews itself.
+ *
+ * A missing `refreshTokenExpiresAt` → not dead, matching the "only report a
+ * *known* death" convention of {@link hostClaudeAccessTokenExpired}: an older
+ * blob that predates the field must not be declared dead on a guess. Note this
+ * cannot see a token that was rotated away by another copy — that is only
+ * observable by trying to use it.
+ */
+export async function hostClaudeLoginDead(
+  path: string = CLAUDE_HOST_BACKUP,
+  now: number = Date.now(),
+): Promise<boolean> {
+  let text: string;
+  try {
+    text = await readFile(path, 'utf8');
+  } catch {
+    return false;
+  }
+  if (!isRealAgentCredential('claude', text)) return true;
+  const exp = oauthRefreshExpiresAt(text);
+  return exp !== null && exp < now;
+}

--- a/packages/agent-claude/src/cli/host-creds.ts
+++ b/packages/agent-claude/src/cli/host-creds.ts
@@ -6,7 +6,7 @@
  */
 import { hostBackupHasCredentials } from '@agentbox/sandbox-docker';
 import { resolveClaudeAuth } from './auth.js';
-import { resolveClaudeCredHealth } from './cred-health.js';
+import { resolveClaudeCredHealth, type ClaudeCredHealthOptions } from './cred-health.js';
 
 /**
  * True when Claude is already authenticated on the host: a forwarded env var
@@ -38,14 +38,20 @@ export async function claudeCredStatus(
   env: NodeJS.ProcessEnv,
   isCloud: boolean,
   image?: string,
+  /** Forwarded to {@link resolveClaudeCredHealth}; see its `probes`. */
+  probes?: ClaudeCredHealthOptions['probes'],
 ): Promise<'ok' | 'missing' | 'expired'> {
   const resolved = await resolveClaudeAuth(env);
   if (resolved.source !== 'none') return 'ok';
-  if (!isCloud) return (await hostBackupHasCredentials()) ? 'ok' : 'missing';
+  if (!isCloud) {
+    const has = probes?.hostBackupHasCredentials ?? hostBackupHasCredentials;
+    return (await has()) ? 'ok' : 'missing';
+  }
   const health = await resolveClaudeCredHealth({
     image: image ?? '',
     // No image to probe with means no renewal; answer off the backup alone.
     ...(image === undefined ? { offlineOnly: true } : {}),
+    ...(probes ? { probes } : {}),
   });
   if (health === 'missing') return 'missing';
   return health === 'dead' ? 'expired' : 'ok';

--- a/packages/agent-claude/src/cli/index.ts
+++ b/packages/agent-claude/src/cli/index.ts
@@ -16,8 +16,14 @@ export { agentModule } from './module.js';
 export { CLAUDE_LOGIN_SPEC, extractOAuthUrl } from './login.js';
 export { claudeLoginBinding } from './login-binding.js';
 export { claudeAuthAvailable, claudeCredStatus } from './host-creds.js';
+export { hostClaudeAccessTokenExpired, hostClaudeLoginDead } from './host-cred-guards.js';
+export { renewClaudeCredential, type RenewClaudeResult } from './credential-renew.js';
 export { resolveClaudeAuth, readAuthFile, AUTH_FILE, type AuthFile } from './auth.js';
-export { resolveClaudeCredHealth } from './cred-health.js';
+export {
+  resolveClaudeCredHealth,
+  type ClaudeCredHealthOptions,
+  type CredHealthProbes,
+} from './cred-health.js';
 export { runClaudeLogin } from './login-run.js';
 export {
   selectLoginMode,

--- a/packages/agent-claude/src/index.ts
+++ b/packages/agent-claude/src/index.ts
@@ -127,3 +127,5 @@ export * from './docker-sync.js';
 export * from './host-stage.js';
 export * from './hooks-filter.js';
 export * from './cloud-json-overlay.js';
+
+export { claudeStagedItems } from './staged-items.js';

--- a/packages/agent-claude/src/index.ts
+++ b/packages/agent-claude/src/index.ts
@@ -8,7 +8,13 @@
  * channel the contract grew to accommodate it.
  */
 
-import { registerAgentSyncModule, type AgentSyncModule } from '@agentbox/sandbox-docker';
+import {
+  registerAgentSyncModule,
+  syncClaudeCredentials,
+  type AgentSyncModule,
+} from '@agentbox/sandbox-docker';
+import { resolveAgentSpec } from '@agentbox/sandbox-core';
+import { hostClaudeAccessTokenExpired } from './cli/host-cred-guards.js';
 import { registerAgentCloudModule, type AgentCloudModule } from '@agentbox/sandbox-cloud';
 import { stageClaudeCredentialsForUpload, stageClaudeStaticForUpload } from './host-stage.js';
 import { seedClaudeJsonAtCreate } from './cloud-json-overlay.js';
@@ -59,6 +65,24 @@ export const claudeSyncModule: AgentSyncModule = {
   },
   sessionInfo: (container) => claudeSessionInfo(container),
   // Claude's OAuth token expires on its own; the others' do not.
+  // Gated on claude's OWN access-token expiry: when the backup's token is still
+  // valid the docker round-trip is skipped entirely (~1-2s, and almost always a
+  // noop on a fresh token). That gate asks "is this blob worth refreshing?",
+  // never "is this login dead?" — the two are different questions and conflating
+  // them produced a daily false alarm.
+  refreshHostBackup: async (image, log) => {
+    if (!(await hostClaudeAccessTokenExpired())) return;
+    log('claude: host credentials backup expired — refreshing from docker shared volume');
+    const r = await syncClaudeCredentials(
+      { volume: resolveAgentSpec('claude').dockerVolume },
+      { image, isolate: false },
+    );
+    if (r.direction === 'extracted') {
+      log('claude: refreshed host credentials backup from docker shared volume');
+    } else if (r.direction === 'noop') {
+      log('claude: no docker shared volume to refresh from (continuing with existing backup)');
+    }
+  },
   warmUpCredentials: async (volume, image, opts) => {
     const r = await warmUpClaudeCredentials(volume, image, opts ?? {});
     return { warmed: r.warmed, notes: r.warmed ? ['claude credentials warmed'] : [] };

--- a/packages/agent-claude/src/staged-items.ts
+++ b/packages/agent-claude/src/staged-items.ts
@@ -1,0 +1,20 @@
+/**
+ * Map claude's pull result to staged-item descriptors.
+ *
+ * One of three `<agent>StagedItems` functions that sat together in
+ * `sandbox-core/src/sync/agent-propagate.ts` — a per-agent table in a layer that
+ * must not know about agents. Each knows only its own agent's pull shape, so
+ * each now lives with that agent. The `StagedItem` contract and the transport
+ * that consumes it stay shared.
+ */
+
+import type { PullClaudeResult, StagedItem } from '@agentbox/sandbox-core';
+
+/** All claude items are directories; plugins live under the cache subpath. */
+export function claudeStagedItems(result: PullClaudeResult): StagedItem[] {
+  return result.newItems.map((it) => ({
+    rel: it.category === 'plugins' ? `plugins/cache/${it.name}` : `${it.category}/${it.name}`,
+    label: `${it.category}/${it.name}`,
+    kind: 'dir' as const,
+  }));
+}

--- a/packages/agent-claude/test/host-cred-guards.test.ts
+++ b/packages/agent-claude/test/host-cred-guards.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { hostClaudeAccessTokenExpired, hostClaudeLoginDead } from '../src/cli/host-cred-guards.js';
+
+/**
+ * Moved here with the guards themselves, out of
+ * `sandbox-core/test/credentials-concern.test.ts`. Both only mean anything for a
+ * `claude-oauth` blob, and the distinction they encode is load-bearing: a lapsed
+ * ACCESS token is normal and renewable, a lapsed REFRESH token is a dead login.
+ * Conflating them produced a daily false sign-in nag whose "yes" rotated the
+ * shared token away.
+ */
+describe('claude host-backup guards', () => {
+  describe('hostClaudeAccessTokenExpired', () => {
+    let dir: string;
+    beforeEach(async () => {
+      dir = await mkdtemp(join(tmpdir(), 'abx-core-exp-'));
+    });
+    afterEach(async () => {
+      await rm(dir, { recursive: true, force: true });
+    });
+
+    const write = async (obj: unknown) => {
+      const p = join(dir, 'creds.json');
+      await writeFile(p, JSON.stringify(obj));
+      return p;
+    };
+
+    it('true when expiresAt is in the past', async () => {
+      const p = await write({ claudeAiOauth: { refreshToken: 'rt', expiresAt: 1000 } });
+      expect(await hostClaudeAccessTokenExpired(p, 2000)).toBe(true);
+    });
+    it('false when expiresAt is in the future', async () => {
+      const p = await write({ claudeAiOauth: { refreshToken: 'rt', expiresAt: 5000 } });
+      expect(await hostClaudeAccessTokenExpired(p, 2000)).toBe(false);
+    });
+    it('false when expiresAt is absent (do not nag)', async () => {
+      const p = await write({ claudeAiOauth: { refreshToken: 'rt' } });
+      expect(await hostClaudeAccessTokenExpired(p, 2000)).toBe(false);
+    });
+    it('false on a missing/garbage file', async () => {
+      expect(await hostClaudeAccessTokenExpired(join(dir, 'nope.json'), 2000)).toBe(false);
+    });
+  });
+
+  describe('hostClaudeLoginDead', () => {
+    let dir: string;
+    beforeEach(async () => {
+      dir = await mkdtemp(join(tmpdir(), 'abx-core-dead-'));
+    });
+    afterEach(async () => {
+      await rm(dir, { recursive: true, force: true });
+    });
+
+    const write = async (obj: unknown) => {
+      const p = join(dir, 'creds.json');
+      await writeFile(p, JSON.stringify(obj));
+      return p;
+    };
+
+    it('false when the access token lapsed but the refresh token is alive', async () => {
+      const p = await write({
+        claudeAiOauth: { refreshToken: 'rt', expiresAt: 1000, refreshTokenExpiresAt: 9000 },
+      });
+      expect(await hostClaudeLoginDead(p, 2000)).toBe(false);
+      expect(await hostClaudeAccessTokenExpired(p, 2000)).toBe(true);
+    });
+    it('true when the refresh token itself has expired', async () => {
+      const p = await write({
+        claudeAiOauth: { refreshToken: 'rt', expiresAt: 5000, refreshTokenExpiresAt: 1000 },
+      });
+      expect(await hostClaudeLoginDead(p, 2000)).toBe(true);
+    });
+    it('true when the refresh token is blank (claude blanks it on a rejected refresh)', async () => {
+      const p = await write({ claudeAiOauth: { refreshToken: '', refreshTokenExpiresAt: 9000 } });
+      expect(await hostClaudeLoginDead(p, 2000)).toBe(true);
+    });
+    it('false when refreshTokenExpiresAt is absent (never declare death on a guess)', async () => {
+      const p = await write({ claudeAiOauth: { refreshToken: 'rt', expiresAt: 1000 } });
+      expect(await hostClaudeLoginDead(p, 2000)).toBe(false);
+    });
+    it('false on a missing file (nothing saved is "missing", not "dead")', async () => {
+      expect(await hostClaudeLoginDead(join(dir, 'nope.json'), 2000)).toBe(false);
+    });
+    it('true on a garbage file that exists', async () => {
+      const p = join(dir, 'creds.json');
+      await writeFile(p, 'not json');
+      expect(await hostClaudeLoginDead(p, 2000)).toBe(true);
+    });
+  });
+});

--- a/packages/agent-claude/test/staged-items.test.ts
+++ b/packages/agent-claude/test/staged-items.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { claudeStagedItems } from '../src/staged-items.js';
+
+/**
+ * Moved with the mapper out of `sandbox-core/test/agent-propagate.test.ts`,
+ * where the three agents' mappers were tested side by side.
+ */
+describe('claudeStagedItems', () => {
+  it('uses category rels, with plugins under plugins/cache', () => {
+    expect(
+      claudeStagedItems({
+        newItems: [
+          { category: 'skills', name: 'foo' },
+          { category: 'plugins', name: 'mkt/plug' },
+        ],
+        mergedRegistries: [],
+      }),
+    ).toEqual([
+      { rel: 'skills/foo', label: 'skills/foo', kind: 'dir' },
+      { rel: 'plugins/cache/mkt/plug', label: 'plugins/mkt/plug', kind: 'dir' },
+    ]);
+  });
+
+  it('maps every claude item as a dir', () => {
+    const items = claudeStagedItems({
+      newItems: [{ category: 'agents', name: 'a' }],
+      mergedRegistries: [],
+    });
+    expect(items.every((i) => i.kind === 'dir')).toBe(true);
+  });
+});

--- a/packages/agent-codex/src/index.ts
+++ b/packages/agent-codex/src/index.ts
@@ -71,3 +71,5 @@ export { ensureCodexAgentsOverride } from './cloud-sync.js';
 export * from './docker-sync.js';
 export * from './host-stage.js';
 export * from './box-config.js';
+
+export { codexStagedItems } from './staged-items.js';

--- a/packages/agent-codex/src/index.ts
+++ b/packages/agent-codex/src/index.ts
@@ -10,7 +10,12 @@
  * The CLI re-exports what it needs from here; nothing below this package does.
  */
 
-import { registerAgentSyncModule, type AgentSyncModule } from '@agentbox/sandbox-docker';
+import { resolveAgentSpec } from '@agentbox/sandbox-core';
+import {
+  extractCodexCredentials,
+  registerAgentSyncModule,
+  type AgentSyncModule,
+} from '@agentbox/sandbox-docker';
 import { registerAgentCloudModule, type AgentCloudModule } from '@agentbox/sandbox-cloud';
 import { ensureCodexAgentsOverride } from './cloud-sync.js';
 import { stageCodexCredentialsForUpload, stageCodexStaticForUpload } from './host-stage.js';
@@ -31,6 +36,12 @@ export const codexSyncModule: AgentSyncModule = {
   sessionInfo: (container) => codexSessionInfo(container),
   // The AGENTS.override.md box-facts fold. It used to be called by name from
   // `docker-sync.ts`; it is Codex's own post-sync step now.
+  // Extract-only: unlike claude there is no docker bind mount of the host's real
+  // ~/.codex into the box, and codex's auth.json carries no expiry field to gate
+  // on — so always try, and let the helper report no-op when there is no volume.
+  refreshHostBackup: async (image) => {
+    await extractCodexCredentials(resolveAgentSpec('codex').dockerVolume, image);
+  },
   afterVolumeSync: async (volume, image) => {
     const r = await seedCodexAgentsOverride(volume, image);
     return { notes: r.seeded ? ['seeded AGENTS.override.md with box facts'] : [] };

--- a/packages/agent-codex/src/staged-items.ts
+++ b/packages/agent-codex/src/staged-items.ts
@@ -1,0 +1,16 @@
+/**
+ * Map codex's pull items to staged-item descriptors. See
+ * `@agentbox/agent-claude`'s `staged-items.ts` for why these live with their
+ * agents rather than as a three-arm table in `sandbox-core`.
+ */
+
+import type { StagedItem } from '@agentbox/sandbox-core';
+
+/** `config.toml` / `auth.json` are files; `prompts` is a directory. */
+export function codexStagedItems(newItems: string[]): StagedItem[] {
+  return newItems.map((name) => ({
+    rel: name,
+    label: name,
+    kind: name === 'prompts' ? ('dir' as const) : ('file' as const),
+  }));
+}

--- a/packages/agent-codex/test/staged-items.test.ts
+++ b/packages/agent-codex/test/staged-items.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { codexStagedItems } from '../src/staged-items.js';
+
+describe('codexStagedItems', () => {
+  it('treats prompts as a dir and everything else as a file', () => {
+    expect(codexStagedItems(['config.toml', 'prompts', 'auth.json']).map((i) => i.kind)).toEqual([
+      'file',
+      'dir',
+      'file',
+    ]);
+  });
+});

--- a/packages/agent-opencode/src/index.ts
+++ b/packages/agent-opencode/src/index.ts
@@ -57,3 +57,5 @@ export function registerOpencodeAgent(): void {
 
 export { seedOpencodeModelState } from './cloud-sync.js';
 export * from './docker-sync.js';
+
+export { opencodeStagedItems } from './staged-items.js';

--- a/packages/agent-opencode/src/index.ts
+++ b/packages/agent-opencode/src/index.ts
@@ -5,7 +5,12 @@
  * than importing it.
  */
 
-import { registerAgentSyncModule, type AgentSyncModule } from '@agentbox/sandbox-docker';
+import { resolveAgentSpec } from '@agentbox/sandbox-core';
+import {
+  extractOpencodeCredentials,
+  registerAgentSyncModule,
+  type AgentSyncModule,
+} from '@agentbox/sandbox-docker';
 import { registerAgentCloudModule, type AgentCloudModule } from '@agentbox/sandbox-cloud';
 import { seedOpencodeModelState } from './cloud-sync.js';
 import { stageOpencodeCredentialsForUpload } from './host-stage.js';
@@ -23,6 +28,12 @@ export const opencodeSyncModule: AgentSyncModule = {
   buildMounts: (spec, env) => buildOpencodeMounts(spec, env),
   ensureVolume: async (spec, opts) => ensureOpencodeVolume(spec, opts),
   sessionInfo: (container) => opencodeSessionInfo(container),
+  // Extract-only, same as codex: no host bind mount and no expiry field, so the
+  // helper is called unconditionally and reports { copied: false } if there is
+  // no volume to read.
+  refreshHostBackup: async (image) => {
+    await extractOpencodeCredentials(resolveAgentSpec('opencode').dockerVolume, image);
+  },
 };
 
 /**

--- a/packages/agent-opencode/src/staged-items.ts
+++ b/packages/agent-opencode/src/staged-items.ts
@@ -1,0 +1,15 @@
+/**
+ * Map opencode's pull labels (`auth.json`, `config/<item>`) to volume-style
+ * rels. See `@agentbox/agent-claude`'s `staged-items.ts` for why these live with
+ * their agents rather than as a three-arm table in `sandbox-core`.
+ */
+
+import type { StagedItem } from '@agentbox/sandbox-core';
+
+export function opencodeStagedItems(newItems: string[]): StagedItem[] {
+  return newItems.map((label) => {
+    const name = label.startsWith('config/') ? label.slice('config/'.length) : label;
+    const isFile = name === 'auth.json' || name === 'opencode.json' || name === 'opencode.jsonc';
+    return { rel: label, label, kind: isFile ? ('file' as const) : ('dir' as const) };
+  });
+}

--- a/packages/agent-opencode/test/staged-items.test.ts
+++ b/packages/agent-opencode/test/staged-items.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { opencodeStagedItems } from '../src/staged-items.js';
+
+describe('opencodeStagedItems', () => {
+  it('marks auth + global config as files and extension dirs as dirs', () => {
+    expect(
+      opencodeStagedItems(['auth.json', 'config/opencode.json', 'config/skills']).map((i) => [
+        i.rel,
+        i.kind,
+      ]),
+    ).toEqual([
+      ['auth.json', 'file'],
+      ['config/opencode.json', 'file'],
+      ['config/skills', 'dir'],
+    ]);
+  });
+
+  it('keeps the config/ prefix in the rel while classifying on the basename', () => {
+    // The `config/` prefix is the VOLUME layout; the file-vs-dir decision is
+    // about the item itself, so stripping it for the test and keeping it in the
+    // rel is the behaviour, not an accident.
+    expect(opencodeStagedItems(['config/opencode.jsonc'])).toEqual([
+      { rel: 'config/opencode.jsonc', label: 'config/opencode.jsonc', kind: 'file' },
+    ]);
+  });
+});

--- a/packages/sandbox-core/src/sync/agent-propagate.ts
+++ b/packages/sandbox-core/src/sync/agent-propagate.ts
@@ -28,7 +28,6 @@ import {
   CLAUDE_BOX_CONFIG_DIR,
   CODEX_BOX_CONFIG_DIR,
   OPENCODE_BOX_DATA_DIR,
-  type PullClaudeResult,
 } from './agent-pull.js';
 
 /** One staged settings item, in the volume-style relative layout. */
@@ -62,32 +61,10 @@ export function agentBoxConfigDir(agent: AgentId): string {
   }
 }
 
-/** Map a claude pull result to staged-item descriptors (all claude items are dirs). */
-export function claudeStagedItems(result: PullClaudeResult): StagedItem[] {
-  return result.newItems.map((it) => ({
-    rel: it.category === 'plugins' ? `plugins/cache/${it.name}` : `${it.category}/${it.name}`,
-    label: `${it.category}/${it.name}`,
-    kind: 'dir' as const,
-  }));
-}
-
-/** Map codex pull items (`config.toml`/`auth.json` files, `prompts` dir). */
-export function codexStagedItems(newItems: string[]): StagedItem[] {
-  return newItems.map((name) => ({
-    rel: name,
-    label: name,
-    kind: name === 'prompts' ? ('dir' as const) : ('file' as const),
-  }));
-}
-
-/** Map opencode pull labels (`auth.json`, `config/<item>`) to volume-style rels. */
-export function opencodeStagedItems(newItems: string[]): StagedItem[] {
-  return newItems.map((label) => {
-    const name = label.startsWith('config/') ? label.slice('config/'.length) : label;
-    const isFile = name === 'auth.json' || name === 'opencode.json' || name === 'opencode.jsonc';
-    return { rel: label, label, kind: isFile ? ('file' as const) : ('dir' as const) };
-  });
-}
+// The three `<agent>StagedItems` mappers lived here — a per-agent table in a
+// layer that must not know about agents. Each knew only its own agent's pull
+// shape, so each moved to `packages/agent-<id>/src/staged-items.ts`. The
+// `StagedItem` contract and the transport that consumes it stay shared.
 
 /** Stage box-side items into `stagingDir` (volume-style layout) over a transport. */
 export async function stageItemsViaTransport(

--- a/packages/sandbox-core/src/sync/concerns/credentials.ts
+++ b/packages/sandbox-core/src/sync/concerns/credentials.ts
@@ -5,7 +5,7 @@
  * snapshot.
  *
  * What lives here is the provider-neutral core of the concern:
- *  - the pure host-side guards (`isRealAgentCredential`, `hostClaudeAccessTokenExpired`,
+ *  - the pure host-side guards (`isRealAgentCredential`,
  *    `hostBackupHasCredentials`) — the "is this blob real / expired?" decisions,
  *    driven by the registry's `credential.realShape` so the per-agent switch has
  *    one home;
@@ -71,65 +71,6 @@ export function isRealAgentCredential(agent: CredentialAgentKind, text: string):
     return typeof rt === 'string' && rt.length > 0;
   }
   return Object.keys(parsed as Record<string, unknown>).length > 0;
-}
-
-/**
- * True iff the claude host backup's *access* token has lapsed
- * (`claudeAiOauth.expiresAt`, ms epoch, < now). Access tokens live ~8h, so this
- * is true of a perfectly healthy login most of the time — it answers "is this
- * blob worth renewing before we hand it to a box?", NOT "is this login dead?".
- * For that, see {@link hostClaudeLoginDead}.
- *
- * A missing `expiresAt` (or unreadable file) → false: we only report a *known*
- * lapse. `now` is injectable for tests. Claude is the only agent with a
- * token-expiry field (codex / opencode auth files carry no comparable one).
- */
-export async function hostClaudeAccessTokenExpired(
-  path: string = CLAUDE_HOST_BACKUP,
-  now: number = Date.now(),
-): Promise<boolean> {
-  try {
-    const parsed = JSON.parse(await readFile(path, 'utf8')) as {
-      claudeAiOauth?: { expiresAt?: unknown };
-    };
-    const exp = parsed?.claudeAiOauth?.expiresAt;
-    return typeof exp === 'number' && Number.isFinite(exp) && exp < now;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * True iff the saved claude login can no longer be renewed: no usable refresh
- * token at all, or the refresh token's own ~30-day life
- * (`claudeAiOauth.refreshTokenExpiresAt`) has run out.
- *
- * This is the question every "should we ask the user to sign in again?" gate
- * actually wants. Gating those on the access token instead produced a daily
- * false alarm — and accepting that alarm runs a login container that refreshes
- * and ROTATES the shared token before the user types anything, so a cancelled
- * sign-in left every copy of the login (host backup, custody, other boxes)
- * holding a spent token. A merely-lapsed access token renews itself.
- *
- * A missing `refreshTokenExpiresAt` → not dead, matching the "only report a
- * *known* death" convention of {@link hostClaudeAccessTokenExpired}: an older
- * blob that predates the field must not be declared dead on a guess. Note this
- * cannot see a token that was rotated away by another copy — that is only
- * observable by trying to use it.
- */
-export async function hostClaudeLoginDead(
-  path: string = CLAUDE_HOST_BACKUP,
-  now: number = Date.now(),
-): Promise<boolean> {
-  let text: string;
-  try {
-    text = await readFile(path, 'utf8');
-  } catch {
-    return false;
-  }
-  if (!isRealAgentCredential('claude', text)) return true;
-  const exp = claudeRefreshExpiresAt(text);
-  return exp !== null && exp < now;
 }
 
 /**
@@ -235,7 +176,7 @@ export function parseCredentialsUpdate(payload: unknown): CredentialsUpdate | nu
 }
 
 /** `claudeAiOauth.expiresAt` (ms epoch) of a claude blob, or null. */
-export function claudeExpiresAt(text: string): number | null {
+export function oauthExpiresAt(text: string): number | null {
   try {
     const parsed = JSON.parse(text) as { claudeAiOauth?: { expiresAt?: unknown } };
     const exp = parsed?.claudeAiOauth?.expiresAt;
@@ -250,7 +191,7 @@ export function claudeExpiresAt(text: string): number | null {
  * The refresh token's own life (~30 days from the original sign-in) — the field
  * that says whether the login is still renewable, unlike `expiresAt`.
  */
-export function claudeRefreshExpiresAt(text: string): number | null {
+export function oauthRefreshExpiresAt(text: string): number | null {
   try {
     const parsed = JSON.parse(text) as { claudeAiOauth?: { refreshTokenExpiresAt?: unknown } };
     const exp = parsed?.claudeAiOauth?.refreshTokenExpiresAt;
@@ -275,8 +216,8 @@ export function shouldAcceptCredentialUpdate(
   if (existing === null) return { accept: true, reason: 'no existing backup' };
   if (existing === incoming) return { accept: false, reason: 'unchanged' };
   if (resolveAgentSpec(agent).credential.realShape === 'claude-oauth') {
-    const incomingExp = claudeExpiresAt(incoming);
-    const existingExp = claudeExpiresAt(existing);
+    const incomingExp = oauthExpiresAt(incoming);
+    const existingExp = oauthExpiresAt(existing);
     if (incomingExp === null) return { accept: false, reason: 'incoming blob has no expiresAt' };
     if (existingExp !== null && incomingExp <= existingExp) {
       return { accept: false, reason: 'not newer than backup' };

--- a/packages/sandbox-core/src/sync/index.ts
+++ b/packages/sandbox-core/src/sync/index.ts
@@ -137,13 +137,11 @@ export {
 } from './concerns/skills.js';
 export {
   isRealAgentCredential,
-  hostClaudeAccessTokenExpired,
-  hostClaudeLoginDead,
   hostBackupHasCredentials,
   extractCredentials,
   parseCredentialsUpdate,
-  claudeExpiresAt,
-  claudeRefreshExpiresAt,
+  oauthExpiresAt,
+  oauthRefreshExpiresAt,
   shouldAcceptCredentialUpdate,
   writeCredentialBackup,
   readCredentialBackup,

--- a/packages/sandbox-core/src/sync/index.ts
+++ b/packages/sandbox-core/src/sync/index.ts
@@ -62,9 +62,6 @@ export {
 } from './agent-descriptor.js';
 export {
   agentBoxConfigDir,
-  claudeStagedItems,
-  codexStagedItems,
-  opencodeStagedItems,
   makeStagingDir,
   removeStagingDir,
   stageItemsViaTransport,

--- a/packages/sandbox-core/test/agent-propagate.test.ts
+++ b/packages/sandbox-core/test/agent-propagate.test.ts
@@ -3,52 +3,15 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  claudeStagedItems,
-  codexStagedItems,
   makeRecordingTransport,
-  opencodeStagedItems,
   planPropagateTargets,
   propagateStagedSettings,
   transportSettingsTarget,
   type SettingsTarget,
 } from '../src/index.js';
 
-describe('staged item mappers', () => {
-  it('claude: category rels, plugins under plugins/cache', () => {
-    expect(
-      claudeStagedItems({
-        newItems: [
-          { category: 'skills', name: 'foo' },
-          { category: 'plugins', name: 'mkt/plug' },
-        ],
-        mergedRegistries: [],
-      }),
-    ).toEqual([
-      { rel: 'skills/foo', label: 'skills/foo', kind: 'dir' },
-      { rel: 'plugins/cache/mkt/plug', label: 'plugins/mkt/plug', kind: 'dir' },
-    ]);
-  });
-
-  it('codex: prompts is a dir, the rest are files', () => {
-    expect(codexStagedItems(['config.toml', 'prompts']).map((i) => i.kind)).toEqual([
-      'file',
-      'dir',
-    ]);
-  });
-
-  it('opencode: auth/global config are files, extension dirs are dirs', () => {
-    expect(
-      opencodeStagedItems(['auth.json', 'config/opencode.json', 'config/skills']).map((i) => [
-        i.rel,
-        i.kind,
-      ]),
-    ).toEqual([
-      ['auth.json', 'file'],
-      ['config/opencode.json', 'file'],
-      ['config/skills', 'dir'],
-    ]);
-  });
-});
+// The three `<agent>StagedItems` mappers moved to their agent packages; their
+// tests went with them (`packages/agent-<id>/test/staged-items.test.ts`).
 
 describe('planPropagateTargets', () => {
   const boxes = [

--- a/packages/sandbox-core/test/credential-fanout-helpers.test.ts
+++ b/packages/sandbox-core/test/credential-fanout-helpers.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  claudeExpiresAt,
+  oauthExpiresAt,
   makeRecordingTransport,
   parseCredentialsUpdate,
   pushCredentialToBox,
@@ -27,13 +27,16 @@ describe('parseCredentialsUpdate', () => {
     });
     expect(update).not.toBeNull();
     expect(update!.agent).toBe('claude');
-    expect(claudeExpiresAt(update!.content)).toBe(123);
+    expect(oauthExpiresAt(update!.content)).toBe(123);
   });
 
   it.each([
     ['unknown agent', { agent: 'gpt', contentBase64: b64('{"a":1}') }],
     ['missing content', { agent: 'codex' }],
-    ['placeholder claude blob', { agent: 'claude', contentBase64: b64('{"claudeAiOauth":{"refreshToken":""}}') }],
+    [
+      'placeholder claude blob',
+      { agent: 'claude', contentBase64: b64('{"claudeAiOauth":{"refreshToken":""}}') },
+    ],
     ['empty json for codex', { agent: 'codex', contentBase64: b64('{}') }],
     ['non-object', 'nope'],
   ])('rejects %s', (_name, payload) => {
@@ -43,9 +46,15 @@ describe('parseCredentialsUpdate', () => {
 
 describe('shouldAcceptCredentialUpdate', () => {
   it('claude: newest expiresAt wins, equal or older rejected', () => {
-    expect(shouldAcceptCredentialUpdate('claude', claudeBlob(200), claudeBlob(100)).accept).toBe(true);
-    expect(shouldAcceptCredentialUpdate('claude', claudeBlob(100), claudeBlob(100, 'other')).accept).toBe(false);
-    expect(shouldAcceptCredentialUpdate('claude', claudeBlob(50), claudeBlob(100)).accept).toBe(false);
+    expect(shouldAcceptCredentialUpdate('claude', claudeBlob(200), claudeBlob(100)).accept).toBe(
+      true,
+    );
+    expect(
+      shouldAcceptCredentialUpdate('claude', claudeBlob(100), claudeBlob(100, 'other')).accept,
+    ).toBe(false);
+    expect(shouldAcceptCredentialUpdate('claude', claudeBlob(50), claudeBlob(100)).accept).toBe(
+      false,
+    );
   });
 
   it('claude: accepts when there is no existing backup or it has no expiresAt', () => {
@@ -71,7 +80,9 @@ describe('shouldAcceptCredentialUpdate', () => {
 
   it('codex/opencode: content change wins, identical is a no-op', () => {
     expect(shouldAcceptCredentialUpdate('codex', '{"t":"new"}', '{"t":"old"}').accept).toBe(true);
-    expect(shouldAcceptCredentialUpdate('codex', '{"t":"same"}', '{"t":"same"}').accept).toBe(false);
+    expect(shouldAcceptCredentialUpdate('codex', '{"t":"same"}', '{"t":"same"}').accept).toBe(
+      false,
+    );
     expect(shouldAcceptCredentialUpdate('opencode', '{"t":"x"}', null).accept).toBe(true);
   });
 });
@@ -107,8 +118,12 @@ describe('pushCredentialToBox', () => {
     const push = t.ops.find((o) => o.op === 'pushFile');
     expect(push!.args['boxDestPath']).toBe('/home/vscode/.claude/.credentials.json');
     const execs = t.ops.filter((o) => o.op === 'exec');
-    expect(execs.some((e) => (e.args['cmd'] as string[]).join(' ').includes('mkdir -p'))).toBe(true);
-    expect(execs.some((e) => (e.args['cmd'] as string[]).join(' ').includes('chmod 600'))).toBe(true);
+    expect(execs.some((e) => (e.args['cmd'] as string[]).join(' ').includes('mkdir -p'))).toBe(
+      true,
+    );
+    expect(execs.some((e) => (e.args['cmd'] as string[]).join(' ').includes('chmod 600'))).toBe(
+      true,
+    );
   });
 
   it('fails loudly when the in-box normalize fails', async () => {

--- a/packages/sandbox-core/test/credentials-concern.test.ts
+++ b/packages/sandbox-core/test/credentials-concern.test.ts
@@ -7,10 +7,8 @@ import { AGENT_SYNC_SPECS } from '../src/sync/registry.js';
 import {
   SEED_MARKER,
   extractCredentials,
-  claudeRefreshExpiresAt,
+  oauthRefreshExpiresAt,
   hostBackupHasCredentials,
-  hostClaudeAccessTokenExpired,
-  hostClaudeLoginDead,
   isRealAgentCredential,
 } from '../src/sync/concerns/credentials.js';
 
@@ -44,102 +42,24 @@ describe('credentials concern — guards', () => {
     });
   });
 
-  describe('hostClaudeAccessTokenExpired', () => {
-    let dir: string;
-    beforeEach(async () => {
-      dir = await mkdtemp(join(tmpdir(), 'abx-core-exp-'));
-    });
-    afterEach(async () => {
-      await rm(dir, { recursive: true, force: true });
-    });
-
-    const write = async (obj: unknown) => {
-      const p = join(dir, 'creds.json');
-      await writeFile(p, JSON.stringify(obj));
-      return p;
-    };
-
-    it('true when expiresAt is in the past', async () => {
-      const p = await write({ claudeAiOauth: { refreshToken: 'rt', expiresAt: 1000 } });
-      expect(await hostClaudeAccessTokenExpired(p, 2000)).toBe(true);
-    });
-    it('false when expiresAt is in the future', async () => {
-      const p = await write({ claudeAiOauth: { refreshToken: 'rt', expiresAt: 5000 } });
-      expect(await hostClaudeAccessTokenExpired(p, 2000)).toBe(false);
-    });
-    it('false when expiresAt is absent (do not nag)', async () => {
-      const p = await write({ claudeAiOauth: { refreshToken: 'rt' } });
-      expect(await hostClaudeAccessTokenExpired(p, 2000)).toBe(false);
-    });
-    it('false on a missing/garbage file', async () => {
-      expect(await hostClaudeAccessTokenExpired(join(dir, 'nope.json'), 2000)).toBe(false);
-    });
-  });
-
-  describe('claudeRefreshExpiresAt', () => {
+  describe('oauthRefreshExpiresAt', () => {
     it('reads refreshTokenExpiresAt, null when absent or unparseable', () => {
       expect(
-        claudeRefreshExpiresAt(JSON.stringify({ claudeAiOauth: { refreshTokenExpiresAt: 42 } })),
+        oauthRefreshExpiresAt(JSON.stringify({ claudeAiOauth: { refreshTokenExpiresAt: 42 } })),
       ).toBe(42);
-      expect(claudeRefreshExpiresAt(JSON.stringify({ claudeAiOauth: { expiresAt: 42 } }))).toBe(
+      expect(oauthRefreshExpiresAt(JSON.stringify({ claudeAiOauth: { expiresAt: 42 } }))).toBe(
         null,
       );
       expect(
-        claudeRefreshExpiresAt(JSON.stringify({ claudeAiOauth: { refreshTokenExpiresAt: 'no' } })),
+        oauthRefreshExpiresAt(JSON.stringify({ claudeAiOauth: { refreshTokenExpiresAt: 'no' } })),
       ).toBe(null);
-      expect(claudeRefreshExpiresAt('not json')).toBe(null);
+      expect(oauthRefreshExpiresAt('not json')).toBe(null);
     });
   });
 
   // The distinction this whole gate exists for: a lapsed ACCESS token is a
   // healthy login that renews itself, and reporting it as expired produced a
   // daily false alarm whose "fix" (a login container) rotated the shared token.
-  describe('hostClaudeLoginDead', () => {
-    let dir: string;
-    beforeEach(async () => {
-      dir = await mkdtemp(join(tmpdir(), 'abx-core-dead-'));
-    });
-    afterEach(async () => {
-      await rm(dir, { recursive: true, force: true });
-    });
-
-    const write = async (obj: unknown) => {
-      const p = join(dir, 'creds.json');
-      await writeFile(p, JSON.stringify(obj));
-      return p;
-    };
-
-    it('false when the access token lapsed but the refresh token is alive', async () => {
-      const p = await write({
-        claudeAiOauth: { refreshToken: 'rt', expiresAt: 1000, refreshTokenExpiresAt: 9000 },
-      });
-      expect(await hostClaudeLoginDead(p, 2000)).toBe(false);
-      expect(await hostClaudeAccessTokenExpired(p, 2000)).toBe(true);
-    });
-    it('true when the refresh token itself has expired', async () => {
-      const p = await write({
-        claudeAiOauth: { refreshToken: 'rt', expiresAt: 5000, refreshTokenExpiresAt: 1000 },
-      });
-      expect(await hostClaudeLoginDead(p, 2000)).toBe(true);
-    });
-    it('true when the refresh token is blank (claude blanks it on a rejected refresh)', async () => {
-      const p = await write({ claudeAiOauth: { refreshToken: '', refreshTokenExpiresAt: 9000 } });
-      expect(await hostClaudeLoginDead(p, 2000)).toBe(true);
-    });
-    it('false when refreshTokenExpiresAt is absent (never declare death on a guess)', async () => {
-      const p = await write({ claudeAiOauth: { refreshToken: 'rt', expiresAt: 1000 } });
-      expect(await hostClaudeLoginDead(p, 2000)).toBe(false);
-    });
-    it('false on a missing file (nothing saved is "missing", not "dead")', async () => {
-      expect(await hostClaudeLoginDead(join(dir, 'nope.json'), 2000)).toBe(false);
-    });
-    it('true on a garbage file that exists', async () => {
-      const p = join(dir, 'creds.json');
-      await writeFile(p, 'not json');
-      expect(await hostClaudeLoginDead(p, 2000)).toBe(true);
-    });
-  });
-
   describe('hostBackupHasCredentials', () => {
     let dir: string;
     let path: string;

--- a/packages/sandbox-docker/src/credential-refresh.ts
+++ b/packages/sandbox-docker/src/credential-refresh.ts
@@ -18,117 +18,29 @@
  * helper swallows its own failures (no docker, missing volume) and returns a
  * noop result.
  *
- * Gated on `hostClaudeAccessTokenExpired`: when the claude backup's access token
- * is still valid we skip the docker round-trip entirely (`docker run` against
- * the shared volume is ~1-2s and almost always a noop on fresh tokens). That is
- * the one place the access-token check belongs — it asks "is this blob worth
- * refreshing?", not "is this login dead?".
+ * Registry-driven. It used to name three agents in sequence — a claude sync
+ * gated on claude's access-token expiry, then a codex extract, then an opencode
+ * extract — so a fourth agent got no refresh at all and nothing said so. Each
+ * agent now supplies its own step through `AgentSyncModule.refreshHostBackup`,
+ * including the expiry gate that is claude's own business (skipping the ~1-2s
+ * `docker run` when the token is still fresh).
  */
-import { hostClaudeAccessTokenExpired, resolveAgentSpec } from '@agentbox/sandbox-core';
 import type { DockerCredentialRefresher } from '@agentbox/sandbox-core';
-import { requireAgentSyncModule } from './sync/agents/module.js';
+import { registeredAgentSyncModules } from './sync/agents/module.js';
 import { DEFAULT_BOX_IMAGE } from './image.js';
-import {
-  extractCodexCredentials,
-  extractOpencodeCredentials,
-  syncClaudeCredentials,
-} from './sync/claude-credentials.js';
 
 export const dockerCredentialRefresh: DockerCredentialRefresher = async (opts) => {
   const log = opts.onLog ?? (() => {});
-  if (!(await hostClaudeAccessTokenExpired())) {
-    return;
-  }
-  log('claude: host credentials backup expired — refreshing from docker shared volume');
   const image = DEFAULT_BOX_IMAGE;
-  try {
-    const r = await syncClaudeCredentials(
-      { volume: resolveAgentSpec('claude').dockerVolume },
-      { image, isolate: false },
-    );
-    if (r.direction === 'extracted') {
-      log('claude: refreshed host credentials backup from docker shared volume');
-    } else if (r.direction === 'noop') {
-      log('claude: no docker shared volume to refresh from (continuing with existing backup)');
+  // Every registered agent, not three by name. Each decides for itself whether
+  // there is anything to do — claude gates on its own token expiry, codex and
+  // opencode are extract-only — and an agent that registers no module (or no
+  // `refreshHostBackup`) is simply skipped rather than silently mishandled.
+  for (const mod of registeredAgentSyncModules()) {
+    try {
+      await mod.refreshHostBackup?.(image, log);
+    } catch {
+      /* best-effort: one agent's refresh must never block another's, or a box start */
     }
-  } catch {
-    /* best-effort — syncClaudeCredentials already swallows internally */
-  }
-  // codex + opencode are extract-only (no docker bind mount of the host's real
-  // ~/.codex into the box like claude has), so always try when the docker
-  // volume exists. Both helpers return { copied: false } on any error.
-  try {
-    await extractCodexCredentials(resolveAgentSpec('codex').dockerVolume, image);
-  } catch {
-    /* best-effort */
-  }
-  try {
-    await extractOpencodeCredentials(resolveAgentSpec('opencode').dockerVolume, image);
-  } catch {
-    /* best-effort */
   }
 };
-
-/** Outcome of {@link renewClaudeCredential}. */
-export type RenewClaudeResult = 'renewed' | 'unchanged' | 'failed';
-
-/**
- * Actively renew the saved claude login through the shared docker volume, and
- * report whether it still works.
- *
- * A credential's health is not readable off disk: `expiresAt` only dates the
- * ~8h access token, and a refresh token that was rotated away by another copy
- * looks perfectly valid until you try it. The only honest test is to use it —
- * so drive the same pair the successful-login path runs in its `finalize`:
- *
- *  1. `syncClaudeCredentials` — converge volume and backup on the newer blob,
- *     so we renew from the freshest copy rather than whichever the volume holds.
- *  2. `warmUpClaudeCredentials` — a headless `claude -p` forces a real OAuth
- *     refresh, minting a fresh access token into the volume.
- *  3. `syncClaudeCredentials` again — extract that fresh blob to the host backup
- *     so the cloud seed (and every later box) gets a live credential.
- *
- * This is what keeps the fleet logged in without nagging: a lapsed access token
- * is renewed silently, and only a genuine failure — `'failed'` — is worth
- * asking the user to sign in again for.
- *
- * `attempts` is deliberately small (2 by default): the login path's 6 exist to
- * outwait the fresh-token first-request 400, but on the create path every extra
- * attempt costs the user 5s + a container start before we can say "dead".
- *
- * Best-effort: any docker failure resolves to `'failed'`, never throws.
- */
-export async function renewClaudeCredential(opts: {
-  image?: string;
-  attempts?: number;
-  onLog?: (msg: string) => void;
-}): Promise<RenewClaudeResult> {
-  const log = opts.onLog ?? (() => {});
-  const image = opts.image ?? DEFAULT_BOX_IMAGE;
-  try {
-    await syncClaudeCredentials(
-      { volume: resolveAgentSpec('claude').dockerVolume },
-      { image, isolate: false },
-    );
-    // Through the registry: the warm-up is claude's own behavior and lives in
-    // its package now, which this one cannot import.
-    const claude = requireAgentSyncModule('claude');
-    const warm = (await claude.warmUpCredentials?.(resolveAgentSpec('claude').dockerVolume, image, {
-      attempts: opts.attempts ?? 2,
-      onProgress: (line: string) => {
-        log(line);
-      },
-    })) ?? { warmed: false, notes: [] };
-    if (!warm.warmed) {
-      log('claude: saved login did not renew — it may have been rotated away by another box');
-      return 'failed';
-    }
-    const synced = await syncClaudeCredentials(
-      { volume: resolveAgentSpec('claude').dockerVolume },
-      { image, isolate: false },
-    );
-    return synced.direction === 'extracted' ? 'renewed' : 'unchanged';
-  } catch {
-    return 'failed';
-  }
-}

--- a/packages/sandbox-docker/src/index.ts
+++ b/packages/sandbox-docker/src/index.ts
@@ -35,8 +35,6 @@ export {
   CODEX_CREDENTIALS_BACKUP_FILE,
   OPENCODE_CREDENTIALS_BACKUP_FILE,
   hostBackupHasCredentials,
-  hostClaudeAccessTokenExpired,
-  hostClaudeLoginDead,
   isRealAgentCredential,
   parseSyncResult,
   parseExtractResult,
@@ -156,11 +154,7 @@ export {
 // there now. This package only supplies the docker-side Portless hooks the CLI
 // installs into the hub seam.
 export { dockerHubPortlessHooks } from './hub-portless.js';
-export {
-  dockerCredentialRefresh,
-  renewClaudeCredential,
-  type RenewClaudeResult,
-} from './credential-refresh.js';
+export { dockerCredentialRefresh } from './credential-refresh.js';
 // The host-config stage producers now live in the provider-neutral sync layer
 // (`@agentbox/sandbox-core`); cloud consumers import them from there. The claude
 // per-project path helpers + Stage types stay re-exported here (from core) for

--- a/packages/sandbox-docker/src/sync/agents/module.ts
+++ b/packages/sandbox-docker/src/sync/agents/module.ts
@@ -107,6 +107,21 @@ export interface AgentSyncModule {
     image: string,
     opts?: { attempts?: number; onProgress?: (line: string) => void },
   ): Promise<{ warmed: boolean; notes: string[] }>;
+
+  /**
+   * Bring this agent's HOST credential backup up to date from its docker volume,
+   * before a box starts.
+   *
+   * `dockerCredentialRefresh` used to do this for three agents by name — a
+   * claude sync gated on claude's token expiry, then a codex extract, then an
+   * opencode extract. A fourth agent got no refresh at all, silently, which is
+   * the same gap `assert-creds` and the cloud volume table each had.
+   *
+   * Optional, and best-effort by contract: the caller swallows throws, so an
+   * agent with nothing to refresh omits it and one whose docker volume is
+   * missing simply reports no change.
+   */
+  refreshHostBackup?(image: string, log: (line: string) => void): Promise<void>;
 }
 
 /**

--- a/packages/sandbox-docker/src/sync/claude-credentials.ts
+++ b/packages/sandbox-docker/src/sync/claude-credentials.ts
@@ -4,16 +4,18 @@ import { basename, join } from 'node:path';
 import { execa } from 'execa';
 import { STATE_DIR } from '../state.js';
 
-// The pure credential guards (`isRealAgentCredential`, `hostClaudeAccessTokenExpired`,
-// `hostClaudeLoginDead`, `hostBackupHasCredentials`) + `CredentialAgentKind` moved to the provider-
-// neutral credentials concern in @agentbox/sandbox-core (the per-agent
-// real-credential shape is now registry data, `credential.realShape`, shared
-// with cloud). Re-exported here so existing docker importers/tests — and the
-// `@agentbox/sandbox-docker` barrel — are untouched.
+// The pure, agent-neutral credential guards moved to the credentials concern in
+// @agentbox/sandbox-core (the per-agent real-credential shape is registry data,
+// `credential.realShape`, shared with cloud). Re-exported here so existing
+// docker importers/tests — and the `@agentbox/sandbox-docker` barrel — are
+// untouched.
+//
+// The two claude-OAUTH guards that used to ride along here
+// (`hostClaudeAccessTokenExpired` / `hostClaudeLoginDead`) went further: they
+// only mean anything for a `claude-oauth` blob, so they live in
+// `@agentbox/agent-claude` now.
 export {
   isRealAgentCredential,
-  hostClaudeAccessTokenExpired,
-  hostClaudeLoginDead,
   hostBackupHasCredentials,
   type CredentialAgentKind,
 } from '@agentbox/sandbox-core';

--- a/packages/sandbox-docker/test/claude-credentials.test.ts
+++ b/packages/sandbox-docker/test/claude-credentials.test.ts
@@ -5,8 +5,6 @@ import { execa } from 'execa';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   hostBackupHasCredentials,
-  hostClaudeAccessTokenExpired,
-  hostClaudeLoginDead,
   isRealAgentCredential,
   parseExtractResult,
   parseSyncResult,
@@ -56,52 +54,10 @@ describe('parseVolumeClaudeCredentials', () => {
   });
 });
 
-describe('hostClaudeAccessTokenExpired', () => {
-  let dir: string;
-  beforeEach(async () => {
-    dir = await mkdtemp(join(tmpdir(), 'abx-exp-'));
-  });
-  afterEach(async () => {
-    await rm(dir, { recursive: true, force: true });
-  });
-
-  const write = async (obj: unknown) => {
-    const p = join(dir, 'creds.json');
-    await writeFile(p, JSON.stringify(obj));
-    return p;
-  };
-
-  it('true when expiresAt is in the past', async () => {
-    const p = await write({ claudeAiOauth: { refreshToken: 'rt', expiresAt: 1000 } });
-    expect(await hostClaudeAccessTokenExpired(p, 2000)).toBe(true);
-  });
-  it('false when expiresAt is in the future', async () => {
-    const p = await write({ claudeAiOauth: { refreshToken: 'rt', expiresAt: 5000 } });
-    expect(await hostClaudeAccessTokenExpired(p, 2000)).toBe(false);
-  });
-  it('false when expiresAt is absent (do not nag)', async () => {
-    const p = await write({ claudeAiOauth: { refreshToken: 'rt' } });
-    expect(await hostClaudeAccessTokenExpired(p, 2000)).toBe(false);
-  });
-  it('false on a missing/garbage file', async () => {
-    expect(await hostClaudeAccessTokenExpired(join(dir, 'nope.json'), 2000)).toBe(false);
-  });
-
-  // The two predicates must stay distinguishable through the docker re-export:
-  // a lapsed access token is a healthy login, only a spent refresh token is dead.
-  it('is not the same question as hostClaudeLoginDead', async () => {
-    const p = await write({
-      claudeAiOauth: { refreshToken: 'rt', expiresAt: 1000, refreshTokenExpiresAt: 9000 },
-    });
-    expect(await hostClaudeAccessTokenExpired(p, 2000)).toBe(true);
-    expect(await hostClaudeLoginDead(p, 2000)).toBe(false);
-
-    const spent = await write({
-      claudeAiOauth: { refreshToken: 'rt', expiresAt: 5000, refreshTokenExpiresAt: 1000 },
-    });
-    expect(await hostClaudeLoginDead(spent, 2000)).toBe(true);
-  });
-});
+// The `hostClaudeAccessTokenExpired` / `hostClaudeLoginDead` block that sat
+// here tested a re-export. Both guards only mean anything for a `claude-oauth`
+// blob, so they live in `@agentbox/agent-claude` now, and so does their
+// coverage (`packages/agent-claude/test/host-cred-guards.test.ts`).
 
 describe('isRealAgentCredential', () => {
   it('claude requires a non-empty claudeAiOauth.refreshToken', () => {

--- a/packages/sandbox-docker/test/credential-refresh-registry.test.ts
+++ b/packages/sandbox-docker/test/credential-refresh-registry.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { dockerCredentialRefresh } from '../src/credential-refresh.js';
+import {
+  registerAgentSyncModule,
+  registeredAgentSyncModules,
+  type AgentSyncModule,
+} from '../src/sync/agents/module.js';
+
+/**
+ * `dockerCredentialRefresh` used to name three agents in sequence: a claude sync
+ * gated on claude's token expiry, then a codex extract, then an opencode
+ * extract. A fourth agent got no host-backup refresh at all — silently, since
+ * every step is best-effort — so its cloud boxes were seeded from a stale token.
+ *
+ * It walks the module registry now. These tests are about THAT property: every
+ * registered agent is offered the step, and one agent's failure cannot swallow
+ * another's.
+ */
+function stub(id: string, calls: string[], opts: { throws?: boolean } = {}): AgentSyncModule {
+  return {
+    id,
+    resolveVolume: () => ({ volume: `v-${id}`, isolated: false }),
+    buildMounts: () => ({ args: [], env: {} }),
+    ensureVolume: async () => ({ created: false, synced: false }),
+    sessionInfo: async () => ({ running: false, sessionName: id, startedAt: null, title: null }),
+    refreshHostBackup: async () => {
+      calls.push(id);
+      if (opts.throws) throw new Error(`${id} exploded`);
+    },
+  } as unknown as AgentSyncModule;
+}
+
+describe('dockerCredentialRefresh walks the agent registry', () => {
+  let calls: string[];
+  beforeEach(() => {
+    calls = [];
+  });
+
+  it('offers the step to a newly registered agent, with no edit here', async () => {
+    // The whole point: a fourth agent is refreshed because it registered, not
+    // because this function learned its name.
+    registerAgentSyncModule(stub('zz-fourth-agent', calls));
+    await dockerCredentialRefresh({});
+    expect(calls).toContain('zz-fourth-agent');
+  });
+
+  it('keeps going when one agent throws', async () => {
+    registerAgentSyncModule(stub('zz-boom', calls, { throws: true }));
+    registerAgentSyncModule(stub('zz-after', calls));
+    await expect(dockerCredentialRefresh({})).resolves.toBeUndefined();
+    expect(calls).toContain('zz-boom');
+    expect(calls).toContain('zz-after');
+  });
+
+  it('skips an agent that declares no refresh step', async () => {
+    const bare = { ...stub('zz-bare', calls) };
+    delete (bare as { refreshHostBackup?: unknown }).refreshHostBackup;
+    registerAgentSyncModule(bare as AgentSyncModule);
+    await expect(dockerCredentialRefresh({})).resolves.toBeUndefined();
+    expect(calls).not.toContain('zz-bare');
+    expect(registeredAgentSyncModules().some((m) => m.id === 'zz-bare')).toBe(true);
+  });
+});


### PR DESCRIPTION
Continues the agents-as-packages work. Allowlist in `no-agent-named-exports.test.ts`: **16 -> 13**.

### `64327f94` — credential guards + renewal into `agent-claude`

`hostClaudeAccessTokenExpired` / `hostClaudeLoginDead` (sandbox-core) and `renewClaudeCredential` (sandbox-docker) only mean anything for a `claude-oauth` blob, and their only consumer was already `@agentbox/agent-claude`. Moving the renewal also deletes an inversion: it reached claude's own warm-up through `requireAgentSyncModule('claude')` purely because it sat in the wrong package.

The OAuth field parsers stayed in `sandbox-core`, renamed for the shape rather than the agent (`oauthExpiresAt` / `oauthRefreshExpiresAt`) — the generic accept-gate needs them and dispatches on `credential.realShape`.

**Defect found on the way:** `dockerCredentialRefresh` named three agents in sequence — claude sync gated on claude's expiry, then codex extract, then opencode extract. A fourth agent got **no host-backup refresh at all**, silently (every step is best-effort), so its cloud boxes were seeded from a stale token. It walks the module registry now via a new optional `AgentSyncModule.refreshHostBackup`; verified live that all three agents register one, so coverage is unchanged.

`resolveClaudeCredHealth` gained an explicit `probes` seam — those four IO calls were mockable before only because they crossed a package boundary.

### `601902a9` — staged-item mappers into their packages

`claudeStagedItems` / `codexStagedItems` / `opencodeStagedItems` were three per-agent functions in the agent-neutral propagate layer. Each moved to `packages/agent-<id>/src/staged-items.ts` with its test; the `StagedItem` contract and transport stay shared.

### Verification

Full gate green (plugin-skill, lint, build, hub standalone, cloud-backends, typecheck, test). Every new guard mutation-checked — narrowing the registry walk back to one agent fails the test. Live on docker: box create, and the box's claude completing a **real authenticated turn** (`claude -p`), which is the check that actually exercises the credential path end to end.

https://claude.ai/code/session_01PkEcUxA2Jqs4CPD4ni1rXP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pre-box credential gating, cloud seed refresh, and OAuth renewal paths; behavior is intended to be preserved but registry-driven refresh and moved guards affect every box create on docker/cloud hosts.
> 
> **Overview**
> **Phase 4b** of agents-as-packages: Claude-specific credential logic and per-agent download propagate mappers leave shared `sandbox-core` / `sandbox-docker`, and host backup refresh becomes registry-driven so new agents are not silently skipped.
> 
> Claude OAuth **access vs refresh** health (`hostClaudeAccessTokenExpired`, `hostClaudeLoginDead`) and **`renewClaudeCredential`** move into `@agentbox/agent-claude`, with `resolveClaudeCredHealth` exposing an injectable **`probes`** seam for tests. Generic OAuth field helpers in core are renamed to **`oauthExpiresAt` / `oauthRefreshExpiresAt`**. CLI **`download-*`** commands import **`claudeStagedItems` / `codexStagedItems` / `opencodeStagedItems`** from each agent package instead of `sandbox-core`.
> 
> **`dockerCredentialRefresh`** no longer hardcodes claude → codex → opencode; it loops **`registeredAgentSyncModules()`** and calls optional **`AgentSyncModule.refreshHostBackup`** (Claude gates on access-token expiry; codex/opencode extract-only). **`renewClaudeCredential`** is no longer exported from `sandbox-docker`.
> 
> The three **`<agent>StagedItems`** mappers and their tests relocate to **`packages/agent-*/src/staged-items.ts`**; shared **`StagedItem`** / propagate transport stay in core. The **no-agent-named-exports** allowlist shrinks accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 601902a9d85c056724bfbeeac3ef8d20f076df28. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->