### PR TITLE
feat: pick a box size at create time, in the web hub and the tray

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -9,6 +9,18 @@ Entries are generated from the commit history with `/release-notes` and then
 hand-reviewed — they describe what changed for someone using the `agentbox`
 CLI, not the raw commits.
 
+## [Unreleased]
+
+### Added
+
+- **Pick a box size when you create one, in the web hub and the macOS tray.** The
+  choices come from the provider (`cx43` on Hetzner, `4` vCPU on Vercel, `4-8-10`
+  on Daytona — there is no common grammar), with a custom-value field where the
+  backend accepts free-form sizes. On Daytona and E2B, where the size is fixed
+  when the base is baked, choosing a different one rebuilds the base first and the
+  form says so. A community provider gets the same picker by declaring `sizes` on
+  its descriptor.
+
 ## [0.30.0] - 2026-09-05
 
 ### Added

--- a/apps/cli/test/provider-sizes.test.ts
+++ b/apps/cli/test/provider-sizes.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Guard the descriptors' declared `sizes` against the parsers that have to
+ * accept them.
+ *
+ * A size key is a literal `--size` value for one backend, so a typo here is
+ * invisible until someone picks it in the create form and the box fails to
+ * provision. Three providers parse the spec locally and can be asked directly;
+ * hetzner and digitalocean take opaque slugs their API validates, so those get
+ * a shape check only.
+ *
+ * Lives in apps/cli because `@agentbox/config` cannot depend on the provider
+ * packages (they depend on it) — same reason as `provider-descriptors.test.ts`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { PROVIDERS } from '@agentbox/config';
+import { parseDaytonaSize } from '@agentbox/sandbox-daytona';
+import { parseE2bSize } from '@agentbox/sandbox-e2b';
+import { parseVercelVcpus } from '@agentbox/sandbox-vercel';
+
+function descriptor(name: string) {
+  const d = PROVIDERS.find((p) => p.name === name);
+  if (!d) throw new Error(`no descriptor for ${name}`);
+  return d as (typeof PROVIDERS)[number] & {
+    sizes?: readonly { key: string; label: string }[];
+    sizeHint?: string;
+    sizeAppliesAt?: 'create' | 'bake';
+  };
+}
+
+function sizesOf(name: string): readonly { key: string; label: string }[] {
+  return descriptor(name).sizes ?? [];
+}
+
+describe('declared provider sizes', () => {
+  it('docker declares none — its knobs are box.memory / box.cpus', () => {
+    expect(descriptor('docker').sizes).toBeUndefined();
+  });
+
+  it('every other provider declares at least two', () => {
+    for (const p of PROVIDERS) {
+      if (p.name === 'docker') continue;
+      expect(sizesOf(p.name).length, p.name).toBeGreaterThan(1);
+    }
+  });
+
+  it('keys are unique and labels non-empty', () => {
+    for (const p of PROVIDERS) {
+      const sizes = sizesOf(p.name);
+      expect(new Set(sizes.map((s) => s.key)).size, p.name).toBe(sizes.length);
+      for (const s of sizes) expect(s.label.trim().length, `${p.name}/${s.key}`).toBeGreaterThan(0);
+    }
+  });
+
+  it('daytona keys parse as cpu-memory-disk', () => {
+    for (const { key } of sizesOf('daytona')) {
+      expect(parseDaytonaSize(key), key).toBeDefined();
+    }
+  });
+
+  it('e2b keys parse as cpu-memory', () => {
+    for (const { key } of sizesOf('e2b')) {
+      expect(parseE2bSize(key), key).toBeDefined();
+    }
+  });
+
+  it('vercel keys are accepted vCPU counts', () => {
+    for (const { key } of sizesOf('vercel')) {
+      expect(() => parseVercelVcpus(key), key).not.toThrow();
+    }
+  });
+
+  it('vercel declares no sizeHint — its set is closed, so no custom-value escape', () => {
+    // `parseVercelVcpus` throws outside the declared set, so a UI offering a
+    // free-text box here would only ever produce a failed create.
+    expect(descriptor('vercel').sizeHint).toBeUndefined();
+    expect(() => parseVercelVcpus('3')).toThrow();
+  });
+
+  it('every open list carries a hint for its custom-value field', () => {
+    for (const p of PROVIDERS) {
+      if (p.name === 'docker' || p.name === 'vercel') continue;
+      expect(descriptor(p.name).sizeHint, p.name).toBeTruthy();
+    }
+  });
+
+  it('slug providers declare plausible slugs', () => {
+    for (const name of ['hetzner', 'digitalocean']) {
+      for (const { key } of sizesOf(name)) {
+        expect(key, `${name}/${key}`).toMatch(/^[a-z0-9-]+$/);
+      }
+    }
+  });
+
+  it('bake-scoped providers are exactly the ones with a sizeIgnoredReason hook', async () => {
+    // The two are the same fact: a size fixed at bake time is one the backend
+    // rejects per-create, which is what `sizeIgnoredReason` reports. If a new
+    // provider grows one without the other, a UI either offers a dead control
+    // or bakes when it did not need to.
+    const baked = PROVIDERS.filter((p) => descriptor(p.name).sizeAppliesAt === 'bake').map(
+      (p) => p.name,
+    );
+    expect([...baked].sort()).toEqual(['daytona', 'e2b']);
+  });
+});

--- a/apps/cli/test/provider-sizes.test.ts
+++ b/apps/cli/test/provider-sizes.test.ts
@@ -14,9 +14,11 @@
 
 import { describe, expect, it } from 'vitest';
 import { PROVIDERS } from '@agentbox/config';
-import { parseDaytonaSize } from '@agentbox/sandbox-daytona';
-import { parseE2bSize } from '@agentbox/sandbox-e2b';
-import { parseVercelVcpus } from '@agentbox/sandbox-vercel';
+import { DAYTONA_DEFAULT_RESOURCES, parseDaytonaSize } from '@agentbox/sandbox-daytona';
+import { DIGITALOCEAN_DEFAULT_SIZE } from '@agentbox/sandbox-digitalocean';
+import { DEFAULT_CPU, DEFAULT_MEMORY_MB, parseE2bSize } from '@agentbox/sandbox-e2b';
+import { HETZNER_DEFAULT_SERVER_TYPE } from '@agentbox/sandbox-hetzner';
+import { parseVercelVcpus, VERCEL_DEFAULT_VCPUS } from '@agentbox/sandbox-vercel';
 
 function descriptor(name: string) {
   const d = PROVIDERS.find((p) => p.name === name);
@@ -90,6 +92,23 @@ describe('declared provider sizes', () => {
         expect(key, `${name}/${key}`).toMatch(/^[a-z0-9-]+$/);
       }
     }
+  });
+
+  // The picker labels one entry "(default)" — the size you get with no --size.
+  // That is a claim about the backend, so pin it to the backend's own constant
+  // rather than to a comment someone has to remember to update.
+  it.each([
+    [
+      'daytona',
+      `${String(DAYTONA_DEFAULT_RESOURCES.cpu)}-${String(DAYTONA_DEFAULT_RESOURCES.memory)}-${String(DAYTONA_DEFAULT_RESOURCES.disk)}`,
+    ],
+    ['hetzner', HETZNER_DEFAULT_SERVER_TYPE],
+    ['vercel', String(VERCEL_DEFAULT_VCPUS)],
+    ['e2b', `${String(DEFAULT_CPU)}-${String(DEFAULT_MEMORY_MB / 1024)}`],
+    ['digitalocean', DIGITALOCEAN_DEFAULT_SIZE],
+  ])('%s labels its real fallback size as the default', (name, expected) => {
+    const marked = sizesOf(name).filter((s) => s.label.includes('(default)'));
+    expect(marked.map((s) => s.key)).toEqual([expected]);
   });
 
   it('bake-scoped providers are exactly the ones with a sizeIgnoredReason hook', async () => {

--- a/apps/hub/app/(dashboard)/api/v1/lib/openapi.ts
+++ b/apps/hub/app/(dashboard)/api/v1/lib/openapi.ts
@@ -775,18 +775,9 @@ export function buildOpenApi(): Record<string, unknown> {
               name: 'id',
               in: 'path',
               required: true,
-              schema: {
-                type: 'string',
-                enum: [
-                  'docker',
-                  'daytona',
-                  'hetzner',
-                  'vercel',
-                  'e2b',
-                  'digitalocean',
-                  'remote-docker',
-                ],
-              },
+              description:
+                'Provider name. Built-ins are docker, daytona, hetzner, vercel, e2b, digitalocean, remote-docker; a provider registered with `agentbox plugin add` uses its own name.',
+              schema: { type: 'string' },
             },
           ],
           requestBody: {
@@ -817,6 +808,69 @@ export function buildOpenApi(): Record<string, unknown> {
           },
         },
       },
