### PR TITLE
feat(openclaw): tell the gateway which box it is running in

### DIFF
--- a/apps/web/content/docs/openclaw.mdx
+++ b/apps/web/content/docs/openclaw.mdx
@@ -158,9 +158,9 @@ Two things, both AgentBox's rather than yours, refreshed on every boot:
   description Claude and Codex get, so the gateway's agent knows it is in a
   sandbox, that `/workspace` is box-local, and how to reach your machine. It has
   to live inside the workspace because OpenClaw reads a system prompt from
-  nowhere else, so AgentBox adds `.agentbox/` to the box's own
-  `.git/info/exclude` — it will not follow an `agentbox download` into your repo,
-  and your own `AGENTS.md` is never touched.
+  nowhere else, but `agentbox download` and `agentbox clone` both skip
+  `.agentbox/` — it will not follow a pull into your repo, and your own
+  `AGENTS.md` is never touched.
 
 Both are regenerated each time the supervisor starts, which is what keeps a
 cloned box from inheriting the facts of the box it was cloned from.

--- a/apps/web/content/docs/openclaw.mdx
+++ b/apps/web/content/docs/openclaw.mdx
@@ -147,6 +147,24 @@ The unit names (`openclaw`, `openclaw-onboard`, `openclaw-render`) are public su
 
 Only one unit may `expose:`. If your `agentbox.yaml` already publishes the box's web port, OpenClaw's `expose:` is dropped with a warning rather than silently taking it over.
 
+## What AgentBox adds to the box
+
+Two things, both AgentBox's rather than yours, refreshed on every boot:
+
+- **A skill** at `/opt/agentbox/skills/` — outside your workspace, registered
+  through OpenClaw's `skills.load.extraDirs` at its lowest precedence, so a skill
+  of your own with the same name wins. It never travels with `agentbox clone`.
+- **The box facts** at `/workspace/.agentbox/AGENTS.md` — the same sandbox
+  description Claude and Codex get, so the gateway's agent knows it is in a
+  sandbox, that `/workspace` is box-local, and how to reach your machine. It has
+  to live inside the workspace because OpenClaw reads a system prompt from
+  nowhere else, so AgentBox adds `.agentbox/` to the box's own
+  `.git/info/exclude` — it will not follow an `agentbox download` into your repo,
+  and your own `AGENTS.md` is never touched.
+
+Both are regenerated each time the supervisor starts, which is what keeps a
+cloned box from inheriting the facts of the box it was cloned from.
+
 ## State, sync and clones
 
 | Path in the box                   | What it is                      | Travels?                         |

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -381,6 +381,17 @@ declares instead of the TUI machinery:
 - **`service.urlFields`** — values `<agent> url` prints beside the URL, read out
   of the daemon's own config file (a Control UI's gateway token). Data, because
   the only per-agent parts are which file and which dotted key.
