### PR TITLE
fix(cloud): stop the in-box forwarder racing portless for :80

### DIFF
--- a/apps/cli/src/agents/command/service-action.ts
+++ b/apps/cli/src/agents/command/service-action.ts
@@ -28,7 +28,8 @@ import type {
 import { persistentRefusal, resolveCreatePersistent, UserFacingError } from '@agentbox/core';
 import { intro, log, outro, makeProgressReporter, openCommandLog } from '@agentbox/cli-kit';
 import { ensureAgentInstalled, readState, resolveBoxRef } from '@agentbox/sandbox-core';
-import { recordLastAgent } from '@agentbox/sandbox-docker';
+import { readBoxStatus, recordLastAgent } from '@agentbox/sandbox-docker';
+import { webProxyWarning } from '../../lib/web-proxy-warning.js';
 import { runCarryGate } from '../../lib/carry-gate.js';
 import { handleLifecycleError } from '../../commands/_errors.js';
 import { providerForBox, providerForCreate } from '../../provider/registry.js';
@@ -421,6 +422,10 @@ export async function runServiceAgent(
       log.info(`${f.label}: ${f.value}`);
     }
     const url = service.expose ? await resolveServiceUrl(box) : null;
+    // A URL we cannot forward to is worse than no URL: the port is held by
+    // something else, so it answers with the wrong thing rather than failing.
+    const warning = url ? webProxyWarning(await readBoxStatus(box)) : null;
+    if (warning) log.warn(warning);
     if (url) outro(`${spec.id} on ${box.name}: ${url}`);
     else outro(`${spec.id} on ${box.name}`);
   } catch (err) {

--- a/apps/cli/src/agents/command/service-factory.ts
+++ b/apps/cli/src/agents/command/service-factory.ts
@@ -30,6 +30,8 @@ import { Command } from 'commander';
 import { log } from '@agentbox/cli-kit';
 import type { AgentSyncSpec, BoxRecord } from '@agentbox/core';
 import { renderStatusTable, type ServiceState, type ServiceStatus } from '@agentbox/ctl';
+import { readBoxStatus } from '@agentbox/sandbox-docker';
+import { webProxyWarning } from '../../lib/web-proxy-warning.js';
 import { resolveBoxOrExit } from '../../box-ref.js';
 import { handleLifecycleError } from '../../commands/_errors.js';
 import { providerForBox } from '../../provider/registry.js';
@@ -219,6 +221,10 @@ export function buildServiceAgentCommand(spec: AgentSyncSpec): Command {
           // documented idiom into a node stack trace.
           const extra = await readServiceUrlFields(box, service.urlFields ?? []);
           process.stdout.write([url, ...extra.map((f) => `${f.label}: ${f.value}`), ''].join('\n'));
+          // STDERR on purpose: stdout here is the documented `| head -1` surface,
+          // and a warning printed into it would BE the first line.
+          const warning = webProxyWarning(await readBoxStatus(box));
+          if (warning) process.stderr.write(`warning: ${warning}\n`);
         } catch (err) {
           handleLifecycleError(err);
         }

--- a/apps/cli/src/commands/_status-render.ts
+++ b/apps/cli/src/commands/_status-render.ts
@@ -6,6 +6,7 @@ import {
   type StatusReply,
 } from '@agentbox/ctl';
 import { execInBox } from '@agentbox/sandbox-docker';
+import { webProxyWarning } from '../lib/web-proxy-warning.js';
 
 export async function fetchLive(state: string, container: string): Promise<StatusReply | null> {
   // Only a running container is reachable via `docker exec` (macOS can see the
@@ -51,6 +52,12 @@ export function renderPersistedSections(s: BoxStatus): string[] {
         (svc) => `  ${svc.name}  ${svc.state}${svc.port !== null ? `  :${String(svc.port)}` : ''}`,
       ),
     );
+  }
+  const warning = webProxyWarning(s);
+  if (warning) {
+    // Not folded into SERVICES: the service itself is fine, and saying so under
+    // its row would read as the service being broken.
+    out.push('', 'WEB', `  ${warning}`);
   }
   out.push('');
   out.push('PORTS');

--- a/apps/cli/src/lib/web-proxy-warning.ts
+++ b/apps/cli/src/lib/web-proxy-warning.ts
@@ -1,0 +1,18 @@
+import type { BoxStatus } from '@agentbox/ctl';
+
+/**
+ * The one-line warning for a box whose in-box web forwarder could not bind.
+ *
+ * A box in this state is the worst kind of broken: `create` reports ready, the
+ * service is genuinely healthy on its loopback port, and the URL we hand out
+ * belongs to whatever else won the port — so it answers, with the wrong thing.
+ * The bind failure used to reach only `/var/log/agentbox/web-proxy.log`.
+ *
+ * Returns null when the forwarder is healthy AND when the snapshot predates the
+ * field: absent means "no information", never "fine".
+ */
+export function webProxyWarning(status: BoxStatus | null | undefined): string | null {
+  const err = status?.webProxy?.error;
+  if (err === undefined || err.length === 0) return null;
+  return `the box's web forwarder is not listening (${err}) — the URL above will not reach the service`;
+}

