### PR TITLE
feat(agents): let an agent declare it has no credential

### DIFF
--- a/apps/cli/src/commands/control-plane.ts
+++ b/apps/cli/src/commands/control-plane.ts
@@ -117,7 +117,10 @@ import { AGENT_SYNC_SPECS } from '@agentbox/sandbox-core';
  * after them — including one installed by `agentbox agent add`, which can never
  * be in a compiled-in list.
  */
-const CREDENTIAL_AGENT_IDS = (): string[] => AGENT_SYNC_SPECS.map((a) => a.id);
+// Only agents that DECLARE a credential: `--agent openclaw` has nothing to push
+// or pull, so naming it is a user error worth reporting as one.
+const CREDENTIAL_AGENT_IDS = (): string[] =>
+  AGENT_SYNC_SPECS.filter((a) => a.credential).map((a) => a.id);
 import { handleLifecycleError } from './_errors.js';
 import { isAgentKind, type AgentId } from '@agentbox/core';
 
@@ -1391,12 +1394,14 @@ const credentialsPullSub = new Command('pull')
       let pulled = 0;
       for (const spec of AGENT_SYNC_SPECS) {
         if (opts.agent && spec.id !== opts.agent) continue;
-        const data = await client.get(`agents/${spec.id}/${spec.credential.boxRelPath}`);
+        const cred = spec.credential;
+        if (!cred) continue;
+        const data = await client.get(`agents/${spec.id}/${cred.boxRelPath}`);
         if (data === null) continue;
-        await mkdir(dirname(spec.credential.hostBackup), { recursive: true });
-        await writeFile(spec.credential.hostBackup, data, { mode: 0o600 });
-        await chmod(spec.credential.hostBackup, 0o600);
-        log.info(`pulled ${spec.id} credentials → ${spec.credential.hostBackup}`);
+        await mkdir(dirname(cred.hostBackup), { recursive: true });
+        await writeFile(cred.hostBackup, data, { mode: 0o600 });
+        await chmod(cred.hostBackup, 0o600);
+        log.info(`pulled ${spec.id} credentials → ${cred.hostBackup}`);
         pulled++;
       }
       if (pulled === 0) log.info('No agent credentials in custody to pull.');

--- a/apps/cli/src/commands/credentials.ts
+++ b/apps/cli/src/commands/credentials.ts
@@ -9,7 +9,7 @@ import {
   type AgentId,
 } from '@agentbox/sandbox-core';
 import { DEFAULT_BOX_IMAGE, volumeSettingsTarget } from '@agentbox/sandbox-docker';
-import { agentConfigVolume } from '@agentbox/core';
+import { agentConfigVolume, requireAgentCredential } from '@agentbox/core';
 import { providerForBox } from '../provider/registry.js';
 import { handleLifecycleError } from './_errors.js';
 