+- **`service.tasks`** is also where AgentBox asserts config it OWNS. openclaw's
+  `openclaw-agentbox-env` task installs the AgentBox skill under
+  `/opt/agentbox/skills` (registered via `skills.load.extraDirs`, outside the
+  workspace so a clone never carries it) and writes the box facts to
+  `/workspace/.agentbox/AGENTS.md` (registered via the `bootstrap-extra-files`
+  hook, which refuses any path outside the workspace and any name that is not
+  one of openclaw's six canonical bootstrap basenames). It runs on EVERY boot,
+  because the workspace file travels with `agentbox clone` and would otherwise
+  describe the box it came from. `configRender` is not the seam for this: it
+  reads only the user's `agentbox.yaml` block, and the render runs after this
+  task so the user still has the last word on any key both name.
 - **`service.repl`** — argv for an interactive CLIENT of the daemon, opened by
   `agentbox attach`, `agentbox <agent> attach` and `agentbox open --in <app>`.
   It does NOT make the agent a TUI one and does NOT get an `attachWrapped`:

--- a/packages/agent-openclaw/test/spec.test.ts
+++ b/packages/agent-openclaw/test/spec.test.ts
@@ -40,15 +40,20 @@ describe('openclaw registry row', () => {
     expect(text).not.toContain('AGENTBOX_AUTO_SECRET');
   });
 
-  it('onboards once, then renders the overlay, then starts', () => {
+  it('onboards once, seeds the box context, renders the overlay, then starts', () => {
     const tasks = SPEC.service?.tasks ?? [];
     const onboard = tasks.find((t) => t.name === 'openclaw-onboard');
+    const env = tasks.find((t) => t.name === 'openclaw-agentbox-env');
     const render = tasks.find((t) => t.name === 'openclaw-render');
     // `runOnce` is what keeps a warm boot from re-onboarding and replacing the
     // identity the box already has.
     expect(onboard?.runOnce).toBe('marker');
     expect(onboard?.command).toContain('--non-interactive');
-    expect(render?.needs).toEqual(['openclaw-onboard']);
+    // The AgentBox-owned keys go in BETWEEN: after onboard wrote the config file
+    // they patch, and before the render, so the user's own overlay is the last
+    // word on any key both of them name.
+    expect(env?.needs).toEqual(['openclaw-onboard']);
+    expect(render?.needs).toEqual(['openclaw-agentbox-env']);
     expect(SPEC.service?.needs).toEqual(['openclaw-render']);
   });
 

--- a/packages/agent-registry/src/specs/openclaw.ts
+++ b/packages/agent-registry/src/specs/openclaw.ts
@@ -49,6 +49,101 @@ const OPENCLAW_XDG_LINK = `${BOX_HOME}/.config/openclaw`;
 /** Loopback port the gateway binds. Named once — probe, expose and URL all read it. */
 const GATEWAY_PORT = 18789;
 
+/**
+ * Where AgentBox keeps the skills it owns, and the box "system prompt" it
+ * derives. Both are AgentBox's, not the user's.
+ *
+ * The skill lives OUTSIDE the workspace on purpose: `skills.load.extraDirs` is
+ * documented for exactly this ("shared skill packs ... without copying them
+ * into the OpenClaw workspace"), at LOWEST precedence, so a user skill of the
+ * same name wins. Nothing about it travels with `agentbox clone`.
+ *
+ * The prompt file cannot do the same. openclaw's `bootstrap-extra-files` hook
+ * resolves every path from the workspace and REALPATH-CHECKS it, so a symlink
+ * out is refused, and only the six canonical bootstrap basenames are accepted —
+ * hence a real `AGENTS.md`, inside `/workspace`, under a namespaced dir.
+ */
+const AGENTBOX_SKILLS_DIR = '/opt/agentbox/skills';
+/** Baked into every provider's base image; see each `install-box.sh`. */
+const BAKED_SETUP_SKILL = '/usr/local/share/agentbox/setup-guide.md';
+/** The per-provider box facts. Claude reads it directly; codex folds it in too. */
+const BOX_FACTS = '/etc/claude-code/CLAUDE.md';
+const AGENTBOX_CTX_DIR = '/workspace/.agentbox';
+/** First line of the generated file: makes a re-run idempotent, and says whose it is. */
+const CTX_SENTINEL = '<!-- agentbox:box-facts (generated every boot; edit AGENTS.md instead) -->';
+
+/**
+ * The keys AgentBox OWNS in openclaw's config, applied through openclaw's own
+ * validated merge. Deliberately not the `openclaw:` overlay in agentbox.yaml —
+ * that is the user's, and `configRender` reads only from there.
+ *
+ * `openclaw-render` applies the user's overlay afterwards and sends only the
+ * keys they CHANGED, so these survive unless the user names the same key, which
+ * is the precedence we want.
+ */
+const AGENTBOX_OWNED_CONFIG = JSON.stringify({
+  skills: { load: { extraDirs: [AGENTBOX_SKILLS_DIR] } },
+  hooks: {
+    internal: {
+      enabled: true,
+      entries: { 'bootstrap-extra-files': { enabled: true, paths: ['.agentbox/AGENTS.md'] } },
+    },
+  },
+});
+
+/**
+ * Teach the box's gateway where it is running.
+ *
+ * Runs on EVERY supervisor start, not once: the prompt file sits in the
+ * workspace, so `agentbox clone` carries a copy of the SOURCE box's facts into
+ * the new one. Regenerating overwrites it from this box's own `/etc/claude-code`
+ * before the gateway ever reads it — which is what makes a clone, a re-provision
+ * or a move to another provider self-correcting rather than quietly wrong.
+ *
+ * Best-effort throughout: none of this is worth failing a box over, so every
+ * step is guarded and the task still exits 0 on a base too old to carry the
+ * baked files.
+ */
+function buildAgentboxContextScript(): string {
+  return [
+    'set -u',
+    // The skill. COPIED, not symlinked, and as `<name>/SKILL.md` rather than a
+    // flat `.md` — both measured against openclaw 2026.9.2, which discovered
+    // neither other shape: it takes skills as directories, and rejects a symlink
+    // whose real target sits outside the source root unless that target is in
+    // `skills.load.allowSymlinkTargets`. Re-copied every boot, so a re-baked
+    // base image still propagates.
+    `if [ -f ${BAKED_SETUP_SKILL} ]; then`,
+    `  D=${AGENTBOX_SKILLS_DIR}/agentbox-setup`,
+    '  (sudo -n mkdir -p "$D" 2>/dev/null || mkdir -p "$D") || true',
+    `  (sudo -n install -m 0644 ${BAKED_SETUP_SKILL} "$D/SKILL.md" 2>/dev/null ||`,
+    `   install -m 0644 ${BAKED_SETUP_SKILL} "$D/SKILL.md") || true`,
+    'fi',
+    // The box facts, written atomically so a reader never sees a half file.
+    `if [ -f ${BOX_FACTS} ]; then`,
+    `  mkdir -p ${AGENTBOX_CTX_DIR} || true`,
+    `  TMP=${AGENTBOX_CTX_DIR}/AGENTS.md.agentbox.tmp`,
+    '  {',
+    `    printf '%s\\n\\n' '${CTX_SENTINEL}'`,
+    `    cat ${BOX_FACTS}`,
+    '  } > "$TMP" && mv "$TMP" ' + `${AGENTBOX_CTX_DIR}/AGENTS.md || true`,
+    'fi',
+    // Keep it out of the user's repo. `agentbox download` selects with
+    // `git ls-files --others --exclude-standard` and deliberately does NOT apply
+    // the exclude list in git mode, so the only thing that hides an untracked
+    // file there is git itself. `.git/info/exclude` is per-clone and in the BOX,
+    // so the user's own .gitignore is never touched.
+    'if [ -d /workspace/.git ]; then',
+    '  mkdir -p /workspace/.git/info || true',
+    "  grep -qxF '.agentbox/' /workspace/.git/info/exclude 2>/dev/null ||",
+    "    printf '%s\\n' '.agentbox/' >> /workspace/.git/info/exclude || true",
+    'fi',
+    // One validated merge rather than several `config set` calls.
+    `printf '%s' '${AGENTBOX_OWNED_CONFIG}' | openclaw config patch --stdin >/dev/null || true`,
+    'exit 0',
+  ].join('\n');
+}
+
 export const openclawSpec: AgentSyncSpec = {
   id: 'openclaw',
   aliases: [],
@@ -178,9 +273,19 @@ export const openclawSpec: AgentSyncSpec = {
           '--skip-channels --skip-health --no-install-daemon',
       },
       {
+        // Everything AgentBox owns in this box: the skill root outside the
+        // workspace, the derived box facts inside it, and the two config keys
+        // that make openclaw read both. No `runOnce` — see the builder's doc.
+        name: 'openclaw-agentbox-env',
+        command: buildAgentboxContextScript(),
+        needs: ['openclaw-onboard'],
+      },
+      {
         name: 'openclaw-render',
         command: 'agentbox-ctl agent render openclaw',
-        needs: ['openclaw-onboard'],
+        // After the AgentBox keys, so the user's overlay is the last word on any
+        // key they and we both name.
+        needs: ['openclaw-agentbox-env'],
       },
     ],
     // The Control UI asks for the gateway token on first load, and openclaw's

--- a/packages/agent-registry/src/specs/openclaw.ts
+++ b/packages/agent-registry/src/specs/openclaw.ts
@@ -113,7 +113,7 @@ const CTX_REL_PATH = '.agentbox/AGENTS.md';
  * so the exit code alone cannot separate a fresh box from a broken config.
  */
 export const OPENCLAW_CONFIG_MERGE_PROGRAM = `
-const [skillDir, ctxPath, rawDirs, rawEntry, rawHooksEnabled] = process.argv.slice(2);
+const [skillDir, ctxPath, rawDirs, rawEntries, rawHooksEnabled] = process.argv.slice(2);
 const read = (s) => {
   try {
     return JSON.parse(s);
@@ -123,7 +123,7 @@ const read = (s) => {
 };
 const withMember = (arr, v) =>
   Array.isArray(arr) ? (arr.includes(v) ? arr.slice() : [...arr, v]) : [v];
-const entry = read(rawEntry) ?? {};
+const entry = read(rawEntries)?.['bootstrap-extra-files'] ?? {};
 process.stdout.write(
   JSON.stringify({
     skills: { load: { extraDirs: withMember(read(rawDirs), skillDir) } },
@@ -192,7 +192,12 @@ function buildAgentboxContextScript(): string {
     // right.
     'if openclaw config validate >/dev/null 2>&1; then',
     `  DIRS=$(openclaw config get 'skills.load.extraDirs' 2>/dev/null || true)`,
-    `  ENTRY=$(openclaw config get "hooks.internal.entries['bootstrap-extra-files']" 2>/dev/null || true)`,
+    // The whole `entries` object, by plain dot path, and the one key is picked out
+    // in the program. Reading `entries['bootstrap-extra-files']` directly does
+    // work on 2026.9.2, but it leans on the CLI's bracket-and-quote parsing for a
+    // key with a hyphen in it — and a get that fails here is indistinguishable
+    // from unset, which would silently replace the user's `paths`.
+    `  ENTRIES=$(openclaw config get 'hooks.internal.entries' 2>/dev/null || true)`,
     `  HOOKS=$(openclaw config get 'hooks.internal.enabled' 2>/dev/null || true)`,
     // Written to a file first: a quoted heredoc keeps the program safe from the
     // shell, and it avoids process substitution, which some provider bases have
@@ -201,7 +206,7 @@ function buildAgentboxContextScript(): string {
     '  cat > "$PROG" <<\'AGENTBOX_MERGE_EOF\'',
     OPENCLAW_CONFIG_MERGE_PROGRAM.trim(),
     'AGENTBOX_MERGE_EOF',
-    `  node "$PROG" ${AGENTBOX_SKILLS_DIR} ${CTX_REL_PATH} "$DIRS" "$ENTRY" "$HOOKS" |`,
+    `  node "$PROG" ${AGENTBOX_SKILLS_DIR} ${CTX_REL_PATH} "$DIRS" "$ENTRIES" "$HOOKS" |`,
     '    openclaw config patch --stdin >/dev/null || true',
     '  rm -f "$PROG" || true',
     'fi',

--- a/packages/agent-registry/src/specs/openclaw.ts
+++ b/packages/agent-registry/src/specs/openclaw.ts
@@ -72,8 +72,6 @@ const AGENTBOX_CTX_DIR = '/workspace/.agentbox';
 /** First line of the generated file: makes a re-run idempotent, and says whose it is. */
 const CTX_SENTINEL = '<!-- agentbox:box-facts (generated every boot; edit AGENTS.md instead) -->';
 
-/** openclaw's config file — the same path `configRender` renders into. */
-const OPENCLAW_CONFIG_FILE = `${OPENCLAW_BOX_DIR}/openclaw.json`;
 /** Scratch path for the merge program; removed again as soon as it has run. */
 const MERGE_PROGRAM_PATH = '/tmp/agentbox-openclaw-config-merge.cjs';
 
@@ -101,23 +99,37 @@ const CTX_REL_PATH = '.agentbox/AGENTS.md';
  * Emitted as a program rather than a static JSON blob because the merge has to
  * happen IN the box, against that box's live config. node is guaranteed there —
  * openclaw is a node application.
+ *
+ * It is handed the current values rather than reading `openclaw.json` itself.
+ * That file is JSON5 — openclaw reads a config with a `//` comment in it quite
+ * happily, and `JSON.parse` throws on the same file (both verified in a box) —
+ * so parsing it here would see `{}` for a commented config and clobber exactly
+ * the arrays this program exists to preserve. `openclaw config get` is the
+ * tool's own reader, and it also resolves defaults, profiles and env overrides.
+ *
+ * An unreadable value is treated as UNSET, which is only safe because the caller
+ * gates the whole step on `openclaw config validate`: openclaw prints nothing
+ * and exits 1 both for a path that is merely unset and for one it cannot read,
+ * so the exit code alone cannot separate a fresh box from a broken config.
  */
 export const OPENCLAW_CONFIG_MERGE_PROGRAM = `
-const fs = require('fs');
-const [cfgPath, skillDir, ctxPath] = process.argv.slice(2);
-let cur = {};
-try {
-  cur = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
-} catch {}
+const [skillDir, ctxPath, rawDirs, rawEntry, rawHooksEnabled] = process.argv.slice(2);
+const read = (s) => {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return undefined;
+  }
+};
 const withMember = (arr, v) =>
   Array.isArray(arr) ? (arr.includes(v) ? arr.slice() : [...arr, v]) : [v];
-const entry = cur?.hooks?.internal?.entries?.['bootstrap-extra-files'] ?? {};
+const entry = read(rawEntry) ?? {};
 process.stdout.write(
   JSON.stringify({
-    skills: { load: { extraDirs: withMember(cur?.skills?.load?.extraDirs, skillDir) } },
+    skills: { load: { extraDirs: withMember(read(rawDirs), skillDir) } },
     hooks: {
       internal: {
-        enabled: cur?.hooks?.internal?.enabled === false ? false : true,
+        enabled: read(rawHooksEnabled) === false ? false : true,
         entries: {
           'bootstrap-extra-files': {
             ...entry,
@@ -172,16 +184,27 @@ function buildAgentboxContextScript(): string {
     // COMPUTED from the box's live config (see the program's own comment) so the
     // two arrays gain our entry instead of being replaced by it.
     //
+    // Gated on openclaw's own validator. A `config get` prints nothing and exits
+    // 1 both for a value that is merely unset and for one it cannot read, so
+    // without this gate a broken config would look like a fresh box and be
+    // overwritten with just our entry. With the config known good, an empty read
+    // means genuinely unset, which is the one case where writing ours alone is
+    // right.
+    'if openclaw config validate >/dev/null 2>&1; then',
+    `  DIRS=$(openclaw config get 'skills.load.extraDirs' 2>/dev/null || true)`,
+    `  ENTRY=$(openclaw config get "hooks.internal.entries['bootstrap-extra-files']" 2>/dev/null || true)`,
+    `  HOOKS=$(openclaw config get 'hooks.internal.enabled' 2>/dev/null || true)`,
     // Written to a file first: a quoted heredoc keeps the program safe from the
     // shell, and it avoids process substitution, which some provider bases have
     // no `/dev/fd` for.
-    `PROG=${MERGE_PROGRAM_PATH}`,
-    'cat > "$PROG" <<\'AGENTBOX_MERGE_EOF\'',
+    `  PROG=${MERGE_PROGRAM_PATH}`,
+    '  cat > "$PROG" <<\'AGENTBOX_MERGE_EOF\'',
     OPENCLAW_CONFIG_MERGE_PROGRAM.trim(),
     'AGENTBOX_MERGE_EOF',
-    `node "$PROG" ${OPENCLAW_CONFIG_FILE} ${AGENTBOX_SKILLS_DIR} ${CTX_REL_PATH} |`,
-    '  openclaw config patch --stdin >/dev/null || true',
-    'rm -f "$PROG" || true',
+    `  node "$PROG" ${AGENTBOX_SKILLS_DIR} ${CTX_REL_PATH} "$DIRS" "$ENTRY" "$HOOKS" |`,
+    '    openclaw config patch --stdin >/dev/null || true',
+    '  rm -f "$PROG" || true',
+    'fi',
     'exit 0',
   ].join('\n');
 }

--- a/packages/agent-registry/src/specs/openclaw.ts
+++ b/packages/agent-registry/src/specs/openclaw.ts
@@ -128,16 +128,6 @@ function buildAgentboxContextScript(): string {
     `    cat ${BOX_FACTS}`,
     '  } > "$TMP" && mv "$TMP" ' + `${AGENTBOX_CTX_DIR}/AGENTS.md || true`,
     'fi',
-    // Keep it out of the user's repo. `agentbox download` selects with
-    // `git ls-files --others --exclude-standard` and deliberately does NOT apply
-    // the exclude list in git mode, so the only thing that hides an untracked
-    // file there is git itself. `.git/info/exclude` is per-clone and in the BOX,
-    // so the user's own .gitignore is never touched.
-    'if [ -d /workspace/.git ]; then',
-    '  mkdir -p /workspace/.git/info || true',
-    "  grep -qxF '.agentbox/' /workspace/.git/info/exclude 2>/dev/null ||",
-    "    printf '%s\\n' '.agentbox/' >> /workspace/.git/info/exclude || true",
-    'fi',
     // One validated merge rather than several `config set` calls.
     `printf '%s' '${AGENTBOX_OWNED_CONFIG}' | openclaw config patch --stdin >/dev/null || true`,
     'exit 0',

--- a/packages/agent-registry/src/specs/openclaw.ts
+++ b/packages/agent-registry/src/specs/openclaw.ts
@@ -72,24 +72,64 @@ const AGENTBOX_CTX_DIR = '/workspace/.agentbox';
 /** First line of the generated file: makes a re-run idempotent, and says whose it is. */
 const CTX_SENTINEL = '<!-- agentbox:box-facts (generated every boot; edit AGENTS.md instead) -->';
 
+/** openclaw's config file — the same path `configRender` renders into. */
+const OPENCLAW_CONFIG_FILE = `${OPENCLAW_BOX_DIR}/openclaw.json`;
+/** Scratch path for the merge program; removed again as soon as it has run. */
+const MERGE_PROGRAM_PATH = '/tmp/agentbox-openclaw-config-merge.cjs';
+
+/** Workspace-relative path of the generated prompt file, as the hook names it. */
+const CTX_REL_PATH = '.agentbox/AGENTS.md';
+
 /**
- * The keys AgentBox OWNS in openclaw's config, applied through openclaw's own
- * validated merge. Deliberately not the `openclaw:` overlay in agentbox.yaml —
- * that is the user's, and `configRender` reads only from there.
+ * Build the config patch AgentBox applies, as a MEMBERSHIP assertion on the two
+ * arrays rather than a value for them.
  *
- * `openclaw-render` applies the user's overlay afterwards and sends only the
- * keys they CHANGED, so these survive unless the user names the same key, which
- * is the precedence we want.
+ * Both keys are arrays, and `openclaw config patch` replaces an array wholesale
+ * rather than merging it — so sending a literal `[ourDir]` every boot would be a
+ * silent data-loss bug, not merely rude. `openclaw-render` re-sends only the
+ * overlay keys that CHANGED since its last render, so a user value that is
+ * stable (in `agentbox.yaml`, or set in the box with `openclaw config set`)
+ * would not be re-asserted afterwards: it would survive the first boot and
+ * vanish on the second.
+ *
+ * Reading the current value and unioning ours in keeps AgentBox's claim to the
+ * narrowest true one — "our skills dir is on the list, our prompt file is in the
+ * bootstrap set" — and leaves every other entry, and every neighbouring key,
+ * alone. An explicit `enabled: false` on the hook is preserved too: disabling
+ * the box facts is a choice the user is allowed to make and have stick.
+ *
+ * Emitted as a program rather than a static JSON blob because the merge has to
+ * happen IN the box, against that box's live config. node is guaranteed there —
+ * openclaw is a node application.
  */
-const AGENTBOX_OWNED_CONFIG = JSON.stringify({
-  skills: { load: { extraDirs: [AGENTBOX_SKILLS_DIR] } },
-  hooks: {
-    internal: {
-      enabled: true,
-      entries: { 'bootstrap-extra-files': { enabled: true, paths: ['.agentbox/AGENTS.md'] } },
+export const OPENCLAW_CONFIG_MERGE_PROGRAM = `
+const fs = require('fs');
+const [cfgPath, skillDir, ctxPath] = process.argv.slice(2);
+let cur = {};
+try {
+  cur = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+} catch {}
+const withMember = (arr, v) =>
+  Array.isArray(arr) ? (arr.includes(v) ? arr.slice() : [...arr, v]) : [v];
+const entry = cur?.hooks?.internal?.entries?.['bootstrap-extra-files'] ?? {};
+process.stdout.write(
+  JSON.stringify({
+    skills: { load: { extraDirs: withMember(cur?.skills?.load?.extraDirs, skillDir) } },
+    hooks: {
+      internal: {
+        enabled: cur?.hooks?.internal?.enabled === false ? false : true,
+        entries: {
+          'bootstrap-extra-files': {
+            ...entry,
+            enabled: entry.enabled === false ? false : true,
+            paths: withMember(entry.paths, ctxPath),
+          },
+        },
+      },
     },
-  },
-});
+  }),
+);
+`;
 
 /**
  * Teach the box's gateway where it is running.
@@ -128,8 +168,20 @@ function buildAgentboxContextScript(): string {
     `    cat ${BOX_FACTS}`,
     '  } > "$TMP" && mv "$TMP" ' + `${AGENTBOX_CTX_DIR}/AGENTS.md || true`,
     'fi',
-    // One validated merge rather than several `config set` calls.
-    `printf '%s' '${AGENTBOX_OWNED_CONFIG}' | openclaw config patch --stdin >/dev/null || true`,
+    // One validated merge rather than several `config set` calls. The patch is
+    // COMPUTED from the box's live config (see the program's own comment) so the
+    // two arrays gain our entry instead of being replaced by it.
+    //
+    // Written to a file first: a quoted heredoc keeps the program safe from the
+    // shell, and it avoids process substitution, which some provider bases have
+    // no `/dev/fd` for.
+    `PROG=${MERGE_PROGRAM_PATH}`,
+    'cat > "$PROG" <<\'AGENTBOX_MERGE_EOF\'',
+    OPENCLAW_CONFIG_MERGE_PROGRAM.trim(),
+    'AGENTBOX_MERGE_EOF',
+    `node "$PROG" ${OPENCLAW_CONFIG_FILE} ${AGENTBOX_SKILLS_DIR} ${CTX_REL_PATH} |`,
+    '  openclaw config patch --stdin >/dev/null || true',
+    'rm -f "$PROG" || true',
     'exit 0',
   ].join('\n');
 }

--- a/packages/agent-registry/test/openclaw-agentbox-env.test.ts
+++ b/packages/agent-registry/test/openclaw-agentbox-env.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { AGENT_SPECS } from '../src/index.js';
+
+/**
+ * The task that tells an OpenClaw box where it is running.
+ *
+ * Every shape below was MEASURED against openclaw 2026.9.2 on a live box, not
+ * inferred — each assertion pins something that silently produced nothing when
+ * it was wrong.
+ */
+const spec = AGENT_SPECS.find((s) => s.id === 'openclaw')!;
+const task = spec.service!.tasks!.find((t) => t.name === 'openclaw-agentbox-env')!;
+const script = task.command as string;
+
+describe('openclaw-agentbox-env', () => {
+  it('runs after onboard and before the render', () => {
+    // onboard writes the config file this task patches; the render applies the
+    // USER's overlay afterwards, so the user has the last word on a shared key.
+    expect(task.needs).toEqual(['openclaw-onboard']);
+    const render = spec.service!.tasks!.find((t) => t.name === 'openclaw-render')!;
+    expect(render.needs).toEqual(['openclaw-agentbox-env']);
+  });
+
+  it('re-runs on every boot rather than once', () => {
+    // The prompt file lives in the workspace, so `agentbox clone` carries the
+    // SOURCE box's facts into the new box. A `runOnce` marker would let those
+    // stale facts stand.
+    expect(task.runOnce).toBeUndefined();
+  });
+
+  it('installs the skill as a directory, not a flat .md', () => {
+    // openclaw discovers skills as `<name>/SKILL.md`; a flat `agentbox-setup.md`
+    // in the same root was NOT found.
+    expect(script).toContain('/opt/agentbox/skills/agentbox-setup');
+    expect(script).toContain('SKILL.md');
+  });
+
+  it('copies the skill rather than symlinking it', () => {
+    // openclaw refuses a skill symlink whose real target is outside the source
+    // root unless it is in `skills.load.allowSymlinkTargets`. A symlink to
+    // /usr/local/share/agentbox was silently skipped.
+    expect(script).not.toMatch(/ln -s/);
+    expect(script).toContain('install -m 0644');
+  });
+
+  it('keeps the generated file out of the user repo via git itself', () => {
+    // `agentbox download` selects with `git ls-files --others
+    // --exclude-standard` and does not apply the exclude list in git mode, so
+    // the box's own .git/info/exclude is the only thing that hides it there.
+    expect(script).toContain('/workspace/.git/info/exclude');
+    expect(script).toContain('.agentbox/');
+  });
+
+  it('writes the prompt file atomically, behind a sentinel', () => {
+    // The sentinel is what makes a re-run idempotent instead of folding the
+    // previous generation into the next one.
+    expect(script).toMatch(/agentbox:box-facts/);
+    expect(script).toMatch(/AGENTS\.md\.agentbox\.tmp/);
+    expect(script).toMatch(/mv "\$TMP"/);
+  });
+
+  it('asserts both config keys in ONE validated merge', () => {
+    // `config patch --stdin` is openclaw's own validated recursive merge — the
+    // exact payload was dry-run against a live gateway.
+    expect(script).toContain('openclaw config patch --stdin');
+    const json = /'(\{"skills".*?\})'/.exec(script)?.[1];
+    expect(json, 'the owned-config payload is not in the script').toBeDefined();
+    const parsed = JSON.parse(json!) as Record<string, unknown>;
+    expect(parsed).toEqual({
+      skills: { load: { extraDirs: ['/opt/agentbox/skills'] } },
+      hooks: {
+        internal: {
+          enabled: true,
+          entries: { 'bootstrap-extra-files': { enabled: true, paths: ['.agentbox/AGENTS.md'] } },
+        },
+      },
+    });
+  });
+
+  it('names a bootstrap basename openclaw actually accepts', () => {
+    // The hook loads only the six canonical names; `.agentbox/AGENTBOX.md`
+    // would be rejected as `invalid-bootstrap-filename`.
+    const canonical = [
+      'AGENTS.md',
+      'SOUL.md',
+      'IDENTITY.md',
+      'USER.md',
+      'BOOTSTRAP.md',
+      'MEMORY.md',
+    ];
+    const json = /'(\{"skills".*?\})'/.exec(script)![1]!;
+    const paths = (
+      JSON.parse(json) as { hooks: { internal: { entries: Record<string, { paths: string[] }> } } }
+    ).hooks.internal.entries['bootstrap-extra-files']!.paths;
+    for (const p of paths) expect(canonical).toContain(p.split('/').pop());
+  });
+
+  it('never fails the box: every step is guarded', () => {
+    // A base image too old to carry the baked files must still boot.
+    expect(script).toContain('set -u');
+    expect(script).not.toContain('set -e');
+    expect(script.trimEnd().endsWith('exit 0')).toBe(true);
+  });
+});