--- a/apps/cli/test/web-proxy-warning.test.ts
+++ b/apps/cli/test/web-proxy-warning.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import type { BoxStatus } from '@agentbox/ctl';
+import { webProxyWarning } from '../src/lib/web-proxy-warning.js';
+
+/**
+ * Absent must never read as healthy.
+ *
+ * `webProxy` is an additive field on a schema-1 snapshot, so every box whose
+ * ctl was baked before it simply lacks it. If that were treated as "no error",
+ * fine — it is. The trap is the opposite reading: an EMPTY error string, which
+ * a naive truthiness check on the object would turn into a warning on a working
+ * box, and warnings that fire on working boxes stop being read.
+ */
+function status(webProxy?: BoxStatus['webProxy']): BoxStatus {
+  return {
+    schema: 1,
+    boxId: 'b1',
+    timestamp: '2026-09-06T00:00:00.000Z',
+    services: [],
+    tasks: [],
+    ports: [],
+    ...(webProxy === undefined ? {} : { webProxy }),
+  };
+}
+
+describe('webProxyWarning', () => {
+  it('warns, naming the bind failure, when the forwarder is not listening', () => {
+    const w = webProxyWarning(
+      status({ port: 80, target: 18789, error: 'listen :80 failed: EADDRINUSE' }),
+    );
+    expect(w).toContain('EADDRINUSE');
+    // The user's actual question is "why doesn't the URL work" — say that, not
+    // just the errno.
+    expect(w).toContain('will not reach the service');
+  });
+
+  it('stays quiet for a healthy forwarder', () => {
+    expect(webProxyWarning(status({ port: 8080, target: 18789 }))).toBeNull();
+  });
+
+  it('stays quiet when nothing is exposed', () => {
+    expect(webProxyWarning(status({ port: 80, target: null }))).toBeNull();
+  });
+
+  it('stays quiet on a snapshot from a ctl that predates the field', () => {
+    expect(webProxyWarning(status())).toBeNull();
+  });
+
+  it('stays quiet with no snapshot at all', () => {
+    // A cloud box that has not pushed one yet, or a stopped box.
+    expect(webProxyWarning(null)).toBeNull();
+    expect(webProxyWarning(undefined)).toBeNull();
+  });
+
+  it('treats an empty error string as no error', () => {
+    expect(webProxyWarning(status({ port: 80, target: 18789, error: '' }))).toBeNull();
+  });
+});

--- a/apps/web/content/docs/web-apps-and-tunnels.mdx
+++ b/apps/web/content/docs/web-apps-and-tunnels.mdx
@@ -108,7 +108,7 @@ agentbox url my-cloud-box --ttl 86400
 | Docker       | Only `:80` (web) and `:6080` (noVNC) are host-published; shell in to hit other ports |
 | Hetzner      | On-demand SSH forwards reach _any_ in-box port                                       |
 | DigitalOcean | On-demand SSH forwards reach _any_ in-box port (same as Hetzner)                     |
-| Vercel       | Up to 4 exposed ports (3 already spent on `80`/`6080`/`8788`)                        |
+| Vercel       | Up to 4 exposed ports (3 already spent on `8080`/`6080`/`8788`)                      |
 | E2B          | Public `<port>-<sandbox-id>.e2b.app` URL for each exposed port                       |
 | Daytona      | Per-service preview URLs for each `expose.port`                                      |
 

--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -865,6 +865,16 @@ decorates these URLs with Portless aliases for symmetric
 `<box-name>.localhost` URLs (handled provider-side, not in the
 backend, so the backend stays focused on plumbing).
 
+Because that in-box mirror owns `:443` and holds `:80` for the http→https
+redirect, ctl's `WebProxy` cannot have the reserved web port on these two
+providers: hetzner and digitalocean declare `webProxyPort: 8080`, which reaches
+ctl as `AGENTBOX_WEB_PROXY_PORT`, is what the in-box `portless alias` points at,
+and is the remote port the host forwards. Before that they raced for `:80`, the
+proxy lost, and the box published a URL Portless answered with a 302 into a 404
+— while still reporting ready. A restart now adopts the backend's current port
+and writes it back to `cloud.webPort`, so a box created before this heals
+itself.
+
 When the host Portless proxy runs in **TLS** mode, the in-box mirror serves a
 self-signed CA the box doesn't trust by default, so in-box Chromium (VNC window)
 and Playwright would reject `https://<box>.localhost`. The baked
@@ -951,7 +961,8 @@ snapshots and `sandbox.domain(port)` public preview URLs. The shape in brief:
 - **Preview URLs are public HTTPS.** `previewUrl`/`signedPreviewUrl` both return
   `sandbox.domain(port)` — reachable from the host browser AND from inside the
   box, so (like Daytona) the Portless in-box mirror is skipped. Max 4 exposed
-  ports; we declare 80 (WebProxy), 6080 (noVNC), 8788 (relay/ctl bridge).
+  ports; we declare 8080 (WebProxy), 6080 (noVNC), 8788 (relay/ctl bridge), and
+  fill the fourth slot from `agentbox.yaml`'s `expose:` ports.
 - **No SSH → custom attach.** `@vercel/sandbox` exposes no stdin/PTY channel, so
   `buildAttach` is overridden to spawn `attach-helper.js`, which bridges the
   local terminal to a box-side tmux session via `send-keys`/`capture-pane` over

--- a/docs/plans/service-boxes-backlog.md
+++ b/docs/plans/service-boxes-backlog.md
@@ -364,3 +364,55 @@ So the fix has to be ours. Three options, none of them free:
 
 Not decided here. Whichever way it goes, the smoke test must fetch `/`, not
 `/healthz`.