@@ -39,10 +39,16 @@ const propagateCommand = new Command('propagate')
     try {
       const spec = resolveAgentSpec(opts.agent);
       const agent = spec.id;
+      // An agent that declares no credential has nothing to propagate and no
+      // backup path to name in the error, so say the real reason.
+      const cred = spec.credential;
+      if (!cred) {
+        throw new Error(`${agent} has no host-side credential — there is nothing to propagate`);
+      }
       const content = await readCredentialBackup(agent);
       if (content === null || !isRealAgentCredential(agent, content)) {
         throw new Error(
-          `no usable ${agent} credential backup at ${spec.credential.hostBackup}; nothing to propagate`,
+          `no usable ${agent} credential backup at ${cred.hostBackup}; nothing to propagate`,
         );
       }
 
@@ -68,7 +74,7 @@ const propagateCommand = new Command('propagate')
       for (const vol of plan.dockerVolumes) {
         try {
           await volumeSettingsTarget(vol.volume, image, vol.volume).writeText(
-            spec.credential.boxRelPath,
+            cred.boxRelPath,
             content,
             { mode: 0o600 },
           );
@@ -139,7 +145,7 @@ async function pushCredentialToCustody(agent: AgentId, content: string): Promise
     if (!target) return;
     const { CustodyClient, planPush } = await import('../control-plane/custody-client.js');
     const client = new CustodyClient(target);
-    const path = `agents/${agent}/${resolveAgentSpec(agent).credential.boxRelPath}`;
+    const path = `agents/${agent}/${requireAgentCredential(resolveAgentSpec(agent)).boxRelPath}`;
     const item = { path, data: Buffer.from(content, 'utf8') };
     const manifest = await client.list('agents');
     if (planPush([item], manifest)[0]!.action === 'skip') return;

--- a/apps/cli/src/control-plane/custody-client.ts
+++ b/apps/cli/src/control-plane/custody-client.ts
@@ -291,6 +291,8 @@ export async function collectAgentCredentialUploads(only?: AgentId): Promise<Upl
   const items: UploadItem[] = [];
   for (const spec of AGENT_SYNC_SPECS) {
     if (only && spec.id !== only) continue;
+    // No declared credential -> no host backup to collect.
+    if (!spec.credential) continue;
     const text = await readCredentialBackup(spec.id);
     if (text === null || !isRealAgentCredential(spec.id, text)) continue;
     items.push({

--- a/apps/hub/lib/hub-worker.ts
+++ b/apps/hub/lib/hub-worker.ts
@@ -77,6 +77,8 @@ export async function seedHostBackupsFromCustody(
   log: (l: string) => void,
 ): Promise<void> {
   for (const spec of AGENT_SYNC_SPECS) {
+    // Nothing was ever uploaded for an agent that declares no credential.
+    if (!spec.credential) continue;
     const custodyPath = `agents/${spec.id}/${spec.credential.boxRelPath}`;
     try {
       const found = await custody.get(custodyPath);

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -203,6 +203,8 @@ makes a single list safe for both:
 - **The credential file**, from `credential.boxRelPath`. Out of a `'snapshot'`
   (shared by every box made from it); INTO a `'volume'`, which is that box's own
   login store. All three agents listed it and all three meant the same thing.
+  An agent that declares no `credential` contributes no such entry — there is no
+  file to keep out of a shared snapshot.
 - **`LIVE_DATABASE_EXCLUDES`** (`*.sqlite*`, `*.db`, `*.db-*`), for every agent,
   with an `allowDatabases` opt-out nothing declares. Hand-enumerating these is
   what went stale: codex's list named `state_*` and `logs_*`, and three later
@@ -434,7 +436,7 @@ name; the render lints for a secret-shaped literal and warns.
 1. **Add the row** to `AGENT_SYNC_SPECS`: `id`, `binary`, `install`
    (recipe + `runAs` + any OS `packages` (+ `packagesOptional`) +
    `postInstall`), `sessionName`,
-   `dockerVolume`, `staticPaths`, `credential`, `forwardedEnvKeys`, `caps`,
+   `dockerVolume`, `staticPaths`, `forwardedEnvKeys`, `caps`,
    plus `seeds` / `launchFlags` if the agent needs an agentbox-owned file in
    place to work (see step 4), and `settings` (+ `install.alternatesFrom` /
    `tuiEnvFrom`) for anything the user should be able to configure per agent
@@ -442,6 +444,20 @@ name; the render lints for a secret-shaped literal and warns.
    Keep it JSON-serializable — no closures — so the descriptor can later be
    shipped into a box whose `agentbox-ctl` was baked before the agent existed,
    and so `agentbox agent add` can snapshot it verbatim.
+
+   **`credential` is optional.** Declare it when the agent has a login the HOST
+   holds and AgentBox moves into the box — claude's OAuth blob, codex's
+   `auth.json`. Omit it when the agent authenticates entirely inside the box, as
+   openclaw does: its gateway token is generated per box by `openclaw onboard`,
+   so there is nothing on the host to back up or push. Omitting is the only
+   correct way to say that. The credential watch is FANOUT — whatever the field
+   names is copied into every other box — so pointing it at the agent's real
+   config would hand every box the first box's identity, and naming a file
+   nothing ever writes adds a fiction every consumer has to know about. With the
+   field absent the agent gets no credentials-volume mount, no `agents.list`
+   credential watch, no host-backup probe and no entry in the relay fan-out;
+   everything else about it is unchanged. Absent is not a placeholder for "not
+   wired up yet" — if the agent has a host-side login, declare it.
 2. **Add the agent's package** — `packages/agent-<id>/`, with its CLI surface
    under `src/cli/` — and its arm in the `AGENT_MODULES` table
    (`apps/cli/src/agents/index.ts`): the guided-login detector, and a

--- a/docs/plans/service-boxes-backlog.md
+++ b/docs/plans/service-boxes-backlog.md
@@ -149,13 +149,22 @@ here rather than sidequesting. Promote an item to the plan if it turns out to be
 
 ## From Phases 6-8 (openclaw as a service agent, 2026-09-02)
 
-- **`AgentSyncSpec.credential` should be optional.** OpenClaw has no host-side credential at all —
-  its gateway token is generated per box and must never leave it — but the field is required, so the
-  row names a path nothing writes (`~/.openclaw/agentbox-credential.json`) to make every credential
-  mechanism a clean no-op. That is honest but indirect, and it forces a `WATCHED_CREDENTIALS` row in
-  ctl for a file that will never exist. Making the field optional touches ~10 shared call sites
-  (`agent-descriptor`, `credentials-watcher`, the cloud `agentSpecs()`, the credentials concern, the
-  relay fanout, the hub catalog); worth doing when a second credential-less agent appears.
+- ~~**`AgentSyncSpec.credential` should be optional.**~~ **Done.** The field is optional, openclaw
+  declares none, and every mechanism (descriptor watch, ctl `WATCHED_CREDENTIALS`, the cloud
+  `agentSpecs()` mounts, the credentials concern, the relay fanout, the custody upload set, the hub
+  catalog) skips an agent without one. `requireAgentCredential(spec)` is the unwrap for the call
+  sites that only exist to move a credential.
+- **Nothing checks `agentDirPrelude`'s creds-subdir against `credential.cloudSubpath`.** The
+  argument is now optional (omit it for a credential-less agent), but when it IS passed it is a
+  hand-typed string that must match the spec's `cloudSubpath` or the recipe creates a mount point at
+  a path nothing mounts. `creds-dir-postinstall.test.ts` only checks that a subdir is created, not
+  that it is the right one. Deriving it from the spec would remove the class.
+- **`CLAUDE_HOST_BACKUP` in the credentials concern falls back to `''`.** It resolves
+  `resolveAgentSpec('claude').credential?.hostBackup ?? ''` at module load, so if claude ever
+  stopped declaring a credential the reads would silently target the empty path rather than fail.
+  `requireAgentCredential` is the right unwrap, but throwing at import time is its own hazard — the
+  fix is to resolve it lazily inside the two functions that use it.
+
 - **`agentbox-ctl reload` does not re-run a service agent's render.** Reload applies the *unit*
   diff, and the render task's definition has not changed when only the overlay block has — so
   editing `openclaw:` needs `agentbox-ctl run-task openclaw-render --force`. Teaching reload to

--- a/packages/agent-claude/src/cli/host-cred-guards.ts
+++ b/packages/agent-claude/src/cli/host-cred-guards.ts
@@ -18,8 +18,9 @@ import {
   oauthRefreshExpiresAt,
   resolveAgentSpec,
 } from '@agentbox/sandbox-core';
+import { requireAgentCredential } from '@agentbox/core';
 
-const CLAUDE_HOST_BACKUP = resolveAgentSpec('claude').credential.hostBackup;
+const CLAUDE_HOST_BACKUP = requireAgentCredential(resolveAgentSpec('claude')).hostBackup;
 
 /**
  * True iff the claude host backup's *access* token has lapsed

--- a/packages/agent-claude/src/host-stage.ts
+++ b/packages/agent-claude/src/host-stage.ts
@@ -1,4 +1,4 @@
-import { agentPushExcludes } from '@agentbox/core';
+import { agentPushExcludes, requireAgentCredential } from '@agentbox/core';
 /**
  * Claude's host-side staging — the part that is more than a copy.
  *
@@ -38,7 +38,7 @@ import {
 
 /** Workspace path inside every cloud sandbox — matches the Docker model. */
 const CLOUD_WORKSPACE = '/workspace';
-const CREDENTIALS_BACKUP_FILE = resolveAgentSpec('claude').credential.hostBackup;
+const CREDENTIALS_BACKUP_FILE = requireAgentCredential(resolveAgentSpec('claude')).hostBackup;
 
 // ---------- claude ----------
 

--- a/packages/agent-codex/test/volume-excludes.test.ts
+++ b/packages/agent-codex/test/volume-excludes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { agentPushExcludes, LIVE_DATABASE_EXCLUDES } from '@agentbox/core';
+import { agentPushExcludes, LIVE_DATABASE_EXCLUDES, requireAgentCredential } from '@agentbox/core';
 import { resolveAgentSpec } from '@agentbox/sandbox-core';
 import { volumeExcludeFlags, volumeIncludeFlags, volumePurgeCommand } from '../src/docker-sync.js';
 
@@ -51,9 +51,12 @@ describe('codex docker-volume excludes', () => {
   });
 
   it('KEEPS the credential file — the volume is the box login store', () => {
-    expect(patterns).not.toContain(spec.credential.boxRelPath);
+    // Codex declares one; `requireAgentCredential` states that rather than
+    // letting an optional-chained `undefined` make both assertions vacuous.
+    const cred = requireAgentCredential(spec);
+    expect(patterns).not.toContain(cred.boxRelPath);
     // ...while the shared snapshot must not carry it.
-    expect(agentPushExcludes(spec, path, 'snapshot')).toContain(spec.credential.boxRelPath);
+    expect(agentPushExcludes(spec, path, 'snapshot')).toContain(cred.boxRelPath);
   });
 
   it('keeps config.toml out (reconciled separately) and the carve-in first', () => {

--- a/packages/agent-pi/src/cli/runtime.ts
+++ b/packages/agent-pi/src/cli/runtime.ts
@@ -22,7 +22,7 @@ import {
   type SignInResult,
 } from '@agentbox/cli-kit';
 import { ensureImage, extractVolumeAuthToBackup, type BoxRecord } from '@agentbox/sandbox-docker';
-import { agentConfigVolume } from '@agentbox/core';
+import { agentConfigVolume, requireAgentCredential } from '@agentbox/core';
 import { resolveAgentSpec } from '@agentbox/sandbox-core';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
@@ -43,6 +43,8 @@ import { piAuthAvailable } from './host-creds.js';
 import { piAuthFileHasProviders } from '../auth-shape.js';
 
 const PI_SPEC = resolveAgentSpec('pi');
+/** Pi declares a credential; unwrap once so the two call sites below share it. */
+const PI_HOST_BACKUP = requireAgentCredential(PI_SPEC).hostBackup;
 
 /**
  * Hand the terminal to Pi in a throwaway container against the shared volume.
@@ -105,7 +107,7 @@ async function cloudPiCredAvailable(env: NodeJS.ProcessEnv = process.env): Promi
   // sign-in offer would then never appear and the box would be seeded with an
   // empty credential. `piAuthAvailable` already had this rule; these two paths
   // did not, which is the inconsistency Bugbot caught.
-  for (const p of [PI_SPEC.credential.hostBackup, join(homedir(), '.pi', 'agent', 'auth.json')]) {
+  for (const p of [PI_HOST_BACKUP, join(homedir(), '.pi', 'agent', 'auth.json')]) {
     if (await piAuthFileHasProviders(p)) return true;
   }
   return false;
@@ -174,7 +176,7 @@ export const piRuntime: AgentRuntime = {
     const { copied } = await extractVolumeAuthToBackup({
       volume: SHARED_PI_VOLUME,
       image,
-      backupFile: PI_SPEC.credential.hostBackup,
+      backupFile: PI_HOST_BACKUP,
     });
     if (copied) log.success('Signed in to Pi — saved for future boxes.');
     else

--- a/packages/agent-pi/src/index.ts
+++ b/packages/agent-pi/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { resolveAgentSpec } from '@agentbox/sandbox-core';
+import { requireAgentCredential } from '@agentbox/core';
 import {
   extractVolumeAuthToBackup,
   registerAgentSyncModule,
@@ -34,7 +35,7 @@ export const piSyncModule: AgentSyncModule = {
     await extractVolumeAuthToBackup({
       volume: spec.dockerVolume,
       image,
-      backupFile: spec.credential.hostBackup,
+      backupFile: requireAgentCredential(spec).hostBackup,
     });
   },
 };

--- a/packages/agent-registry/src/plugin-agents.ts
+++ b/packages/agent-registry/src/plugin-agents.ts
@@ -82,7 +82,9 @@ const REQUIRED_SPEC_FIELDS = [
   'install',
   'dockerVolume',
   'staticPaths',
-  'credential',
+  // NOT `credential`: an agent may declare it has none (openclaw generates its
+  // gateway token inside the box and there is nothing on the host to sync). A
+  // credential that IS present is still shape-checked — see `credentialProblem`.
   'forwardedEnvKeys',
   'boxRunEnv',
   'caps',
@@ -209,7 +211,8 @@ export function agentSpecProblem(raw: unknown): string | null {
   if (!Array.isArray(spec.aliases)) return '`aliases` must be an array';
   const shape =
     installProblem(spec.install) ??
-    credentialProblem(spec.credential) ??
+    // Optional field: absent is a legitimate declaration, malformed is not.
+    (spec.credential === undefined ? null : credentialProblem(spec.credential)) ??
     staticPathsProblem(spec.staticPaths);
   if (shape !== null) return shape;
   // A spec that isn't JSON-round-trippable cannot reach a box: it travels to

--- a/packages/agent-registry/src/specs/openclaw.ts
+++ b/packages/agent-registry/src/specs/openclaw.ts
@@ -31,8 +31,6 @@
 
 import { BOX_HOME, BOX_USER, agentDirPrelude } from '@agentbox/core';
 import type { AgentSyncSpec } from '@agentbox/core';
-import { join } from 'node:path';
-import { STATE_DIR } from '@agentbox/config';
 
 /** OpenClaw's state root: config, sqlite state, per-agent dirs, migrations. */
 const OPENCLAW_BOX_DIR = `${BOX_HOME}/.openclaw`;
@@ -73,10 +71,9 @@ export const openclawSpec: AgentSyncSpec = {
       // `install -d -o u -g g a/b` applies ownership to the FINAL component
       // only, so a nested path alone leaves the parent root-owned and the later
       // static-config stage (which runs as the box user) cannot write it.
-      ...agentDirPrelude(
-        [OPENCLAW_BOX_DIR, OPENCLAW_XDG_BOX_DIR, `${BOX_HOME}/.config`],
-        'openclaw',
-      ),
+      // No creds-subdir argument: with no `credential` declared there is no
+      // subpath of the shared credentials volume to create a mount point for.
+      ...agentDirPrelude([OPENCLAW_BOX_DIR, OPENCLAW_XDG_BOX_DIR, `${BOX_HOME}/.config`]),
       // Point `~/.config/openclaw` into the state root so it rides the one
       // config volume. `ln -sfn` onto an existing DIRECTORY would create the
       // link inside it, so the real dir goes first -- it is either absent or
@@ -120,30 +117,20 @@ export const openclawSpec: AgentSyncSpec = {
       relocToSubpath: OPENCLAW_XDG_SUBPATH,
     },
   ],
-  // OPENCLAW HAS NO HOST-SIDE CREDENTIAL, and this slot names a path nothing
-  // ever writes so every credential mechanism degrades to a clean no-op: no
-  // host backup to read, nothing to push at create, and ctl's watcher finds no
-  // file to fan out.
+  // NO `credential`: openclaw has no host-side credential to sync. Its gateway
+  // token is generated per box by `openclaw onboard` and must never leave that
+  // box, so there is no host backup to read, nothing to push at create, no
+  // subpath of the shared credentials volume to reserve, and no credential watch.
   //
-  // That last one is the reason the path is deliberately fictional rather than
-  // pointed at `openclaw.json`. The credential watch is FANOUT by contract — a
-  // rotating secret redistributed to every other box — and fanning openclaw's
-  // config out would give every openclaw box box #1's gateway identity.
+  // Pointing this at `openclaw.json` to fill the slot would be harmful, not
+  // redundant: the credential watch is FANOUT by contract
+  // (`buildAgentDescriptors` emits `sync: 'fanout'` for every credential it
+  // sees), so every other openclaw box would receive box #1's gateway identity
+  // and channel pairings — the multi-tenancy failure openclaw forbids, and the
+  // one `clone`'s fresh-identity rule exists to prevent.
+  //
   // Channel tokens are real secrets, but they ride a `carry:` entry into a 0600
-  // env file and the overlay references them by name; they are never a
-  // credential AgentBox holds.
-  //
-  // The slot is required today because `AgentSyncSpec.credential` is not
-  // optional; making it optional is a backlog item
-  // (`docs/plans/service-boxes-backlog.md`).
-  credential: {
-    boxRelPath: 'agentbox-credential.json',
-    boxAbsPath: `${OPENCLAW_BOX_DIR}/agentbox-credential.json`,
-    hostBackup: join(STATE_DIR, 'openclaw-credentials.json'),
-    cloudMountPath: `${BOX_HOME}/.agentbox-creds/openclaw`,
-    cloudSubpath: 'openclaw/',
-    realShape: 'nonempty-json',
-  },
+  // env file and the overlay references them by name; AgentBox never holds them.
   forwardedEnvKeys: [],
   boxRunEnv: {
     // Honoured by `onboard`, which writes it to `agents.defaults.workspace`

--- a/packages/agent-registry/test/creds-dir-postinstall.test.ts
+++ b/packages/agent-registry/test/creds-dir-postinstall.test.ts
@@ -15,6 +15,10 @@ import { BUILTIN_AGENT_SPECS } from '../src/index.js';
  * Every agent's recipe, including a plugin's, must therefore create that subdir
  * without asserting ownership of it.
  */
+function byId(id: string) {
+  return BUILTIN_AGENT_SPECS.find((s) => s.id === id);
+}
+
 function postInstalls(): { id: string; script: string }[] {
   const out: { id: string; script: string }[] = [];
   for (const spec of BUILTIN_AGENT_SPECS) {
@@ -56,9 +60,22 @@ describe('agent post-install vs the credentials mount', () => {
     }
   });
 
-  it('still creates the agent subdir of the mount', () => {
+  it('still creates the agent subdir of the mount -- for an agent that has a credential', () => {
     for (const { id, script } of postInstalls()) {
+      if (!byId(id)?.credential) continue;
       expect(script, id).toContain(`mkdir -p ${BOX_CREDS_DIR}/`);
+    }
+  });
+
+  it('creates no subdir at all for an agent that declares no credential', () => {
+    // `credential` is optional and openclaw declares none, so it gets no
+    // subpath of the shared credentials volume. Creating one would reserve a
+    // mount point nothing will ever mount.
+    const credentialless = BUILTIN_AGENT_SPECS.filter((s) => !s.credential).map((s) => s.id);
+    expect(credentialless).toContain('openclaw');
+    for (const { id, script } of postInstalls()) {
+      if (!credentialless.includes(id)) continue;
+      expect(script, id).not.toContain(BOX_CREDS_DIR);
     }
   });
 });

--- a/packages/agent-registry/test/plugin-agents.test.ts
+++ b/packages/agent-registry/test/plugin-agents.test.ts
@@ -100,7 +100,26 @@ describe('agentSpecProblem', () => {
     const problem = agentSpecProblem({ id: 'x', aliases: [] });
     expect(problem).toMatch(/missing required field/);
     expect(problem).toContain('sessionName');
-    expect(problem).toContain('credential');
+    expect(problem).toContain('dockerVolume');
+    // `credential` is NOT required: an agent may declare it has none.
+    expect(problem).not.toContain('credential');
+  });
+
+  it('accepts a spec that declares no credential', () => {
+    // Absent means "this agent has no host-side credential to sync" -- the
+    // openclaw case, where the gateway token is generated inside the box. A
+    // plugin agent must be able to say that; requiring the field forced such an
+    // agent to name a file nothing writes, or worse, its own config.
+    const { credential: _credential, ...noCredential } = exampleSpec;
+    expect(agentSpecProblem(noCredential)).toBeNull();
+    expect(agentSpecProblem({ ...exampleSpec, credential: undefined })).toBeNull();
+  });
+
+  it('still rejects a malformed credential when one IS declared', () => {
+    // Optional is not unchecked: a present credential is the fan-out's write
+    // target, so it is shape-checked exactly as before.
+    expect(agentSpecProblem({ ...exampleSpec, credential: {} })).toMatch(/credential/);
+    expect(agentSpecProblem({ ...exampleSpec, credential: 'yes' })).toMatch(/credential/);
   });
 
   it('rejects a structurally wrong `install`, not merely a missing one', () => {

--- a/packages/core/src/sync/agent-spec.ts
+++ b/packages/core/src/sync/agent-spec.ts
@@ -115,7 +115,7 @@ export type AgentPushTarget = 'snapshot' | 'volume';
  * The credential file is DERIVED from `spec.credential.boxRelPath` rather than
  * listed, which is why the specs no longer name it: it is the one entry whose
  * correct value differs by target, and deriving it is what makes a single list
- * safe for both.
+ * safe for both. An agent that declares no credential contributes no such entry.
  */
 export function agentPushExcludes(
   spec: AgentSyncSpec,
@@ -125,7 +125,9 @@ export function agentPushExcludes(
   return [
     ...(path.allowDatabases ? [] : LIVE_DATABASE_EXCLUDES),
     ...(path.exclude ?? []),
-    ...(target === 'snapshot' ? [spec.credential.boxRelPath] : []),
+    // An agent with no credential (`credential` absent) contributes nothing
+    // here: there is no file to keep out of a shared snapshot.
+    ...(target === 'snapshot' && spec.credential ? [spec.credential.boxRelPath] : []),
   ];
 }
 
@@ -178,6 +180,25 @@ export interface AgentCredential {
    * means no credential watch at all.
    */
   freshness?: { jsonPath: readonly string[] };
+}
+
+/**
+ * This agent's credential, for a call site that only works with one.
+ *
+ * `credential` is optional, but some code exists only to move a credential —
+ * claude's host-backup guards, pi's volume extract, the custody upload set.
+ * Those callers already know their agent has one, and a `?? ''` fallback at
+ * each site would turn a spec change into a silent write to the wrong path.
+ * A throw here means a spec changed under a mechanism that requires the field.
+ */
+export function requireAgentCredential(spec: AgentSyncSpec): AgentCredential {
+  if (!spec.credential) {
+    throw new Error(
+      `agent '${spec.id}' declares no credential — this code path requires one; ` +
+        `gate on \`spec.credential\` before calling it`,
+    );
+  }
+  return spec.credential;
 }
 
 /**
@@ -563,7 +584,24 @@ export interface AgentSyncSpec {
   dockerVolume: string;
   /** Host→box static-config source map (1 entry for claude/codex, 3 for opencode). */
   staticPaths: AgentPathMap[];
-  credential: AgentCredential;
+  /**
+   * Where this agent's login credential lives, when it HAS one.
+   *
+   * ABSENT MEANS "this agent has no host-side credential to sync". That is a
+   * declaration, not a shortcut for "not wired up yet". An agent that
+   * authenticates inside the box — openclaw generates its gateway token during
+   * `openclaw onboard` — has nothing on the host to back up, push, watch or fan
+   * out, and every mechanism skips it: no credentials-volume mount, no
+   * `agents.list` credential watch, no relay fan-out entry, no host backup probe.
+   *
+   * Omitting is the only correct way to say that. Naming a path nothing writes
+   * buys a no-op at the cost of a fictional file every consumer has to know
+   * about. Pointing it at the agent's real config is worse: the credential watch
+   * is FANOUT by contract (`buildAgentDescriptors` emits `sync: 'fanout'` for
+   * every credential it sees), so one box's identity would be copied into every
+   * other box.
+   */
+  credential?: AgentCredential;
   /** Host env keys forwarded into the box so an env-authed agent finds its creds. */
   forwardedEnvKeys: readonly string[];
   /**
@@ -757,11 +795,18 @@ export const BOX_CREDS_DIR = `${BOX_HOME}/.agentbox-creds`;
  * `cannot change owner and permissions of '…/.agentbox-creds/<agent>'`, so an
  * agent missing from a snapshot could never be installed into a live box.
  */
-export function agentDirPrelude(agentDirs: readonly string[], credsSubdir: string): string[] {
+export function agentDirPrelude(agentDirs: readonly string[], credsSubdir?: string): string[] {
   return [
     `install -d -o ${BOX_USER} -g ${BOX_USER} ${agentDirs.join(' ')}`,
-    `mkdir -p ${BOX_CREDS_DIR}/${credsSubdir}`,
-    `chown -R ${BOX_USER}:${BOX_USER} ${BOX_CREDS_DIR} 2>/dev/null || true`,
+    // Omitted for an agent that declares no `credential`: it gets no subpath of
+    // the shared credentials volume, so creating a dir there would reserve a
+    // mount point nothing will ever mount.
+    ...(credsSubdir === undefined
+      ? []
+      : [
+          `mkdir -p ${BOX_CREDS_DIR}/${credsSubdir}`,
+          `chown -R ${BOX_USER}:${BOX_USER} ${BOX_CREDS_DIR} 2>/dev/null || true`,
+        ]),
   ];
 }
 /**

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -33,6 +33,7 @@ export type {
 } from './agent-spec.js';
 export {
   agentPushExcludes,
+  requireAgentCredential,
   LIVE_DATABASE_EXCLUDES,
   resolveAgentInstall,
   BOX_USER,

--- a/packages/ctl/src/credentials-watcher.ts
+++ b/packages/ctl/src/credentials-watcher.ts
@@ -55,18 +55,15 @@ export const WATCHED_CREDENTIALS: readonly WatchedCredential[] = [
     shape: 'nonempty-json',
   },
   { agent: 'pi', path: '/home/vscode/.pi/agent/auth.json', shape: 'nonempty-json' },
-  // OpenClaw has no host-side credential: its gateway token is self-generated
-  // per box and must never leave it, and channel tokens ride a `carry:` entry
-  // instead. The registry names a path nothing ever writes so this watch is a
-  // permanent no-op -- deliberately NOT `openclaw.json`, which a fanout would
-  // copy into every other box along with box #1's gateway identity. The entry
-  // exists because the drift test pairs one watcher with every non-hidden
-  // registry row, and an absent row would read as "someone forgot".
-  {
-    agent: 'openclaw',
-    path: '/home/vscode/.openclaw/agentbox-credential.json',
-    shape: 'nonempty-json',
-  },
+  // NO OPENCLAW ROW, deliberately: openclaw's registry row declares no
+  // `credential`, because its gateway token is generated per box during
+  // `openclaw onboard` and must never leave it. A row pointed at
+  // `openclaw.json` would be harmful, not redundant -- this list is FANOUT, so
+  // every other box would receive box #1's gateway identity and channel
+  // pairings. Channel tokens are real secrets, but they ride a `carry:` entry
+  // into a 0600 env file; AgentBox never holds them. The drift test pairs a
+  // watcher with every baked agent that declares a credential, so this absence
+  // is asserted rather than tolerated.
 ];
 
 /** Mirror of the sandbox-core `isRealAgentCredential` shapes (drift-tested). */

--- a/packages/ctl/test/credentials-watcher.test.ts
+++ b/packages/ctl/test/credentials-watcher.test.ts
@@ -41,16 +41,39 @@ function fakeRelay(outcomes: PostOutcome[] = []): {
  * the daemon.
  */
 const BAKED_SPECS = AGENT_SYNC_SPECS.filter((s) => !s.hidden);
+/**
+ * The watcher's domain: baked agents that DECLARE a credential.
+ *
+ * `credential` is optional; absent means the agent has no host-side credential
+ * at all (openclaw generates its gateway token inside the box). Such an agent
+ * gets no watcher row, because this list is FANOUT — a row here is a file
+ * copied into every other box.
+ */
+const BAKED_WITH_CREDENTIAL = BAKED_SPECS.filter((s) => s.credential);
 
 describe('WATCHED_CREDENTIALS drift vs @agentbox/sandbox-core registry', () => {
   it('mirrors credential.boxAbsPath and realShape per baked agent', () => {
-    for (const spec of BAKED_SPECS) {
+    for (const spec of BAKED_WITH_CREDENTIAL) {
       const watched = WATCHED_CREDENTIALS.find((w) => w.agent === spec.id);
       expect(watched, `missing watcher entry for '${spec.id}'`).toBeDefined();
-      expect(watched!.path).toBe(spec.credential.boxAbsPath);
-      expect(watched!.shape).toBe(spec.credential.realShape);
+      expect(watched!.path).toBe(spec.credential?.boxAbsPath);
+      expect(watched!.shape).toBe(spec.credential?.realShape);
     }
-    expect(WATCHED_CREDENTIALS).toHaveLength(BAKED_SPECS.length);
+    expect(WATCHED_CREDENTIALS).toHaveLength(BAKED_WITH_CREDENTIAL.length);
+  });
+
+  it('watches nothing for a baked agent that declares no credential', () => {
+    // The absence is the declaration, so assert it. A row for openclaw pointed
+    // at `openclaw.json` would fan one box's gateway identity and channel
+    // pairings out to every other box.
+    const credentialless = BAKED_SPECS.filter((s) => !s.credential);
+    expect(credentialless.map((s) => s.id)).toContain('openclaw');
+    for (const spec of credentialless) {
+      expect(
+        WATCHED_CREDENTIALS.find((w) => w.agent === spec.id),
+        `'${spec.id}' declares no credential but is watched — the watch is fanout`,
+      ).toBeUndefined();
+    }
   });
 
   it('isRealCredentialText agrees with isRealAgentCredential', () => {
@@ -62,7 +85,7 @@ describe('WATCHED_CREDENTIALS drift vs @agentbox/sandbox-core registry', () => {
       'not-json',
       JSON.stringify([1, 2]),
     ];
-    for (const spec of BAKED_SPECS) {
+    for (const spec of BAKED_WITH_CREDENTIAL) {
       const watched = WATCHED_CREDENTIALS.find((w) => w.agent === spec.id)!;
       for (const sample of samples) {
         expect(

--- a/packages/relay/src/credentials-fanout.ts
+++ b/packages/relay/src/credentials-fanout.ts
@@ -112,6 +112,11 @@ export class CredentialsFanout {
     if (!this.custody) return;
     try {
       const spec = resolveAgentSpec(agent);
+      // An agent that declares no credential has nothing to mirror. Unreachable
+      // via `handle` (`parseCredentialsUpdate` rejects such an agent), but this
+      // is the write to custody -- the copy every later create seeds from -- so
+      // it checks rather than trusting its caller.
+      if (!spec.credential) return;
       await this.custody.put(
         `agents/${agent}/${spec.credential.boxRelPath}`,
         Buffer.from(content, 'utf8'),

--- a/packages/sandbox-cloud/src/sync/agent-credentials.ts
+++ b/packages/sandbox-cloud/src/sync/agent-credentials.ts
@@ -88,10 +88,15 @@ interface AgentSpec {
   kind: CloudAgentKind;
   /** Where stage*Static tarballs extract (sandbox FS, snapshot-captured). */
   staticMountPath: string;
-  /** Where the credentials-volume subpath gets mounted at runtime. */
-  credentialsMountPath: string;
+  /**
+   * Where the credentials-volume subpath gets mounted at runtime, or undefined
+   * when the agent declares no `credential`. Both fields move together: a mount
+   * is a reserved slot in a volume shared by the whole org, and an agent with no
+   * host-side credential would never have anything to put in it.
+   */
+  credentialsMountPath?: string;
   /** Subdir of the shared credentials volume for this agent. */
-  credentialsSubpath: string;
+  credentialsSubpath?: string;
   stageStatic?: (opts: { hostWorkspace?: string }) => Promise<StageResult>;
   stageCredentials?: () => Promise<StageResult>;
 }
@@ -106,8 +111,12 @@ function agentSpecs(): AgentSpec[] {
     out.push({
       kind: spec.id,
       staticMountPath: boxDir,
-      credentialsMountPath: spec.credential.cloudMountPath,
-      credentialsSubpath: spec.credential.cloudSubpath,
+      ...(spec.credential
+        ? {
+            credentialsMountPath: spec.credential.cloudMountPath,
+            credentialsSubpath: spec.credential.cloudSubpath,
+          }
+        : {}),
       ...(mod?.stageStatic ? { stageStatic: (o) => mod.stageStatic!(o) } : {}),
       ...(mod?.stageCredentials ? { stageCredentials: () => mod.stageCredentials!() } : {}),
     });
@@ -214,11 +223,13 @@ export async function ensureAgentVolumesForCloud(
     return { mounts: [], env: buildForwardedEnv([]), agents: [] };
   }
 
-  const mounts: CloudVolumeMount[] = specs.map((spec) => ({
-    volumeId,
-    mountPath: spec.credentialsMountPath,
-    subpath: spec.credentialsSubpath,
-  }));
+  // `flatMap`, not `map`: an agent with no declared credential gets no mount at
+  // all rather than a mount at `undefined`.
+  const mounts: CloudVolumeMount[] = specs.flatMap((spec) =>
+    spec.credentialsMountPath !== undefined && spec.credentialsSubpath !== undefined
+      ? [{ volumeId, mountPath: spec.credentialsMountPath, subpath: spec.credentialsSubpath }]
+      : [],
+  );
   return { mounts, env: buildForwardedEnv(allAgents), agents: allAgents };
 }
 
@@ -385,6 +396,12 @@ async function seedCredentialsOne(
 ): Promise<void> {
   const log = opts.onLog ?? (() => {});
 
+  // No declared credential at all: no mount was reserved and there is no
+  // host-side blob, so there is nothing to probe or seed. Checked before the
+  // stager so the box is never touched on this agent's behalf.
+  const credentialsMountPath = spec.credentialsMountPath;
+  if (credentialsMountPath === undefined) return;
+
   // Before anything touches the box: an agent whose cloud module supplies no
   // credential stager has nothing to send, so probing its marker would be a
   // round-trip for a seed that cannot happen. Its MOUNTS still exist, so an
@@ -410,7 +427,7 @@ async function seedCredentialsOne(
     typeof backend.ensureVolume === 'function' && cloudVolumesUsable(handle.sandboxClass);
 
   if (hasVolume && !opts.force) {
-    const probe = await backend.exec(handle, `test -f ${spec.credentialsMountPath}/${SEED_MARKER}`);
+    const probe = await backend.exec(handle, `test -f ${credentialsMountPath}/${SEED_MARKER}`);
     if (probe.exitCode === 0) {
       log(`${spec.kind}: credentials already seeded — mounting only`);
       return;
@@ -466,9 +483,9 @@ async function seedCredentialsOne(
             `rm -rf ${stageDir}; ` +
             `mkdir -p ${stageDir}; ` +
             `tar -xzf ${remoteTar} -C ${stageDir}; ` +
-            `cp -r ${stageDir}/. ${spec.credentialsMountPath}/; ` +
+            `cp -r ${stageDir}/. ${credentialsMountPath}/; ` +
             `rm -rf ${stageDir}; ` +
-            `date -u +%FT%TZ > ${spec.credentialsMountPath}/${SEED_MARKER}; ` +
+            `date -u +%FT%TZ > ${credentialsMountPath}/${SEED_MARKER}; ` +
             `rm -f ${remoteTar}`
           );
         })()
@@ -484,8 +501,8 @@ async function seedCredentialsOne(
         // `--no-same-permissions --no-same-owner -m` flags mirror what
         // vercel/hetzner did in their old custom pushers.
         `set -e; ` +
-        `mkdir -p ${spec.credentialsMountPath}; ` +
-        `tar -xzf ${remoteTar} -C ${spec.credentialsMountPath} --no-same-permissions --no-same-owner -m; ` +
+        `mkdir -p ${credentialsMountPath}; ` +
+        `tar -xzf ${remoteTar} -C ${credentialsMountPath} --no-same-permissions --no-same-owner -m; ` +
         `rm -f ${remoteTar}`;
     const extract = hasVolume
       ? await backend.exec(handle, extractCmd)
@@ -511,14 +528,17 @@ async function seedCredentialsOne(
 export function agentSpecsForCloud(): Array<{
   kind: CloudAgentKind;
   staticMountPath: string;
-  credentialsMountPath: string;
-  credentialsSubpath: string;
+  /** Absent for an agent that declares no `credential` — it gets no mount. */
+  credentialsMountPath?: string;
+  credentialsSubpath?: string;
 }> {
   return agentSpecs().map((s) => ({
     kind: s.kind,
     staticMountPath: s.staticMountPath,
-    credentialsMountPath: s.credentialsMountPath,
-    credentialsSubpath: s.credentialsSubpath,
+    ...(s.credentialsMountPath !== undefined
+      ? { credentialsMountPath: s.credentialsMountPath }
+      : {}),
+    ...(s.credentialsSubpath !== undefined ? { credentialsSubpath: s.credentialsSubpath } : {}),
   }));
 }
 
@@ -628,6 +648,8 @@ export async function reconcileAgentCredentialsViaTransport(
   const wanted = opts.agents ? new Set<string>(opts.agents) : undefined;
   for (const spec of AGENT_SYNC_SPECS) {
     if (wanted && !wanted.has(spec.id)) continue;
+    // No host-side credential to reconcile in either direction.
+    if (!spec.credential) continue;
     const backupPath = opts.backups?.[spec.id];
     try {
       const hostText = await readCredentialBackup(spec.id, { backupPath });

--- a/packages/sandbox-cloud/test/agent-credentials.test.ts
+++ b/packages/sandbox-cloud/test/agent-credentials.test.ts
@@ -33,6 +33,7 @@ import {
   seedAgentVolumesIfFresh,
 } from '../src/sync/agent-credentials.js';
 import { registerAgentCloudModule } from '../src/sync/agent-cloud-module.js';
+import { requireAgentCredential } from '@agentbox/core';
 
 interface ExecCall {
   cmd: string;
@@ -119,6 +120,14 @@ function makeMockBackend(opts: {
  * be a hardcoded three, which meant a fourth agent got no mounts at all.
  */
 const EXPECTED_AGENTS = AGENT_SYNC_SPECS.filter((a) => a.staticPaths[0]?.boxDir).map((a) => a.id);
+/**
+ * Mounts track the agents that DECLARE a credential, which is a subset: an
+ * agent may have none (openclaw), and it then gets a static mount but no
+ * subpath of the shared credentials volume.
+ */
+const EXPECTED_MOUNTED = AGENT_SYNC_SPECS.filter(
+  (a) => a.staticPaths[0]?.boxDir && a.credential,
+).map((a) => a.id);
 
 /**
  * `sandbox-cloud` cannot import an agent package — that is the cycle — so the
@@ -135,7 +144,8 @@ async function stageHostFile(hostPath: string, entryName: string) {
 registerAgentCloudModule({
   id: 'claude',
   afterSeed: () => Promise.resolve(),
-  stageCredentials: () => stageHostFile(join(homedir(), '.agentbox', 'claude-credentials.json'), '.credentials.json'),
+  stageCredentials: () =>
+    stageHostFile(join(homedir(), '.agentbox', 'claude-credentials.json'), '.credentials.json'),
 });
 registerAgentCloudModule({
   id: 'codex',
@@ -156,7 +166,7 @@ describe('ensureAgentVolumesForCloud', () => {
     // Derived, not listed: the rows come from the registry now, so an agent
     // added later gets a mount instead of being silently absent.
     expect(res.agents).toEqual(EXPECTED_AGENTS);
-    expect(res.mounts).toHaveLength(EXPECTED_AGENTS.length);
+    expect(res.mounts).toHaveLength(EXPECTED_MOUNTED.length);
 
     // Every mount shares the same volumeId (single shared volume).
     const volumeIds = new Set(res.mounts.map((m) => m.volumeId));
@@ -181,11 +191,9 @@ describe('ensureAgentVolumesForCloud', () => {
     const res = await ensureAgentVolumesForCloud(backend);
     expect(res.agents).toContain('example');
     const byPath = new Map(res.mounts.map((m) => [m.mountPath, m] as const));
-    const spec = AGENT_SYNC_SPECS.find((a) => a.id === 'example');
+    const cred = requireAgentCredential(AGENT_SYNC_SPECS.find((a) => a.id === 'example')!);
     // Both paths come from its registry row, with nothing hand-written here.
-    expect(byPath.get(spec!.credential.cloudMountPath)?.subpath).toBe(
-      spec!.credential.cloudSubpath,
-    );
+    expect(byPath.get(cred.cloudMountPath)?.subpath).toBe(cred.cloudSubpath);
   });
 
   it('derives every mount from the registry row, not a local copy', async () => {
@@ -194,11 +202,36 @@ describe('ensureAgentVolumesForCloud', () => {
     const byPath = new Map(res.mounts.map((m) => [m.mountPath, m] as const));
     for (const spec of AGENT_SYNC_SPECS) {
       if (!spec.staticPaths[0]?.boxDir) continue;
-      expect(byPath.get(spec.credential.cloudMountPath), spec.id).toBeDefined();
-      expect(byPath.get(spec.credential.cloudMountPath)?.subpath, spec.id).toBe(
-        spec.credential.cloudSubpath,
-      );
+      const cred = spec.credential;
+      if (!cred) continue;
+      expect(byPath.get(cred.cloudMountPath), spec.id).toBeDefined();
+      expect(byPath.get(cred.cloudMountPath)?.subpath, spec.id).toBe(cred.cloudSubpath);
     }
+  });
+
+  it('reserves NO credentials-volume mount for an agent that declares none', async () => {
+    // The shared `agentbox-credentials` volume is per-org, and a mount is a
+    // reserved subpath in it. An agent with no host-side credential would never
+    // have anything to put there, so it gets no mount at all — not a mount at an
+    // invented path. openclaw is the live case.
+    const { backend } = makeMockBackend({});
+    const res = await ensureAgentVolumesForCloud(backend);
+    const credentialless = AGENT_SYNC_SPECS.filter(
+      (s) => !s.credential && s.staticPaths[0]?.boxDir,
+    );
+    expect(credentialless.map((s) => s.id)).toContain('openclaw');
+    // It is still a real agent of this box: static config, run-env, install.
+    for (const spec of credentialless) expect(res.agents).toContain(spec.id);
+    // Every mount that IS reserved traces back to a declared credential.
+    const declared = new Set(
+      AGENT_SYNC_SPECS.flatMap((s) => (s.credential ? [s.credential.cloudMountPath] : [])),
+    );
+    for (const mount of res.mounts) {
+      expect(declared.has(mount.mountPath), `unexpected mount ${mount.mountPath}`).toBe(true);
+      expect(mount.mountPath).toBeDefined();
+      expect(mount.subpath).toBeDefined();
+    }
+    expect(res.mounts).toHaveLength(declared.size);
   });
 
   it('returns empty mounts but full agents list when backend has no volume primitive', async () => {
@@ -378,7 +411,6 @@ describe('seedAgentVolumesIfFresh (credentials-only)', () => {
 
     await rm(codexDir, { recursive: true, force: true });
   });
-
 });
 
 describe('extractCloudAgentCredentials', () => {

--- a/packages/sandbox-cloud/test/agent-selection.test.ts
+++ b/packages/sandbox-cloud/test/agent-selection.test.ts
@@ -56,9 +56,14 @@ describe('cloud agent selection', () => {
     // since `CloudAgentKind` is an open string. Hardcoding the expectation here
     // is what let that ship.
     const expected = AGENT_SYNC_SPECS.filter((a) => a.staticPaths[0]?.boxDir).map((a) => a.id);
+    // One mount per agent that declares a credential -- fewer than `expected`,
+    // because an agent may declare none and then gets no subpath of the shared
+    // volume at all.
+    const mounted = expected.filter((id) => AGENT_SYNC_SPECS.find((a) => a.id === id)?.credential);
+    expect(mounted.length).toBeLessThan(expected.length);
     const res = await ensureAgentVolumesForCloud(volumeBackend(), {});
     expect(res.agents).toEqual(expected);
-    expect(res.mounts).toHaveLength(expected.length);
+    expect(res.mounts).toHaveLength(mounted.length);
     // The canary specifically: a hidden agent is still a real one here.
     expect(res.agents).toContain('example');
   });

--- a/packages/sandbox-core/src/sync/agent-descriptor.ts
+++ b/packages/sandbox-core/src/sync/agent-descriptor.ts
@@ -112,6 +112,9 @@ export interface AgentDescriptorPayload {
  * behaviour, restated as data. Additional watches come from the spec, and
  * default to `backup`: `fanout` has to be asked for, because getting it wrong
  * overwrites files in every other box.
+ *
+ * An agent that declares NO `credential` emits no credential watch at all: this
+ * watch is fanout, so a file named here is copied into every other box.
  */
 export function buildAgentDescriptors(): AgentDescriptorPayload {
   return {
@@ -124,11 +127,15 @@ export function buildAgentDescriptors(): AgentDescriptorPayload {
       ...(spec.service ? { service: spec.service } : {}),
       ...(spec.configRender ? { configRender: spec.configRender } : {}),
       watch: [
-        {
-          path: spec.credential.boxAbsPath,
-          sync: 'fanout' as const,
-          shape: spec.credential.realShape,
-        },
+        ...(spec.credential
+          ? [
+              {
+                path: spec.credential.boxAbsPath,
+                sync: 'fanout' as const,
+                shape: spec.credential.realShape,
+              },
+            ]
+          : []),
         ...(spec.watch ?? []).map((w) => ({
           path: w.path,
           sync: w.sync ?? ('backup' as const),

--- a/packages/sandbox-core/src/sync/concerns/credentials.ts
+++ b/packages/sandbox-core/src/sync/concerns/credentials.ts
@@ -44,8 +44,12 @@ export type CredentialAgentKind = AgentId;
  */
 export const SEED_MARKER = '.agentbox-seeded-at';
 
-/** Host backup of the claude OAuth blob — the registry is the single source of truth. */
-const CLAUDE_HOST_BACKUP = resolveAgentSpec('claude').credential.hostBackup;
+/**
+ * Host backup of the claude OAuth blob — the registry is the single source of
+ * truth. Claude always declares a credential; the `?? ''` is the type's, not a
+ * real case (an empty path simply fails the `readFile` below).
+ */
+const CLAUDE_HOST_BACKUP = resolveAgentSpec('claude').credential?.hostBackup ?? '';
 
 /**
  * True iff `text` looks like a real (usable) credential for `agent`, not an
@@ -65,7 +69,7 @@ export function isRealAgentCredential(agent: CredentialAgentKind, text: string):
   }
   if (typeof parsed !== 'object' || parsed === null) return false;
   const spec = AGENT_SYNC_SPECS.find((s) => s.id === agent);
-  if (spec?.credential.realShape === 'claude-oauth') {
+  if (spec?.credential?.realShape === 'claude-oauth') {
     const rt = (parsed as { claudeAiOauth?: { refreshToken?: unknown } }).claudeAiOauth
       ?.refreshToken;
     return typeof rt === 'string' && rt.length > 0;
@@ -119,6 +123,10 @@ export async function extractCredentials(
   const log = opts.onLog ?? (() => {});
   const extracted: AgentId[] = [];
   for (const spec of AGENT_SYNC_SPECS) {
+    // No credential declared → nothing on the box to read and nowhere on the
+    // host to put it. Skipped before the `readText`, so a credential-less agent
+    // costs no round-trip per box.
+    if (!spec.credential) continue;
     const hostBackup = opts.backups?.[spec.id] ?? spec.credential.hostBackup;
     try {
       // `readText` is `cat <path> 2>/dev/null` with noRetry → null on a missing
@@ -162,7 +170,11 @@ export function parseCredentialsUpdate(payload: unknown): CredentialsUpdate | nu
   if (payload === null || typeof payload !== 'object') return null;
   const obj = payload as Record<string, unknown>;
   const agent = obj['agent'];
-  if (typeof agent !== 'string' || !AGENT_SYNC_SPECS.some((s) => s.id === agent)) return null;
+  // Unknown agent, or one that declares no credential: there is no host backup
+  // to write and no fan-out to run, so an event naming it is malformed.
+  // Rejecting here keeps every writer below total.
+  if (typeof agent !== 'string' || !AGENT_SYNC_SPECS.some((s) => s.id === agent && s.credential))
+    return null;
   const b64 = obj['contentBase64'];
   if (typeof b64 !== 'string' || b64.length === 0 || b64.length > MAX_CREDENTIAL_BYTES) return null;
   let content: string;
@@ -197,7 +209,7 @@ export function jsonNumberAt(text: string, path: readonly string[]): number | nu
 
 /** The agent's declared freshness value for a blob, or null when it declares none. */
 export function credentialFreshness(agent: CredentialAgentKind, text: string): number | null {
-  const path = resolveAgentSpec(agent).credential.freshness?.jsonPath;
+  const path = resolveAgentSpec(agent).credential?.freshness?.jsonPath;
   return path ? jsonNumberAt(text, path) : null;
 }
 
@@ -224,7 +236,7 @@ export function shouldAcceptCredentialUpdate(
 ): { accept: boolean; reason: string } {
   if (existing === null) return { accept: true, reason: 'no existing backup' };
   if (existing === incoming) return { accept: false, reason: 'unchanged' };
-  const path = resolveAgentSpec(agent).credential.freshness?.jsonPath;
+  const path = resolveAgentSpec(agent).credential?.freshness?.jsonPath;
   if (path) {
     const field = path.join('.');
     const incomingExp = jsonNumberAt(incoming, path);
@@ -244,7 +256,13 @@ export async function writeCredentialBackup(
   content: string,
   opts: { backupPath?: string } = {},
 ): Promise<void> {
-  const path = opts.backupPath ?? resolveAgentSpec(agent).credential.hostBackup;
+  const path = opts.backupPath ?? resolveAgentSpec(agent).credential?.hostBackup;
+  // An agent with no credential has no backup file. Reaching here means a caller
+  // skipped a gate (`parseCredentialsUpdate` and `extractCredentials` both drop
+  // these agents), so say so rather than writing to `undefined`.
+  if (path === undefined) {
+    throw new Error(`agent '${agent}' declares no credential — there is no host backup to write`);
+  }
   await mkdir(dirname(path), { recursive: true });
   const tmp = `${path}.tmp-${String(process.pid)}`;
   await writeFile(tmp, content, { mode: 0o600 });
@@ -257,7 +275,9 @@ export async function readCredentialBackup(
   agent: CredentialAgentKind,
   opts: { backupPath?: string } = {},
 ): Promise<string | null> {
-  const path = opts.backupPath ?? resolveAgentSpec(agent).credential.hostBackup;
+  const path = opts.backupPath ?? resolveAgentSpec(agent).credential?.hostBackup;
+  // No credential declared ⇒ no backup, which reads the same as "absent".
+  if (path === undefined) return null;
   try {
     return await readFile(path, 'utf8');
   } catch {
@@ -284,6 +304,9 @@ export async function readCredentialBackup(
  */
 export async function resolveHostCredential(agent: CredentialAgentKind): Promise<string | null> {
   const spec = resolveAgentSpec(agent);
+  // The agent declares no host-side credential, so there is no backup AND no
+  // tool path to fall back to.
+  if (!spec.credential) return null;
   const backup = await readCredentialBackup(agent);
   if (backup !== null && isRealAgentCredential(agent, backup)) return backup;
 
@@ -303,7 +326,15 @@ export async function pushCredentialToBox(
   agent: CredentialAgentKind,
   content: string,
 ): Promise<void> {
-  const abs = resolveAgentSpec(agent).credential.boxAbsPath;
+  const abs = resolveAgentSpec(agent).credential?.boxAbsPath;
+  // Same reasoning as `writeCredentialBackup`: no declared credential means no
+  // canonical in-box path, so there is nowhere to push. A caller that got here
+  // skipped its gate.
+  if (abs === undefined) {
+    throw new Error(
+      `agent '${agent}' declares no credential — there is nothing to push into a box`,
+    );
+  }
   const dir = abs.slice(0, abs.lastIndexOf('/'));
   const stage = await mkdtemp(join(tmpdir(), 'agentbox-cred-push-'));
   try {

--- a/packages/sandbox-core/test/agent-descriptor.test.ts
+++ b/packages/sandbox-core/test/agent-descriptor.test.ts
@@ -5,16 +5,39 @@ import { AGENT_SYNC_SPECS } from '../src/sync/registry.js';
 describe('buildAgentDescriptors', () => {
   it('reproduces the credential watch list ctl has baked in today', () => {
     // The whole point of shipping this over RPC is that a box's behaviour does
-    // not change on day one. Every agent's credential must still be watched,
-    // with the same path and the same validator.
+    // not change on day one. Every agent that DECLARES a credential must still
+    // be watched, with the same path and the same validator.
     const { agents } = buildAgentDescriptors();
     expect(agents).toHaveLength(AGENT_SYNC_SPECS.length);
     for (const spec of AGENT_SYNC_SPECS) {
+      const declared = spec.credential;
+      if (!declared) continue;
       const got = agents.find((a) => a.id === spec.id);
-      const cred = got?.watch.find((w) => w.path === spec.credential.boxAbsPath);
+      const cred = got?.watch.find((w) => w.path === declared.boxAbsPath);
       expect(cred, spec.id).toBeDefined();
       expect(cred?.sync).toBe('fanout');
-      expect(cred?.shape).toBe(spec.credential.realShape);
+      expect(cred?.shape).toBe(declared.realShape);
+    }
+  });
+
+  it('emits NO credential watch for an agent that declares none', () => {
+    // The credential watch is FANOUT: whatever it names is copied into every
+    // other box. An agent with no host-side credential contributes no watch at
+    // all — not one on a fictional path, and not one on its own config, which
+    // would hand every box the first box's identity. openclaw is the live case
+    // (its gateway token is generated per box).
+    const { agents } = buildAgentDescriptors();
+    const credentialless = AGENT_SYNC_SPECS.filter((s) => !s.credential);
+    expect(credentialless.map((s) => s.id)).toContain('openclaw');
+    for (const spec of credentialless) {
+      const got = agents.find((a) => a.id === spec.id);
+      expect(got, spec.id).toBeDefined();
+      // It still ships a descriptor (session, activity, service, configRender)
+      // — only the credential watch is absent.
+      expect(
+        got?.watch.filter((w) => w.sync === 'fanout'),
+        spec.id,
+      ).toEqual([]);
     }
   });
 
@@ -47,6 +70,7 @@ describe('buildAgentDescriptors', () => {
     // a box it is meaningless, and sending it leaks the host's home layout.
     const json = JSON.stringify(buildAgentDescriptors());
     for (const spec of AGENT_SYNC_SPECS) {
+      if (!spec.credential) continue;
       expect(json, spec.id).not.toContain(spec.credential.hostBackup);
     }
     expect(json).not.toContain('/Users/');

--- a/packages/sandbox-core/test/credentials-concern.test.ts
+++ b/packages/sandbox-core/test/credentials-concern.test.ts
@@ -130,13 +130,19 @@ describe('credentials concern — extractCredentials', () => {
     const extracted = await extractCredentials(t, { backups: b });
     expect(extracted).toEqual(['claude']);
 
-    // One readText per agent, in registry order, at the canonical box paths.
-    // Derived from the registry rather than listed: this asserts the concern
-    // visits EVERY agent, which a hardcoded list quietly stops doing the moment
-    // an agent is added.
-    expect(t.ops.map((o) => o.op)).toEqual(AGENT_SYNC_SPECS.map(() => 'readText'));
+    // One readText per CREDENTIAL-DECLARING agent, in registry order, at the
+    // canonical box paths. Derived from the registry rather than listed: this
+    // asserts the concern visits every such agent, which a hardcoded list
+    // quietly stops doing the moment an agent is added.
+    //
+    // An agent with no declared credential is skipped before the transport is
+    // touched — there is no file to read and nowhere to put it — so it costs no
+    // round-trip per box. openclaw is the live case, so the two lists differ.
+    const withCredential = AGENT_SYNC_SPECS.filter((spec) => spec.credential);
+    expect(withCredential.length).toBeLessThan(AGENT_SYNC_SPECS.length);
+    expect(t.ops.map((o) => o.op)).toEqual(withCredential.map(() => 'readText'));
     expect(t.ops.map((o) => o.args['boxPath'])).toEqual(
-      AGENT_SYNC_SPECS.map((spec) => spec.credential.boxAbsPath),
+      withCredential.map((spec) => spec.credential?.boxAbsPath),
     );
 
     expect(await readFile(b.claude, 'utf8')).toBe(realClaude);

--- a/packages/sandbox-core/test/registry.test.ts
+++ b/packages/sandbox-core/test/registry.test.ts
@@ -1,7 +1,7 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { agentPushExcludes, LIVE_DATABASE_EXCLUDES } from '@agentbox/core';
+import { agentPushExcludes, LIVE_DATABASE_EXCLUDES, requireAgentCredential } from '@agentbox/core';
 import { AGENT_SYNC_SPECS, agentIds, resolveAgentSpec } from '../src/sync/registry.js';
 
 describe('agent sync registry', () => {
@@ -23,16 +23,14 @@ describe('agent sync registry', () => {
   });
 
   it('credential + volume data matches the known docker/cloud layout', () => {
-    const claude = resolveAgentSpec('claude');
-    expect(claude.dockerVolume).toBe('agentbox-claude-config');
-    expect(claude.credential.boxAbsPath).toBe('/home/vscode/.claude/.credentials.json');
-    expect(claude.credential.hostBackup).toBe(
-      join(homedir(), '.agentbox', 'claude-credentials.json'),
-    );
-    expect(claude.credential.cloudMountPath).toBe('/home/vscode/.agentbox-creds/claude');
+    const claude = requireAgentCredential(resolveAgentSpec('claude'));
+    expect(resolveAgentSpec('claude').dockerVolume).toBe('agentbox-claude-config');
+    expect(claude.boxAbsPath).toBe('/home/vscode/.claude/.credentials.json');
+    expect(claude.hostBackup).toBe(join(homedir(), '.agentbox', 'claude-credentials.json'));
+    expect(claude.cloudMountPath).toBe('/home/vscode/.agentbox-creds/claude');
 
     const codex = resolveAgentSpec('codex');
-    expect(codex.credential.boxAbsPath).toBe('/home/vscode/.codex/auth.json');
+    expect(requireAgentCredential(codex).boxAbsPath).toBe('/home/vscode/.codex/auth.json');
     expect(codex.forwardedEnvKeys).toEqual(['OPENAI_API_KEY']);
   });
 
@@ -131,7 +129,7 @@ describe('agent sync registry', () => {
     // The credential file is the one entry that differs by target: out of a
     // SHARED snapshot, into the box's OWN volume (which is its login store).
     for (const id of ['claude', 'codex', 'opencode']) {
-      const cred = resolveAgentSpec(id).credential.boxRelPath;
+      const cred = requireAgentCredential(resolveAgentSpec(id)).boxRelPath;
       expect(pushExcludes(id, 'snapshot')).toContain(cred);
       expect(pushExcludes(id, 'volume')).not.toContain(cred);
     }

--- a/packages/sandbox-docker/src/sync/claude-credentials.ts
+++ b/packages/sandbox-docker/src/sync/claude-credentials.ts
@@ -20,6 +20,7 @@ export {
   type CredentialAgentKind,
 } from '@agentbox/sandbox-core';
 import { resolveAgentSpec } from '@agentbox/sandbox-core';
+import { requireAgentCredential } from '@agentbox/core';
 
 /**
  * Host-side backup of the in-box Claude Code OAuth credentials.
@@ -240,7 +241,10 @@ export function parseSyncResult(stdout: string): SyncClaudeCredentialsResult {
  * copy that could drift; `credential-freshness.test.ts` pins the two together.
  */
 const FRESHNESS_JQ = (
-  resolveAgentSpec('claude').credential.freshness?.jsonPath ?? ['claudeAiOauth', 'expiresAt']
+  requireAgentCredential(resolveAgentSpec('claude')).freshness?.jsonPath ?? [
+    'claudeAiOauth',
+    'expiresAt',
+  ]
 )
   .map((k: string) => `.${k}`)
   .join('');

--- a/packages/sandbox-docker/test/credential-freshness-drift.test.ts
+++ b/packages/sandbox-docker/test/credential-freshness-drift.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { resolveAgentSpec } from '@agentbox/sandbox-core';
+import { requireAgentCredential } from '@agentbox/core';
 import { SYNC_SCRIPT } from '../src/sync/claude-credentials.js';
 
 /**
@@ -13,7 +14,7 @@ import { SYNC_SCRIPT } from '../src/sync/claude-credentials.js';
  * whole fleet out.
  */
 describe('the docker sync script and the spec agree on the freshness field', () => {
-  const path = resolveAgentSpec('claude').credential.freshness?.jsonPath;
+  const path = requireAgentCredential(resolveAgentSpec('claude')).freshness?.jsonPath;
 
   it('claude declares one', () => {
     // Without it, `shouldAcceptCredentialUpdate` silently degrades claude to


### PR DESCRIPTION
## What

`AgentSyncSpec.credential` is now **optional**. Absent means "this agent has no host-side credential to sync" — a declaration, not a placeholder for "not wired up yet". The dummy credential is gone from the openclaw spec.

## Why

openclaw has no host-side credential: its gateway token is generated per box by `openclaw onboard` and must never leave that box. The required field was satisfied by naming a path nothing ever writes.

The obvious workaround is worse than the dummy. Pointing the field at `~/.openclaw/openclaw.json` would be **actively harmful**, because the credential watch is **fanout by contract** — `buildAgentDescriptors` emits `sync: 'fanout'` for every agent's credential. It would copy one box's gateway identity and channel pairings into every other box: exactly the multi-tenancy failure openclaw forbids, and the one `clone`'s fresh-identity rule exists to prevent.

## What an absent credential means

No credentials-volume mount, no `agents.list` credential watch, no host-backup probe, no relay fan-out entry, no custody upload, no snapshot push-exclude. Everything else about the agent is unchanged.

## Changes

- `packages/core/src/sync/agent-spec.ts` — `credential?: AgentCredential` with the rule documented on the field; `agentPushExcludes` skips the derived entry; `agentDirPrelude`'s creds-subdir argument is optional; new `requireAgentCredential(spec)` for the call sites that exist *only* to move a credential (claude's host-backup guards, pi's volume extract, the custody push), instead of a `?? ''` at each one.
- `packages/agent-registry/src/plugin-agents.ts` — `credential` dropped from `REQUIRED_SPEC_FIELDS`; `credentialProblem` still runs when the field **is** present, so a malformed credential is rejected as before.
- `packages/agent-registry/src/specs/openclaw.ts` — dummy credential and its apology removed.
- Consumers: `sandbox-core` agent-descriptor + credentials concern (`extractCredentials`, `parseCredentialsUpdate`, `resolveHostCredential`, `pushCredentialToBox`, backup read/write), `sandbox-cloud` `agentSpecs()` / mount plan / `seedCredentialsOne` / reconcile, `sandbox-docker` freshness jq, `ctl` `WATCHED_CREDENTIALS`, `relay` credentials-fanout, `apps/cli` custody client + credential commands, `apps/hub` worker.
- Docs: `docs/agents.md` (the credential row in "Adding a new agent", plus the excludes note) and `docs/plans/service-boxes-backlog.md` (item marked done; two new minor items).

## Tests

New, all mutation-checked (revert the change → the test fails):

| test | asserts |
|---|---|
| `agent-registry/test/plugin-agents.test.ts` | a spec with no credential validates; a malformed one still doesn't |
| `agent-registry/test/creds-dir-postinstall.test.ts` | a credential-less agent creates no subdir of the creds mount |
| `sandbox-core/test/agent-descriptor.test.ts` | no credential watch emitted; no fanout entry |
| `sandbox-cloud/test/agent-credentials.test.ts` + `agent-selection.test.ts` | no credentials-volume mount reserved; mount count tracks credential-declaring agents |
| `ctl/test/credentials-watcher.test.ts` | no watcher row for a credential-less baked agent |
| `sandbox-core/test/credentials-concern.test.ts` | `extractCredentials` skips it before touching the transport |

Mutations verified: re-adding openclaw's credential (fails in 4 packages), emitting the watch unconditionally, re-adding `'credential'` to `REQUIRED_SPEC_FIELDS`, `flatMap`→`map` in the cloud mount plan, and removing the `extractCredentials` skip.

`pnpm typecheck` green across all 47 tasks; `build` + `lint` green; every touched package's suite green.

## Smoke (docker, real box)

```
$ curl -s -o /dev/null -w "healthz HTTP %{http_code}\n" http://127.0.0.1:32772/healthz
healthz HTTP 200
$ curl -s http://127.0.0.1:32772/healthz
{"ok":true,"status":"live"}

$ agentbox openclaw status credopt2
NAME      STATE  PID  RESTARTS  LAST EXIT  BLOCKED ON  COMMAND
openclaw  ready  585  0         -          -           openclaw gateway
```

No credentials mount, and no leftover dummy file:

```
$ docker inspect agentbox-credopt2 --format '...Destination...' | grep agentbox-creds
NONE
$ docker exec agentbox-credopt2 ls -la /home/vscode/.agentbox-creds
ls: cannot access '/home/vscode/.agentbox-creds': No such file or directory
$ docker exec agentbox-credopt2 ls -la /home/vscode/.openclaw/agentbox-credential.json
ls: cannot access '...': No such file or directory
```

`agents.list` as ctl actually received it over the relay RPC:

```
claude     surface=tui      watches=1 fanout=['/home/vscode/.claude/.credentials.json']
codex      surface=tui      watches=1 fanout=['/home/vscode/.codex/auth.json']
opencode   surface=tui      watches=1 fanout=['/home/vscode/.local/share/opencode/auth.json']
pi         surface=tui      watches=1 fanout=['/home/vscode/.pi/agent/auth.json']
openclaw   surface=service  watches=0 fanout=[]
example    surface=tui      watches=1 fanout=['/home/vscode/.agentbox-example/auth.json']
```

openclaw's descriptor keeps its full `service` + `configRender` blocks and carries `"watch": []`. The gateway still generates its own token in-box (`/home/vscode/.openclaw/openclaw.json`, 0600, `gateway.auth.token` present).

https://claude.ai/code/session_01QbBhzAiriizb64ZLSCZX8p

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential fanout, custody, and cloud mount planning across many packages; behavior change is intentional skips rather than dummy paths, with broad test coverage.
> 
> **Overview**
> Makes **`AgentSyncSpec.credential` optional** so an agent can declare it has **no host-side login to sync**. OpenClaw drops the fictional backup path; omitting `credential` is the supported way to say auth stays in-box (per-box gateway token).
> 
> Adds **`requireAgentCredential(spec)`** for paths that only move credentials, and gates every credential mechanism on **`spec.credential`**: snapshot push-excludes, `agentDirPrelude` creds subdirs, descriptor **fanout** watches, ctl `WATCHED_CREDENTIALS`, relay/custody upload and seed, cloud credentials-volume mounts/seeding/reconcile, and CLI **`hub credentials` push/pull** (including **`--agent`** limited to credential-declaring agents). **`credentials propagate`** fails clearly when the agent has nothing to propagate.
> 
> Plugin validation no longer requires `credential` but still shape-checks it when present. Docs and tests assert openclaw gets no watch, mount, or creds subdir.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf83524faea4a211f3390a3e3b2140c3c23907ef. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->