--- a/packages/agent-registry/test/openclaw-agentbox-env.test.ts
+++ b/packages/agent-registry/test/openclaw-agentbox-env.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { AGENT_SPECS } from '../src/index.js';
+import { OPENCLAW_CONFIG_MERGE_PROGRAM } from '../src/specs/openclaw.js';
 
 /**
  * The task that tells an OpenClaw box where it is running.
@@ -61,22 +62,19 @@ describe('openclaw-agentbox-env', () => {
     expect(script).toMatch(/mv "\$TMP"/);
   });
 
-  it('asserts both config keys in ONE validated merge', () => {
-    // `config patch --stdin` is openclaw's own validated recursive merge — the
-    // exact payload was dry-run against a live gateway.
+  it("applies both keys through openclaw's own validated merge", () => {
+    // `config patch --stdin` is openclaw's validated recursive merge. What it
+    // is fed is COMPUTED in the box (see `openclaw-config-merge.test.ts` for the
+    // merge itself) because patch replaces an array wholesale — a static payload
+    // would silently drop a user's own extraDirs on the second boot.
     expect(script).toContain('openclaw config patch --stdin');
-    const json = /'(\{"skills".*?\})'/.exec(script)?.[1];
-    expect(json, 'the owned-config payload is not in the script').toBeDefined();
-    const parsed = JSON.parse(json!) as Record<string, unknown>;
-    expect(parsed).toEqual({
-      skills: { load: { extraDirs: ['/opt/agentbox/skills'] } },
-      hooks: {
-        internal: {
-          enabled: true,
-          entries: { 'bootstrap-extra-files': { enabled: true, paths: ['.agentbox/AGENTS.md'] } },
-        },
-      },
-    });
+    expect(script).toContain(OPENCLAW_CONFIG_MERGE_PROGRAM.trim());
+    expect(script).toContain('/opt/agentbox/skills .agentbox/AGENTS.md');
+  });
+
+  it('feeds the merge the box config, and cleans up after itself', () => {
+    expect(script).toContain('/home/vscode/.openclaw/openclaw.json');
+    expect(script).toMatch(/rm -f "\$PROG"/);
   });
 
   it('names a bootstrap basename openclaw actually accepts', () => {
@@ -90,11 +88,9 @@ describe('openclaw-agentbox-env', () => {
       'BOOTSTRAP.md',
       'MEMORY.md',
     ];
-    const json = /'(\{"skills".*?\})'/.exec(script)![1]!;
-    const paths = (
-      JSON.parse(json) as { hooks: { internal: { entries: Record<string, { paths: string[] }> } } }
-    ).hooks.internal.entries['bootstrap-extra-files']!.paths;
-    for (const p of paths) expect(canonical).toContain(p.split('/').pop());
+    const ctxArg = /\/opt\/agentbox\/skills (\S+)/.exec(script)?.[1];
+    expect(ctxArg, 'the context path is not passed to the merge').toBeDefined();
+    expect(canonical).toContain(ctxArg!.split('/').pop());
   });
 
   it('never fails the box: every step is guarded', () => {

--- a/packages/agent-registry/test/openclaw-agentbox-env.test.ts
+++ b/packages/agent-registry/test/openclaw-agentbox-env.test.ts
@@ -43,12 +43,14 @@ describe('openclaw-agentbox-env', () => {
     expect(script).toContain('install -m 0644');
   });
 
-  it('keeps the generated file out of the user repo via git itself', () => {
-    // `agentbox download` selects with `git ls-files --others
-    // --exclude-standard` and does not apply the exclude list in git mode, so
-    // the box's own .git/info/exclude is the only thing that hides it there.
-    expect(script).toContain('/workspace/.git/info/exclude');
-    expect(script).toContain('.agentbox/');
+  it('does not try to hide itself by editing the box repo', () => {
+    // Keeping the generated file out of the user's project is the PULL layer's
+    // job (`GIT_MODE_EXCLUDE_DIRS`), not this script's. Writing an exclude here
+    // cannot work and is not harmless: in a docker box `/workspace/.git` is a
+    // linked-worktree FILE whose per-worktree `info/exclude` git ignores, and
+    // the common dir it does read is the user's bind-mounted host repo.
+    expect(script).not.toContain('info/exclude');
+    expect(script).not.toMatch(/\.git\b/);
   });
 
   it('writes the prompt file atomically, behind a sentinel', () => {

--- a/packages/agent-registry/test/openclaw-agentbox-env.test.ts
+++ b/packages/agent-registry/test/openclaw-agentbox-env.test.ts
@@ -72,9 +72,20 @@ describe('openclaw-agentbox-env', () => {
     expect(script).toContain('/opt/agentbox/skills .agentbox/AGENTS.md');
   });
 
-  it('feeds the merge the box config, and cleans up after itself', () => {
-    expect(script).toContain('/home/vscode/.openclaw/openclaw.json');
+  it("reads the current values through openclaw's own reader, not the file", () => {
+    // The config is JSON5 — openclaw reads one with a `//` comment in it and
+    // `JSON.parse` throws on the same file (both verified in a box) — so parsing
+    // it here would see nothing and clobber the arrays the merge exists to keep.
+    expect(script).toContain('openclaw config get');
+    expect(script).not.toContain('openclaw.json');
     expect(script).toMatch(/rm -f "\$PROG"/);
+  });
+
+  it('only touches the config when openclaw says the config is good', () => {
+    // `config get` prints nothing and exits 1 both for an unset value and for
+    // one it cannot read, so without this gate a broken config looks exactly
+    // like a fresh box — and would be overwritten with our entry alone.
+    expect(script).toContain('if openclaw config validate');
   });
 
   it('names a bootstrap basename openclaw actually accepts', () => {

--- a/packages/agent-registry/test/openclaw-config-merge.test.ts
+++ b/packages/agent-registry/test/openclaw-config-merge.test.ts
@@ -27,13 +27,13 @@ interface Merged {
  * The three raw arguments are `openclaw config get` output verbatim, which is
  * what the task pipes in: JSON when the value is set, empty when it is not.
  */