+
+### Why the managed Tailscale listener is not a way in
+
+OpenClaw does have a second listener that expects a proxy in front — the one the
+rate-limiting doc describes:
+
+> OpenClaw-managed Tailscale Serve and Funnel use a separate private loopback
+> listener. Reaching that listener establishes the managed ingress path, and
+> Tailscale's rewritten source address selects a normal non-exempt, resettable
+> per-client bucket. Serve tokenless identity auth additionally requires a
+> matching WhoIs result; Funnel requires its marker and password authentication.
+
+Read in context that passage is about which **rate-limit bucket** a request
+lands in, not about accepting arbitrary proxies. Pointing ctl's forwarder at it
+does not work, for four independent reasons:
+
+- **The port is ephemeral.** Managed Serve/Funnel proxies to a dedicated
+  `127.0.0.1:<ephemeral-port>` listener the Gateway picks at startup. There is
+  no stable target to configure a proxy against.
+- **It only exists with Tailscale on.** The listener is created by OpenClaw's
+  own Tailscale integration; with `gateway.tailscale.mode: off` there is nothing
+  listening.
+- **Sharing it is the thing it is designed to prevent.** "Startup fails closed
+  rather than sharing listener provenance, and the foreground claim releases the
+  route when its Gateway owner disappears."
+- **Reaching it is not enough.** Serve additionally requires a matching
+  `tailscale whois`; Funnel requires its marker plus password auth. Portless can
+  produce neither.
+
+So OpenClaw has exactly one sanctioned "there is a proxy in front of me" path,
+and it is Tailscale-shaped end to end.
+
+### Option 4: let OpenClaw manage its own Tailscale Serve
+
+That does make a fourth option real, and for a gateway it may be the best one —
+it is OpenClaw's own remote-access story, needs no change to our proxy, and ends
+at a genuinely stable HTTPS URL instead of a host-only `.localhost` name. Fully
+scriptable:
+
+```sh
+openclaw config set gateway.bind loopback
+openclaw config set gateway.tailscale.mode serve     # or `funnel` for public
+openclaw gateway restart
+```
+
+Result: `https://<host>.<tailnet>.ts.net`. Serve is tailnet-only and needs no
+password; Funnel is public and OpenClaw requires password auth for it.
+
+Prerequisites put this behind an opt-in rather than making it the default: a
+Tailscale daemon logged in inside the box (so a tailnet auth key has to reach
+it), MagicDNS, and HTTPS certs enabled on the tailnet. Users without a tailnet
+get nothing from it, so the default path still needs option 1 or 2.

--- a/docs/plans/service-boxes-backlog.md
+++ b/docs/plans/service-boxes-backlog.md
@@ -318,3 +318,49 @@ things block a straight swap — the contract has no slot for claude's
 claude's own `runtime.startSession` adapter drops it), and none for its
 `rebuildPluginNativeDeps` pre-step. Widening the contract with both, then
 deleting the chains and the list, is the whole job.
+
+## Portless's forwarded headers make OpenClaw refuse its own Control UI (2026-09-06)
+
+Found on a live hetzner box once the `:80` collision was fixed and the URL
+started routing. **Every provider is affected, docker included** — this is not
+cloud-specific, and it means the published box URL has never served the OpenClaw
+dashboard on any provider.
+
+Measured on the box, against the in-box gateway through the SSH tunnel:
+
+| request | result |
+|---|---|
+| no forwarded headers | `200`, the Control UI HTML |
+| `X-Forwarded-For: 127.0.0.1` | `403 proxy_attribution_required` |
+| `X-Forwarded-Proto: https` | `403` |
+| `Forwarded: for=127.0.0.1` | `403` |
+
+Any one forwarded header is enough. Portless always adds them, so
+`https://<box>.localhost/` 403s while `https://<box>.localhost/healthz` — which
+is exempt — returns 200. Every smoke test so far checked `/healthz`, which is
+exactly why this was never caught.
+
+OpenClaw offers no way to ignore the headers. `gateway.trustedProxies`
+(CIDR allowlist) is not sufficient on its own: setting it to `127.0.0.1/32` +
+`::1/128` still 403s, because the policy also wants
+`gateway.auth.trustedProxy.userHeader`, which is REQUIRED once that object
+exists (`config patch` rejects the object without it). That whole mode is built
+for an identity proxy that authenticates the user and forwards who they are —
+oauth2-proxy, not a plain reverse proxy. Portless is not one and cannot become
+one. `portless alias` (0.13.0) has no flag to suppress the headers.
+
+So the fix has to be ours. Three options, none of them free:
+
+1. **Hand out the direct preview URL for such a service.** The raw SSH-tunnel
+   URL already works. Cheapest and it works today, but it drops the symmetric
+   `<box>.localhost` property (see `feedback-symmetric-portless-urls`) for the
+   one agent that most wants a browser. Would be a capability on the agent's
+   `service` spec — "this daemon rejects proxy-forwarded headers" — not an id check.
+2. **Make ctl's `WebProxy` strip forwarded headers.** It is a raw TCP forwarder
+   today; this makes it HTTP-aware, which also means getting the WebSocket
+   upgrade right (the Control UI needs it) and paying that cost on every box.
+3. **Upstream**: ask OpenClaw for an explicit "trust no proxy / ignore forwarded
+   headers" setting for a loopback-bound gateway. Correct, slowest.
+
+Not decided here. Whichever way it goes, the smoke test must fetch `/`, not
+`/healthz`.