+      '/providers/{id}/size-check': {
+        post: {
+          tags: ['Providers'],
+          summary: 'Would a box created at this size actually get it?',
+          description:
+            'Most backends apply a size per create and answer false. Daytona and e2b fix CPU/memory when the base is baked and discard anything else, so they answer true with the reason to show. Lets a create form re-bake only when the size really differs from the baked one. Advisory: an unresolvable provider or a backend with no opinion answers false.',
+          parameters: [
+            {
+              name: 'id',
+              in: 'path',
+              required: true,
+              description:
+                'Provider name. Built-ins are docker, daytona, hetzner, vercel, e2b, digitalocean, remote-docker; a provider registered with `agentbox plugin add` uses its own name.',
+              schema: { type: 'string' },
+            },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    size: {
+                      type: 'string',
+                      description:
+                        'A literal --size value for this provider (e.g. cx43, 4, 4-8-10). Opaque here — the provider parses it.',
+                    },
+                  },
+                  required: ['size'],
+                },
+              },
+            },
+          },
+          responses: {
+            '200': {
+              description: 'Verdict',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      rebakeRequired: {
+                        type: 'boolean',
+                        description:
+                          'true = a plain create would discard this size; bake first with POST /providers/{id}/prepare { size, force: true }. `force` matters: a size change does not move the build-context fingerprint, so without it the bake is a no-op.',
+                      },
+                      reason: {
+                        type: 'string',
+                        description: "Why, in the provider's own words. Only when rebakeRequired.",
+                      },
+                    },
+                    required: ['rebakeRequired'],
+                  },
+                },
+              },
+            },
+            '400': errorResponse,
+            '401': errorResponse,
+            '503': errorResponse,
+          },
+        },
+      },
       '/providers/{id}/prepare': {
         post: {
           tags: ['Providers'],
@@ -827,18 +881,9 @@ export function buildOpenApi(): Record<string, unknown> {
               name: 'id',
               in: 'path',
               required: true,
-              schema: {
-                type: 'string',
-                enum: [
-                  'docker',
-                  'daytona',
-                  'hetzner',
-                  'vercel',
-                  'e2b',
-                  'digitalocean',
-                  'remote-docker',
-                ],
-              },
+              description:
+                'Provider name. Built-ins are docker, daytona, hetzner, vercel, e2b, digitalocean, remote-docker; a provider registered with `agentbox plugin add` uses its own name.',
+              schema: { type: 'string' },
             },
           ],
           requestBody: {
@@ -2140,23 +2185,97 @@ export function buildOpenApi(): Record<string, unknown> {
         },
         Provider: {
           type: 'object',
+          description:
+            'A provider plus its declarative descriptor. The descriptor half comes from a sync snapshot (the built-in table, or ~/.agentbox/plugins.json for a community provider), so it is always present and costs nothing to serve. Clients should render from it rather than hardcoding provider names.',
           properties: {
             id: {
               type: 'string',
-              enum: [
-                'docker',
-                'daytona',
-                'hetzner',
-                'vercel',
-                'e2b',
-                'digitalocean',
-                'remote-docker',
-              ],
+              description:
+                'Built-ins are docker, daytona, hetzner, vercel, e2b, digitalocean, remote-docker; a registered plugin uses its own name.',
             },
             label: { type: 'string' },
             configured: {
               type: 'boolean',
               description: 'Base image baked (usable for create) on this host.',
+            },
+            kind: { type: 'string', enum: ['local', 'cloud'] },
+            credentials: {
+              type: 'object',
+              description: 'What "configured credentials" means, and the form to prompt with.',
+              properties: {
+                envKeys: {
+                  type: 'array',
+                  items: { type: 'string' },
+                  description:
+                    'secrets.env key NAMES whose presence means configured. Values are never read.',
+                },
+                fields: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      key: { type: 'string' },
+                      label: { type: 'string' },
+                      optional: { type: 'boolean' },
+                      secret: { type: 'boolean', description: 'Absent means secret — mask it.' },
+                      hint: { type: 'string' },
+                    },
+                    required: ['key', 'label'],
+                  },
+                },
+              },
+            },
+            bake: {
+              type: 'object',
+              properties: {
+                required: {
+                  type: 'boolean',
+                  description:
+                    'false = the base self-heals on create (docker), so a missing base is a slow first create, not a blocked one.',
+                },
+                approxMinutes: { type: 'string' },
+                createProgressSteps: {
+                  type: 'integer',
+                  description:
+                    'Typical streamed create-log line count, for client progress pacing.',
+                },
+                bakeProgressSteps: { type: 'integer' },
+              },
+            },
+            capabilities: {
+              type: 'object',
+              description:
+                'All DECLARED, not inferred from method presence. pauseSemantics "stop" means pause powers the box off — relabel the control, do not hide it.',
+              additionalProperties: true,
+            },
+            sizes: {
+              type: 'array',
+              description:
+                'Sizes to offer in a create picker, most-modest first. Each key is a literal --size value for THIS backend; there is no cross-provider grammar. Absent = the provider has no size knob (docker).',
+              items: {
+                type: 'object',
+                properties: { key: { type: 'string' }, label: { type: 'string' } },
+                required: ['key', 'label'],
+              },
+            },
+            sizeHint: {
+              type: 'string',
+              description:
+                'Placeholder for a free-text size. Its PRESENCE is what says `sizes` is an open list — offer a custom-value field only when there is a hint for it.',
+            },
+            sizeAppliesAt: {
+              type: 'string',
+              enum: ['create', 'bake'],
+              description:
+                'bake = the size is fixed when the base is baked and rejected per-create (daytona, e2b), so a change must go through POST /providers/{id}/prepare with { size, force: true } first. Absent = create. POST /providers/{id}/size-check says whether a SPECIFIC size needs that.',
+            },
+            regions: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: { key: { type: 'string' }, label: { type: 'string' } },
+                required: ['key', 'label'],
+              },
             },
             hasCredentials: {
               type: 'boolean',
@@ -2168,6 +2287,20 @@ export function buildOpenApi(): Record<string, unknown> {
               description: 'Id of an in-flight bake (prepare) job for this provider, if any.',
             },
             reason: { type: 'string' },
+            baseStatus: {
+              type: 'string',
+              enum: ['fresh', 'stale', 'unprepared', 'unknown'],
+              description:
+                'Only when ?freshness=1. stale = re-bake wanted; unknown = could not verify.',
+            },
+            baseStaleReason: { type: 'string' },
+            origin: {
+              type: 'string',
+              enum: ['local', 'hub'],
+              description:
+                'hub = this row came from a remote control box, which is where its boxes are created.',
+            },
+            hubUrl: { type: 'string' },
           },
           required: ['id', 'label', 'configured'],
         },

--- a/apps/hub/app/(dashboard)/api/v1/lib/validate.ts
+++ b/apps/hub/app/(dashboard)/api/v1/lib/validate.ts
@@ -282,6 +282,17 @@ export function parseProviderCredentials(body: unknown): Parsed<Record<string, s
   return { ok: true, value: out };
 }
 
+// A size is an opaque, provider-specific string (`cx43`, `4`, `4-8-10`) — the
+// provider's own parser is the only thing that can judge it, so this checks
+// nothing but presence.
+export function parseSizeCheck(body: unknown): Parsed<string> {
+  if (!isObject(body)) return { ok: false, message: 'body must be a JSON object' };
+  const size = optionalString(body['size'], 'size');
+  if (!size.ok) return size;
+  if (size.value === undefined) return { ok: false, message: 'size is required' };
+  return { ok: true, value: size.value };
+}
+
 export function parseProviderPrepare(body: unknown): Parsed<{
   force?: boolean;
   agentSettings?: Record<string, Record<string, string | boolean>>;

--- a/apps/hub/app/(dashboard)/api/v1/providers/[id]/size-check/route.ts
+++ b/apps/hub/app/(dashboard)/api/v1/providers/[id]/size-check/route.ts
@@ -1,0 +1,38 @@
+// POST /api/v1/providers/:id/size-check — would a box created at `size` actually
+// get that size?
+//
+// Most backends apply a size per create and answer `{ rebakeRequired: false }`.
+// Daytona and e2b fix CPU/memory when the base is baked and discard anything
+// else, so they answer true with the sentence to show the user. That is what
+// lets a create form re-bake only when the size really differs from the baked
+// one, instead of firing a 2-10 minute bake on every size change.
+//
+// Advisory, so it never fails the caller: an unresolvable provider or a backend
+// without the hook answers false rather than erroring.
+import { backendOrNull } from '../../../lib/backend';
+import { fail, ok } from '../../../lib/envelope';
+import { isProviderId, parseSizeCheck } from '../../../lib/validate';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const { id } = await ctx.params;
+  if (!isProviderId(id)) return fail('invalid_request', `unknown provider: ${id}`);
+  const backend = backendOrNull();
+  if (!backend) return fail('backend_unavailable', 'hub backend unavailable (run the hub server)');
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return fail('invalid_request', 'body must be valid JSON');
+  }
+  const parsed = parseSizeCheck(body);
+  if (!parsed.ok) return fail('invalid_request', parsed.message, parsed.details);
+
+  return ok(await backend.checkProviderSize(id, parsed.value));
+}

--- a/apps/hub/app/(dashboard)/boxes/components/create-box-modal.tsx
+++ b/apps/hub/app/(dashboard)/boxes/components/create-box-modal.tsx
@@ -509,6 +509,30 @@ function CreateBoxModal({
                     : 'The base image is out of date and will be rebuilt first (can take 5–10 minutes).'}
               </p>
             ) : null}
