### PR TITLE
fix(ctl): git pull merges the branch's remote ref, not origin/HEAD

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -13,6 +13,11 @@ CLI, not the raw commits.
 
 ### Fixed
 
+- **`agentbox git pull` works again.** It merged an unconditional `origin/HEAD`,
+  a ref `git clone` writes and a bind-mounted worktree therefore never has, so
+  every pull ended in `merge: origin/HEAD - not something we can merge`. It now
+  merges the branch's upstream, else its remote-tracking ref — which is also the
+  right branch, where `origin/HEAD` would have pulled the remote's default one.
 - **Adding an agent to a live cloud box no longer fails on Daytona.** An agent's
   post-install claimed ownership of `~/.agentbox-creds`, which at runtime is the
   mounted credentials volume — virtiofs on Daytona, where `chown` fails even for

--- a/packages/ctl/src/commands/git.ts
+++ b/packages/ctl/src/commands/git.ts
@@ -164,6 +164,38 @@ function captureGit(args: string[], cwd: string): Promise<string> {
 }
 
 /**
+ * What `pull` merges: the remote-tracking ref for the branch the box is on.
+ *
+ * The upstream if the branch has one, else `<remote>/<branch>`, else
+ * `<remote>/HEAD` for a freshly cloned worktree that has neither.
+ *
+ * This used to be an unconditional `<remote>/HEAD`, which is wrong twice over.
+ * `refs/remotes/<remote>/HEAD` is written by `git clone`, and a docker box is a
+ * WORKTREE on the host's bind-mounted `.git/` — no clone, so no such ref, and
+ * every pull died with `merge: origin/HEAD - not something we can merge`. Where
+ * the ref does exist it names the remote's DEFAULT branch, so a box on
+ * `agentbox/<name>` would have merged `origin/main` into it.
+ *
+ * FETCH_HEAD is not the answer either, tempting as it looks: the fetch runs
+ * HOST-side through the relay, so FETCH_HEAD lands in the host's git dir, not
+ * in this worktree's (`.git/worktrees/<name>/`), where it does not resolve.
+ */
+export async function resolveMergeTarget(
+  remote: string,
+  cwd: string,
+  probe: (args: string[], cwd: string) => Promise<string> = captureGit,
+): Promise<string> {
+  const upstream = await probe(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'], cwd);
+  if (upstream) return upstream;
+  const branch = await probe(['rev-parse', '--abbrev-ref', 'HEAD'], cwd);
+  if (branch && branch !== 'HEAD') {
+    const tracking = `${remote}/${branch}`;
+    if (await probe(['rev-parse', '--verify', '--quiet', tracking], cwd)) return tracking;
+  }
+  return `${remote}/HEAD`;
+}
+
+/**
  * Control-plane push: instead of the relay pushing host-side, the box leases a
  * repo-scoped GitHub-App token from the control plane and pushes directly.
  * Used when AGENTBOX_GIT_LEASE=1. The host writes that flag into
@@ -339,8 +371,6 @@ export const gitCommand = new Command('git')
         // Merge happens in the container, where the working tree lives. No
         // creds needed; refs are already in the shared .git from the fetch.
         const remote = resolveRemote(opts.remote);
-        // Resolve branch via the current HEAD's upstream, falling back to
-        // `<remote>/HEAD` so a freshly cloned worktree still pulls.
         const cwd = opts.cwd ?? process.cwd();
         // A non-fast-forward merge writes a merge commit, which needs a
         // committer identity. Fall back to a generic agentbox identity only
@@ -363,7 +393,7 @@ export const gitCommand = new Command('git')
           mergeArgs.push('--ff-only');
         }
         mergeArgs.push(...passthroughMergeArgs);
-        mergeArgs.push(`${remote}/HEAD`);
+        mergeArgs.push(await resolveMergeTarget(remote, cwd));
         const mergeCode = await runLocalGit(mergeArgs, cwd);
         process.exit(mergeCode);
       }),

--- a/packages/ctl/test/git-pull-merge-target.test.ts
+++ b/packages/ctl/test/git-pull-merge-target.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { resolveMergeTarget } from '../src/commands/git.js';
+
+/**
+ * What `agentbox git pull` merges after the relay's host-side fetch.
+ *
+ * The bug this pins, caught on a live docker box: the merge target was an
+ * unconditional `origin/HEAD`, so every pull failed with
+ * `merge: origin/HEAD - not something we can merge` — `refs/remotes/origin/HEAD`
+ * is written by `git clone`, and `/workspace` is a WORKTREE on the host's
+ * bind-mounted `.git/`, which never had one.
+ */
+function fakeGit(refs: Record<string, string>) {
+  return async (args: string[]): Promise<string> => {
+    const key = args.join(' ');
+    return refs[key] ?? '';
+  };
+}
+
+describe('resolveMergeTarget', () => {
+  it('prefers the branch upstream when one is configured', async () => {
+    const probe = fakeGit({
+      'rev-parse --abbrev-ref --symbolic-full-name @{u}': 'origin/feature',
+      'rev-parse --abbrev-ref HEAD': 'feature',
+    });
+    expect(await resolveMergeTarget('origin', '/workspace', probe)).toBe('origin/feature');
+  });
+
+  it('falls back to <remote>/<branch> — the box branch, NOT the default branch', async () => {
+    // The docker box case: no upstream, but the branch was pushed so its
+    // remote-tracking ref exists. Merging `origin/HEAD` here would have pulled
+    // `main` into `agentbox/ghsmoke`.
+    const probe = fakeGit({
+      'rev-parse --abbrev-ref HEAD': 'agentbox/ghsmoke',
+      'rev-parse --verify --quiet origin/agentbox/ghsmoke': '35f1a4eb',
+    });
+    expect(await resolveMergeTarget('origin', '/workspace', probe)).toBe('origin/agentbox/ghsmoke');
+  });
+
+  it('falls back to <remote>/HEAD when neither exists', async () => {
+    // A freshly cloned worktree whose branch was never pushed: origin/HEAD is
+    // the only thing that can resolve, and it is what clone wrote.
+    const probe = fakeGit({ 'rev-parse --abbrev-ref HEAD': 'agentbox/fresh' });
+    expect(await resolveMergeTarget('origin', '/workspace', probe)).toBe('origin/HEAD');
+  });
+
+  it('does not build a target from a detached HEAD', async () => {
+    const probe = fakeGit({
+      'rev-parse --abbrev-ref HEAD': 'HEAD',
+      'rev-parse --verify --quiet origin/HEAD': 'deadbeef',
+    });
+    expect(await resolveMergeTarget('origin', '/workspace', probe)).toBe('origin/HEAD');
+  });
+
+  it('honours a non-origin remote', async () => {
+    const probe = fakeGit({
+      'rev-parse --abbrev-ref HEAD': 'agentbox/x',
+      'rev-parse --verify --quiet upstream/agentbox/x': 'cafe',
+    });
+    expect(await resolveMergeTarget('upstream', '/workspace', probe)).toBe('upstream/agentbox/x');
+  });
+});


### PR DESCRIPTION
Found by the post-merge smoke on a live docker box.

`agentbox git pull` fetched fine and then died on the merge:

```
merge: origin/HEAD - not something we can merge
```

`refs/remotes/origin/HEAD` is written by `git clone`, and a docker box's
`/workspace` is a **worktree on the host's bind-mounted `.git/`** — no clone, so
no such ref, so no pull ever succeeded there. Where the ref *does* exist it names
the remote's DEFAULT branch, so a box on `agentbox/<name>` would have merged
`origin/main` into it.

`resolveMergeTarget` now does what the comment beside it always claimed: the
branch's upstream if it has one, else `<remote>/<branch>`, else `<remote>/HEAD`
for a freshly cloned worktree with neither.

`FETCH_HEAD` looks like the obvious answer and is not — the fetch runs host-side
through the relay, so it lands in the host's git dir, not the worktree's, where
it does not resolve. I tried that first and the live box disproved it.

**Verified** on box `ghsmoke`: resolved target `origin/agentbox/ghsmoke-2`,
fast-forward merge, and a commit pushed to the remote from the host arrived in
`/workspace`. Plus 5 unit cases on the resolver.

Note: this touches `packages/ctl`, which tsup inlines into the box image, so the
build-context fingerprint moves to `sha-1f7d466696c85612` — merging will publish
a new box image.

https://claude.ai/code/session_017bjSm3o3JDVXLLJgvva32P

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core git pull merge resolution for all boxes; wrong ref choice could merge unexpected branches, though behavior matches documented intent and is covered by tests.
> 
> **Overview**
> **`agentbox git pull` no longer always merges `origin/HEAD`.** After the host-side fetch, the in-box merge step now uses a new **`resolveMergeTarget`** helper: configured upstream (`@{u}`) first, then **`&lt;remote&gt;/&lt;current-branch&gt;`** if that tracking ref exists, and only then **`&lt;remote&gt;/HEAD`** for worktrees that have neither.
> 
> That fixes docker boxes where **`origin/HEAD` is missing** (worktree on a bind-mounted `.git/` without a clone-written ref), which previously failed every pull with `merge: origin/HEAD - not something we can merge`. It also avoids merging the **remote default branch** into a box on something like `agentbox/&lt;name&gt;` when `origin/HEAD` did exist.
> 
> Unit tests cover upstream preference, branch tracking fallback, detached HEAD, and non-`origin` remotes. The CLI changelog documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9c97a56259d2627455919270399a1cf98541963. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->