--- a/packages/ctl/src/status-reporter.ts
+++ b/packages/ctl/src/status-reporter.ts
@@ -259,6 +259,7 @@ export class StatusReporter {
       schema: BOX_STATUS_SCHEMA,
       boxId: this.boxId,
       timestamp: new Date().toISOString(),
+      webProxy: this.supervisor.webProxyState(),
       services,
       tasks,
       ports,

--- a/packages/ctl/src/supervisor.ts
+++ b/packages/ctl/src/supervisor.ts
@@ -15,7 +15,7 @@ import { DEFAULT_STATE_DIR } from './types.js';
 import { resolveWritableStateDir } from './state-dir.js';
 import { startProbe, type ProbeHandle } from './probe.js';
 import { RelayClient } from './relay-client.js';
-import { WebProxy } from './web-proxy.js';
+import { WebProxy, type WebProxyState } from './web-proxy.js';
 import type {
   LogEvent,
   ServiceState,
@@ -731,6 +731,15 @@ export class Supervisor extends EventEmitter<SupervisorEvents> {
       if (expose) out.set(u.name, expose);
     }
     return out;
+  }
+
+  /**
+   * What the in-box forwarder is doing, including a bind that failed. The
+   * status reporter ships this so the host can tell the user the box's URL
+   * will not answer — see `WebProxyState`.
+   */
+  webProxyState(): WebProxyState {
+    return this.webProxy.state();
   }
 
   /** (Re)point the in-box :80 forwarder at the `expose:`-flagged service. */

--- a/packages/ctl/src/types.ts
+++ b/packages/ctl/src/types.ts
@@ -128,6 +128,15 @@ export interface BoxStatusTaskEntry {
   state: TaskState;
 }
 
+export interface BoxStatusWebProxy {
+  /** Container port the forwarder listens on (80, or 8080 on a cloud box). */
+  port: number;
+  /** In-box service port it forwards to, or null when nothing is exposed. */
+  target: number | null;
+  /** Message from the last failed bind; absent when the listener is healthy. */
+  error?: string;
+}
+
 export interface BoxStatusPort {
   port: number;
   /** Name of the service whose `ready_when` port matches, else null (ad-hoc). */
@@ -150,6 +159,18 @@ export interface BoxStatus {
   tasks: BoxStatusTaskEntry[];
   /** Live-discovered listening TCP ports inside the box. */
   ports: BoxStatusPort[];
+  /**
+   * The in-box web forwarder: the container port it listens on, the exposed
+   * service port it forwards to, and the message from a bind that failed.
+   *
+   * Present so a broken publish is VISIBLE. The forwarder is best-effort by
+   * design and a failed bind only reached a log file, so a box whose reserved
+   * port was already taken still reported ready and still handed out a URL.
+   * Additive field (schema stays 1): absent from snapshots written before it,
+   * and from any box whose ctl predates it — treat absent as "no information",
+   * never as "healthy".
+   */
+  webProxy?: BoxStatusWebProxy;
   /**
    * Every reporting agent, keyed by id. THE source of agent status — the named
    * fields below are a derived mirror of it.

--- a/packages/ctl/src/web-proxy.ts
+++ b/packages/ctl/src/web-proxy.ts
@@ -13,14 +13,41 @@ const DEFAULT_LOG = '/var/log/agentbox/web-proxy.log';
  * Dockerfile.box). Best-effort throughout — it must never throw into the
  * supervisor's lifecycle.
  */
+/**
+ * What the forwarder is currently doing, for the status snapshot.
+ *
+ * `error` is the whole reason this exists: a bind failure used to be a line in
+ * a log file nobody reads, so a box whose :80 was already taken still reported
+ * ready and still printed a URL — one that answered, wrongly, from whatever
+ * else held the port.
+ */
+export interface WebProxyState {
+  /** The container port the forwarder listens on. */
+  port: number;
+  /** The in-box service port it forwards to, or null when nothing is exposed. */
+  target: number | null;
+  /** Message from the last failed bind. Cleared by a bind that succeeds. */
+  error?: string;
+}
+
 export class WebProxy {
   private server: Server | null = null;
   private target: number | null = null;
+  private error: string | null = null;
 
   constructor(
     private readonly listenPort: number = DEFAULT_LISTEN_PORT,
     private readonly logPath: string = DEFAULT_LOG,
   ) {}
+
+  /** Snapshot for the status reporter. */
+  state(): WebProxyState {
+    return {
+      port: this.listenPort,
+      target: this.target,
+      ...(this.error === null ? {} : { error: this.error }),
+    };
+  }
 
   /**
    * Point :80 at `targetPort`. `null` tears the listener down. A no-op when the
@@ -31,6 +58,9 @@ export class WebProxy {
     if (targetPort === this.target) return;
     this.target = targetPort;
     this.closeServer();
+    // A new target gets a clean slate: the previous failure was about a bind
+    // that is no longer being attempted.
+    this.error = null;
     if (targetPort === null) {
       void this.log(`forwarding disabled`);
       return;
@@ -40,6 +70,7 @@ export class WebProxy {
 
   stop(): void {
     this.target = null;
+    this.error = null;
     this.closeServer();
   }
 
@@ -58,10 +89,14 @@ export class WebProxy {
       upstream.pipe(client);
     });
     server.on('error', (err: Error) => {
-      void this.log(`listen :${String(this.listenPort)} failed: ${err.message}`);
+      // Recorded, not just logged: `state()` carries it into the status
+      // snapshot so the host can say the published URL will not work.
+      this.error = `listen :${String(this.listenPort)} failed: ${err.message}`;
+      void this.log(this.error);
       this.server = null;
     });
     server.listen(this.listenPort, '0.0.0.0', () => {
+      this.error = null;
       void this.log(`:${String(this.listenPort)} -> 127.0.0.1:${String(targetPort)}`);
     });
     this.server = server;

--- a/packages/ctl/test/agent-status-map.test.ts
+++ b/packages/ctl/test/agent-status-map.test.ts
@@ -38,6 +38,7 @@ function makeReporter(sessions?: { agent: string; sessionName: string }[]): {
     serviceProbePorts: () => new Map<string, number>(),
     probedServices: () => new Set<string>(),
     serviceExposes: () => new Map<string, { port: number; as: number }>(),
+    webProxyState: () => ({ port: 80, target: null }),
   });
   type Opts = ConstructorParameters<typeof StatusReporter>[0];
   const reporter = new StatusReporter({

--- a/packages/ctl/test/status-reporter.test.ts
+++ b/packages/ctl/test/status-reporter.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events';
 import { describe, expect, it } from 'vitest';
 import { StatusReporter } from '../src/status-reporter.js';
-import type { AgentPlanPayload, AgentQuestionPayload } from '../src/types.js';
+import type { AgentPlanPayload, AgentQuestionPayload, BoxStatus } from '../src/types.js';
 
 // The reporter snapshots itself by probing tmux + listing supervisor services.
 // We don't want either side-effect in unit tests, so we fake the supervisor
@@ -19,6 +19,7 @@ interface StubSupervisor extends EventEmitter {
   serviceProbePorts(): Map<string, number>;
   probedServices(): Set<string>;
   serviceExposes(): Map<string, { port: number; as: number }>;
+  webProxyState(): { port: number; target: number | null; error?: string };
 }
 
 function stubSupervisor(): StubSupervisor {
@@ -29,6 +30,7 @@ function stubSupervisor(): StubSupervisor {
     serviceProbePorts: (): Map<string, number> => new Map(),
     probedServices: (): Set<string> => new Set(),
     serviceExposes: (): Map<string, { port: number; as: number }> => new Map(),
+    webProxyState: (): { port: number; target: number | null } => ({ port: 80, target: null }),
   }) as StubSupervisor;
 }
 
@@ -78,6 +80,30 @@ function latestClaude(posted: Posted[]): PaylClaude | undefined {
   }
   return undefined;
 }
+
+describe('StatusReporter web-proxy reporting', () => {
+  it('carries a failed bind into the snapshot', async () => {
+    // The point of the whole field: a bind failure was log-only, so a box whose
+    // reserved port was taken still reported ready and still published a URL.
+    const sup = stubSupervisor();
+    sup.webProxyState = () => ({ port: 80, target: 18789, error: 'listen :80 failed: EADDRINUSE' });
+    const relay = stubRelay();
+    const reporter = new StatusReporter({
+      supervisor: sup as unknown as ConstructorParameters<typeof StatusReporter>[0]['supervisor'],
+      relay: relay as unknown as ConstructorParameters<typeof StatusReporter>[0]['relay'],
+      boxId: 'b1',
+    });
+    await flushDebounce(reporter, relay);
+    reporter.stop();
+
+    const last = relay.posted.at(-1)?.payload as BoxStatus;
+    expect(last.webProxy).toEqual({
+      port: 80,
+      target: 18789,
+      error: 'listen :80 failed: EADDRINUSE',
+    });
+  });
+});
 
 describe('StatusReporter.setAgentState (sticky end-plan / question)', () => {
   function makeReporter(): { reporter: StatusReporter; relay: ReturnType<typeof stubRelay> } {

--- a/packages/ctl/test/web-proxy.test.ts
+++ b/packages/ctl/test/web-proxy.test.ts
@@ -1,0 +1,86 @@
+import { createServer, type Server } from 'node:net';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { WebProxy } from '../src/web-proxy.js';
+
+/**
+ * The forwarder must SAY when it could not bind.
+ *
+ * A failed bind reached only `/var/log/agentbox/web-proxy.log`, so a cloud box
+ * whose reserved port was already held by its own portless proxy still reported
+ * ready and still handed out a URL — one answered by portless, with a 302 into
+ * a 404. `state()` is what carries the failure into the status snapshot.
+ */
+const listeners: Server[] = [];
+const proxies: WebProxy[] = [];
+
+afterEach(() => {
+  for (const p of proxies.splice(0)) p.stop();
+  for (const s of listeners.splice(0)) s.close();
+});
+
+/** Occupy a port and return it, so the proxy's bind is guaranteed to fail. */
+async function occupiedPort(): Promise<number> {
+  const s = createServer();
+  listeners.push(s);
+  await new Promise<void>((r) => s.listen(0, '0.0.0.0', r));
+  const addr = s.address();
+  if (addr === null || typeof addr === 'string') throw new Error('no port');
+  return addr.port;
+}
+
+async function settle(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 50));
+}
+
+describe('WebProxy.state', () => {
+  it('reports the port and target with no error once bound', async () => {
+    const logPath = join(await mkdtemp(join(tmpdir(), 'wp-')), 'web-proxy.log');
+    const proxy = new WebProxy(0, logPath);
+    proxies.push(proxy);
+    proxy.reconfigure(4321);
+    await settle();
+    expect(proxy.state()).toEqual({ port: 0, target: 4321 });
+  });
+
+  it('reports null target when nothing is exposed', () => {
+    const proxy = new WebProxy(0, join(tmpdir(), 'unused.log'));
+    proxies.push(proxy);
+    expect(proxy.state().target).toBeNull();
+  });
+
+  it('records a bind failure instead of only logging it', async () => {
+    const taken = await occupiedPort();
+    const logPath = join(await mkdtemp(join(tmpdir(), 'wp-')), 'web-proxy.log');
+    const proxy = new WebProxy(taken, logPath);
+    proxies.push(proxy);
+    proxy.reconfigure(4321);
+    await settle();
+
+    const state = proxy.state();
+    expect(state.port).toBe(taken);
+    // The target is still what it was asked to forward to: the SERVICE is fine,
+    // it is the publish that is broken, and conflating the two sends whoever
+    // reads this to the wrong place.
+    expect(state.target).toBe(4321);
+    expect(state.error).toMatch(/EADDRINUSE/);
+    // Still logged as well — the log is what a person tails inside the box.
+    expect(await readFile(logPath, 'utf8')).toMatch(/EADDRINUSE/);
+  });
+
+  it('clears the error when pointed at a new target', async () => {
+    const taken = await occupiedPort();
+    const proxy = new WebProxy(taken, join(await mkdtemp(join(tmpdir(), 'wp-')), 'p.log'));
+    proxies.push(proxy);
+    proxy.reconfigure(4321);
+    await settle();
+    expect(proxy.state().error).toBeDefined();
+
+    // A reconfigure is a fresh attempt; carrying the old failure forward would
+    // make a healthy box look broken until its next restart.
+    proxy.reconfigure(null);
+    expect(proxy.state()).toEqual({ port: taken, target: null });
+  });
+});

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -439,7 +439,13 @@ export function createCloudProvider(
     // Preview URLs (and their tokens) can rotate across stop/start — refresh
     // the web + relay preview URLs and persist so `agentbox url` and the
     // host poller see the live values.
-    const webPort = box.cloud?.webPort ?? backend.webProxyPort ?? CLOUD_WEB_PROXY_PORT;
+    // BACKEND-first here, unlike every read-only resolver (which trusts the
+    // record). A restart re-launches ctl, re-mints the preview URL and
+    // re-registers the portless alias, so it is the one moment all three can
+    // move together — and the value is written back below. That is what lets a
+    // box created before hetzner/digitalocean moved off :80 heal itself instead
+    // of staying pinned to a port its own portless proxy owns.
+    const webPort = backend.webProxyPort ?? box.cloud?.webPort ?? CLOUD_WEB_PROXY_PORT;
     let webPreview: { url: string; token?: string } | undefined;
     try {
       webPreview = await backend.previewUrl(h, webPort);
@@ -594,7 +600,11 @@ export function createCloudProvider(
       relayUrl: `http://127.0.0.1:${String(8788)}`,
       relayToken: box.relayToken ?? '',
       bridgeToken: box.cloud?.bridgeToken,
-      webProxyPort: backend.webProxyPort,
+      // The SAME port resolved above, minted a preview URL for and written to
+      // the record a few lines up. `box` is the record as it was BEFORE that
+      // refresh, so reading the port off it here is what would let ctl bind one
+      // port while the host forwards another.
+      webProxyPort: webPort,
       launchDockerd: opts.launchDockerd !== false,
       vncPassword: box.vncEnabled ? box.vncPassword : undefined,
       controlPlaneUrl: box.cloud?.controlPlaneUrl,

--- a/packages/sandbox-cloud/src/cloud-provider.ts
+++ b/packages/sandbox-cloud/src/cloud-provider.ts
@@ -86,6 +86,7 @@ import {
 } from './checkpoint.js';
 import { loadEffectiveConfig } from '@agentbox/config';
 import { isSnapshotGoneError } from './snapshot-error.js';
+import { mergePreviewUrls } from './preview-urls.js';
 import { readExposedServicePorts } from './expose-ports.js';
 import { downloadFromCloudBox, pullCloudDirContents, uploadToCloudBox } from './cloud-cp.js';
 import { kickCloudBootstrap } from './bootstrap-launch.js';
@@ -479,13 +480,13 @@ export function createCloudProvider(
         ? { url: box.cloud.relayPreviewUrl, token: box.cloud.relayPreviewToken }
         : undefined;
     }
-    // Build the refreshed preview map: keep cached values for ports we
-    // couldn't re-resolve, overlay fresh URLs from this start.
-    const mergedPreviews: Record<number, string> = {
-      ...(box.cloud?.previewUrls ?? {}),
-      ...servicePreviews,
-    };
-    if (webPreview !== undefined) mergedPreviews[webPort] = webPreview.url;
+    const mergedPreviews = mergePreviewUrls({
+      cached: box.cloud?.previewUrls,
+      fresh: servicePreviews,
+      previousWebPort: box.cloud?.webPort,
+      webPort,
+      webUrl: webPreview?.url,
+    });
 
     // Portless: the `ssh -L` local port is fresh after `agentbox start`
     // (pickFreePort picks again), and the in-VPS portless proxy died with

--- a/packages/sandbox-cloud/src/preview-urls.ts
+++ b/packages/sandbox-cloud/src/preview-urls.ts
@@ -1,0 +1,28 @@
+/**
+ * Rebuilding a cloud box's port -> preview-URL map on start.
+ *
+ * Cached entries are kept because a preview URL we could not re-resolve this
+ * start is still better than none. The one thing that must NOT survive is the
+ * port the box has moved off: `inspect` reports every non-web entry as a
+ * reachable `service-<port>` endpoint, so a stale web port would be published
+ * as a second URL pointing at the port we just abandoned.
+ */
+export function mergePreviewUrls(args: {
+  /** The map on the record, from a previous start. */
+  cached: Record<number, string> | undefined;
+  /** Per-service URLs re-minted this start. */
+  fresh: Record<number, string>;
+  /** The web port recorded before this start, if any. */
+  previousWebPort: number | undefined;
+  /** The web port this start resolved. */
+  webPort: number;
+  /** Freshly minted web preview URL, or undefined when it could not be resolved. */
+  webUrl: string | undefined;
+}): Record<number, string> {
+  const merged: Record<number, string> = { ...(args.cached ?? {}), ...args.fresh };
+  if (args.previousWebPort !== undefined && args.previousWebPort !== args.webPort) {
+    delete merged[args.previousWebPort];
+  }
+  if (args.webUrl !== undefined) merged[args.webPort] = args.webUrl;
+  return merged;
+}

--- a/packages/sandbox-cloud/test/preview-urls.test.ts
+++ b/packages/sandbox-cloud/test/preview-urls.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { mergePreviewUrls } from '../src/preview-urls.js';
+
+/**
+ * The bug this pins: hetzner and digitalocean moved their in-box WebProxy off
+ * `:80`, and a box created before that heals onto the new port on its next
+ * start. The cached map still held `80 -> <old forward>`, and `inspect` reports
+ * every non-web entry as a reachable `service-<port>` endpoint — so a healed
+ * box published a second URL aimed at the port it had just abandoned, which is
+ * the dead one portless owns.
+ */
+describe('mergePreviewUrls', () => {
+  it('drops the port the box moved off', () => {
+    const merged = mergePreviewUrls({
+      cached: { 80: 'http://127.0.0.1:1111', 3000: 'http://127.0.0.1:2222' },
+      fresh: {},
+      previousWebPort: 80,
+      webPort: 8080,
+      webUrl: 'http://127.0.0.1:3333',
+    });
+    expect(merged[80]).toBeUndefined();
+    expect(merged[8080]).toBe('http://127.0.0.1:3333');
+    // An unrelated service port is not collateral damage.
+    expect(merged[3000]).toBe('http://127.0.0.1:2222');
+  });
+
+  it('keeps the web entry when the port did not change', () => {
+    const merged = mergePreviewUrls({
+      cached: { 8080: 'http://127.0.0.1:1111' },
+      fresh: {},
+      previousWebPort: 8080,
+      webPort: 8080,
+      webUrl: 'http://127.0.0.1:9999',
+    });
+    expect(merged).toEqual({ 8080: 'http://127.0.0.1:9999' });
+  });
+
+  it('still drops the old port when the new web URL could not be resolved', () => {
+    // Leaving the stale entry as the only web-ish URL would be the worst case:
+    // the box would publish exclusively the dead one.
+    const merged = mergePreviewUrls({
+      cached: { 80: 'http://127.0.0.1:1111' },
+      fresh: {},
+      previousWebPort: 80,
+      webPort: 8080,
+      webUrl: undefined,
+    });
+    expect(merged).toEqual({});
+  });
+
+  it('keeps cached entries this start could not re-resolve', () => {
+    const merged = mergePreviewUrls({
+      cached: { 3000: 'http://127.0.0.1:2222', 9000: 'http://127.0.0.1:4444' },
+      fresh: { 3000: 'http://127.0.0.1:5555' },
+      previousWebPort: 8080,
+      webPort: 8080,
+      webUrl: 'http://127.0.0.1:3333',
+    });
+    expect(merged[3000]).toBe('http://127.0.0.1:5555');
+    expect(merged[9000]).toBe('http://127.0.0.1:4444');
+  });
+
+  it('is a no-op on a box that has never recorded a web port', () => {
+    const merged = mergePreviewUrls({
+      cached: undefined,
+      fresh: {},
+      previousWebPort: undefined,
+      webPort: 80,
+      webUrl: 'http://127.0.0.1:1111',
+    });
+    expect(merged).toEqual({ 80: 'http://127.0.0.1:1111' });
+  });
+});

--- a/packages/sandbox-digitalocean/src/backend.ts
+++ b/packages/sandbox-digitalocean/src/backend.ts
@@ -369,6 +369,22 @@ async function ensureLiveTarget(sandboxId: string): Promise<{
 export const digitaloceanBackend: CloudBackend = {
   name: 'digitalocean',
 
+  /**
+   * The in-box WebProxy binds 8080, not the reserved :80.
+   *
+   * A DigitalOcean box runs its OWN portless proxy (see `startInBoxPortless`) so
+   * `https://<box>.localhost` resolves identically on the host and inside the
+   * box. That proxy owns :443 and holds :80 for the http->https redirect, so
+   * ctl's WebProxy lost the race for :80 and logged `EADDRINUSE` — leaving
+   * `agentbox url` printing a URL that redirected into portless and 404'd,
+   * with the box still reporting ready. Docker never hits this: there portless
+   * runs on the HOST, and the container's :80 is free.
+   *
+   * 8080 rather than some other port because vercel and e2b already bind it —
+   * one in-box convention across every provider that cannot use :80.
+   */
+  webProxyPort: 8080,
+
   async provision(req: CloudProvisionRequest): Promise<CloudHandle> {
     const c = client();
     const onLog = req.onLog ?? (() => {});

--- a/packages/sandbox-digitalocean/test/web-proxy-port.test.ts
+++ b/packages/sandbox-digitalocean/test/web-proxy-port.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { digitaloceanBackend } from '../src/backend.js';
+
+/**
+ * The box's own portless proxy owns :80.
+ *
+ * `startInBoxPortless` runs `portless proxy start` inside the droplet so
+ * `https://<box>.localhost` resolves the same on the host and in the box. That
+ * proxy takes :443 and holds :80 for the http->https redirect, so ctl's
+ * WebProxy — which binds the reserved web port — lost the race and logged
+ * EADDRINUSE. Nothing failed: the box reported ready and `agentbox url` printed
+ * a URL that portless answered with a 302 into a 404.
+ *
+ * Declaring a non-privileged port moves ctl out of the way; it reaches the box
+ * as AGENTBOX_WEB_PROXY_PORT and is also what the in-box `portless alias`
+ * points at, so both sides move together.
+ */
+describe('digitalocean webProxyPort', () => {
+  it('keeps the in-box forwarder off the port portless owns', () => {
+    expect(digitaloceanBackend.webProxyPort).toBeDefined();
+    expect(digitaloceanBackend.webProxyPort).not.toBe(80);
+  });
+
+  it('uses the same port vercel and e2b already use', () => {
+    // One in-box convention for every provider that cannot use :80 — the value
+    // is baked into docs and into `agentbox shell <box> -- curl :8080`.
+    expect(digitaloceanBackend.webProxyPort).toBe(8080);
+  });
+});

--- a/packages/sandbox-hetzner/src/backend.ts
+++ b/packages/sandbox-hetzner/src/backend.ts
@@ -374,6 +374,22 @@ async function ensureLiveTarget(sandboxId: string): Promise<{
 export const hetznerBackend: CloudBackend = {
   name: 'hetzner',
 
+  /**
+   * The in-box WebProxy binds 8080, not the reserved :80.
+   *
+   * A hetzner box runs its OWN portless proxy (see `startInBoxPortless`) so
+   * `https://<box>.localhost` resolves identically on the host and inside the
+   * box. That proxy owns :443 and holds :80 for the http->https redirect, so
+   * ctl's WebProxy lost the race for :80 and logged `EADDRINUSE` — leaving
+   * `agentbox url` printing a URL that redirected into portless and 404'd,
+   * with the box still reporting ready. Docker never hits this: there portless
+   * runs on the HOST, and the container's :80 is free.
+   *
+   * 8080 rather than some other port because vercel and e2b already bind it —
+   * one in-box convention across every provider that cannot use :80.
+   */
+  webProxyPort: 8080,
+
   async provision(req: CloudProvisionRequest): Promise<CloudHandle> {
     const c = client();
     const onLog = req.onLog ?? (() => {});

--- a/packages/sandbox-hetzner/test/web-proxy-port.test.ts
+++ b/packages/sandbox-hetzner/test/web-proxy-port.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { hetznerBackend } from '../src/backend.js';
+
+/**
+ * The box's own portless proxy owns :80.
+ *
+ * `startInBoxPortless` runs `portless proxy start` inside the VPS so
+ * `https://<box>.localhost` resolves the same on the host and in the box. That
+ * proxy takes :443 and holds :80 for the http->https redirect, so ctl's
+ * WebProxy — which binds the reserved web port — lost the race and logged
+ * EADDRINUSE. Nothing failed: the box reported ready and `agentbox url` printed
+ * a URL that portless answered with a 302 into a 404.
+ *
+ * Declaring a non-privileged port moves ctl out of the way; it reaches the box
+ * as AGENTBOX_WEB_PROXY_PORT and is also what the in-box `portless alias`
+ * points at, so both sides move together.
+ */
+describe('hetzner webProxyPort', () => {
+  it('keeps the in-box forwarder off the port portless owns', () => {
+    expect(hetznerBackend.webProxyPort).toBeDefined();
+    expect(hetznerBackend.webProxyPort).not.toBe(80);
+  });
+
+  it('uses the same port vercel and e2b already use', () => {
+    // One in-box convention for every provider that cannot use :80 — the value
+    // is baked into docs and into `agentbox shell <box> -- curl :8080`.
+    expect(hetznerBackend.webProxyPort).toBe(8080);
+  });
+});


### PR DESCRIPTION
Phase A of `docs/plans/box-endpoints-plan.md`. Closes blocker #1 of the
service-boxes plan.

## The bug

A hetzner or digitalocean box runs its **own** portless proxy so
`https://<box>.localhost` resolves the same inside the box and on the host.
That proxy owns `:443` and holds `:80` for the http→https redirect — so ctl's
`WebProxy`, which binds the reserved web port, lost the race:

```
web-proxy.log: listen :80 failed: EADDRINUSE
```

and nothing failed. The box reported `ready`, `agentbox openclaw` printed a URL,
and that URL was answered by portless with a 302 into a 404. Docker is immune:
there portless runs on the **host**, and the container's `:80` is free.

## The fix

Both backends declare `webProxyPort: 8080` — the port vercel and e2b already
use. One value drives all three sides: it reaches ctl as
`AGENTBOX_WEB_PROXY_PORT`, it is what the in-box `portless alias` points at, and
it is the remote port the host forwards. A restart adopts the backend's current
port and writes it back to `cloud.webPort`, so a box created before this heals
itself instead of staying pinned to a port its own proxy owns.

The silence was the worse half of the bug. `WebProxy` now records a failed bind
and the supervisor reports it on the status snapshot, so `agentbox status`,
`<agent> url` and a service-agent launch say the URL will not answer rather than
handing it over. Absent is treated as "no information", never as healthy — the
field is additive on a schema-1 snapshot, so every box baked before it lacks one.

## Verified live on Hetzner

Real box, real VPS, `agentbox openclaw --provider hetzner`:

```
AGENTBOX_WEB_PROXY_PORT=8080
LISTEN  0.0.0.0:8080     ctl WebProxy
LISTEN  127.0.0.1:80     portless
LISTEN  127.0.0.1:443    portless
```

No collision, and the box's published URL now reaches the gateway
(`/healthz` → 200 through the full host→tunnel→WebProxy→gateway chain; it 404'd
before). The box was destroyed after the run; no orphan servers.

Tests: `WebProxy.state` (including a real EADDRINUSE against an occupied port),
the reporter carrying it into the snapshot, both backends' declared port, and
the host-side warning's quiet cases. The two behavioural ones are mutation-checked.

## Found while verifying, NOT fixed here

Once the URL routed, a **second** gate appeared: OpenClaw 403s
(`proxy_attribution_required`) on **any** forwarded header, and portless always
adds them. `/healthz` is exempt — which is why every smoke test so far passed.
This affects every provider, docker included, and it needs a product decision;
the evidence and the three options are in `docs/plans/service-boxes-backlog.md`.

https://claude.ai/code/session_01ChpFVKPMobDd3xk3uwG6gj

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default web forwarding ports and URL plumbing on Hetzner/DigitalOcean; mistakes could break published URLs, though restart self-heal and new warnings reduce silent failure.
> 
> **Overview**
> **Hetzner and DigitalOcean** no longer let ctl’s in-box `WebProxy` fight the box’s Portless mirror for `:80`. Both backends now declare **`webProxyPort: 8080`** (same convention as Vercel/E2B), so ctl binds `8080`, Portless aliases point there, and host SSH forwards use that port. On **restart/reconnect**, `reEnsureCloudBox` prefers the backend’s current port over a stale `cloud.webPort` and passes the same value into bootstrap so older boxes can heal without a recreate.
> 
> **Bind failures are visible instead of log-only.** `WebProxy` keeps a `WebProxyState` (listen port, target, optional `error`), the supervisor exposes it, and status snapshots include **`webProxy`**. The CLI’s new **`webProxyWarning`** helper warns when a published URL likely won’t reach the service—on service-agent launch, on `<agent> url` (stderr so `| head -1` stays clean), and under a **WEB** section in persisted status output. Missing `webProxy` on old snapshots is treated as “no information,” not healthy.
> 
> Docs note the `8080` web slot on Vercel and the Hetzner/DO port story; the backlog records a **separate** OpenClaw Control UI `403` from Portless forwarded headers—not addressed here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 989164806e27e0ce74f3008f2ae3489cb09bc348. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->