-function run(rawDirs: string, rawEntry = '', rawHooksEnabled = ''): Merged {
+function run(rawDirs: string, rawEntries = '', rawHooksEnabled = ''): Merged {
   const dir = mkdtempSync(join(tmpdir(), 'openclaw-merge-'));
   const prog = join(dir, 'merge.cjs');
   writeFileSync(prog, OPENCLAW_CONFIG_MERGE_PROGRAM, 'utf8');
   const out = execFileSync(
     process.execPath,
-    [prog, SKILL_DIR, CTX_PATH, rawDirs, rawEntry, rawHooksEnabled],
+    [prog, SKILL_DIR, CTX_PATH, rawDirs, rawEntries, rawHooksEnabled],
     { encoding: 'utf8' },
   );
   return JSON.parse(out) as Merged;
@@ -56,7 +56,7 @@ describe('the openclaw config merge', () => {
     // silently reverted on the second.
     const r = run(
       JSON.stringify(['/home/vscode/my-skills']),
-      JSON.stringify({ paths: ['NOTES.md'] }),
+      JSON.stringify({ 'bootstrap-extra-files': { paths: ['NOTES.md'] } }),
     );
     expect(r.skills.load.extraDirs).toEqual(['/home/vscode/my-skills', SKILL_DIR]);
     expect(entryOf(r).paths).toEqual(['NOTES.md', CTX_PATH]);
@@ -76,15 +76,30 @@ describe('the openclaw config merge', () => {
   });
 
   it('leaves the rest of the hook entry alone', () => {
-    const r = run('', JSON.stringify({ paths: [], maxCharsPerFile: 1234 }));
+    const r = run(
+      '',
+      JSON.stringify({ 'bootstrap-extra-files': { paths: [], maxCharsPerFile: 1234 } }),
+    );
     expect(entryOf(r).maxCharsPerFile).toBe(1234);
   });
 
   it('lets the user turn the box facts OFF and have it stick', () => {
     // Disabling the injection is a choice they are allowed to make. Re-enabling
     // it every boot would be the same class of bug as clobbering the array.
-    expect(entryOf(run('', JSON.stringify({ enabled: false }))).enabled).toBe(false);
+    expect(
+      entryOf(run('', JSON.stringify({ 'bootstrap-extra-files': { enabled: false } }))).enabled,
+    ).toBe(false);
     expect(run('', '', 'false').hooks.internal.enabled).toBe(false);
+  });
+
+  it('leaves a neighbouring hook entry untouched', () => {
+    // `session-memory` is enabled on every box. Reading the whole `entries`
+    // object and naming only our key keeps it out of the patch entirely.
+    const r = run(
+      '',
+      JSON.stringify({ 'session-memory': { enabled: true }, 'bootstrap-extra-files': {} }),
+    );
+    expect(Object.keys(r.hooks.internal.entries)).toEqual(['bootstrap-extra-files']);
   });
 
   it('never crashes on output it cannot parse', () => {

--- a/packages/agent-registry/test/openclaw-config-merge.test.ts
+++ b/packages/agent-registry/test/openclaw-config-merge.test.ts
@@ -1,0 +1,105 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { OPENCLAW_CONFIG_MERGE_PROGRAM } from '../src/specs/openclaw.js';
+
+/**
+ * The merge AgentBox applies to openclaw's config, exercised by RUNNING it.
+ *
+ * The program only ever executes in a box, so a test that asserted on its source
+ * text would pin the wrong thing. node is the same interpreter there.
+ */
+const SKILL_DIR = '/opt/agentbox/skills';
+const CTX_PATH = '.agentbox/AGENTS.md';
+
+interface Merged {
+  skills: { load: { extraDirs: string[] } };
+  hooks: { internal: { enabled: boolean; entries: Record<string, Record<string, unknown>> } };
+}
+
+/**
+ * Run it exactly as the box does: written to a FILE and invoked as `node
+ * <file> …`. Not `node -e`, which shifts argv by one — a test that used `-e`
+ * passed while the real box read the config path as the skills dir.
+ */
+function run(cfgPath: string): Merged {
+  const dir = mkdtempSync(join(tmpdir(), 'openclaw-merge-prog-'));
+  const prog = join(dir, 'merge.cjs');
+  writeFileSync(prog, OPENCLAW_CONFIG_MERGE_PROGRAM, 'utf8');
+  const out = execFileSync(process.execPath, [prog, cfgPath, SKILL_DIR, CTX_PATH], {
+    encoding: 'utf8',
+  });
+  return JSON.parse(out) as Merged;
+}
+
+function merge(config: unknown): Merged {
+  const dir = mkdtempSync(join(tmpdir(), 'openclaw-merge-'));
+  const cfg = join(dir, 'openclaw.json');
+  writeFileSync(cfg, JSON.stringify(config), 'utf8');
+  return run(cfg);
+}
+
+const entryOf = (r: Merged) => r.hooks.internal.entries['bootstrap-extra-files']!;
+
+describe('the openclaw config merge', () => {
+  it('asserts both keys on a config that has neither', () => {
+    const r = merge({});
+    expect(r.skills.load.extraDirs).toEqual([SKILL_DIR]);
+    expect(entryOf(r).paths).toEqual([CTX_PATH]);
+    expect(entryOf(r).enabled).toBe(true);
+  });
+
+  it("KEEPS the user's own entries in both arrays", () => {
+    // The regression this program exists for. `openclaw config patch` replaces
+    // an array wholesale, and `openclaw-render` re-sends only the overlay keys
+    // that CHANGED — so a stable user value would survive the first boot and be
+    // silently reverted on the second.
+    const r = merge({
+      skills: { load: { extraDirs: ['/home/vscode/my-skills'] } },
+      hooks: {
+        internal: { entries: { 'bootstrap-extra-files': { paths: ['NOTES.md'] } } },
+      },
+    });
+    expect(r.skills.load.extraDirs).toEqual(['/home/vscode/my-skills', SKILL_DIR]);
+    expect(entryOf(r).paths).toEqual(['NOTES.md', CTX_PATH]);
+  });
+
+  it('is idempotent — a second boot adds nothing', () => {
+    const twice = merge(merge({}));
+    expect(twice.skills.load.extraDirs).toEqual([SKILL_DIR]);
+    expect(entryOf(twice).paths).toEqual([CTX_PATH]);
+  });
+
+  it('leaves the rest of the hook entry alone', () => {
+    const r = merge({
+      hooks: {
+        internal: {
+          entries: { 'bootstrap-extra-files': { paths: [], maxCharsPerFile: 1234 } },
+        },
+      },
+    });
+    expect(entryOf(r).maxCharsPerFile).toBe(1234);
+  });
+
+  it('lets the user turn the box facts OFF and have it stick', () => {
+    // Disabling the injection is a choice they are allowed to make. Re-enabling
+    // it every boot would be the same class of bug as clobbering the array.
+    const offEntry = merge({
+      hooks: { internal: { entries: { 'bootstrap-extra-files': { enabled: false } } } },
+    });
+    expect(entryOf(offEntry).enabled).toBe(false);
+    expect(merge({ hooks: { internal: { enabled: false } } }).hooks.internal.enabled).toBe(false);
+  });
+
+  it('survives a config file that is missing or corrupt', () => {
+    // Best-effort: the task must not fail a box over this.
+    const dir = mkdtempSync(join(tmpdir(), 'openclaw-merge-'));
+    const bad = join(dir, 'openclaw.json');
+    writeFileSync(bad, '{not json', 'utf8');
+    for (const path of [bad, join(dir, 'absent.json')]) {
+      expect(run(path).skills.load.extraDirs).toEqual([SKILL_DIR]);
+    }
+  });
+});

--- a/packages/agent-registry/test/openclaw-config-merge.test.ts
+++ b/packages/agent-registry/test/openclaw-config-merge.test.ts
@@ -20,32 +20,30 @@ interface Merged {
 }
 
 /**
- * Run it exactly as the box does: written to a FILE and invoked as `node
- * <file> …`. Not `node -e`, which shifts argv by one — a test that used `-e`
- * passed while the real box read the config path as the skills dir.
+ * Run it exactly as the box does: written to a FILE and invoked as `node <file>
+ * …`. Not `node -e`, which shifts argv by one — a test that used `-e` passed
+ * while the real box read its first argument as the wrong parameter.
+ *
+ * The three raw arguments are `openclaw config get` output verbatim, which is
+ * what the task pipes in: JSON when the value is set, empty when it is not.
  */
-function run(cfgPath: string): Merged {
-  const dir = mkdtempSync(join(tmpdir(), 'openclaw-merge-prog-'));
+function run(rawDirs: string, rawEntry = '', rawHooksEnabled = ''): Merged {
+  const dir = mkdtempSync(join(tmpdir(), 'openclaw-merge-'));
   const prog = join(dir, 'merge.cjs');
   writeFileSync(prog, OPENCLAW_CONFIG_MERGE_PROGRAM, 'utf8');
-  const out = execFileSync(process.execPath, [prog, cfgPath, SKILL_DIR, CTX_PATH], {
-    encoding: 'utf8',
-  });
+  const out = execFileSync(
+    process.execPath,
+    [prog, SKILL_DIR, CTX_PATH, rawDirs, rawEntry, rawHooksEnabled],
+    { encoding: 'utf8' },
+  );
   return JSON.parse(out) as Merged;
-}
-
-function merge(config: unknown): Merged {
-  const dir = mkdtempSync(join(tmpdir(), 'openclaw-merge-'));
-  const cfg = join(dir, 'openclaw.json');
-  writeFileSync(cfg, JSON.stringify(config), 'utf8');
-  return run(cfg);
 }
 
 const entryOf = (r: Merged) => r.hooks.internal.entries['bootstrap-extra-files']!;
 
 describe('the openclaw config merge', () => {
-  it('asserts both keys on a config that has neither', () => {
-    const r = merge({});
+  it('asserts both keys on a box where neither is set', () => {
+    const r = run('');
     expect(r.skills.load.extraDirs).toEqual([SKILL_DIR]);
     expect(entryOf(r).paths).toEqual([CTX_PATH]);
     expect(entryOf(r).enabled).toBe(true);
@@ -56,50 +54,45 @@ describe('the openclaw config merge', () => {
     // an array wholesale, and `openclaw-render` re-sends only the overlay keys
     // that CHANGED — so a stable user value would survive the first boot and be
     // silently reverted on the second.
-    const r = merge({
-      skills: { load: { extraDirs: ['/home/vscode/my-skills'] } },
-      hooks: {
-        internal: { entries: { 'bootstrap-extra-files': { paths: ['NOTES.md'] } } },
-      },
-    });
+    const r = run(
+      JSON.stringify(['/home/vscode/my-skills']),
+      JSON.stringify({ paths: ['NOTES.md'] }),
+    );
     expect(r.skills.load.extraDirs).toEqual(['/home/vscode/my-skills', SKILL_DIR]);
     expect(entryOf(r).paths).toEqual(['NOTES.md', CTX_PATH]);
   });
 
+  it('reads the pretty-printed shape `config get` actually prints', () => {
+    // Not a JSON formatting detail: the task pipes this output in verbatim.
+    const r = run('[\n  "/home/vscode/my-skills"\n]\n');
+    expect(r.skills.load.extraDirs).toEqual(['/home/vscode/my-skills', SKILL_DIR]);
+  });
+
   it('is idempotent — a second boot adds nothing', () => {
-    const twice = merge(merge({}));
+    const once = run('');
+    const twice = run(JSON.stringify(once.skills.load.extraDirs), JSON.stringify(entryOf(once)));
     expect(twice.skills.load.extraDirs).toEqual([SKILL_DIR]);
     expect(entryOf(twice).paths).toEqual([CTX_PATH]);
   });
 
   it('leaves the rest of the hook entry alone', () => {
-    const r = merge({
-      hooks: {
-        internal: {
-          entries: { 'bootstrap-extra-files': { paths: [], maxCharsPerFile: 1234 } },
-        },
-      },
-    });
+    const r = run('', JSON.stringify({ paths: [], maxCharsPerFile: 1234 }));
     expect(entryOf(r).maxCharsPerFile).toBe(1234);
   });
 
   it('lets the user turn the box facts OFF and have it stick', () => {
     // Disabling the injection is a choice they are allowed to make. Re-enabling
     // it every boot would be the same class of bug as clobbering the array.
-    const offEntry = merge({
-      hooks: { internal: { entries: { 'bootstrap-extra-files': { enabled: false } } } },
-    });
-    expect(entryOf(offEntry).enabled).toBe(false);
-    expect(merge({ hooks: { internal: { enabled: false } } }).hooks.internal.enabled).toBe(false);
+    expect(entryOf(run('', JSON.stringify({ enabled: false }))).enabled).toBe(false);
+    expect(run('', '', 'false').hooks.internal.enabled).toBe(false);
   });
 
-  it('survives a config file that is missing or corrupt', () => {
-    // Best-effort: the task must not fail a box over this.
-    const dir = mkdtempSync(join(tmpdir(), 'openclaw-merge-'));
-    const bad = join(dir, 'openclaw.json');
-    writeFileSync(bad, '{not json', 'utf8');
-    for (const path of [bad, join(dir, 'absent.json')]) {
-      expect(run(path).skills.load.extraDirs).toEqual([SKILL_DIR]);
+  it('never crashes on output it cannot parse', () => {
+    // `config get` prints a human sentence for a valid-but-unset path, and
+    // nothing at all when it fails. Neither may take the task down; the caller's
+    // `config validate` gate is what makes treating these as "unset" safe.
+    for (const raw of ['', 'Config path is valid but unset: skills.load.extraDirs.', '{not json']) {
+      expect(run(raw).skills.load.extraDirs).toEqual([SKILL_DIR]);
     }
   });
 });

--- a/packages/agent-registry/test/openclaw-config-merge.test.ts
+++ b/packages/agent-registry/test/openclaw-config-merge.test.ts
@@ -70,7 +70,14 @@ describe('the openclaw config merge', () => {
 
   it('is idempotent — a second boot adds nothing', () => {
     const once = run('');
-    const twice = run(JSON.stringify(once.skills.load.extraDirs), JSON.stringify(entryOf(once)));
+    // The second boot is fed exactly what `config get` would print AFTER the
+    // first: the whole entries map, not the inner hook object. Passing the inner
+    // object here made the lookup miss and quietly re-tested the unset path,
+    // where a duplicate `paths` entry could never show up.
+    const twice = run(
+      JSON.stringify(once.skills.load.extraDirs),
+      JSON.stringify(once.hooks.internal.entries),
+    );
     expect(twice.skills.load.extraDirs).toEqual([SKILL_DIR]);
     expect(entryOf(twice).paths).toEqual([CTX_PATH]);
   });

--- a/packages/sandbox-core/src/sync/concerns/workspace-files.ts
+++ b/packages/sandbox-core/src/sync/concerns/workspace-files.ts
@@ -38,8 +38,23 @@ import { AGENT_SYNC_SPECS } from '../registry.js';
  * at any depth. `.git` and `node_modules` are the historical pair; `media` is
  * new — a service agent (an AI gateway, a chat backend) accumulates uploaded
  * attachments under `media/` and they are not source.
+ *
+ * `.agentbox` is ours, not the user's: a box-local dir AgentBox regenerates
+ * every boot (openclaw's derived box facts live there, because openclaw will
+ * only read a system prompt from inside its own workspace). Pulling it back
+ * would put a generated file describing THIS box into the user's project.
+ *
+ * Note this covers exclude-list mode and `clone` only. `download` on a git
+ * workspace deliberately does not apply these (see `dropExcludedInGitMode`), so
+ * git has to be told separately — the openclaw task adds `.agentbox/` to the
+ * box's own `.git/info/exclude`.
  */
-export const WORKSPACE_EXCLUDE_DIR_NAMES: readonly string[] = ['.git', 'node_modules', 'media'];
+export const WORKSPACE_EXCLUDE_DIR_NAMES: readonly string[] = [
+  '.git',
+  'node_modules',
+  'media',
+  '.agentbox',
+];
 
 /**
  * Agent state directories, derived from every registered agent's declared

--- a/packages/sandbox-core/src/sync/concerns/workspace-files.ts
+++ b/packages/sandbox-core/src/sync/concerns/workspace-files.ts
@@ -44,10 +44,9 @@ import { AGENT_SYNC_SPECS } from '../registry.js';
  * only read a system prompt from inside its own workspace). Pulling it back
  * would put a generated file describing THIS box into the user's project.
  *
- * Note this covers exclude-list mode and `clone` only. `download` on a git
- * workspace deliberately does not apply these (see `dropExcludedInGitMode`), so
- * git has to be told separately — the openclaw task adds `.agentbox/` to the
- * box's own `.git/info/exclude`.
+ * This list covers exclude-list mode and `clone` only, since `download` on a
+ * git workspace deliberately does not apply it (see `dropExcludedInGitMode`).
+ * `.agentbox` is dropped in git mode too, by {@link GIT_MODE_EXCLUDE_DIRS}.
  */
 export const WORKSPACE_EXCLUDE_DIR_NAMES: readonly string[] = [
   '.git',
@@ -55,6 +54,24 @@ export const WORKSPACE_EXCLUDE_DIR_NAMES: readonly string[] = [
   'media',
   '.agentbox',
 ];
+
+/**
+ * Directories dropped from the GIT-mode selection as well, by pathspec.
+ *
+ * Git mode otherwise carries everything `git ls-files --cached --others
+ * --exclude-standard` reports, on purpose: a tracked `.claude/` there is the
+ * user's own content and dropping it would be a regression. `.agentbox` is the
+ * one thing that is never the user's content — AgentBox generates it in the box
+ * every boot (openclaw's derived box facts, which have to live inside the
+ * workspace because openclaw will not read a system prompt from outside it), so
+ * pulling it back would write a file describing THIS box into the project.
+ *
+ * A pathspec rather than the box's `.git/info/exclude`, which cannot do the job:
+ * in a docker box `/workspace/.git` is a linked-worktree FILE whose per-worktree
+ * `info/exclude` git does not read, and the common dir it does read is the
+ * user's bind-mounted host repo.
+ */
+export const GIT_MODE_EXCLUDE_DIRS: readonly string[] = ['.agentbox'];
 
 /**
  * Agent state directories, derived from every registered agent's declared
@@ -164,12 +181,15 @@ export function buildWorkspaceListScript(opts: WorkspaceListScriptOptions): stri
   const findCmd = `find . ${prune}\\( \\( -type f -o -type l \\) ${fileFilter} -print0 \\)`;
   const gitProbe =
     opts.respectGitignore === false ? 'false' : 'git rev-parse --is-inside-work-tree';
+  // `:(exclude)<dir>` matches the directory and everything under it (verified
+  // against git 2.43 in a box), so one pathspec per name is enough.
+  const gitExcludePathspecs = GIT_MODE_EXCLUDE_DIRS.map((d) => sq(`:(exclude)${d}`)).join(' ');
   return [
     `set -u`,
     `cd ${sq(dir)} 2>/dev/null || exit 3`,
     `if ${gitProbe} >/dev/null 2>&1; then`,
     `  printf 'MODE=git\\n'`,
-    `  git ls-files -z --cached --others --exclude-standard`,
+    `  git ls-files -z --cached --others --exclude-standard -- . ${gitExcludePathspecs}`,
     `else`,
     `  printf 'MODE=exclude\\n'`,
     `  ${findCmd}`,

--- a/packages/sandbox-core/test/agent-descriptor.test.ts
+++ b/packages/sandbox-core/test/agent-descriptor.test.ts
@@ -1,3 +1,4 @@
+import { homedir } from 'node:os';
 import { describe, expect, it } from 'vitest';
 import { buildAgentDescriptors } from '../src/sync/agent-descriptor.js';
 import { AGENT_SYNC_SPECS } from '../src/sync/registry.js';
@@ -74,7 +75,16 @@ describe('buildAgentDescriptors', () => {
       expect(json, spec.id).not.toContain(spec.credential.hostBackup);
     }
     expect(json).not.toContain('/Users/');
-    expect(json).not.toContain('.agentbox/');
+    expect(json).not.toContain(homedir());
+    // An ABSOLUTE `/.agentbox` is the cross-platform tell for a host path, since
+    // the host backup lives under `$HOME/.agentbox`. It is not banned outright:
+    // openclaw's box-context task names `/workspace/.agentbox/AGENTS.md`, a path
+    // in the BOX. So every absolute one has to be rooted at /workspace. (The
+    // workspace-RELATIVE `.agentbox/AGENTS.md` in its config payload has no
+    // leading slash and is never a host path.)
+    for (let i = json.indexOf('/.agentbox/'); i !== -1; i = json.indexOf('/.agentbox/', i + 1)) {
+      expect(json.slice(0, i), `unrooted /.agentbox/ at ${i}`).toMatch(/\/workspace$/);
+    }
   });
 
   it('is JSON round-trippable — it crosses a wire', () => {

--- a/packages/sandbox-core/test/workspace-files.test.ts
+++ b/packages/sandbox-core/test/workspace-files.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   agentStateExcludePaths,
+  GIT_MODE_EXCLUDE_DIRS,
   buildWorkspaceListScript,
   isExcludedPath,
   overlayHostDirIntoBox,
@@ -60,6 +61,26 @@ describe('buildWorkspaceListScript', () => {
     expect(script).toContain('MODE=git');
     expect(script).toContain('MODE=exclude');
     expect(script).toContain("-name 'node_modules'");
+  });
+
+  it('drops the box-local .agentbox dir from the GIT selection too', () => {
+    // Git mode otherwise carries everything `ls-files --cached --others` reports
+    // on purpose (a tracked `.claude/` there is the user's own content). The one
+    // exception is the dir AgentBox itself generates in the box every boot:
+    // pulling it back writes a file describing THIS box into the user's project.
+    //
+    // The pathspec is the only mechanism that works everywhere. `.git/info/exclude`
+    // does not: in a docker box `/workspace/.git` is a linked-worktree FILE whose
+    // per-worktree `info/exclude` git does not read (verified in a live box), and
+    // the common dir it does read is the user's bind-mounted host repo.
+    const script = buildWorkspaceListScript({ excludes: [] });
+    for (const dir of GIT_MODE_EXCLUDE_DIRS) {
+      expect(script).toContain(`':(exclude)${dir}'`);
+    }
+    expect(GIT_MODE_EXCLUDE_DIRS).toContain('.agentbox');
+    // …and it is on the ls-files line, not merely somewhere in the script.
+    const gitLine = script.split('\n').find((l) => l.includes('git ls-files'))!;
+    expect(gitLine).toContain("':(exclude).agentbox'");
   });
 
   it('skips the git probe entirely when gitignore is off', () => {


### PR DESCRIPTION
An openclaw box got no box facts and no setup skill. Its registry row declares no `seeds`, so an agent that can code, run scripts and move files had no idea it was in a sandbox, that `/workspace` is box-local, or that `agentbox-ctl cp` is how a file reaches the user's machine — while claude gets `/etc/claude-code/CLAUDE.md` + the setup skill, and codex gets the same facts folded into `AGENTS.override.md`.

## What it does

One new supervisor task, `openclaw-agentbox-env`, between onboard and render:

```
openclaw-onboard -> openclaw-agentbox-env -> openclaw-render -> openclaw (service)
```

- **Skill** at `/opt/agentbox/skills/agentbox-setup/SKILL.md`, registered via `skills.load.extraDirs` — outside the workspace, lowest precedence, so a user skill of the same name wins and nothing travels with `clone`.
- **Box facts** at `/workspace/.agentbox/AGENTS.md`, derived from the per-provider `/etc/claude-code/CLAUDE.md` and loaded by the bundled `bootstrap-extra-files` hook.

It re-runs on every boot rather than `runOnce`: the prompt file lives in the workspace, so a clone carries the *source* box's facts into the new box, and regenerating overwrites them before the gateway reads them. It runs after onboard (which writes the config file it patches) and before render, so the user's `openclaw:` overlay still has the last word on any shared key.

## Three shapes that were measured, not assumed

Each of these silently produced nothing when it was wrong, against openclaw 2026.9.2:

- The skill must be a **directory** with `SKILL.md`; a flat `agentbox-setup.md` in the same root was not discovered.
- It must be **copied, not symlinked** — openclaw rejects a skill symlink whose real target is outside the source root.
- The prompt file must be a **real file inside the workspace** with one of six canonical basenames; the hook realpath-checks every path, so a symlink out is refused.

## Keeping it out of your repo

`agentbox download` selects with `git ls-files --cached --others --exclude-standard` and deliberately does not apply the exclude list in git mode (dropping a tracked `.claude/` would be a regression), so an untracked `.agentbox/` would have been pulled into the user's project.

The first cut used the box's `.git/info/exclude`. A live box showed that cannot work: `/workspace/.git` in a docker box is a linked-worktree **file**, and git does not read a per-worktree `info/exclude` anyway — the common dir it *does* read is the user's bind-mounted host repo, so writing there would have edited their repo to hide our file. The second commit moves it to the pull layer as a pathspec (`GIT_MODE_EXCLUDE_DIRS`), which covers every provider and both call sites.

## Verification

Unit: 9 tests pin the task (needs-chain, no `runOnce`, directory-not-flat, copy-not-symlink, sentinel + atomic write, the exact config payload, canonical basenames, guarded/`exit 0`) plus one on the pathspec — all mutation-checked. The `sandbox-core` host-path guard was tightened rather than relaxed: an **absolute** `/.agentbox/` must be rooted at `/workspace`, and injecting `/home/ci/.agentbox/…` still fails it.

Live, on a docker box against a git workspace:

- openclaw's own `/context detail` lists `.agentbox/AGENTS.md` among its **injected workspace files** (3,001 chars, alongside the workspace's own 7,926-char `AGENTS.md`) and `agentbox-setup` among its 38 skills — the file reaches the model, not just the disk.
- The in-box listing reports `.agentbox/AGENTS.md` without the pathspec and nothing with it, and a real `agentbox download` left the repo clean.

Not covered: the cloud providers were not re-run for this. The task is provider-agnostic (one ctl task, riding the `agents.list` RPC), but the prompt half depends on `OPENCLAW_WORKSPACE_DIR` reaching the box, which lands in #370.

https://claude.ai/code/session_01ChpFVKPMobDd3xk3uwG6gj

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Boot-time OpenClaw config patching and workspace pull exclusions affect every OpenClaw box; mistakes could clobber user skill/bootstrap paths or leak box-local prompts into repos, though merges are defensive and user overlay still runs last.
> 
> **Overview**
> OpenClaw boxes now get the same **sandbox context** Claude/Codex already receive: a per-boot supervisor task **`openclaw-agentbox-env`** runs after onboard and before config render.
> 
> It **copies** the baked setup guide into `/opt/agentbox/skills/agentbox-setup/SKILL.md` and registers that dir via a **union merge** into `skills.load.extraDirs` (so user dirs are not wiped on the second boot). It **regenerates** `/workspace/.agentbox/AGENTS.md` from the provider box facts and adds that path to the `bootstrap-extra-files` hook the same way. Patching is gated on `openclaw config validate` and uses `openclaw config get` plus an in-box Node merge program because `config patch` replaces arrays wholesale and the config file may be JSON5.
> 
> **Sync/pull** now drops `.agentbox` everywhere it would leak generated box facts into the user's repo: exclude-list mode, clone, and git-mode `download` via `GIT_MODE_EXCLUDE_DIRS` pathspecs. Docs describe the two injected artifacts and the task ordering; tests cover the merge program, task script shape, and workspace listing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3706bec2019749abbd860e923067e93694884ca. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->