+            {/* Base branch picker: the box forks its per-box branch from this ref.
+                Hidden on the hosted path (no local repo → empty branch list). */}
+            {branches === null ? (
+              <Field label="Base branch">
+                <Select value="" disabled>
+                  <option value="">Loading branches…</option>
+                </Select>
+              </Field>
+            ) : branches.length > 0 ? (
+              <Field label="Base branch">
+                <Select value={fromBranch} onChange={(e) => setFromBranch(e.target.value)}>
+                  {/* Empty = the repo's current HEAD when it isn't a named ref. */}
+                  {selected?.currentBranch && !branches.includes(selected.currentBranch) ? (
+                    <option value="">{selected.currentBranch} (current)</option>
+                  ) : null}
+                  {branches.map((b) => (
+                    <option key={b} value={b}>
+                      {b}
+                      {b === selected?.currentBranch ? ' (current)' : ''}
+                    </option>
+                  ))}
+                </Select>
+              </Field>
+            ) : null}
             <Field label="Agent">
               <Select value={agent} onChange={(e) => setAgent(e.target.value as Agent)}>
                 {agents.map((a) => (
@@ -550,7 +574,8 @@ function CreateBoxModal({
                 SSH (<span className="text-secondary-foreground">agentbox shell</span>).
               </p>
             ) : null}
-            {/* Advanced: base branch + initial prompt, collapsed to keep the form lean. */}
+            {/* Advanced: size + initial prompt, collapsed to keep the form lean.
+                Same two rows as the tray's Advanced section — keep them in step. */}
             <div className="flex flex-col gap-4">
               <button
                 type="button"
@@ -564,30 +589,6 @@ function CreateBoxModal({
               </button>
               {showAdvanced ? (
                 <>
-                  {/* Base branch picker: the box forks its per-box branch from this ref.
-                      Hidden on the hosted path (no local repo → empty branch list). */}
-                  {branches === null ? (
-                    <Field label="Base branch">
-                      <Select value="" disabled>
-                        <option value="">Loading branches…</option>
-                      </Select>
-                    </Field>
-                  ) : branches.length > 0 ? (
-                    <Field label="Base branch">
-                      <Select value={fromBranch} onChange={(e) => setFromBranch(e.target.value)}>
-                        {/* Empty = the repo's current HEAD when it isn't a named ref. */}
-                        {selected?.currentBranch && !branches.includes(selected.currentBranch) ? (
-                          <option value="">{selected.currentBranch} (current)</option>
-                        ) : null}
-                        {branches.map((b) => (
-                          <option key={b} value={b}>
-                            {b}
-                            {b === selected?.currentBranch ? ' (current)' : ''}
-                          </option>
-                        ))}
-                      </Select>
-                    </Field>
-                  ) : null}
                   {/* Size. Entirely descriptor-driven: the choices, the grammar
                       hint, and whether a change needs a re-bake all come from
                       the provider, so a community plugin gets the same picker
@@ -623,15 +624,15 @@ function CreateBoxModal({
                         />
                       ) : null}
                       {sizeRebake?.required ? (
-                        <p className="font-mono text-xs text-amber-500">
-                          {sizeRebake.reason
-                            ? trimSizeReason(sizeRebake.reason, providerId)
-                            : 'This size is fixed when the base image is built.'}{' '}
-                          The base image is rebuilt at this size first
+                        // The provider's own sentence names the baked size, which is
+                        // detail rather than a decision — it rides the tooltip.
+                        <p className="font-mono text-xs text-amber-500" title={sizeRebake.reason}>
+                          {providerOption.label} fixes the size at bake time, so the base image is
+                          rebuilt first
                           {providerOption.bake?.approxMinutes
                             ? ` (about ${providerOption.bake.approxMinutes} min)`
                             : ''}
-                          , then the box is created.
+                          .
                         </p>
                       ) : null}
                     </div>
@@ -766,27 +767,6 @@ function JobStatusBadge({
       Working…
     </Badge>
   );
-}
-
-/**
- * `sizeIgnoredReason` is written for a TERMINAL: it names the mismatch, then
- * tells you to run `agentbox prepare --force`. In the create modal the second
- * half is wrong advice — the form is about to do exactly that — and the `id: `
- * prefix restates the provider you just picked. Keep the useful half (which
- * size is actually baked) and drop the rest.
- *
- * Both cuts are optional: an unrecognised sentence falls through unchanged, so
- * a community provider's wording is shown verbatim rather than mangled.
- */
-function trimSizeReason(reason: string, providerId: string): string {
-  // providerId can be a `docker:<alias>` spec or a plugin's own name, so escape
-  // it — an alias with a regex metacharacter would otherwise throw here and
-  // blank the note.
-  const id = providerId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return reason
-    .replace(new RegExp(`^${id}:\\s*`, 'i'), '')
-    .replace(/\s*[—-]\s*re-bake with[\s\S]*$/i, '.')
-    .trim();
 }
 
 function Field({ label, children }: { label: string; children: ReactNode }) {

--- a/apps/hub/app/(dashboard)/boxes/components/create-box-modal.tsx
+++ b/apps/hub/app/(dashboard)/boxes/components/create-box-modal.tsx
@@ -304,7 +304,10 @@ function CreateBoxModal({
       // Docker auto-bakes (its base self-heals — same rule as the CLI); a
       // stale CLOUD base gets the CLI wizard's rebuild-vs-use-existing choice.
       // An in-flight bake is never re-asked — the create just waits on it.
+      // Not asked when the SIZE is what forces the bake: "use existing image"
+      // would boot at the baked size and silently drop what was just picked.
       if (
+        !sizeRebake?.required &&
         providerId !== 'docker' &&
         providerFreshness?.baseStatus === 'stale' &&
         !providerFreshness.jobId

--- a/apps/hub/app/(dashboard)/boxes/components/create-box-modal.tsx
+++ b/apps/hub/app/(dashboard)/boxes/components/create-box-modal.tsx
@@ -26,6 +26,12 @@ import { JobLogStream, type JobLoginState } from './job-log-stream';
 
 type Agent = CreateBoxInput['agent'];
 
+// Select value that swaps the size dropdown for a free-text field. Only offered
+// when the provider declares a `sizeHint` — its absence means the list is closed
+// (vercel's parser throws on anything outside it), so a custom value there could
+// only ever produce a failed create.
+const CUSTOM_SIZE = '__custom__';
+
 // Docker is always available; used when the server sent no provider list (the
 // hosted/Postgres path, where host readiness isn't known).
 const DOCKER_ONLY: ProviderOption[] = [{ id: 'docker', label: 'Docker (local)', configured: true }];
@@ -105,6 +111,15 @@ function CreateBoxModal({
   const [branches, setBranches] = useState<string[] | null>(null);
   const [runSetup, setRunSetup] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
+  // VM size. '' = the provider's own default; CUSTOM_SIZE swaps in a free-text
+  // field. There is no cross-provider size grammar (hetzner takes `cx43`,
+  // vercel a vCPU count, daytona `cpu-mem-disk` GB), so the choices come
+  // entirely from the provider's descriptor and reset when it changes.
+  const [size, setSize] = useState('');
+  const [customSize, setCustomSize] = useState('');
+  // For a provider that fixes resources at bake time (daytona, e2b): whether
+  // THIS size would be discarded by a plain create. Null = not asked yet.
+  const [sizeRebake, setSizeRebake] = useState<{ required: boolean; reason?: string } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [jobId, setJobId] = useState<string | null>(null);
   const [jobStatus, setJobStatus] = useState<string>('streaming');
@@ -191,12 +206,58 @@ function CreateBoxModal({
   // points there rather than leaving the disabled options unexplained.
   const controlBoxUrl = providers.find((p) => p.origin === 'hub' && p.hubUrl)?.hubUrl;
   const providerFreshness = freshness?.[providerId];
+  const chosenSize = (size === CUSTOM_SIZE ? customSize : size).trim();
   // An in-flight bake job counts as "bake needed" too — the create must wait on it.
   const bakeNeeded =
     !!providerFreshness &&
     (!!providerFreshness.jobId ||
       providerFreshness.baseStatus === 'unprepared' ||
       providerFreshness.baseStatus === 'stale');
+
+  // A size is a literal value for ONE backend, so carrying `cx43` over to vercel
+  // would only fail at provision. Reset on every provider change.
+  useEffect(() => {
+    setSize('');
+    setCustomSize('');
+    setSizeRebake(null);
+  }, [providerId]);
+
+  // Daytona and e2b fix CPU/memory when the base is baked and discard anything
+  // else at create, so ask the hub whether THIS size needs a re-bake first.
+  // Debounced because a custom value is typed a character at a time.
+  useEffect(() => {
+    if (providerOption?.sizeAppliesAt !== 'bake' || chosenSize.length === 0) {
+      setSizeRebake(null);
+      return;
+    }
+    let cancelled = false;
+    const t = setTimeout(() => {
+      void (async () => {
+        try {
+          const res = await fetch(
+            `/api/v1/providers/${encodeURIComponent(providerId)}/size-check`,
+            {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              credentials: 'same-origin',
+              body: JSON.stringify({ size: chosenSize }),
+            },
+          );
+          if (!res.ok || cancelled) return;
+          const j = (await res.json()) as { rebakeRequired?: boolean; reason?: string };
+          if (cancelled) return;
+          setSizeRebake({ required: !!j.rebakeRequired, reason: j.reason });
+        } catch {
+          // Advisory only — a failed check must not block the create. Worst
+          // case the backend warns at provision, exactly as the CLI does.
+        }
+      })();
+    }, 400);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [providerId, chosenSize, providerOption?.sizeAppliesAt]);
 
   // Load the selected project's branches for the base-branch picker, and default
   // the base + setup-wizard toggle from the project. Re-runs when the project
@@ -232,6 +293,13 @@ function CreateBoxModal({
       setError('pick a project');
       return;
     }
+    // A size the base has to be re-baked at is the same two-phase flow as a
+    // missing base, minus the stale-base question (the user just asked for
+    // this, so there is nothing to confirm).
+    if (sizeRebake?.required && !bakeNeeded) {
+      startBake();
+      return;
+    }
     if (bakeNeeded) {
       // Docker auto-bakes (its base self-heals — same rule as the CLI); a
       // stale CLOUD base gets the CLI wizard's rebuild-vs-use-existing choice.
@@ -265,9 +333,17 @@ function CreateBoxModal({
           method: 'POST',
           headers: { 'content-type': 'application/json' },
           credentials: 'same-origin',
-          // No force: a fresh-again base becomes a fast no-op job; a stale
-          // fingerprint still triggers the rebuild.
-          body: JSON.stringify({}),
+          // No force by default: a fresh-again base becomes a fast no-op job; a
+          // stale fingerprint still triggers the rebuild.
+          //
+          // A SIZE change is the exception and needs force. It does not move the
+          // build-context fingerprint, so the base still reads as fresh and the
+          // bake would no-op — leaving the box at the old size with nothing to
+          // show for the wait.
+          body: JSON.stringify({
+            ...(chosenSize.length > 0 ? { size: chosenSize } : {}),
+            ...(sizeRebake?.required ? { force: true } : {}),
+          }),
         });
         const j = (await res.json().catch(() => null)) as {
           jobId?: string;
@@ -301,6 +377,11 @@ function CreateBoxModal({
             ? fromBranch.trim()
             : undefined,
         setupWizard: agent !== 'none' && runSetup,
+        // Only for providers that apply a size per create — daytona and e2b
+        // reject it there, and got theirs baked in above.
+        ...(chosenSize.length > 0 && providerOption?.sizeAppliesAt !== 'bake'
+          ? { opts: { size: chosenSize } }
+          : {}),
       });
       if (!res.ok) {
         setError(res.error);
@@ -504,6 +585,54 @@ function CreateBoxModal({
                       </Select>
                     </Field>
                   ) : null}
+                  {/* Size. Entirely descriptor-driven: the choices, the grammar
+                      hint, and whether a change needs a re-bake all come from
+                      the provider, so a community plugin gets the same picker
+                      by declaring `sizes`. Absent for docker, whose knobs are
+                      box.memory / box.cpus. */}
+                  {providerOption?.sizes?.length ? (
+                    <div className="flex flex-col gap-1.5">
+                      <Field label="Size">
+                        <Select
+                          value={size}
+                          onChange={(e) => {
+                            setSize(e.target.value);
+                            if (e.target.value !== CUSTOM_SIZE) setCustomSize('');
+                          }}
+                        >
+                          <option value="">Provider default</option>
+                          {providerOption.sizes.map((s) => (
+                            <option key={s.key} value={s.key}>
+                              {s.label}
+                            </option>
+                          ))}
+                          {providerOption.sizeHint ? (
+                            <option value={CUSTOM_SIZE}>Custom…</option>
+                          ) : null}
+                        </Select>
+                      </Field>
+                      {size === CUSTOM_SIZE ? (
+                        <Input
+                          value={customSize}
+                          onChange={(e) => setCustomSize(e.target.value)}
+                          placeholder={providerOption.sizeHint}
+                          autoFocus
+                        />
+                      ) : null}
+                      {sizeRebake?.required ? (
+                        <p className="font-mono text-xs text-amber-500">
+                          {sizeRebake.reason
+                            ? trimSizeReason(sizeRebake.reason, providerId)
+                            : 'This size is fixed when the base image is built.'}{' '}
+                          The base image is rebuilt at this size first
+                          {providerOption.bake?.approxMinutes
+                            ? ` (about ${providerOption.bake.approxMinutes} min)`
+                            : ''}
+                          , then the box is created.
+                        </p>
+                      ) : null}
+                    </div>
+                  ) : null}
                   {agent !== 'none' ? (
                     <Field label="Initial prompt (optional)">
                       <Textarea
@@ -634,6 +763,27 @@ function JobStatusBadge({
       Working…
     </Badge>
   );
+}
+
+/**
+ * `sizeIgnoredReason` is written for a TERMINAL: it names the mismatch, then
+ * tells you to run `agentbox prepare --force`. In the create modal the second
+ * half is wrong advice — the form is about to do exactly that — and the `id: `
+ * prefix restates the provider you just picked. Keep the useful half (which
+ * size is actually baked) and drop the rest.
+ *
+ * Both cuts are optional: an unrecognised sentence falls through unchanged, so
+ * a community provider's wording is shown verbatim rather than mangled.
+ */
+function trimSizeReason(reason: string, providerId: string): string {
+  // providerId can be a `docker:<alias>` spec or a plugin's own name, so escape
+  // it — an alias with a regex metacharacter would otherwise throw here and
+  // blank the note.
+  const id = providerId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return reason
+    .replace(new RegExp(`^${id}:\\s*`, 'i'), '')
+    .replace(/\s*[—-]\s*re-bake with[\s\S]*$/i, '.')
+    .trim();
 }
 
 function Field({ label, children }: { label: string; children: ReactNode }) {

--- a/apps/hub/lib/boxes/backend-types.ts
+++ b/apps/hub/lib/boxes/backend-types.ts
@@ -1,4 +1,4 @@
-import type { HubState, ProviderOption } from './types';
+import type { HubState, ProviderOption, ProviderSizeCheck } from './types';
 import type { AgentId } from '@agentbox/core';
 
 // Result of a lifecycle server action.
@@ -426,6 +426,13 @@ export interface HubBackend {
   // to ~/.agentbox/secrets.env). `fields` is provider-specific (e.g. { apiKey },
   // { token }, { token, teamId?, projectId? }). Never returns secret values.
   setProviderCredentials(id: string, fields: Record<string, string>): Promise<ActionResult>;
+  // Would creating a box at `size` on this provider actually get that size?
+  // Most backends honour a size per create and answer `false`. Daytona and e2b
+  // fix resources when the base is baked and discard anything else, so they
+  // answer `true` with the sentence to show the user — which is what lets a
+  // create form re-bake only when it has to, instead of on every size change.
+  // A provider with no `sizeIgnoredReason` hook answers `false`.
+  checkProviderSize(id: string, size: string): Promise<ProviderSizeCheck>;
   // Enqueue a background image-bake (prepare) job for a provider; returns the
   // jobId (progress streams over the per-job log SSE, like create). Reuses an
   // in-flight bake for the same provider if one exists.

--- a/apps/hub/lib/boxes/types.ts
+++ b/apps/hub/lib/boxes/types.ts
@@ -163,6 +163,17 @@ export interface Approval {
 // A provider the box could be created on. `configured` = usable on this host
 // (docker always; a cloud provider needs its base baked — see hub-backend). The
 // modal disables unconfigured options and shows `reason`.
+/** Answer to `POST /api/v1/providers/{id}/size-check`. */
+export interface ProviderSizeCheck {
+  /**
+   * The size will NOT take effect on a plain create — the base has to be
+   * re-baked at it first (`prepare` with `{ size, force: true }`).
+   */
+  rebakeRequired: boolean;
+  /** Why, in the provider's own words. Present only when `rebakeRequired`. */
+  reason?: string;
+}
+
 export interface ProviderOption {
   id: string;
   label: string;
@@ -209,6 +220,17 @@ export interface ProviderOption {
     timeoutModel?: 'absolute' | 'inactivity';
   };
   sizes?: readonly { key: string; label: string }[];
+  /**
+   * Placeholder for a free-text size. Its PRESENCE is what says `sizes` is an
+   * open list — render a custom-value field only when there is a hint for it.
+   */
+  sizeHint?: string;
+  /**
+   * 'bake' = the size is fixed when the base is baked and rejected per-create,
+   * so a change has to go through `POST /providers/{id}/prepare` with
+   * `{ size, force: true }` first. Absent/'create' = it rides the create.
+   */
+  sizeAppliesAt?: 'create' | 'bake';
   regions?: readonly { key: string; label: string }[];
   // Whether the provider has credentials on this host (docker: always true). A
   // cloud provider can have credentials but not yet be `configured` (baked).

--- a/apps/hub/lib/hub-backend.ts
+++ b/apps/hub/lib/hub-backend.ts
@@ -165,6 +165,7 @@ import type {
   HubState,
   Project,
   ProviderOption,
+  ProviderSizeCheck,
   User,
 } from './boxes/types';
 
@@ -838,6 +839,8 @@ function listProviders(jobs: QueueJob[]): ProviderOption[] {
       bake: d.bake,
       capabilities: d.capabilities,
       ...(d.sizes ? { sizes: d.sizes } : {}),
+      ...(d.sizeHint ? { sizeHint: d.sizeHint } : {}),
+      ...(d.sizeAppliesAt ? { sizeAppliesAt: d.sizeAppliesAt } : {}),
       ...(d.regions ? { regions: d.regions } : {}),
     };
   });
@@ -2356,6 +2359,22 @@ export function createHubBackend(handle: RelayServerHandle): HubBackend {
         return res.ok ? { ok: true } : { ok: false, error: res.error ?? 'invalid credentials' };
       } catch (err) {
         return { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    },
+    async checkProviderSize(id, size): Promise<ProviderSizeCheck> {
+      const spec = size.trim();
+      if (spec.length === 0) return { rebakeRequired: false };
+      // Advisory, never fatal: an unknown provider, a plugin that fails to
+      // import, or a backend without the hook all mean "nothing to say", and a
+      // create form must not be blocked by a question it only asked to be
+      // helpful. Mirrors `apps/cli/src/lib/size-advisory.ts`.
+      try {
+        if (!isRuntimeProviderName(id)) return { rebakeRequired: false };
+        const mod = await loadProviderModuleByName(id);
+        const reason = mod.sizeIgnoredReason?.(spec) ?? null;
+        return reason ? { rebakeRequired: true, reason } : { rebakeRequired: false };
+      } catch {
+        return { rebakeRequired: false };
       }
     },
     prepareProvider(id, opts): Promise<CreateBoxResult> {

--- a/apps/web/content/docs/build-a-provider.mdx
+++ b/apps/web/content/docs/build-a-provider.mdx
@@ -115,6 +115,13 @@ const descriptor: ProviderDescriptor = {
     pauseSemantics: 'freeze',
     hubRoutable: true,
   },
+  // The size picker in the create forms. Optional — omit and no picker appears.
+  sizes: [
+    { key: '2', label: '2 vCPU / 4 GB' },
+    { key: '4', label: '4 vCPU / 8 GB' },
+  ],
+  sizeHint: 'vCPU count, e.g. 8', // omit for a CLOSED set (no custom field)
+  sizeAppliesAt: 'create', // 'bake' if you reject per-create resources
   blurb: 'MyProvider microVMs',
   sizeDesc: 'Per-provider override of `box.size` for myprovider.',
   imageDesc: 'Per-provider override of `box.image` for myprovider.',
@@ -126,6 +133,24 @@ export const providerModule: ProviderModule = { provider, backend, descriptor /*
 `agentbox plugin add` snapshots this, so the CLI, hub and tray all read it without importing your package.
 
 **Declare what code can't reveal.** AgentBox doesn't infer capabilities from your `Provider` object: `createCloudProvider` gives _every_ cloud provider a `checkpoint`, `setInbound` and `enableDirectGit`, so their presence says which scaffold you used, not what you support. Three values are cross-checked against your `CloudBackend` (which you wrote, so it means something) — `prune` must equal `!!backend.list`, `inbound` must equal `!!backend.setInbound`, and `timeoutModel` must equal `backend.timeoutModel`.
+
+### Sizes
+
+There's no cross-provider size grammar. `--size` is an opaque string you parse however you like — hetzner reads a server-type slug (`cx43`), vercel a vCPU count (`4`), daytona `cpu-memory-disk` in GB (`4-8-10`). So the size picker in the web hub's create modal and the tray's create panel is built entirely from what you declare:
+
+- **`sizes`** — the offered choices, most-modest first. Each `key` is a literal `--size` value for _your_ backend; the `label` says what it buys. Omit it and no picker appears (`--size` still reaches you from the CLI).
+- **`sizeHint`** — placeholder for the free-text field. **Its presence is what opens the list**: a UI offers a custom value only when there's a hint to put in the box. Omit it when your parser rejects anything outside `sizes` — that's what vercel does.
+- **`sizeAppliesAt`** — `'create'` (the default) or `'bake'`.
+
+Use `sizeAppliesAt: 'bake'` when your backend fixes CPU/memory as the base image is built and **rejects resources on the create call** — daytona's snapshot path and e2b's templates both work this way. Declaring it makes the UI rebuild the base at the chosen size instead of silently handing you a value you'll discard. Pair it with `sizeIgnoredReason(size)`, which returns a sentence when `size` disagrees with what's baked and `null` when it doesn't — that's what stops the UI firing a bake it didn't need:
+
+```ts
+sizeIgnoredReason(size) {
+  const baked = readPreparedState()?.base?.size;
+  if (!baked || baked === size) return null;
+  return `myprovider fixes resources at bake time: this box will run at ${baked}, not ${size}.`;
+}
+```
 
 Three capabilities are easy to get wrong:
 

--- a/apps/web/content/docs/hub.mdx
+++ b/apps/web/content/docs/hub.mdx
@@ -67,7 +67,8 @@ a cookie (30 days) and strips it from the address, so from then on a plain
   offers docker plus any cloud provider set up on this host — providers you haven't
   configured yet show up disabled (set them up under **Settings → Sandbox
   providers**, below). Pick a **Base branch** to fork the box from a ref other than
-  the project's current HEAD (like `--from-branch`), and a **Size** to give the box
+  the project's current HEAD (like `--from-branch`). Under **Advanced**, pick a
+  **Size** to give the box
   more CPU and RAM than the provider's default — the choices come from the provider
   itself (`cx43` on Hetzner, `4` vCPU on Vercel, `4-8-10` on Daytona; there is no
   common grammar), with a **Custom…** option where the backend accepts free-form

--- a/apps/web/content/docs/hub.mdx
+++ b/apps/web/content/docs/hub.mdx
@@ -67,7 +67,13 @@ a cookie (30 days) and strips it from the address, so from then on a plain
   offers docker plus any cloud provider set up on this host — providers you haven't
   configured yet show up disabled (set them up under **Settings → Sandbox
   providers**, below). Pick a **Base branch** to fork the box from a ref other than
-  the project's current HEAD (like `--from-branch`). When a project has no
+  the project's current HEAD (like `--from-branch`), and a **Size** to give the box
+  more CPU and RAM than the provider's default — the choices come from the provider
+  itself (`cx43` on Hetzner, `4` vCPU on Vercel, `4-8-10` on Daytona; there is no
+  common grammar), with a **Custom…** option where the backend accepts free-form
+  values. Docker has no Size row: it sizes with `box.memory` / `box.cpus`. On Daytona
+  and E2B the size is fixed when the base image is baked, so choosing a different one
+  rebuilds the base first — the form says so before you commit. When a project has no
   `agentbox.yaml` and no default snapshot, a **Run setup wizard** toggle (on by
   default) seeds the agent's first turn to explore the repo and propose an
   `agentbox.yaml`.

--- a/docs/box-size-picker-plan.md
+++ b/docs/box-size-picker-plan.md
@@ -1,0 +1,137 @@
+# Pick a box size at create time — plan
+
+Status: **phase 1 done**. Phases 2-4 open.
+
+## Why
+
+A box's VM size is reachable only from the CLI (`--size`, or the `box.size<P>`
+config key), and the legal values live only as prose inside each provider's
+`sizeDesc`. There is no way to start a bigger box from the web hub or the tray —
+the concrete blocker being a desktop box with enough RAM for something like
+Godot (8 GB+), which no default provides.
+
+`--size` has **no common grammar**; each backend parses it natively:
+
+| provider | grammar | 8 GB | applies at |
+|---|---|---|---|
+| docker | *ignored* (`box.memory` / `box.cpus`) | — | — |
+| hetzner | server-type slug | `cx33` (4·8), `cx43` (8·16) | create |
+| digitalocean | droplet slug | `s-4vcpu-8gb` | create |
+| vercel | vCPU count, RAM coupled 2 GB/vCPU | `4` | create |
+| remote-docker | `cpu-mem` GB | `4-8` | create |
+| daytona | `cpu-mem-disk` GB | `4-8-10` | **bake** |
+| e2b | `cpu-mem` GB | `4-8` | **bake** |
+
+That variation is what a UI needs told declaratively, and `ProviderDescriptor`
+already had the field for it (`sizes`), served all the way to both clients by
+`listProviders` -> `GET /api/v1/providers` -> `ProviderOption`, and populated by
+nobody. The rail existed end to end and was empty.
+
+## Out of scope, deliberately
+
+To be done later as one piece: the generic per-provider config namespace
+(`box.*` -> provider-specific blocks, the way agents got `claude.install`), a
+settings-page control that persists a default size, and the other per-provider
+knobs (regions, timeouts, network policy, daytona's sandbox class). Nothing here
+blocks that or has to be undone by it — this adds descriptor data and two create
+forms, and touches no config key.
+
+## Design
+
+### Descriptor
+
+`packages/config/src/providers.ts`. `sizes` gains labels with real numbers, plus
+two siblings:
+
+- `sizeHint` — grammar hint for a free-text size. **Its presence is what says
+  the list is OPEN**: a UI offers a custom-value escape only when there is a
+  hint to place in it. One field doing two jobs, so there is no separate boolean
+  to keep in sync. Vercel omits it because `parseVercelVcpus` throws on anything
+  outside `sizes`.
+- `sizeAppliesAt: 'create' | 'bake'` — `'bake'` means the size is fixed when the
+  base is baked and rejected per-create (daytona's snapshot path, e2b
+  templates), so a different size needs `prepare --force --size` first.
+  `ProviderModule.sizeIgnoredReason` answers whether a *given* size actually
+  needs that re-bake.
+
+Docker declares none: its knobs are `box.memory` / `box.cpus` / `box.disk`, and
+an inert dropdown is worse than no dropdown.
+
+Plugins get all of this for free — `ProviderDescriptor` is already re-exported
+by the SDK and `agentbox plugin add` already snapshots the whole descriptor into
+`~/.agentbox/plugins.json`. Additive to an optional field, so `SDK_API_VERSION`
+stays **4**.
+
+### Hub API
+
+`sizes` already flows through `listProviders` untouched; `sizeHint` and
+`sizeAppliesAt` join the same pass-through and `ProviderOption`.
+
+One new route, `POST /api/v1/providers/:id/size-check`, body `{ size }` ->
+`{ rebakeRequired, reason? }`, calling the existing `sizeIgnoredReason` hook.
+This is what stops the UI firing a pointless 2-10 minute bake when the requested
+size is already the baked one, and it returns the exact sentence the CLI prints.
+
+Nothing else is needed: `opts.size` on `POST /api/v1/boxes` and `size` on
+`POST /api/v1/providers/:id/prepare` already exist and are already honored.
+
+### Clients
+
+Web (`create-box-modal.tsx`): a Size field in the existing `showAdvanced`
+disclosure — a select over `sizes` plus a `Custom…` option gated on `sizeHint`,
+hidden when the provider declares no `sizes`. On a `bake`-scoped provider a
+changed size runs `size-check` and, if required, routes through the existing
+two-phase bake-then-create with `{ size, force: true }`. **`force` is
+load-bearing**: a size change does not move the build-context fingerprint, so
+without it the bake is a fast no-op and the size never lands.
+
+Tray (`CreateBoxPanel.swift`): a Size `NSPopUpButton` under the provider popup,
+same rules, driven entirely by `option.sizes` — no switch on provider id.
+
+## Phases
+
+| # | Phase | Status |
+|---|---|---|
+| 1 | Descriptor fields + built-in size tables + SDK bump/docs + drift test | done |
+| 2 | Hub API: field pass-through, `POST /providers/:id/size-check`, openapi | open |
+| 3 | Web create modal: Size field, custom entry, bake-scoped re-bake | open |
+| 4 | Tray create panel + client methods; public docs + CHANGELOG | open |
+
+### Phase 1 — what landed
+
+- `ProviderDescriptor.sizeHint` / `.sizeAppliesAt`; `sizes` populated for the
+  six non-docker built-ins (values read off each backend's own parser/default,
+  not invented).
+- `parseDaytonaSize` / `parseE2bSize` / `parseVercelVcpus` exported from their
+  package barrels, purely so the declared keys can be asserted against the
+  parsers that must accept them.
+- `apps/cli/test/provider-sizes.test.ts` — the guard. Notably it pins
+  `sizeAppliesAt: 'bake'` to exactly the providers implementing
+  `sizeIgnoredReason`: the two are the same fact, and a provider growing one
+  without the other gives a UI either a dead control or a needless bake.
+- SDK 4.0.0 -> 4.1.0 (**needs a republish**), `docs/provider-plugins.md` ->
+  "Declaring sizes", and the example provider declares a picker as the E2E
+  fixture.
+
+## Verification
+
+1. `pnpm test` + `pnpm typecheck` (tsup does not typecheck; CI runs tsc).
+2. Hub is a persistent daemon serving the standalone bundle — rebuild and
+   restart or you test stale code:
+   ```
+   pnpm --filter @agentbox/hub build:standalone
+   AGENTBOX_HUB_BIN="$PWD/apps/hub/dist-standalone/apps/hub/server.js" node apps/cli/dist/index.js hub restart
+   curl -s -H "Authorization: Bearer $(cat ~/.agentbox/hub/token)" \
+     'http://127.0.0.1:8787/api/v1/providers' | jq '.data.providers[] | {id, sizes, sizeHint, sizeAppliesAt}'
+   ```
+3. A real box is the only proof the size is honored. Background it and watch the
+   log rather than blocking:
+   `node apps/cli/dist/index.js create -y -n size-smoke --provider hetzner &`
+   then `tail -f ~/.agentbox/logs/create.log` until `box … ready`, and confirm
+   with `curl -H "Authorization: Bearer $HCLOUD_TOKEN" https://api.hetzner.cloud/v1/servers | jq '.servers[].server_type.name'`.
+4. Bake-scoped path: pick a daytona size different from the baked one and
+   confirm the prepare job carries `force: true` — without it the bake no-ops
+   and the size silently does not land.
+5. Plugin: declare `sizes` in `examples/agentbox-provider-example`, `npm pack`
+   -> install -> `agentbox plugin add`, confirm the snapshot carries them; then
+   a plugin with **no** `sizes` must be unchanged.

--- a/docs/box-size-picker-plan.md
+++ b/docs/box-size-picker-plan.md
@@ -1,6 +1,6 @@
 # Pick a box size at create time — plan
 
-Status: **phase 1 done**. Phases 2-4 open.
+Status: **done** (all four phases). Kept as the record of WHY the shape is this one.
 
 ## Why
 

--- a/docs/provider-plugins.md
+++ b/docs/provider-plugins.md
@@ -121,6 +121,13 @@ const descriptor: ProviderDescriptor = {
     pauseSemantics: 'freeze',
     hubRoutable: true,
   },
+  // The size picker in the create forms. Optional — omit and no picker appears.
+  sizes: [
+    { key: '2', label: '2 vCPU / 4 GB' },
+    { key: '4', label: '4 vCPU / 8 GB' },
+  ],
+  sizeHint: 'vCPU count, e.g. 8',      // omit for a CLOSED set (no custom field)
+  sizeAppliesAt: 'create',             // 'bake' if you reject per-create resources
   blurb: 'MyProvider microVMs',
   sizeDesc: 'Per-provider override of `box.size` for myprovider (vCPU count).',
   imageDesc: 'Per-provider override of `box.image` for myprovider (snapshot id).',
@@ -149,6 +156,37 @@ which therefore means something — declare them to match or a test will disagre
 | `capabilities.prune` | `!!backend.list` |
 | `capabilities.inbound` | `!!backend.setInbound` |
 | `capabilities.timeoutModel` | `backend.timeoutModel` |
+
+### Declaring sizes
+
+There is **no cross-provider size grammar**. `--size` is an opaque string your
+backend parses however it likes — hetzner reads a server-type slug (`cx43`),
+vercel a vCPU count (`4`), daytona `cpu-memory-disk` in GB (`4-8-10`). So the
+picker in the web hub's create modal and the tray's create panel is built
+entirely from what you declare:
+
+| Field | Meaning |
+|---|---|
+| `sizes` | The offered choices, most-modest first. Each `key` is a literal `--size` value for *your* backend; the `label` says what it buys ("4 vCPU / 8 GB"). Absent = no picker, and `--size` still reaches you from the CLI. |
+| `sizeHint` | Placeholder for the free-text field, e.g. `cpu-memory in GB, e.g. 4-8`. **Its presence is what opens the list**: a UI offers a custom value only when there is a hint to put in the box. Omit it when your parser rejects anything outside `sizes` — vercel does exactly that. |
+| `sizeAppliesAt` | `'create'` (the default) or `'bake'`. |
+
+`sizeAppliesAt: 'bake'` is for a backend that fixes CPU/memory when the base
+image is built and **rejects resources on the create call** — daytona on its
+snapshot path and e2b's templates both work this way. Declaring it makes the UI
+route a size change through `prepare --force --size <spec>` instead of silently
+handing you a value you will discard. Pair it with
+`ProviderModule.sizeIgnoredReason(size)`, which returns a human sentence when
+`size` disagrees with what is baked and `null` when it does not — that is what
+stops the UI firing a ten-minute bake it did not need.
+
+```ts
+sizeIgnoredReason(size) {
+  const baked = readPreparedState()?.base?.size;
+  if (!baked || baked === size) return null;
+  return `myprovider fixes resources at bake time: this box will run at ${baked}, not ${size}. Re-bake with: agentbox prepare --provider myprovider --force --size ${size}`;
+}
+```
 
 ## Choosing capability values
 

--- a/examples/agentbox-provider-example/src/index.ts
+++ b/examples/agentbox-provider-example/src/index.ts
@@ -164,6 +164,14 @@ export const exampleDescriptor: ProviderDescriptor = {
     pauseSemantics: 'freeze',
     hubRoutable: true,
   },
+  // The create-form size picker. `key` is a literal `--size` value this backend
+  // parses; the hint's presence is what opens the list to a custom value.
+  sizes: [
+    { key: '2', label: '2 vCPU / 4 GB' },
+    { key: '4', label: '4 vCPU / 8 GB' },
+    { key: '8', label: '8 vCPU / 16 GB' },
+  ],
+  sizeHint: 'vCPU count, e.g. 8',
   blurb: 'the example community provider',
   sizeDesc: 'Per-provider override of `box.size` for example (vCPU count).',
   imageDesc: 'Per-provider override of `box.image` for example (snapshot id).',

--- a/packages/config/src/providers.ts
+++ b/packages/config/src/providers.ts
@@ -237,12 +237,13 @@ export const PROVIDERS = [
       hubRoutable: true,
       timeoutModel: 'inactivity',
     },
-    // `cpu-memory-disk` GB (parseDaytonaSize). Disk is capped at 10 GB per
-    // sandbox on the free plan, so no preset asks for more.
+    // `cpu-memory-disk` GB (parseDaytonaSize). First entry is
+    // DAYTONA_DEFAULT_RESOURCES. Disk is capped at 10 GB per sandbox on the
+    // free plan, so no preset asks for more.
     sizes: [
-      { key: '1-1-3', label: '1 vCPU / 1 GB / 3 GB disk' },
-      { key: '2-4-10', label: '2 vCPU / 4 GB / 10 GB disk' },
+      { key: '2-4-8', label: '2 vCPU / 4 GB / 8 GB disk (default)' },
       { key: '4-8-10', label: '4 vCPU / 8 GB / 10 GB disk' },
+      { key: '8-16-10', label: '8 vCPU / 16 GB / 10 GB disk' },
     ],
     sizeHint: 'cpu-memory-disk in GB, e.g. 4-8-10',
     sizeAppliesAt: 'bake',
@@ -287,7 +288,7 @@ export const PROVIDERS = [
     // Server-type slugs. The Arm `cax*` line is deliberately absent: the base
     // snapshot is amd64, so booting one would fail at create.
     sizes: [
-      { key: 'cx23', label: 'cx23 - 2 vCPU / 4 GB' },
+      { key: 'cx23', label: 'cx23 - 2 vCPU / 4 GB (default)' },
       { key: 'cx33', label: 'cx33 - 4 vCPU / 8 GB' },
       { key: 'cx43', label: 'cx43 - 8 vCPU / 16 GB' },
     ],
@@ -340,7 +341,7 @@ export const PROVIDERS = [
     // therefore no custom-value escape).
     sizes: [
       { key: '1', label: '1 vCPU / 2 GB' },
-      { key: '2', label: '2 vCPU / 4 GB' },
+      { key: '2', label: '2 vCPU / 4 GB (default)' },
       { key: '4', label: '4 vCPU / 8 GB' },
       { key: '8', label: '8 vCPU / 16 GB' },
     ],
@@ -381,7 +382,7 @@ export const PROVIDERS = [
     // `cpu-memory` GB. Template-level: E2B rejects per-create resources, so a
     // different size means rebuilding the template.
     sizes: [
-      { key: '2-4', label: '2 vCPU / 4 GB' },
+      { key: '2-4', label: '2 vCPU / 4 GB (default)' },
       { key: '4-8', label: '4 vCPU / 8 GB' },
       { key: '8-16', label: '8 vCPU / 16 GB' },
     ],
@@ -440,7 +441,7 @@ export const PROVIDERS = [
       hubRoutable: true,
     },
     sizes: [
-      { key: 's-2vcpu-4gb', label: '2 vCPU / 4 GB' },
+      { key: 's-2vcpu-4gb', label: '2 vCPU / 4 GB (default)' },
       { key: 's-4vcpu-8gb', label: '4 vCPU / 8 GB' },
       { key: 's-8vcpu-16gb', label: '8 vCPU / 16 GB' },
     ],

--- a/packages/config/src/providers.ts
+++ b/packages/config/src/providers.ts
@@ -132,8 +132,29 @@ export interface ProviderDescriptor {
     readonly bakeProgressSteps?: number;
   };
   readonly capabilities: ProviderCapabilities;
-  /** Known VM sizes. Absent = free-form string the backend interprets. */
+  /**
+   * Sizes offered as a picker, most-modest first. Each `key` is a literal
+   * `--size` value for THIS backend (there is no cross-provider grammar); the
+   * label spells out what it buys ("4 vCPU / 8 GB"). Absent = the provider has
+   * no size knob at all (docker, whose knobs are `box.memory` / `box.cpus`).
+   */
   readonly sizes?: readonly { readonly key: string; readonly label: string }[];
+  /**
+   * Grammar hint for a free-text size, e.g. `cpu-mem-disk GB, e.g. 4-8-10`.
+   * Presence is also what says the list is OPEN: a UI offers a custom-value
+   * escape only when there is a hint to place in it. Vercel omits it because
+   * `parseVercelVcpus` throws on anything outside `sizes`.
+   */
+  readonly sizeHint?: string;
+  /**
+   * When a size takes effect. 'create' (the default when absent) = the next
+   * box. 'bake' = fixed when the base is baked and rejected per-create
+   * (daytona's snapshot path, e2b templates), so a different size needs
+   * `prepare --force --size` first — a UI must say so rather than offer a
+   * control that silently does nothing. `ProviderModule.sizeIgnoredReason`
+   * answers whether a given size actually needs that re-bake.
+   */
+  readonly sizeAppliesAt?: 'create' | 'bake';
   /** Known regions/datacenters. Absent = the provider has no region choice. */
   readonly regions?: readonly { readonly key: string; readonly label: string }[];
   /** Fragment describing this backend, joined into the `box.provider` enum description. */
@@ -216,6 +237,15 @@ export const PROVIDERS = [
       hubRoutable: true,
       timeoutModel: 'inactivity',
     },
+    // `cpu-memory-disk` GB (parseDaytonaSize). Disk is capped at 10 GB per
+    // sandbox on the free plan, so no preset asks for more.
+    sizes: [
+      { key: '1-1-3', label: '1 vCPU / 1 GB / 3 GB disk' },
+      { key: '2-4-10', label: '2 vCPU / 4 GB / 10 GB disk' },
+      { key: '4-8-10', label: '4 vCPU / 8 GB / 10 GB disk' },
+    ],
+    sizeHint: 'cpu-memory-disk in GB, e.g. 4-8-10',
+    sizeAppliesAt: 'bake',
     blurb: 'Daytona Cloud sandboxes',
     sizeDesc:
       'Per-provider override of `box.size` for daytona. `cpu-memory-disk` GB spec (e.g. `4-8-20`). Only honored on the image/Dockerfile create path; on the snapshot path the size is fixed at bake time (Daytona rejects custom resources on snapshot-resume).',
@@ -254,6 +284,14 @@ export const PROVIDERS = [
       pauseSemantics: 'stop',
       hubRoutable: true,
     },
+    // Server-type slugs. The Arm `cax*` line is deliberately absent: the base
+    // snapshot is amd64, so booting one would fail at create.
+    sizes: [
+      { key: 'cx23', label: 'cx23 - 2 vCPU / 4 GB' },
+      { key: 'cx33', label: 'cx33 - 4 vCPU / 8 GB' },
+      { key: 'cx43', label: 'cx43 - 8 vCPU / 16 GB' },
+    ],
+    sizeHint: 'any Hetzner server type, e.g. cpx41',
     blurb: 'Hetzner Cloud VPSes',
     sizeDesc:
       'Per-provider override of `box.size` for hetzner. Server type string (e.g. `cx23`, `cx33`, `cx43`).',
@@ -297,6 +335,15 @@ export const PROVIDERS = [
       pauseSemantics: 'freeze',
       hubRoutable: true,
     },
+    // vCPU count; Vercel couples RAM at 2048 MB/vCPU. A CLOSED set -
+    // `parseVercelVcpus` throws on anything else, so no `sizeHint` (and
+    // therefore no custom-value escape).
+    sizes: [
+      { key: '1', label: '1 vCPU / 2 GB' },
+      { key: '2', label: '2 vCPU / 4 GB' },
+      { key: '4', label: '4 vCPU / 8 GB' },
+      { key: '8', label: '8 vCPU / 16 GB' },
+    ],
     blurb: 'Vercel Sandboxes',
     sizeDesc:
       'Per-provider override of `box.size` for vercel. vCPU count — one of `1`, `2`, `4`, `8` (Vercel couples RAM at 2048 MB/vCPU). Default 2.',
@@ -331,6 +378,15 @@ export const PROVIDERS = [
       hubRoutable: true,
       timeoutModel: 'inactivity',
     },
+    // `cpu-memory` GB. Template-level: E2B rejects per-create resources, so a
+    // different size means rebuilding the template.
+    sizes: [
+      { key: '2-4', label: '2 vCPU / 4 GB' },
+      { key: '4-8', label: '4 vCPU / 8 GB' },
+      { key: '8-16', label: '8 vCPU / 16 GB' },
+    ],
+    sizeHint: 'cpu-memory in GB, e.g. 4-8',
+    sizeAppliesAt: 'bake',
     blurb: 'E2B microVMs',
     sizeDesc:
       'Per-provider override of `box.size` for e2b. `cpu-memory` GB spec (e.g. `4-8`). Template-level: baked by `agentbox prepare --provider e2b --size <spec>`; E2B rejects per-create resources.',
@@ -383,6 +439,12 @@ export const PROVIDERS = [
       pauseSemantics: 'stop',
       hubRoutable: true,
     },
+    sizes: [
+      { key: 's-2vcpu-4gb', label: '2 vCPU / 4 GB' },
+      { key: 's-4vcpu-8gb', label: '4 vCPU / 8 GB' },
+      { key: 's-8vcpu-16gb', label: '8 vCPU / 16 GB' },
+    ],
+    sizeHint: 'any DigitalOcean size slug, e.g. c-4',
     blurb: 'DigitalOcean Droplets',
     sizeDesc:
       'Per-provider override of `box.size` for digitalocean. Droplet size slug (e.g. `s-2vcpu-4gb`, `s-4vcpu-8gb`).',
@@ -417,6 +479,15 @@ export const PROVIDERS = [
       // Docker on YOUR OWN machine — a control box can't reach it.
       hubRoutable: false,
     },
+    // `cpu-memory` GB, mapped to the container's `--cpus` / `--memory`. The
+    // empty key is a real choice: no limits, the remote engine's defaults.
+    sizes: [
+      { key: '', label: 'Unlimited (engine default)' },
+      { key: '2-4', label: '2 CPU / 4 GB' },
+      { key: '4-8', label: '4 CPU / 8 GB' },
+      { key: '8-16', label: '8 CPU / 16 GB' },
+    ],
+    sizeHint: 'cpu-memory in GB, e.g. 4-8',
     blurb: 'Docker on a remote machine over SSH',
     sizeDesc:
       "Per-provider override of `box.size` for remote-docker. `cpu-memory` GB spec (e.g. `4-8`) mapped to the container's `--cpus` / `--memory`. Empty = unlimited (the remote engine's defaults).",

--- a/packages/provider-sdk/package.json
+++ b/packages/provider-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madarco/agentbox-provider-sdk",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Public SDK for building AgentBox sandbox providers as installable community packages",
   "license": "MIT",
   "author": "Marco D'Alia",

--- a/packages/provider-sdk/src/index.ts
+++ b/packages/provider-sdk/src/index.ts
@@ -85,6 +85,20 @@ export {
 // OPTIONAL: omit it and you get a descriptor derived from your module plus
 // defaults that reproduce pre-descriptor behavior — nothing breaks, you just
 // show up as your bare provider name.
+//
+// `sizes` / `sizeHint` / `sizeAppliesAt` drive the size picker in the create
+// forms (web hub and macOS tray). There is no cross-provider size grammar, so
+// each `sizes[].key` is a literal `--size` value YOUR backend parses:
+//   sizes: [{ key: 'small', label: '2 vCPU / 4 GB' }, ...]
+//   sizeHint: 'cpu-memory in GB, e.g. 4-8'   // omit for a CLOSED set: the
+//                                            // hint is what gates the
+//                                            // custom-value field
+//   sizeAppliesAt: 'bake'   // your backend rejects per-create resources, so a
+//                           // different size means re-baking the base first.
+//                           // Pair it with `ProviderModule.sizeIgnoredReason`,
+//                           // which decides whether a given size really needs
+//                           // that bake.
+// Declare nothing and no picker appears — the CLI's `--size` still reaches you.
 export {
   type ProviderDescriptor,
   type ProviderCapabilities,

--- a/packages/sandbox-daytona/src/index.ts
+++ b/packages/sandbox-daytona/src/index.ts
@@ -41,6 +41,9 @@ export const providerModule: ProviderModule = {
 };
 
 export { DAYTONA_DEFAULT_RESOURCES, daytonaBackend, DEFAULT_BOX_IMAGE_REF };
+// Exported so the descriptor's declared `sizes` can be asserted against the
+// parser that actually accepts them (apps/cli/test/provider-sizes.test.ts).
+export { parseDaytonaSize } from './backend.js';
 export { resolveDockerfileContext, type DockerfileContext } from './dockerfile-context.js';
 export { ensureDaytonaEnvLoaded } from './env-loader.js';
 export { currentDaytonaBaseFingerprintLive } from './prepared-state.js';

--- a/packages/sandbox-digitalocean/src/backend.ts
+++ b/packages/sandbox-digitalocean/src/backend.ts
@@ -86,7 +86,7 @@ const ACTION_DEADLINE_MS = 5 * 60_000;
 const SNAPSHOT_DEADLINE_MS = 30 * 60_000;
 // s-2vcpu-4gb: 2 vCPU / 4 GB / 80 GB SSD — the closest match to Hetzner's
 // cx23 default. nyc3 is a broadly-available US region.
-const DIGITALOCEAN_DEFAULT_SIZE = 's-2vcpu-4gb';
+export const DIGITALOCEAN_DEFAULT_SIZE = 's-2vcpu-4gb';
 const DIGITALOCEAN_DEFAULT_REGION = 'nyc3';
 
 /**

--- a/packages/sandbox-digitalocean/src/index.ts
+++ b/packages/sandbox-digitalocean/src/index.ts
@@ -41,6 +41,9 @@ export const providerModule: ProviderModule = {
 };
 
 export { digitaloceanBackend, DIGITALOCEAN_DEFAULT_BOX_IMAGE_REF };
+// Exported so the descriptor's declared default `size` can be asserted against
+// the value the backend really falls back to (apps/cli/test/provider-sizes.test.ts).
+export { DIGITALOCEAN_DEFAULT_SIZE } from './backend.js';
 export { ensureDigitalOceanEnvLoaded } from './env-loader.js';
 export {
   ensureDigitalOceanCredentials,

--- a/packages/sandbox-e2b/src/index.ts
+++ b/packages/sandbox-e2b/src/index.ts
@@ -176,7 +176,7 @@ export const providerModule: ProviderModule = {
 export { e2bBackend, DEFAULT_BOX_IMAGE_REF };
 // Exported so the descriptor's declared `sizes` can be asserted against the
 // parser that actually accepts them (apps/cli/test/provider-sizes.test.ts).
-export { parseE2bSize } from './prepare.js';
+export { parseE2bSize, DEFAULT_CPU, DEFAULT_MEMORY_MB } from './prepare.js';
 export { ensureE2bEnvLoaded, reloadE2bEnv } from './env-loader.js';
 export {
   ensureE2bCredentials,

--- a/packages/sandbox-e2b/src/index.ts
+++ b/packages/sandbox-e2b/src/index.ts
@@ -174,6 +174,9 @@ export const providerModule: ProviderModule = {
 };
 
 export { e2bBackend, DEFAULT_BOX_IMAGE_REF };
+// Exported so the descriptor's declared `sizes` can be asserted against the
+// parser that actually accepts them (apps/cli/test/provider-sizes.test.ts).
+export { parseE2bSize } from './prepare.js';
 export { ensureE2bEnvLoaded, reloadE2bEnv } from './env-loader.js';
 export {
   ensureE2bCredentials,

--- a/packages/sandbox-e2b/src/prepare.ts
+++ b/packages/sandbox-e2b/src/prepare.ts
@@ -115,8 +115,8 @@ function templateNameFor(variantKey: string): string {
   return `agentbox-${variantKey.replaceAll(',', '-')}:${DEFAULT_TAG}`;
 }
 
-const DEFAULT_CPU = 2;
-const DEFAULT_MEMORY_MB = 4096;
+export const DEFAULT_CPU = 2;
+export const DEFAULT_MEMORY_MB = 4096;
 
 /**
  * Parse a `cpu-memory` GB size spec (e.g. `4-8`) into E2B's

--- a/packages/sandbox-hetzner/src/backend.ts
+++ b/packages/sandbox-hetzner/src/backend.ts
@@ -85,7 +85,7 @@ const ACTION_DEADLINE_MS = 5 * 60_000;
 const SNAPSHOT_DEADLINE_MS = 20 * 60_000;
 // `cx22` was deprecated by Hetzner in early 2026; `cx23` is the drop-in
 // replacement with the same 2 vCPU / 4 GB / 40 GB shape on x86.
-const HETZNER_DEFAULT_SERVER_TYPE = 'cx23';
+export const HETZNER_DEFAULT_SERVER_TYPE = 'cx23';
 const HETZNER_DEFAULT_LOCATION = 'nbg1';
 
 /**
@@ -158,7 +158,10 @@ async function getServerStrict(id: number): Promise<HetznerServer> {
 }
 
 /** Lookup an image by description ("snapshot name" in user-facing terms). */
-async function findImageByDescription(c: HetznerClient, description: string): Promise<HetznerImage | null> {
+async function findImageByDescription(
+  c: HetznerClient,
+  description: string,
+): Promise<HetznerImage | null> {
   const all = await c.listImages({ type: 'snapshot' });
   return all.find((i) => i.description === description) ?? null;
 }
@@ -171,7 +174,10 @@ async function findImageByDescription(c: HetznerClient, description: string): Pr
  *   - any other string → treated as a snapshot description (checkpoint name)
  *     and looked up via the API.
  */
-async function resolveImageId(c: HetznerClient, req: CloudProvisionRequest): Promise<number | string> {
+async function resolveImageId(
+  c: HetznerClient,
+  req: CloudProvisionRequest,
+): Promise<number | string> {
   const ref = req.snapshot ?? req.image;
   // `box.imageHetzner` is pinned to the base's own description by every bake, so
   // by the time we get here `ref` usually NAMES OUR OWN BASE rather than being
@@ -407,7 +413,11 @@ export const hetznerBackend: CloudBackend = {
     // Control-plane-topology creates: the control box locks the box to its own
     // egress IP; add the admin-supplied PC egress CIDR(s) so direct PC→box SSH
     // still works. Skipped when `open` (already 0.0.0.0/0). Deduped.
-    if (inboundPolicy.mode !== 'open' && req.extraInboundCidrs && req.extraInboundCidrs.length > 0) {
+    if (
+      inboundPolicy.mode !== 'open' &&
+      req.extraInboundCidrs &&
+      req.extraInboundCidrs.length > 0
+    ) {
       for (const cidr of req.extraInboundCidrs) {
         const normalized = normalizeSourceCidr(cidr);
         if (!sources.includes(normalized)) sources.push(normalized);
@@ -677,7 +687,9 @@ export const hetznerBackend: CloudBackend = {
     try {
       await c.deleteServer(id);
     } catch (err) {
-      if (!(err instanceof HetznerApiError && (err.statusCode === 404 || err.code === 'not_found'))) {
+      if (
+        !(err instanceof HetznerApiError && (err.statusCode === 404 || err.code === 'not_found'))
+      ) {
         throw err;
       }
     }
@@ -720,27 +732,23 @@ export const hetznerBackend: CloudBackend = {
 
   async uploadFile(h, localPath, remotePath): Promise<void> {
     const { target } = await ensureLiveTarget(h.sandboxId);
-    const argv = [
-      ...sshOptArgs(target),
-      localPath,
-      `${target.user}@${target.host}:${remotePath}`,
-    ];
+    const argv = [...sshOptArgs(target), localPath, `${target.user}@${target.host}:${remotePath}`];
     const res = await execa('scp', argv, { reject: false, timeout: 300_000 });
     if (res.exitCode !== 0) {
-      throw new Error(`hetzner: scp upload failed (exit ${String(res.exitCode)}): ${res.stderr || ''}`);
+      throw new Error(
+        `hetzner: scp upload failed (exit ${String(res.exitCode)}): ${res.stderr || ''}`,
+      );
     }
   },
 
   async downloadFile(h, remotePath, localPath): Promise<void> {
     const { target } = await ensureLiveTarget(h.sandboxId);
-    const argv = [
-      ...sshOptArgs(target),
-      `${target.user}@${target.host}:${remotePath}`,
-      localPath,
-    ];
+    const argv = [...sshOptArgs(target), `${target.user}@${target.host}:${remotePath}`, localPath];
     const res = await execa('scp', argv, { reject: false, timeout: 300_000 });
     if (res.exitCode !== 0) {
-      throw new Error(`hetzner: scp download failed (exit ${String(res.exitCode)}): ${res.stderr || ''}`);
+      throw new Error(
+        `hetzner: scp download failed (exit ${String(res.exitCode)}): ${res.stderr || ''}`,
+      );
     }
   },
 
@@ -851,7 +859,10 @@ export const hetznerBackend: CloudBackend = {
     // the two state dirs are disjoint. Using sudo for both keeps them
     // pointed at the same `/root/.portless`.
     const tlsFlag = opts.tls ? '' : '--no-tls';
-    const startCmd = `sudo portless proxy start ${tlsFlag} -p ${String(opts.proxyPort)}`.replace(/\s+/g, ' ');
+    const startCmd = `sudo portless proxy start ${tlsFlag} -p ${String(opts.proxyPort)}`.replace(
+      /\s+/g,
+      ' ',
+    );
     const aliasCmd = `sudo portless alias ${shellQuote(opts.boxName)} ${String(opts.webPort)}`;
     const cmds = [startCmd, aliasCmd];
     if (opts.tls) {
@@ -874,11 +885,7 @@ export const hetznerBackend: CloudBackend = {
     // Reuse the ControlMaster via `-S <sock>` — no new auth handshake, no
     // SSH-token mint pressure (unlike Daytona). Callers append `-t '<cmd>'`
     // or similar in the `buildAttach` helper.
-    return [
-      'ssh',
-      ...sshOptArgs(target),
-      `${target.user}@${target.host}`,
-    ];
+    return ['ssh', ...sshOptArgs(target), `${target.user}@${target.host}`];
   },
 
   async createSnapshot(h, name): Promise<void> {
@@ -910,7 +917,8 @@ export const hetznerBackend: CloudBackend = {
     try {
       await c.deleteImage(img.id);
     } catch (err) {
-      if (err instanceof HetznerApiError && (err.statusCode === 404 || err.code === 'not_found')) return;
+      if (err instanceof HetznerApiError && (err.statusCode === 404 || err.code === 'not_found'))
+        return;
       throw err;
     }
   },
@@ -918,4 +926,3 @@ export const hetznerBackend: CloudBackend = {
 
 /** Exposed for the CLI's `firewall sync` / `show` subcommands. */
 export { tunnels as _hetznerTunnels };
-

--- a/packages/sandbox-hetzner/src/index.ts
+++ b/packages/sandbox-hetzner/src/index.ts
@@ -46,6 +46,9 @@ export const providerModule: ProviderModule = {
 };
 
 export { hetznerBackend, HETZNER_DEFAULT_BOX_IMAGE_REF };
+// Exported so the descriptor's declared default `size` can be asserted against
+// the value the backend really falls back to (apps/cli/test/provider-sizes.test.ts).
+export { HETZNER_DEFAULT_SERVER_TYPE } from './backend.js';
 export { ensureHetznerEnvLoaded } from './env-loader.js';
 export {
   ensureHetznerCredentials,

--- a/packages/sandbox-vercel/src/backend.ts
+++ b/packages/sandbox-vercel/src/backend.ts
@@ -114,6 +114,8 @@ export function parseNetworkPolicy(raw: string | undefined): NetworkPolicy | und
 
 /** vCPU counts Vercel accepts; anything else fails `Sandbox.create` with a 400. */
 const VERCEL_VCPUS = [1, 2, 4, 8] as const;
+/** vCPUs a sandbox gets when no `--size` is given. */
+export const VERCEL_DEFAULT_VCPUS = 2;
 export type VercelVcpus = (typeof VERCEL_VCPUS)[number];
 
 /**
@@ -327,7 +329,7 @@ export const vercelBackend: CloudBackend = {
         const sb = await Sandbox.create({
           name: req.name,
           source: { type: 'snapshot', snapshotId },
-          resources: { vcpus: vcpus ?? 2 },
+          resources: { vcpus: vcpus ?? VERCEL_DEFAULT_VCPUS },
           ports: buildExposedPorts(req.exposePorts),
           timeout: req.timeoutMs ?? DEFAULT_TIMEOUT_MS,
           env: req.env,

--- a/packages/sandbox-vercel/src/index.ts
+++ b/packages/sandbox-vercel/src/index.ts
@@ -121,6 +121,9 @@ export const providerModule: ProviderModule = {
 };
 
 export { vercelBackend, DEFAULT_BOX_IMAGE_REF };
+// Exported so the descriptor's declared `sizes` can be asserted against the
+// parser that actually accepts them (apps/cli/test/provider-sizes.test.ts).
+export { parseVercelVcpus } from './backend.js';
 export { ensureVercelEnvLoaded, reloadVercelEnv } from './env-loader.js';
 export { ensureVercelCredentials, setVercelCredentials } from './credentials.js';
 export type { EnsureVercelCredentialsOptions } from './credentials.js';

--- a/packages/sandbox-vercel/src/index.ts
+++ b/packages/sandbox-vercel/src/index.ts
@@ -123,7 +123,7 @@ export const providerModule: ProviderModule = {
 export { vercelBackend, DEFAULT_BOX_IMAGE_REF };
 // Exported so the descriptor's declared `sizes` can be asserted against the
 // parser that actually accepts them (apps/cli/test/provider-sizes.test.ts).
-export { parseVercelVcpus } from './backend.js';
+export { parseVercelVcpus, VERCEL_DEFAULT_VCPUS } from './backend.js';
 export { ensureVercelEnvLoaded, reloadVercelEnv } from './env-loader.js';
 export { ensureVercelCredentials, setVercelCredentials } from './credentials.js';
 export type { EnsureVercelCredentialsOptions } from './credentials.js';


### PR DESCRIPTION
## Why

A box's VM size was reachable only from the CLI (`--size`, or `box.size<P>`), and the legal values lived only as prose inside each provider's `sizeDesc`. So there was no way to start a bigger box from the web hub or the tray — the concrete blocker being a desktop box with enough RAM for something like Godot (8 GB+), which no default provides.

`--size` has **no common grammar** — each backend parses it natively:

| provider | grammar | 8 GB | applies at |
|---|---|---|---|
| docker | *ignored* (`box.memory` / `box.cpus`) | — | — |
| hetzner | server-type slug | `cx33` (4·8), `cx43` (8·16) | create |
| digitalocean | droplet slug | `s-4vcpu-8gb` | create |
| vercel | vCPU count, RAM coupled 2 GB/vCPU | `4` | create |
| remote-docker | `cpu-mem` GB | `4-8` | create |
| daytona | `cpu-mem-disk` GB | `4-8-10` | **bake** |
| e2b | `cpu-mem` GB | `4-8` | **bake** |

That variation is what a UI needs told declaratively — and `ProviderDescriptor` already had the field for it (`sizes`), served all the way to both clients and populated by nobody. The rail existed end to end and was empty.

## What changed

- **Descriptor** — `sizes` populated for the six non-docker built-ins (values read off each backend's own parser and default constant, not invented), plus `sizeHint` and `sizeAppliesAt`. `sizeHint`'s *presence* is what says the list is open to a custom value; vercel omits it because `parseVercelVcpus` throws outside its set, so one field does two jobs with no flag to keep in sync.
- **Hub API** — the new fields ride the existing descriptor pass-through. One new route, `POST /api/v1/providers/{id}/size-check`, answers whether a *specific* size needs a re-bake, via the `sizeIgnoredReason` hook daytona and e2b already implement. Without it a UI would either bake on every size change (2–10 min) or hand the backend a value it throws away. The stale openapi `Provider` schema is refreshed while there.
- **Web + tray** — a Size field in the create form, driven entirely by the descriptor: no switch on provider id, so a community provider gets the picker by declaring `sizes`.
- **Plugins** — additive on an optional field, so `SDK_API_VERSION` stays **4**. SDK `4.0.0` → `4.1.0`; **needs a republish**.

## One decision worth flagging

When a size needs a re-bake **and** the base is also stale, the stale-base prompt is *skipped*. Its "use existing image" answer would boot at the baked size and silently discard the size just picked — the exact failure this change exists to prevent.

`force` on the bake is likewise load-bearing: a size change does not move the build-context fingerprint, so an unforced bake no-ops and the box comes up on the old size.

## Verification

- `pnpm test` + `pnpm typecheck` green. New `apps/cli/test/provider-sizes.test.ts` asserts every declared size key parses under its own provider's parser, pins each "(default)" label to the backend's real fallback constant (mutation-checked), and ties `sizeAppliesAt: 'bake'` to exactly the providers implementing `sizeIgnoredReason`.
- **Live**: created a hetzner box at `cx43` from the web modal — the Hetzner API reported 8 cores / 16 GB. Destroyed after; no orphan servers or firewalls.
- The daytona bake-scoped path shows the note carrying the real baked size (`2-4-8`), read back through `/size-check`.
- Tray builds and its reason-trimmer was checked against the real daytona/e2b strings plus a pass-through case. **Not visually verified** — I could not drive the menu-bar UI headlessly.

Tray side is on `agentbox-tray` `nightly` (`54412bb`).

https://claude.ai/code/session_01T83kN2Zdcx6e1C4KKj6bsa

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes box provisioning paths (prepare force + create opts.size) and new API surface; mistakes could wrong-size boxes or trigger unnecessary bakes, but behavior is descriptor-driven and size-check is advisory-only.
> 
> **Overview**
> **Create flows can pick VM size from declarative provider metadata**, instead of relying on CLI `--size` alone. Built-in providers now ship populated `sizes` lists plus `sizeHint` (opens a custom value field when present) and `sizeAppliesAt: 'bake'` for Daytona/E2B. Docker still has no size picker.
> 
> The **hub exposes that metadata and a new advisory `POST /api/v1/providers/{id}/size-check`**, which calls each provider's `sizeIgnoredReason` so bake-scoped backends only trigger a re-bake when the chosen size actually differs. OpenAPI **`Provider` paths drop hard-coded provider enums** in favor of string ids (including community plugins), and the schema documents descriptor fields clients should render from.
> 
> The **web create modal** adds an Advanced **Size** control (preset + Custom when `sizeHint` exists), resets size on provider change, debounces size-check for bake providers, and routes submit through **prepare with `{ size, force: true }`** when needed—skipping the stale-base "use existing" path when size forces a bake so the pick is not silently dropped. Create passes `opts.size` only for create-scoped providers.
> 
> **Guardrails and docs:** `apps/cli/test/provider-sizes.test.ts` ties descriptor keys to each backend's parsers/defaults; provider SDK **4.1.0** and docs describe how plugins declare sizes. Base branch moves out of Advanced in the modal layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daaf2356826bbdad8d28a45d678b3a8ac771af87. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->