### PR TITLE
feat(sync): bring a backed-up bot back into a new box

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -25,6 +25,11 @@ CLI, not the raw commits.
   `<project>/.agentbox/bots/<bot>/<timestamp>/`, so a bot can be recreated later or
   on a different provider. The newest three are kept (`--keep`), and live databases
   are captured through SQLite's online-backup API, not copied byte for byte.
+- **`--restore <bot>` puts a backed-up bot back into a new box.** On a
+  service-agent command (`agentbox openclaw --restore ada`) it restores the state
+  dir too, so the bot keeps its identity, pairings and history — on a different
+  provider if you pass one. `agentbox create --restore` takes the workspace only.
+  Refused while the backed-up box is still running, unless `--force`.
 
 ### Fixed
 

--- a/apps/cli/src/agents/command/service-action.ts
+++ b/apps/cli/src/agents/command/service-action.ts
@@ -341,7 +341,27 @@ export async function runServiceAgent(
         );
       }
       await assertSourceBoxNotRunning(restored.bundle, opts.force);
+      // A restore always makes a NEW box. The bare command is create-or-resume,
+      // so without this a second `--restore` into the same directory would push
+      // a bundle's identity over a running bot's — the one thing this must never
+      // do by accident. Checked BEFORE the copy, or `--force` would overwrite
+      // that box's workspace on its way to being refused.
+      const already = await findExistingBox(undefined, restored.workspaceDir, spec.id);
+      if (already) {
+        throw new Error(
+          `box ${already.name} already runs on ${restored.workspaceDir} — ` +
+            `pass --into <dir> to restore alongside it`,
+        );
+      }
+      // Staged BEFORE the config load below, which reads the workspace: on a
+      // first restore the destination does not exist yet, and a config loaded
+      // from a missing directory silently falls back to the defaults.
+      const staged = await stageRestoreWorkspace(restored, opts.force);
       opts.workspace = restored.workspaceDir;
+      log.info(
+        `restoring ${restored.bundle.bot} @ ${restored.bundle.stamp}: ` +
+          `${String(staged.files)} entr(ies) -> ${restored.workspaceDir}`,
+      );
     }
     const project = restored
       ? { root: restored.workspaceDir }
@@ -353,22 +373,6 @@ export async function runServiceAgent(
 
     intro(`agentbox ${spec.id}`);
     const existing = await findExistingBox(boxRef, project.root, spec.id);
-    // A restore always makes a NEW box. The bare command is create-or-resume, so
-    // without this a second `--restore` would push a bundle's identity over a
-    // running bot's — the one thing this feature must never do by accident.
-    if (restored && existing) {
-      throw new Error(
-        `box ${existing.name} already exists for this restore dir; ` +
-          `pass --into <dir> or -n <name> to restore alongside it`,
-      );
-    }
-    if (restored) {
-      const staged = await stageRestoreWorkspace(restored, opts.force);
-      log.info(
-        `restoring ${restored.bundle.bot} @ ${restored.bundle.stamp}: ` +
-          `${String(staged.files)} entr(ies) -> ${restored.workspaceDir}`,
-      );
-    }
     let box: BoxRecord;
 
     if (existing) {

--- a/apps/cli/src/agents/command/service-action.ts
+++ b/apps/cli/src/agents/command/service-action.ts
@@ -38,6 +38,13 @@ import { webProxyWarning } from '../../lib/web-proxy-warning.js';
 import { runCarryGate } from '../../lib/carry-gate.js';
 import { handleLifecycleError } from '../../commands/_errors.js';
 import { providerForBox, providerForCreate } from '../../provider/registry.js';
+import {
+  assertSourceBoxNotRunning,
+  resolveRestoreRequest,
+  restoreStateIntoBox,
+  stageRestoreWorkspace,
+  type RestoreRequest,
+} from '../../commands/_restore.js';
 import { resolveLimits } from '../../limits.js';
 import { resolveProviderChoice } from '../../provider/spec.js';
 import { withOwningHub } from '../../control-plane/with-hub.js';
@@ -61,6 +68,14 @@ export interface ServiceAgentOptions {
   persistent?: boolean;
   /** Seconds to wait for the service to report ready. */
   timeout?: string;
+  /** `--restore <bot>`: recreate that bot from its backup, identity included. */
+  restore?: string;
+  /** `--stamp <s>`: which backup (default: the `latest` link). */
+  stamp?: string;
+  /** `--into <dir>`: where the restored workspace lives. */
+  into?: string;
+  /** `--force`: restore even when the source box runs / the destination is not empty. */
+  force?: boolean;
 }
 
 /**
@@ -276,6 +291,24 @@ export async function readServiceUrlFields(
 }
 
 /**
+ * Stop one supervisor unit in a box.
+ *
+ * Still a `provider.exec` rather than an API call: the hub's services routes
+ * expose `restart` but not `stop` (recorded in the service-boxes backlog). Lives
+ * here rather than in the factory because both callers — `<agent> stop` and the
+ * restore below — need it, and the factory already imports this module.
+ */
+export async function stopUnit(box: BoxRecord, unit: string): Promise<void> {
+  const provider = await providerForBox(box);
+  const r = await provider.exec(box, ['agentbox-ctl', 'stop', unit], { user: 'vscode' });
+  if (r.exitCode !== 0) {
+    throw new Error(
+      `agentbox-ctl stop ${unit} failed: ${r.stderr.trim() || `exit ${String(r.exitCode)}`}`,
+    );
+  }
+}
+
+/**
  * `agentbox <agent> [box]` — create the box if it is missing, start it if it is
  * down, then wait for the service and print its URL.
  *
@@ -294,7 +327,25 @@ export async function runServiceAgent(
   const cmdLog = openCommandLog(spec.id);
 
   try {
-    const project = await findProjectRoot(opts.workspace);
+    // `--restore` is resolved and staged first: the restored tree becomes the
+    // box's workspace, so its own `agentbox.yaml` is the one to load, and the
+    // project root is that directory verbatim — it lives under the ORIGINAL
+    // project's `.agentbox/`, so walking up would seed from the template.
+    let restored: RestoreRequest | undefined;
+    if (opts.restore) {
+      restored = await resolveRestoreRequest(opts.workspace, opts);
+      if (restored.agent && restored.agent !== spec.id) {
+        throw new Error(
+          `${restored.bundle.dir} holds ${restored.agent} state, not ${spec.id} — ` +
+            `restore it with \`agentbox ${restored.agent} --restore ${restored.bundle.bot}\``,
+        );
+      }
+      await assertSourceBoxNotRunning(restored.bundle, opts.force);
+      opts.workspace = restored.workspaceDir;
+    }
+    const project = restored
+      ? { root: restored.workspaceDir }
+      : await findProjectRoot(opts.workspace);
     const cfgLoaded = await loadEffectiveConfig(opts.workspace, {
       cliOverrides: opts.image ? { box: { image: opts.image } } : {},
     });
@@ -302,6 +353,22 @@ export async function runServiceAgent(
 
     intro(`agentbox ${spec.id}`);
     const existing = await findExistingBox(boxRef, project.root, spec.id);
+    // A restore always makes a NEW box. The bare command is create-or-resume, so
+    // without this a second `--restore` would push a bundle's identity over a
+    // running bot's — the one thing this feature must never do by accident.
+    if (restored && existing) {
+      throw new Error(
+        `box ${existing.name} already exists for this restore dir; ` +
+          `pass --into <dir> or -n <name> to restore alongside it`,
+      );
+    }
+    if (restored) {
+      const staged = await stageRestoreWorkspace(restored, opts.force);
+      log.info(
+        `restoring ${restored.bundle.bot} @ ${restored.bundle.stamp}: ` +
+          `${String(staged.files)} entr(ies) -> ${restored.workspaceDir}`,
+      );
+    }
     let box: BoxRecord;
 
     if (existing) {
@@ -430,6 +497,35 @@ export async function runServiceAgent(
       // genuinely up. `handleLifecycleError` turns this into a non-zero exit.
       s.stop(`${service.name} failed`);
       throw err;
+    }
+
+    // The identity goes in only once the service has come up on its own.
+    //
+    // That ordering is deliberate, not a convenience. `openclaw onboard` is a
+    // `run_once: marker` task whose marker lives on the box ROOTFS, not in the
+    // agent's config volume, so it runs on every fresh box no matter what the
+    // volume holds — there is no "write the state in before onboard" that works.
+    // Letting it run first, then replacing what it wrote, means the marker is
+    // already down and onboard never touches the restored identity again, on
+    // this boot or any later one.
+    if (restored) {
+      s.start(`restoring ${spec.id} state into ${box.name}`);
+      try {
+        await stopUnit(box, service.name);
+        const r = await restoreStateIntoBox({ box, agent: spec.id, bundle: restored.bundle });
+        cmdLog.write(`cleared ${String(r.clearedSidecars.length)} stale db sidecar(s)`);
+        await withOwningHub(box, async (client) => {
+          await client.restartService(box.id, service.name);
+        });
+        view = await waitForService(box, service.name, timeoutSeconds, (line) => {
+          s.message(line);
+          cmdLog.write(line);
+        });
+        s.stop(`${spec.id} restored from ${restored.bundle.bot} @ ${restored.bundle.stamp}`);
+      } catch (err) {
+        s.stop('restore failed');
+        throw err;
+      }
     }
 
     // Printed BEFORE the outro so the outro stays the one line a script greps

--- a/apps/cli/src/agents/command/service-action.ts
+++ b/apps/cli/src/agents/command/service-action.ts
@@ -40,7 +40,10 @@ import { handleLifecycleError } from '../../commands/_errors.js';
 import { providerForBox, providerForCreate } from '../../provider/registry.js';
 import {
   assertSourceBoxNotRunning,
+  boxRefWithRestoreRefusal,
+  existingBoxRefusal,
   resolveRestoreRequest,
+  restoreScope,
   restoreStateIntoBox,
   stageRestoreWorkspace,
   type RestoreRequest,
@@ -333,6 +336,8 @@ export async function runServiceAgent(
     // project's `.agentbox/`, so walking up would seed from the template.
     let restored: RestoreRequest | undefined;
     if (opts.restore) {
+      const refRefusal = boxRefWithRestoreRefusal(boxRef);
+      if (refRefusal) throw new Error(refRefusal);
       restored = await resolveRestoreRequest(opts.workspace, opts);
       if (restored.agent && restored.agent !== spec.id) {
         throw new Error(
@@ -347,12 +352,8 @@ export async function runServiceAgent(
       // do by accident. Checked BEFORE the copy, or `--force` would overwrite
       // that box's workspace on its way to being refused.
       const already = await findExistingBox(undefined, restored.workspaceDir, spec.id);
-      if (already) {
-        throw new Error(
-          `box ${already.name} already runs on ${restored.workspaceDir} — ` +
-            `pass --into <dir> to restore alongside it`,
-        );
-      }
+      const alreadyRefusal = existingBoxRefusal(already, restored.workspaceDir);
+      if (alreadyRefusal) throw new Error(alreadyRefusal);
       // Staged BEFORE the config load below, which reads the workspace: on a
       // first restore the destination does not exist yet, and a config loaded
       // from a missing directory silently falls back to the defaults.
@@ -373,6 +374,14 @@ export async function runServiceAgent(
 
     intro(`agentbox ${spec.id}`);
     const existing = await findExistingBox(boxRef, project.root, spec.id);
+    // Belt to the pre-copy guard's braces. That one runs before the workspace is
+    // written (so `--force` cannot clobber a live box on its way to a refusal);
+    // this one is the last word before the resume branch below would hand the
+    // restore an existing box to overwrite.
+    if (restored) {
+      const refusal = existingBoxRefusal(existing, project.root);
+      if (refusal) throw new Error(refusal);
+    }
     let box: BoxRecord;
 
     if (existing) {
@@ -512,7 +521,16 @@ export async function runServiceAgent(
     // Letting it run first, then replacing what it wrote, means the marker is
     // already down and onboard never touches the restored identity again, on
     // this boot or any later one.
-    if (restored) {
+    if (restored && restoreScope(restored.bundle) === 'workspace') {
+      // `download --backup` on a box with no agent captures the workspace alone.
+      // Restoring it is still useful; pretending it brought an identity is not,
+      // and throwing here would leave a perfectly good fresh box behind a
+      // failed command. `create --restore` already says the same thing.
+      log.warn(
+        `${restored.bundle.dir} captured no ${spec.id} state — the workspace is restored, ` +
+          `but ${box.name} has a fresh identity`,
+      );
+    } else if (restored) {
       s.start(`restoring ${spec.id} state into ${box.name}`);
       try {
         await stopUnit(box, service.name);

--- a/apps/cli/src/agents/command/service-factory.ts
+++ b/apps/cli/src/agents/command/service-factory.ts
@@ -28,7 +28,7 @@
 
 import { Command } from 'commander';
 import { log } from '@agentbox/cli-kit';
-import type { AgentSyncSpec, BoxRecord } from '@agentbox/core';
+import type { AgentSyncSpec } from '@agentbox/core';
 import { renderStatusTable, type ServiceState, type ServiceStatus } from '@agentbox/ctl';
 import { readBoxStatus } from '@agentbox/sandbox-docker';
 import { webProxyWarning } from '../../lib/web-proxy-warning.js';
@@ -40,7 +40,6 @@ import { reattachRef, resolveBoxOrExit } from '../../box-ref.js';
 import { findProjectRoot } from '@agentbox/config';
 import { UserFacingError } from '@agentbox/core';
 import { handleLifecycleError } from '../../commands/_errors.js';
-import { providerForBox } from '../../provider/registry.js';
 import { reportBoxNotOnAnyHub, withOwningHub } from '../../control-plane/with-hub.js';
 import type { HubApiServiceView } from '../../control-plane/hub-api-client.js';
 import {
@@ -48,6 +47,7 @@ import {
   readServiceUrlFields,
   resolveServiceUrl,
   runServiceAgent,
+  stopUnit,
   type ServiceAgentOptions,
 } from './service-action.js';
 
@@ -101,6 +101,19 @@ export function buildServiceAgentCommand(spec: AgentSyncSpec): Command {
     )
     .option('--timeout <seconds>', 'how long to wait for the service to report ready', '180')
     .option('--verbose', 'stream create progress instead of a spinner')
+    .option(
+      '--restore <bot>',
+      `recreate a bot from its backup under <project>/.agentbox/bots/<bot>/: the box runs on a copy of the backed-up workspace AND gets the captured ${spec.id} state dir back, identity included. Always creates a new box`,
+    )
+    .option('--stamp <stamp>', 'which --restore backup to use (default: the `latest` link)')
+    .option(
+      '--into <dir>',
+      'dir the restored workspace lives in (default: <project>/.agentbox/bots/<bot>/workspace)',
+    )
+    .option(
+      '--force',
+      'with --restore: proceed even when the backed-up box still runs, or the destination is not empty',
+    )
     .action(async (boxRef: string | undefined, opts: ServiceAgentOptions) => {
       await runServiceAgent(spec, boxRef, opts);
     });
@@ -293,14 +306,4 @@ export function buildServiceAgentCommand(spec: AgentSyncSpec): Command {
   }
 
   return command;
-}
-
-async function stopUnit(box: BoxRecord, unit: string): Promise<void> {
-  const provider = await providerForBox(box);
-  const r = await provider.exec(box, ['agentbox-ctl', 'stop', unit], { user: 'vscode' });
-  if (r.exitCode !== 0) {
-    throw new Error(
-      `agentbox-ctl stop ${unit} failed: ${r.stderr.trim() || `exit ${String(r.exitCode)}`}`,
-    );
-  }
 }

--- a/apps/cli/src/commands/_restore.ts
+++ b/apps/cli/src/commands/_restore.ts
@@ -84,6 +84,44 @@ export async function resolveRestoreRequest(
 }
 
 /**
+ * What this bundle can put back: both halves, or the workspace alone.
+ *
+ * A backup of a box with no agent — or one whose state capture failed — carries
+ * a `workspace/` and nothing else. Restoring it is still worth doing; claiming
+ * it brought an identity is not, and *failing* over it would throw away a
+ * perfectly good box that the command had already created.
+ */
+export function restoreScope(bundle: BotBundle): 'workspace' | 'workspace+state' {
+  return bundle.stateDir ? 'workspace+state' : 'workspace';
+}
+
+/**
+ * Why `--restore` cannot also take a positional box ref, or null when there is
+ * no ref.
+ *
+ * A ref means "use THIS box", and the service command is create-or-resume — so
+ * the two together resume a named box and then write a backup's identity over
+ * it. No reading of `agentbox <agent> foo --restore bar` is safe, so it is
+ * refused before anything is resolved rather than reinterpreted.
+ */
+export function boxRefWithRestoreRefusal(boxRef: string | undefined): string | null {
+  if (boxRef === undefined) return null;
+  return (
+    `--restore always creates a new box, so it cannot also take the box ref "${boxRef}" — ` +
+    'drop the ref, or name the new box with -n <name>'
+  );
+}
+
+/** Why a restore cannot proceed into a directory a box already runs on. */
+export function existingBoxRefusal(
+  existing: { name: string } | null | undefined,
+  dir: string,
+): string | null {
+  if (!existing) return null;
+  return `box ${existing.name} already runs on ${dir} — pass --into <dir> to restore alongside it`;
+}
+
+/**
  * Refuse while the box this bundle came from is still running.
  *
  * Two live gateways holding one identity is the multi-tenancy failure OpenClaw's

--- a/apps/cli/src/commands/_restore.ts
+++ b/apps/cli/src/commands/_restore.ts
@@ -1,0 +1,159 @@
+/**
+ * `--restore <bot>` — the CLI half of putting a backed-up bot back into a box.
+ *
+ * The inverse of `_backup.ts`, and deliberately the same shape: the decisions
+ * that a hub route would also need (which bundle, is the source still alive,
+ * what goes where) live in `@agentbox/sandbox-core`'s bot-backup concern, and
+ * what stays here is what only a CLI knows — which flags were passed, and what
+ * to print.
+ *
+ * A restore is two halves that arrive by different routes. The workspace half is
+ * just a directory, so it becomes the new box's project and rides the ordinary
+ * create with no create-path change at all. The state half cannot: it belongs
+ * inside the agent's own config dir, so it is pushed after the box exists, with
+ * the agent stopped.
+ */
+
+import { log } from '@agentbox/cli-kit';
+import { findProjectRoot } from '@agentbox/config';
+import { cp, mkdir, readdir } from 'node:fs/promises';
+import { isAbsolute, join, resolve } from 'node:path';
+import type { AgentId, BoxRecord } from '@agentbox/core';
+import {
+  botDir,
+  findAgentSpec,
+  readState,
+  resolveBotBundle,
+  restoreAgentState,
+  type BotBundle,
+} from '@agentbox/sandbox-core';
+import { providerForBox } from '../provider/registry.js';
+import { pullTransportForBox } from './_agent-pull-transport.js';
+
+export interface RestoreRequest {
+  bundle: BotBundle;
+  /** The live workspace the restored box runs on — NOT the immutable bundle. */
+  workspaceDir: string;
+  /** The agent whose state the bundle carries, when it carries one. */
+  agent?: AgentId;
+}
+
+export interface RestoreOptions {
+  restore?: string;
+  stamp?: string;
+  into?: string;
+  force?: boolean;
+}
+
+/**
+ * Resolve `--restore` against the project the command was run in.
+ *
+ * The restored box does NOT run on the bundle's own `workspace/`: that copy is
+ * immutable and `--keep` may prune it, so a box writing into it would lose its
+ * workspace to a later backup. It runs on a live sibling,
+ * `<project>/.agentbox/bots/<bot>/workspace`, which stays inside the same
+ * gitignored, never-seeded directory as the backups it came from.
+ */
+export async function resolveRestoreRequest(
+  workspace: string,
+  opts: RestoreOptions,
+): Promise<RestoreRequest> {
+  const bot = (opts.restore ?? '').trim();
+  if (bot.length === 0 || bot.includes('/') || bot === '.' || bot === '..') {
+    throw new Error(`--restore ${opts.restore ?? ''}: a bot name must be a single path segment`);
+  }
+  const projectRoot = (await findProjectRoot(workspace)).root;
+  const bundle = await resolveBotBundle(projectRoot, bot, opts.stamp?.trim() || undefined);
+
+  // `~` is not expanded here for the same reason `clone --into` refuses it: a
+  // quoted tilde reaching us means "home", and creating a directory literally
+  // named `~` is never what was meant.
+  const raw = opts.into?.trim();
+  if (raw === '~' || raw?.startsWith('~/')) {
+    throw new Error(`--into ${raw}: '~' is not expanded here — write the path out`);
+  }
+  const workspaceDir = raw
+    ? isAbsolute(raw)
+      ? raw
+      : resolve(process.cwd(), raw)
+    : join(botDir(projectRoot, bundle.bot), 'workspace');
+
+  const declared = bundle.manifest.agent;
+  const agent = bundle.stateDir && declared ? findAgentSpec(declared)?.id : undefined;
+  return { bundle, workspaceDir, ...(agent ? { agent } : {}) };
+}
+
+/**
+ * Refuse while the box this bundle came from is still running.
+ *
+ * Two live gateways holding one identity is the multi-tenancy failure OpenClaw's
+ * per-box config volume exists to prevent, and a restore is the one operation
+ * that can produce it. The box being GONE is the normal case — that is what a
+ * restore is for — so an unknown or absent record proceeds silently; only a
+ * record we can still see running stops it.
+ */
+export async function assertSourceBoxNotRunning(
+  bundle: BotBundle,
+  force: boolean | undefined,
+): Promise<void> {
+  const state = await readState().catch(() => null);
+  const source = state?.boxes.find((b) => b.id === bundle.manifest.boxId);
+  if (!source) return;
+  let live: string;
+  try {
+    live = await (await providerForBox(source)).probeState(source);
+  } catch {
+    return;
+  }
+  if (live !== 'running') return;
+  if (force) {
+    log.warn(`${source.name} is still running and holds this identity; --force given, continuing`);
+    return;
+  }
+  throw new RestoreSourceRunningError(
+    `box ${source.name} is still running and holds ${bundle.bot}'s identity — ` +
+      `two live gateways cannot share one. Stop or destroy it, or pass --force.`,
+  );
+}
+
+/** Distinguished so the caller can exit 2 rather than 1, as `destroy` does. */
+export class RestoreSourceRunningError extends Error {}
+
+/**
+ * Copy the bundle's workspace half to the live directory the box will run on.
+ *
+ * Refuses a non-empty destination unless `--force`: the usual reason it is
+ * non-empty is an earlier restore of the same bot that is still in use, and
+ * overwriting it in place would take the running box's files out from under it.
+ */
+export async function stageRestoreWorkspace(
+  req: RestoreRequest,
+  force: boolean | undefined,
+): Promise<{ files: number }> {
+  await mkdir(req.workspaceDir, { recursive: true });
+  const existing = await readdir(req.workspaceDir);
+  if (existing.length > 0 && !force) {
+    throw new Error(
+      `${req.workspaceDir} is not empty — pass --into <dir> for a different location, or --force to overwrite it`,
+    );
+  }
+  await cp(req.bundle.workspaceDir, req.workspaceDir, { recursive: true, force: true });
+  return { files: (await readdir(req.workspaceDir)).length };
+}
+
+/**
+ * Push the state half into a box whose agent has been stopped.
+ *
+ * The transport is the same one the backup read through: cloud transport, or for
+ * docker the agent's config volume mounted at its box path.
+ */
+export async function restoreStateIntoBox(args: {
+  box: BoxRecord;
+  agent: AgentId;
+  bundle: BotBundle;
+}): Promise<{ clearedSidecars: string[] }> {
+  const stateDir = args.bundle.stateDir;
+  if (!stateDir) throw new Error(`${args.bundle.dir}: this backup captured no agent state`);
+  const { transport } = await pullTransportForBox(args.box, args.agent);
+  return await restoreAgentState({ agent: args.agent, transport, srcDir: stateDir });
+}

--- a/apps/cli/src/commands/create.ts
+++ b/apps/cli/src/commands/create.ts
@@ -45,6 +45,13 @@ import { withHubClient } from '../control-plane/with-hub.js';
 import { dockerProviderRefusal, remoteHubConfigured } from '../control-plane/remote-hub.js';
 import { attachRelayOptions } from '../control-plane/box-plane.js';
 import { resolveBoxOrExit } from '../box-ref.js';
+import {
+  assertSourceBoxNotRunning,
+  resolveRestoreRequest,
+  RestoreSourceRunningError,
+  stageRestoreWorkspace,
+  type RestoreRequest,
+} from './_restore.js';
 
 interface CreateOptions {
   workspace: string;
@@ -84,6 +91,14 @@ interface CreateOptions {
   inbound?: string;
   /** --remote-host <dest>: SSH destination whose docker engine runs the box. remote-docker-only. */
   remoteHost?: string;
+  /** --restore <bot>: seed the box from that bot's backup under <project>/.agentbox/bots/. */
+  restore?: string;
+  /** --stamp <s>: which backup to restore (default: `latest`). */
+  stamp?: string;
+  /** --into <dir>: where the restored workspace lives (default: the bot's own dir). */
+  into?: string;
+  /** --force: restore even when the source box still runs / the destination is not empty. */
+  force?: boolean;
   /** --from-branch <ref>: base the box's per-box branch on this ref (branch / tag / SHA) instead of HEAD. */
   fromBranch?: string;
   /** -b / --use-branch <name>: reuse an existing branch directly instead of forking agentbox/<name>. */
@@ -386,14 +401,59 @@ export const createCommand = new Command('create')
     'force building the box on this machine even when a control box is configured (the opposite of --via-hub; cloud.viaHub=false makes this the default). Docker boxes are always local.',
   )
   .option('--url <url>', 'control-plane URL for --via-hub (default: relay.controlPlaneUrl)')
+  .option(
+    '--restore <bot>',
+    "recreate a bot from its backup under <project>/.agentbox/bots/<bot>/. The box runs on a copy of the backed-up workspace; the agent's state dir is NOT restored here (see `agentbox <agent> --restore` for that)",
+  )
+  .option('--stamp <stamp>', 'which --restore backup to use (default: the `latest` link)')
+  .option(
+    '--into <dir>',
+    'dir the restored workspace lives in (default: <project>/.agentbox/bots/<bot>/workspace)',
+  )
+  .option(
+    '--force',
+    'with --restore: proceed even when the backed-up box still runs, or the destination is not empty',
+  )
   .action(async (opts: CreateOptions) => {
     const cmdLog = openCommandLog('create');
     intro('Setting up a new box...');
 
+    // `--restore` resolves and stages BEFORE the config load: the restored tree
+    // becomes the box's workspace, so its own `agentbox.yaml` is the one that
+    // must be read. `projectRoot` is then that directory verbatim rather than
+    // `findProjectRoot`'s answer — the restore dir sits under the ORIGINAL
+    // project's `.agentbox/`, so walking up would silently pick the template
+    // project and seed the box from it instead.
+    let restored: RestoreRequest | undefined;
+    if (opts.restore) {
+      try {
+        restored = await resolveRestoreRequest(opts.workspace, opts);
+        await assertSourceBoxNotRunning(restored.bundle, opts.force);
+      } catch (err) {
+        // Exit 2 for "you asked for something this box cannot be", as
+        // `--from-branch` and `destroy`'s persistent guard already do; a stack
+        // trace here would bury the one line that says what to do next.
+        log.error(err instanceof Error ? err.message : String(err));
+        cmdLog.close();
+        process.exit(err instanceof RestoreSourceRunningError ? 2 : 1);
+      }
+      const staged = await stageRestoreWorkspace(restored, opts.force);
+      log.info(
+        `restored ${restored.bundle.bot} @ ${restored.bundle.stamp}: ` +
+          `${String(staged.files)} entr(ies) -> ${restored.workspaceDir}`,
+      );
+      if (restored.agent) {
+        log.warn(
+          `this backup also holds ${restored.agent} state; \`agentbox create\` restores the workspace only — ` +
+            `use \`agentbox ${restored.agent} --restore ${restored.bundle.bot}\` to bring the identity back too`,
+        );
+      }
+      opts.workspace = restored.workspaceDir;
+    }
     const cfg = await loadEffectiveConfig(opts.workspace, {
       cliOverrides: buildCliOverrides(opts),
     });
-    const projectRoot = (await findProjectRoot(opts.workspace)).root;
+    const projectRoot = restored?.workspaceDir ?? (await findProjectRoot(opts.workspace)).root;
     // Register the project in the on-disk registry so the hub / web UI can list
     // it (even before it has any box). Best-effort: never block or fail create.
     // Other create entry points (agent commands, queue worker) are covered by

--- a/apps/cli/test/_fixtures/agent-cli-surface.json
+++ b/apps/cli/test/_fixtures/agent-cli-surface.json
@@ -1011,6 +1011,34 @@
         "defaultValue": null,
         "mandatory": false,
         "negate": false
+      },
+      {
+        "flags": "--restore <bot>",
+        "description": "recreate a bot from its backup under <project>/.agentbox/bots/<bot>/: the box runs on a copy of the backed-up workspace AND gets the captured openclaw state dir back, identity included. Always creates a new box",
+        "defaultValue": null,
+        "mandatory": false,
+        "negate": false
+      },
+      {
+        "flags": "--stamp <stamp>",
+        "description": "which --restore backup to use (default: the `latest` link)",
+        "defaultValue": null,
+        "mandatory": false,
+        "negate": false
+      },
+      {
+        "flags": "--into <dir>",
+        "description": "dir the restored workspace lives in (default: <project>/.agentbox/bots/<bot>/workspace)",
+        "defaultValue": null,
+        "mandatory": false,
+        "negate": false
+      },
+      {
+        "flags": "--force",
+        "description": "with --restore: proceed even when the backed-up box still runs, or the destination is not empty",
+        "defaultValue": null,
+        "mandatory": false,
+        "negate": false
       }
     ],
     "subcommands": [

--- a/apps/cli/test/create.test.ts
+++ b/apps/cli/test/create.test.ts
@@ -25,4 +25,13 @@ describe('agentbox create command', () => {
     const workspace = createCommand.options.find((o) => o.long === '--workspace');
     expect(workspace?.defaultValue).toBe(process.cwd());
   });
+
+  it('carries the restore flags, and says the state half is not its job', () => {
+    const flags = createCommand.options.map((o) => o.long);
+    expect(flags).toEqual(expect.arrayContaining(['--restore', '--stamp', '--into', '--force']));
+    // An agentless box has no agent config volume to restore into, and a user
+    // who reads only the help must not expect their bot's identity back here.
+    const restore = createCommand.options.find((o) => o.long === '--restore');
+    expect(restore?.description).toMatch(/state dir is NOT restored here/);
+  });
 });

--- a/apps/cli/test/restore-guards.test.ts
+++ b/apps/cli/test/restore-guards.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The three refusals that stand between `--restore` and a destroyed bot.
+ *
+ * All three were found by review rather than by a failing run, and each one
+ * fails by doing something plausible: resuming the box you named, restoring a
+ * workspace-only bundle as though it carried an identity, or writing a backup
+ * over a box that is already running on that directory. They are pure functions
+ * precisely so they can be asserted without provisioning anything.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { BotBundle } from '@agentbox/sandbox-core';
+import {
+  boxRefWithRestoreRefusal,
+  existingBoxRefusal,
+  restoreScope,
+} from '../src/commands/_restore.js';
+
+function bundle(over: Partial<BotBundle> = {}): BotBundle {
+  return {
+    dir: '/p/.agentbox/bots/ada/2026-09-07T14-03-11Z',
+    bot: 'ada',
+    stamp: '2026-09-07T14-03-11Z',
+    manifest: {
+      version: 1,
+      stamp: '2026-09-07T14-03-11Z',
+      bot: 'ada',
+      boxId: 'b0dc0ffee',
+      boxName: 'ada',
+      provider: 'docker',
+      state: true,
+    },
+    workspaceDir: '/p/.agentbox/bots/ada/2026-09-07T14-03-11Z/workspace',
+    stateDir: '/p/.agentbox/bots/ada/2026-09-07T14-03-11Z/state',
+    ...over,
+  };
+}
+
+describe('restoreScope', () => {
+  it('reports workspace-only for a bundle that captured no state', () => {
+    // The service command must SKIP the state half here, not throw: the box has
+    // already been created by the time this is known, and failing would leave a
+    // working box behind a failed command.
+    expect(restoreScope(bundle({ stateDir: undefined }))).toBe('workspace');
+  });
+
+  it('reports both halves when the state dir is there', () => {
+    expect(restoreScope(bundle())).toBe('workspace+state');
+  });
+});
+
+describe('boxRefWithRestoreRefusal', () => {
+  it('refuses a positional box ref, naming it', () => {
+    // `agentbox <agent> foo --restore ada` would resume `foo` and then write
+    // ada's identity over it — the create-or-resume path meeting a restore.
+    const msg = boxRefWithRestoreRefusal('foo');
+    expect(msg).toContain('"foo"');
+    expect(msg).toMatch(/always creates a new box/);
+  });
+
+  it('allows the ref-less form', () => {
+    expect(boxRefWithRestoreRefusal(undefined)).toBeNull();
+  });
+});
+
+describe('existingBoxRefusal', () => {
+  it('refuses when a box already runs on the restore directory', () => {
+    const msg = existingBoxRefusal({ name: 'ada' }, '/p/.agentbox/bots/ada/workspace');
+    expect(msg).toContain('ada');
+    expect(msg).toContain('/p/.agentbox/bots/ada/workspace');
+    expect(msg).toMatch(/--into/);
+  });
+
+  it('allows an empty directory, whether the lookup returned null or undefined', () => {
+    // `findExistingBox` answers `null`; a caller with no lookup at all passes
+    // `undefined`. Both mean "nothing in the way".
+    expect(existingBoxRefusal(null, '/p')).toBeNull();
+    expect(existingBoxRefusal(undefined, '/p')).toBeNull();
+  });
+});

--- a/apps/cli/test/service-agent-command.test.ts
+++ b/apps/cli/test/service-agent-command.test.ts
@@ -88,6 +88,14 @@ describe('buildServiceAgentCommand', () => {
     expect(command.opts().persistent).toBeUndefined();
   });
 
+  it('offers the restore flags, and names the agent whose state comes back', () => {
+    expect(flags).toEqual(expect.arrayContaining(['--restore', '--stamp', '--into', '--force']));
+    // This is the surface that restores the IDENTITY (unlike `create --restore`),
+    // so its help has to say which agent's state dir it is putting back.
+    const restore = command.options.find((o) => o.long === '--restore');
+    expect(restore?.description).toContain('demosvc state dir');
+  });
+
   it('refuses to build a command for an agent with no service block', () => {
     const noService = { ...spec, service: undefined } as unknown as AgentSyncSpec;
     expect(() => buildServiceAgentCommand(noService)).toThrow(/declares no service block/);

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -247,6 +247,11 @@ agentbox download 1 --with-env
 agentbox download --backup ada       # capture the bot into .agentbox/bots/
 agentbox download --backup --keep 5 ada
 
+# Put a backed-up bot back into a new box, identity and all
+agentbox openclaw --restore ada
+agentbox openclaw --restore ada --provider hetzner -n ada-hz
+agentbox create --restore ada        # the workspace half only (no agent)
+
 # Push the host workspace INTO a live box (the box wins every conflict)
 agentbox upload
 agentbox upload 1
@@ -297,6 +302,8 @@ agentbox services restart 1 web            # restart one service
 When `/workspace` is not a git repo, `download` and `upload` select files with an **exclude list** rather than `.gitignore` — the normal mode for a service box, not a fallback, and the output labels it. It drops `.git`, `node_modules`, `media/`, live databases (`*.sqlite*`, `*.db`, `*.db-*`) and every agent's state directory.
 
 `download --backup` writes to `<project>/.agentbox/bots/<bot>/<timestamp>/` instead of your working dir, and captures the agent's **state directory with its identity** alongside the workspace — the portable, cross-provider alternative to a checkpoint. `--name <bot>` sets the bot name (default: the box name), `--keep <n>` how many backups to retain (default 3), `--agent <id>` which agent's state to take. It never asks about agent-generated files. See [sync and git](/docs/sync-and-git#back-a-bot-up).
+
+`--restore <bot>` is the other direction: it creates a **new** box seeded from that bot's backup. On a service-agent command (`agentbox openclaw --restore ada`) it also puts the captured state directory back, so the bot keeps its gateway identity, pairings and history — the same bot on a new box, and on a different provider if you pass one. On `agentbox create` it restores the workspace only, because an agentless box has no agent state directory to restore into. `--stamp <t>` picks a backup other than the newest, `--into <dir>` where the restored workspace lives (default `<project>/.agentbox/bots/<bot>/workspace`), and `--force` proceeds when the backed-up box is still running or the destination is not empty. See [sync and git](/docs/sync-and-git#bring-a-bot-back).
 
 Useful flags: `download` takes `--dry-run`, `--no-respect-gitignore` (force exclude-list mode), `--include-node-modules` (keep `node_modules`, in both modes), `--include-agent-files` (take agent-generated files like `AGENTS.md` without being asked), `--with-env`, `--pattern <glob>`; `git push`/`fetch` take `--remote <name>` (default `origin`) and forward extra args like `--force-with-lease`. `git push --host-only` lands the box's branch in your **local** repo without pushing to any remote (nothing is published online) — `--as <branch>` picks the host branch name (default: the box's branch) and `--force` allows a non-fast-forward overwrite. Because nothing leaves the host, `--host-only` skips the push-approval prompt.
 

--- a/apps/web/content/docs/openclaw.mdx
+++ b/apps/web/content/docs/openclaw.mdx
@@ -169,8 +169,8 @@ cloned box from inheriting the facts of the box it was cloned from.
 
 | Path in the box                   | What it is                      | Travels?                         |
 | --------------------------------- | ------------------------------- | -------------------------------- |
-| `~/.openclaw/openclaw.json`       | Config **and gateway identity** | Only into a `--backup`           |
-| `~/.openclaw/state/*.sqlite*`     | Live gateway state              | Only into a `--backup`           |
+| `~/.openclaw/openclaw.json`       | Config **and gateway identity** | `--backup` / `--restore` only    |
+| `~/.openclaw/state/*.sqlite*`     | Live gateway state              | `--backup` / `--restore` only    |
 | `~/.openclaw/tmp/openclaw-<uid>/` | Lock databases                  | Never                            |
 | `~/.openclaw/agents/`             | Your agent definitions          | Both directions                  |
 | `~/.config/openclaw`              | Auth-profile key                | Stays in the box's config volume |
@@ -178,6 +178,8 @@ cloned box from inheriting the facts of the box it was cloned from.
 `agentbox download openclaw [box]` pulls the agent definitions back to your host, additively — an item the host already has is never overwritten. There is deliberately no `--propagate`: an OpenClaw box is a tenant, and copying one tenant's definitions into another's gateway is not a sensible default.
 
 **One exception, and it is opt-in: `agentbox download --backup`.** A backup is the one operation that keeps the identity, because a restore that mints a new gateway token has not restored the bot. It writes `openclaw.json`, the config-journal key and the live `state/` into `<project>/.agentbox/bots/<bot>/<timestamp>/state/` — gitignored and `0700` — while still dropping `tmp/openclaw-<uid>/`, whose name carries the box user's uid and differs per provider. The gateway databases go through SQLite's online-backup API, not a byte copy. See [back a bot up](/docs/sync-and-git#back-a-bot-up).
+
+A backup is restorable, and `agentbox openclaw --restore <bot>` is how: a new box, seeded from the backed-up workspace, with the captured state directory pushed back in once the gateway has come up on its own — same token, same pairings, same history, on whichever provider you point it at. It refuses while the backed-up box is still running, because two gateways holding one identity is the failure the per-box state directory exists to prevent. See [bring a bot back](/docs/sync-and-git#bring-a-bot-back).
 
 If your host happens to run OpenClaw itself, its config and state are excluded from everything pushed into a box, for the same identity reason.
 

--- a/apps/web/content/docs/sync-and-git.mdx
+++ b/apps/web/content/docs/sync-and-git.mdx
@@ -73,6 +73,28 @@ Live databases are captured through SQLite's own online-backup API rather than c
 
 Unlike a plain `download`, a backup never asks about agent-generated files: `SOUL.md` and `IDENTITY.md` are the point of one.
 
+## Bring a bot back
+
+`--restore <bot>` is the other half. It creates a **new** box from a backup:
+
+```bash
+agentbox openclaw --restore ada                       # the newest backup
+agentbox openclaw --restore ada --stamp 2026-09-07T15-09-16Z
+agentbox openclaw --restore ada --provider hetzner    # and on another provider
+```
+
+On a service-agent command the restore covers both halves — the workspace _and_ the captured state directory — so the bot comes back as itself: same gateway token, same channel pairings, same history. On `agentbox create --restore ada` you get the workspace only, and the command says so, because a box created without an agent has no agent state directory to restore into.
+
+The restored box does not run on the backup itself. That copy is immutable, and `--keep` may prune it, so a box writing into it would eventually lose its workspace to a later backup. It runs on a live sibling, `<project>/.agentbox/bots/<bot>/workspace`, which `--into <dir>` overrides.
+
+<Callout type="warn" title="Two boxes cannot share one identity">
+  A restore is refused while the box the backup came from is still running: two live gateways
+  holding one identity is exactly what a per-box state directory exists to prevent. Stop or destroy
+  the old box first, or pass `--force` if you know what you are doing.
+</Callout>
+
+The identity goes in **after** the box has come up on its own, not before. A service agent's onboarding is a run-once task whose marker lives on the box's root filesystem rather than in the agent's config volume, so it runs on every fresh box no matter what that volume holds — there is no "write the state in first" that works. Letting it run and then replacing what it wrote means the marker is already down, and onboarding never touches the restored identity again, on that boot or any later one.
+
 <Callout title="`.agentbox/` never crosses the box boundary">
   Your project's `.agentbox/` is yours and stays on the host — it is never seeded into a box. The
   box's own `/workspace/.agentbox/` is generated fresh every boot and is never pulled back. Same

--- a/docs/plans/bot-clone-spawn-backlog.md
+++ b/docs/plans/bot-clone-spawn-backlog.md
@@ -29,6 +29,11 @@ load-bearing.
   `workspace` sorts after every stamp, so it would have become the newest
   "backup" the prune must keep. Now matched against the stamp shape.
 
+- **The cross-provider claim is now measured, not argued.** A bundle captured on
+  a docker box restored onto a Hetzner VPS with the same gateway token, the same
+  automation row and a clean `openclaw config validate` — which is what a
+  file-shaped backup is for and what a provider snapshot cannot do.
+
 ### Open
 
 - **PoC question 4 is not answerable locally.** "Does OpenClaw refuse when a
@@ -50,5 +55,15 @@ load-bearing.
 - **`agentbox <agent> stop` still bypasses the hub** (the services routes expose
   `restart` but not `stop`), so the restore's stop step is a `provider.exec`.
   Same item as in the service-boxes backlog; the restore is now a second caller.
+- **The source-box guard only knows the box the bundle came from.** It reads
+  `manifest.boxId`, so a *second* restore of the same bundle into a different
+  `--into` directory is not refused — the two live bots would share an identity.
+  Restoring twice into the SAME directory is refused (a box already runs on it).
+  Recording the bundle on the box record would close the gap.
+- **Hetzner `nbg1` had no `cx23` capacity** during this work, and the
+  service-agent command has no `--location` flag (it carries a deliberately small
+  subset of the create flags), so the retry went through
+  `config set box.hetznerLocation fsn1`. Worth adding if VPS restores become
+  routine.
 - **Hermes' shape is still unmeasured.** Its state dir and identity files need
   the same table row openclaw has before a `clone:`/restore story can cover it.

--- a/docs/plans/bot-clone-spawn-backlog.md
+++ b/docs/plans/bot-clone-spawn-backlog.md
@@ -1,0 +1,54 @@
+# Bot backup / restore / spawn — backlog
+
+Findings and deferred items from implementing
+[`bot-clone-spawn-plan.md`](./bot-clone-spawn-plan.md). Each phase appends here
+rather than sidequesting. Promote an item to the plan if it turns out to be
+load-bearing.
+
+## From Phase 2 (restore, 2026-09-07)
+
+### Measured, and now encoded
+
+- **A restore MUST delete the target's stale write-ahead logs first.** Copying a
+  bundle's `openclaw.sqlite` over a fresh box's left that box's own
+  `openclaw.sqlite-wal`/`-shm` beside it, and the gateway then refused to start —
+  `SQLite integrity_check failed for …/openclaw.sqlite: row 1 missing from index
+  idx_gateway_boot_lifecycle_started` — restarting on a backoff loop forever. The
+  naive "rsync the state dir in" implementation ships a broken bot. Only the
+  sidecars of a database the bundle actually replaces are removed: one belonging
+  to a database we are not overwriting may hold the only copy of committed rows.
+- **`run_once: 'marker'` is what makes the ordering easy.** The marker is keyed
+  by the task's command hash and lives on the box ROOTFS
+  (`/var/lib/agentbox/tasks/openclaw-onboard`), not in the agent's config volume,
+  so onboard runs once on every fresh box whatever the volume holds. Restoring
+  *after* it is therefore deterministic and needs no create-path hook, and the
+  marker keeps onboard away from the restored identity on every later boot —
+  verified across a full `stop`/`start` of the box.
+- **`listBackups` counted a restore's live `workspace/` as a backup.** A Phase 1
+  bug the restore exposed: the filter was "any dir that is not `latest`", and
+  `workspace` sorts after every stamp, so it would have become the newest
+  "backup" the prune must keep. Now matched against the stamp shape.
+
+### Open
+
+- **PoC question 4 is not answerable locally.** "Does OpenClaw refuse when a
+  second box holds the same identity while the first still runs?" needs a real
+  channel: two gateways on one host with no channel configured never collide, and
+  the collision that matters is at the channel provider. The guard is a hard
+  error with `--force` until someone can measure it — the safe default, but
+  chosen rather than measured.
+- **`--restore` does not work against a remote hub.** The bundle is a directory
+  on the user's machine and the create API carries a `projectId`, never a path
+  (`hub-backend.ts` resolves the workspace from the hub's own registry — "never
+  trust a client path"). A local hub is the same machine, so the ordinary path
+  works; a control box would need the bundle uploaded first. Not refused
+  explicitly yet: the create simply fails to find the project.
+- **`download` is still the one CLI-inline command**, and `--backup`/`--restore`
+  join it there. Moving the whole command behind `/api/v1` — with a state-push
+  route the restore can use — is one change, not three; `upload` has already
+  moved, `download` has no route at all.
+- **`agentbox <agent> stop` still bypasses the hub** (the services routes expose
+  `restart` but not `stop`), so the restore's stop step is a `provider.exec`.
+  Same item as in the service-boxes backlog; the restore is now a second caller.
+- **Hermes' shape is still unmeasured.** Its state dir and identity files need
+  the same table row openclaw has before a `clone:`/restore story can cover it.

--- a/docs/plans/bot-clone-spawn-plan.md
+++ b/docs/plans/bot-clone-spawn-plan.md
@@ -1,7 +1,8 @@
 # Bot backup, restore and spawn — plan
 
-Status: **not started.** Written 2026-09-07 after the `download` fix (#372)
-and the openclaw box-context task (#371) landed on `nightly`.
+Status: **Phases 1 and 2 done** (backup, restore). Written 2026-09-07 after the
+`download` fix (#372) and the openclaw box-context task (#371) landed on
+`nightly`.
 
 One session per phase. Keep the findings of each phase in
 [`bot-clone-spawn-backlog.md`](./bot-clone-spawn-backlog.md) as they appear,
@@ -49,16 +50,16 @@ Measured against the code (and, where marked, a live box) on 2026-09-07.
 | Channel tokens ride `carry:` into a 0600 `~/.openclaw/.env` and are referenced by name in the overlay | `examples/openclaw-gateway/agentbox.yaml` | A per-bot token is a per-bot **source path**, not a new secret channel. |
 | The box already gets a setup skill (`/opt/agentbox/skills/agentbox-setup/SKILL.md`, copied from `/usr/local/share/agentbox/setup-guide.md`) | `openclaw.ts:66-172`; sources under `apps/cli/runtime/_shared/agentbox-setup-skill.md` | The identity wizard is a second skill of the same shape. |
 
-### To verify live before Phase 2 (PoC gate)
+### The PoC gate — measured 2026-09-07
 
-These are assumed, not measured. Each is cheap to check on a docker box and
-changes the design if wrong.
-
-- Restoring `openclaw.json` + `state/` into a **fresh** box revives the channel
-  pairings and sessions, with nothing else (no `migration`, no `tmp`).
-- A restored bot with the **same** identity as a still-running box is actually
-  refused by openclaw (or misbehaves) — this decides whether "refuse restore
-  while the source runs" is a hard error or a warning.
+- **Restoring `openclaw.json` + `state/` into a fresh box revives the identity.**
+  Verified: same gateway token, the same automation row (same id) back in the
+  restored database, `openclaw config validate` clean. **But only after the
+  target's stale `-wal`/`-shm` are removed** — see the Phase 2 notes.
+- A restored bot with the **same** identity as a still-running box: **not
+  answerable locally.** Two gateways on one host with no channel configured never
+  collide, and the collision that matters is at the channel provider. The guard
+  stays a hard error with `--force`, chosen rather than measured.
 - `agentbox-ctl render --env` substitutes `{{AGENTBOX_BOX_NAME}}` with the box
   name ctl sees (not the container name) on every provider.
 - hermes' state dir and identity files, so its row can be written alongside
@@ -193,7 +194,41 @@ it (gitless project — copy `examples/openclaw-gateway` without `.git`).
 
 </details>
 
-### Phase 2 — restore
+### Phase 2 — restore — **DONE**
+
+Shipped as `--restore <bot>` on `agentbox create` and on the service-agent
+commands. What the implementation found that the plan had not:
+
+- **The PoC's real answer was a bug, not a yes.** Pushing the bundle's `state/`
+  into a fresh box and restarting the gateway does revive the identity — but only
+  after the target's own `-wal`/`-shm` are removed. Leaving them produced
+  `SQLite integrity_check failed … row 1 missing from index` and a permanent
+  restart loop. That deletion is now the first thing `restoreAgentState` does,
+  scoped to the databases the bundle actually replaces.
+- **No create-path surgery was needed at all.** The plan expected to write the
+  state in before onboard. `run_once: 'marker'` makes that impossible *and*
+  unnecessary: the marker lives on the box rootfs, not in the config volume, so
+  onboard runs once on every fresh box regardless — and, having run, never
+  touches the restored identity again. Restore therefore runs after the service
+  is up: stop, push, restart. One order, every provider, no provider code.
+- **The state push must NOT go through `agentPushExcludes`.** It adds
+  `LIVE_DATABASE_EXCLUDES` unconditionally, which matches `*.sqlite*` — precisely
+  what a restore exists to put back.
+- **The workspace half is a create with no new plumbing.** The restored tree is
+  the box's project, so it rides the ordinary create exactly as `clone`'s export
+  dir does. `projectRoot` is that directory verbatim, never `findProjectRoot`'s
+  answer — the restore dir lives under the ORIGINAL project's `.agentbox/`, so
+  walking up would have seeded the box from the template project instead.
+- **Phase 1 had a latent bug this exposed**: `listBackups` counted a restore's
+  live `workspace/` as a backup, and it sorts after every stamp.
+
+Live-verified on docker end to end: same gateway token, the same automation row
+(same id) in the restored database, `openclaw config validate` clean, and all of
+it surviving a full box `stop`/`start`. Findings and what is still open are in
+[`bot-clone-spawn-backlog.md`](./bot-clone-spawn-backlog.md).
+
+<details>
+<summary>Original plan</summary>
 
 PoC gate first (see above). Then:
 
@@ -215,6 +250,8 @@ PoC gate first (see above). Then:
 token, channel still paired, memory intact; then `--restore --provider e2b`.
 A box reaching `ready` proves nothing here — send a message through the
 channel.
+
+</details>
 
 ### Phase 3 — the `clone:` spec field and per-bot carry
 

--- a/docs/plans/bot-clone-spawn-plan.md
+++ b/docs/plans/bot-clone-spawn-plan.md
@@ -222,9 +222,13 @@ commands. What the implementation found that the plan had not:
 - **Phase 1 had a latent bug this exposed**: `listBackups` counted a restore's
   live `workspace/` as a backup, and it sorts after every stamp.
 
-Live-verified on docker end to end: same gateway token, the same automation row
-(same id) in the restored database, `openclaw config validate` clean, and all of
-it surviving a full box `stop`/`start`. Findings and what is still open are in
+Live-verified end to end. On **docker**: same gateway token, the same automation
+row (same id) in the restored database, `openclaw config validate` clean, and all
+of it surviving a full box `stop`/`start`. On **hetzner**, which is the
+acceptance test the plan named — a bundle captured on docker, restored onto a
+VPS: same token, same automation, config valid, workspace intact. And
+`create --restore` gives the workspace half alone, naming the agent whose
+identity it did not bring. Findings and what is still open are in
 [`bot-clone-spawn-backlog.md`](./bot-clone-spawn-backlog.md).
 
 <details>

--- a/packages/sandbox-core/src/sync/concerns/bot-backup.ts
+++ b/packages/sandbox-core/src/sync/concerns/bot-backup.ts
@@ -34,6 +34,7 @@ import {
   writeFile,
 } from 'node:fs/promises';
 import { join } from 'node:path';
+import type { Dirent } from 'node:fs';
 import type { AgentId, SyncTransport } from '@agentbox/core';
 import { LIVE_DATABASE_EXCLUDES } from '@agentbox/core';
 import { resolveAgentSpec } from '../registry.js';
@@ -58,6 +59,18 @@ export function backupStamp(at: Date = new Date()): string {
     .replace(/\.\d+Z$/, 'Z')
     .replace(/:/g, '-');
 }
+
+/**
+ * What {@link backupStamp} produces, and the only directory name under a bot
+ * that IS a backup.
+ *
+ * Matched rather than assumed, because the bot dir is not backups-only: a
+ * restore writes its live `workspace/` tree there as a sibling of the stamps.
+ * Treating "any dir that is not `latest`" as a backup would let that tree take a
+ * slot in the prune's ordering and, since `workspace` sorts after every stamp,
+ * silently make it the newest "backup" nothing may delete.
+ */
+const STAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z$/;
 
 /** `<project>/.agentbox/bots/<bot>`. */
 export function botDir(projectRoot: string, bot: string): string {
@@ -106,7 +119,12 @@ export async function linkLatest(projectRoot: string, bot: string, stamp: string
   await symlink(stamp, link);
 }
 
-/** The backup directory names under `<bot>`, newest first. */
+/**
+ * The backup directory names under `<bot>`, newest first.
+ *
+ * Stamp-shaped names only ({@link STAMP_RE}) — `latest` and a restore's live
+ * `workspace/` are siblings, not backups.
+ */
 export async function listBackups(projectRoot: string, bot: string): Promise<string[]> {
   let entries: string[];
   try {
@@ -116,7 +134,7 @@ export async function listBackups(projectRoot: string, bot: string): Promise<str
   }
   const dirs: string[] = [];
   for (const name of entries) {
-    if (name === 'latest') continue;
+    if (!STAMP_RE.test(name)) continue;
     const st = await lstat(join(botDir(projectRoot, bot), name)).catch(() => null);
     if (st?.isDirectory()) dirs.push(name);
   }
@@ -271,4 +289,153 @@ async function backupStateDatabases(
 
 function quote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/** A bundle resolved on disk, ready to restore from. */
+export interface BotBundle {
+  /** `<project>/.agentbox/bots/<bot>/<stamp>`. */
+  dir: string;
+  bot: string;
+  stamp: string;
+  manifest: BackupManifest;
+  /** The workspace half. */
+  workspaceDir: string;
+  /** The state half; absent when the backup captured only the workspace. */
+  stateDir?: string;
+}
+
+/** Read and shape-check a bundle's manifest. */
+export async function readBackupManifest(dir: string): Promise<BackupManifest> {
+  const path = join(dir, 'manifest.json');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(path, 'utf8'));
+  } catch (err) {
+    throw new Error(
+      `${path}: not a readable backup manifest (${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+  const m = parsed as Partial<BackupManifest>;
+  // Version first: a bundle from a newer AgentBox may hold a layout this code
+  // would half-restore, and half a bot is worse than a refusal.
+  if (m.version !== 1) {
+    throw new Error(
+      `${path}: manifest version ${String(m.version)} is not one this build restores`,
+    );
+  }
+  if (typeof m.bot !== 'string' || typeof m.stamp !== 'string') {
+    throw new Error(`${path}: manifest is missing 'bot' or 'stamp'`);
+  }
+  return m as BackupManifest;
+}
+
+/**
+ * Resolve which backup of `bot` to restore.
+ *
+ * `stamp` absent follows the `latest` symlink, and falls back to the newest
+ * stamped dir when the link is missing — a bundle copied with a tool that drops
+ * symlinks is still restorable, which is the whole point of a relative link.
+ */
+export async function resolveBotBundle(
+  projectRoot: string,
+  bot: string,
+  stamp?: string,
+): Promise<BotBundle> {
+  const base = botDir(projectRoot, bot);
+  let chosen = stamp;
+  if (!chosen) {
+    chosen = (await readlink(join(base, 'latest')).catch(() => null)) ?? undefined;
+    if (chosen === undefined) chosen = (await listBackups(projectRoot, bot))[0];
+  }
+  if (!chosen) {
+    throw new Error(
+      `no backup of '${bot}' under ${base} — run \`agentbox download --backup\` first`,
+    );
+  }
+  const dir = join(base, chosen);
+  const manifest = await readBackupManifest(dir);
+  const workspaceDir = join(dir, 'workspace');
+  if (!(await lstat(workspaceDir).catch(() => null))?.isDirectory()) {
+    throw new Error(`${dir}: the backup has no workspace/ directory`);
+  }
+  const stateDir = join(dir, 'state');
+  const hasState = (await lstat(stateDir).catch(() => null))?.isDirectory() === true;
+  return {
+    dir,
+    bot: manifest.bot,
+    stamp: chosen,
+    manifest,
+    workspaceDir,
+    ...(hasState ? { stateDir } : {}),
+  };
+}
+
+export interface AgentStateRestoreResult {
+  /** Box paths whose stale write-ahead log / shared-memory file was removed. */
+  clearedSidecars: string[];
+}
+
+/**
+ * Push a captured state dir back into a box, IDENTITY INCLUDED — the inverse of
+ * {@link backupAgentState}.
+ *
+ * The caller must have stopped the agent first. Two things this does that a
+ * plain "copy the directory in" does not, both of them load-bearing:
+ *
+ * 1. **The stale write-ahead logs go first.** MEASURED, and it is not a corner
+ *    case: a fresh openclaw box has already onboarded, so its `state/` holds a
+ *    live `openclaw.sqlite` with its own `-wal`/`-shm`. Copying the backup's
+ *    main file over it leaves that WAL in place, pointing at a database it no
+ *    longer describes, and the gateway then refuses to start —
+ *    `SQLite integrity_check failed … row 1 missing from index` — in a restart
+ *    loop. Only the sidecars of a database the bundle actually replaces are
+ *    removed: one belonging to a database we are not overwriting may hold the
+ *    only copy of committed rows.
+ * 2. **Modes are preserved** (`noSamePerms` left off), because the gateway token
+ *    file is 0600 and a restore that widened it would be a downgrade the user
+ *    never asked for.
+ *
+ * NOT routed through `agentPushExcludes`: that helper adds
+ * `LIVE_DATABASE_EXCLUDES` unconditionally, which matches `*.sqlite*` — exactly
+ * the gateway state a restore exists to put back. The bundle was already
+ * filtered when it was captured.
+ */
+export async function restoreAgentState(args: {
+  agent: AgentId;
+  transport: SyncTransport;
+  srcDir: string;
+}): Promise<AgentStateRestoreResult> {
+  const boxDir = agentPullBoxDir(args.agent);
+  const clearedSidecars = await clearStaleSidecars(args, boxDir);
+  await args.transport.pushTree(args.srcDir, boxDir);
+  return { clearedSidecars };
+}
+
+/** Remove the box's `-wal`/`-shm` for every database this bundle replaces. */
+async function clearStaleSidecars(
+  args: { transport: SyncTransport; srcDir: string },
+  boxDir: string,
+): Promise<string[]> {
+  const rels = await findLocalDatabases(args.srcDir);
+  if (rels.length === 0) return [];
+  const paths = rels.flatMap((rel) => [`${boxDir}/${rel}-wal`, `${boxDir}/${rel}-shm`]);
+  await args.transport.exec(['sh', '-c', `rm -f ${paths.map(quote).join(' ')}`]);
+  return paths;
+}
+
+/** Host-side twin of the backup's `find`: the databases the bundle carries. */
+async function findLocalDatabases(root: string, prefix = ''): Promise<string[]> {
+  let entries: Dirent[];
+  try {
+    entries = await readdir(join(root, prefix), { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const e of entries) {
+    const rel = prefix ? join(prefix, e.name) : e.name;
+    if (e.isDirectory()) out.push(...(await findLocalDatabases(root, rel)));
+    else if (e.isFile() && (e.name.endsWith('.sqlite') || e.name.endsWith('.db'))) out.push(rel);
+  }
+  return out;
 }

--- a/packages/sandbox-core/src/sync/concerns/bot-backup.ts
+++ b/packages/sandbox-core/src/sync/concerns/bot-backup.ts
@@ -419,7 +419,19 @@ async function clearStaleSidecars(
   const rels = await findLocalDatabases(args.srcDir);
   if (rels.length === 0) return [];
   const paths = rels.flatMap((rel) => [`${boxDir}/${rel}-wal`, `${boxDir}/${rel}-shm`]);
-  await args.transport.exec(['sh', '-c', `rm -f ${paths.map(quote).join(' ')}`]);
+  const r = await args.transport.exec(['sh', '-c', `rm -f ${paths.map(quote).join(' ')}`]);
+  // FAIL, do not continue. `rm -f` is silent about a file that was not there, so
+  // a non-zero exit means the removal itself did not happen — and pushing the
+  // databases anyway lands them on the leftover logs, which is precisely the
+  // integrity-check restart loop this step exists to prevent. A restore that
+  // stops here leaves a box with its own working identity; one that continues
+  // leaves a box that never boots.
+  if (r.exitCode !== 0) {
+    throw new Error(
+      `could not clear stale write-ahead logs under ${boxDir}: ` +
+        `${r.stderr.trim() || `exit ${String(r.exitCode)}`}`,
+    );
+  }
   return paths;
 }
 

--- a/packages/sandbox-core/src/sync/index.ts
+++ b/packages/sandbox-core/src/sync/index.ts
@@ -172,9 +172,14 @@ export {
   linkLatest,
   listBackups,
   pruneBackups,
+  readBackupManifest,
+  resolveBotBundle,
+  restoreAgentState,
   writeBackupManifest,
   type AgentStateBackupResult,
+  type AgentStateRestoreResult,
   type BackupManifest,
+  type BotBundle,
 } from './concerns/bot-backup.js';
 export {
   GIT_MODE_EXCLUDE_DIRS,

--- a/packages/sandbox-core/test/bot-restore.test.ts
+++ b/packages/sandbox-core/test/bot-restore.test.ts
@@ -114,6 +114,23 @@ describe('restoreAgentState', () => {
     expect(opts?.exclude ?? []).toEqual([]);
   });
 
+  it('FAILS rather than pushing databases onto write-ahead logs it could not remove', async () => {
+    // The two outcomes are not close: stopping here leaves a box with its own
+    // working identity, continuing leaves one that never boots.
+    const root = project();
+    const dir = await makeBundle(root, '2026-09-07T14-03-11Z', {
+      databases: [join('state', 'openclaw.sqlite')],
+    });
+    const t = makeRecordingTransport({
+      execResult: () => ({ exitCode: 1, stdout: '', stderr: 'read-only file system' }),
+    });
+
+    await expect(
+      restoreAgentState({ agent: 'openclaw', transport: t, srcDir: join(dir, 'state') }),
+    ).rejects.toThrow(/could not clear stale write-ahead logs/);
+    expect(t.ops.map((o) => o.op)).not.toContain('pushTree');
+  });
+
   it('runs no removal when the bundle carries no database', async () => {
     const root = project();
     const dir = await makeBundle(root, '2026-09-07T14-03-11Z');

--- a/packages/sandbox-core/test/bot-restore.test.ts
+++ b/packages/sandbox-core/test/bot-restore.test.ts
@@ -1,0 +1,227 @@
+/**
+ * The restore half of the bot-backup concern.
+ *
+ * The load-bearing assertion here is the stale-sidecar removal, and it pins a
+ * MEASURED failure rather than a hypothetical one: pushing a backup's
+ * `openclaw.sqlite` over a fresh box's without removing that box's own
+ * `-wal`/`-shm` left the gateway refusing to start with
+ * `SQLite integrity_check failed … row 1 missing from index`, in a restart loop.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { makeRecordingTransport } from '../src/sync/recording-transport.js';
+import {
+  botBackupDir,
+  linkLatest,
+  listBackups,
+  pruneBackups,
+  readBackupManifest,
+  resolveBotBundle,
+  restoreAgentState,
+  writeBackupManifest,
+  type BackupManifest,
+} from '../src/sync/concerns/bot-backup.js';
+
+const OPENCLAW_DIR = '/home/vscode/.openclaw';
+
+function project(): string {
+  return mkdtempSync(join(tmpdir(), 'agentbox-bot-restore-'));
+}
+
+function manifest(over: Partial<BackupManifest> = {}): BackupManifest {
+  return {
+    version: 1,
+    stamp: '2026-09-07T14-03-11Z',
+    bot: 'ada',
+    boxId: 'b0dc0ffee',
+    boxName: 'ada',
+    provider: 'docker',
+    agent: 'openclaw',
+    state: true,
+    ...over,
+  };
+}
+
+/** A bundle on disk, as `download --backup` would have left it. */
+async function makeBundle(
+  root: string,
+  stamp: string,
+  opts: { state?: boolean; databases?: string[] } = {},
+): Promise<string> {
+  const dir = botBackupDir(root, 'ada', stamp);
+  mkdirSync(join(dir, 'workspace'), { recursive: true });
+  writeFileSync(join(dir, 'workspace', 'SOUL.md'), '# Ada\n');
+  if (opts.state !== false) {
+    mkdirSync(join(dir, 'state'), { recursive: true });
+    writeFileSync(join(dir, 'state', 'openclaw.json'), '{}');
+    for (const rel of opts.databases ?? []) {
+      mkdirSync(join(dir, 'state', rel, '..'), { recursive: true });
+      writeFileSync(join(dir, 'state', rel), '');
+    }
+  }
+  await writeBackupManifest(dir, manifest({ stamp, state: opts.state !== false }));
+  return dir;
+}
+
+describe('restoreAgentState', () => {
+  it('clears the stale write-ahead logs of the databases it replaces, then pushes', async () => {
+    const root = project();
+    const dir = await makeBundle(root, '2026-09-07T14-03-11Z', {
+      databases: [join('state', 'openclaw.sqlite'), join('agents', 'main', 'agent', 'a.sqlite')],
+    });
+    const t = makeRecordingTransport();
+
+    const r = await restoreAgentState({
+      agent: 'openclaw',
+      transport: t,
+      srcDir: join(dir, 'state'),
+    });
+
+    const rm = t.ops.find((o) => o.op === 'exec');
+    const cmd = String((rm?.args as { cmd?: string[] }).cmd?.join(' ') ?? '');
+    for (const rel of ['state/openclaw.sqlite', 'agents/main/agent/a.sqlite']) {
+      expect(cmd).toContain(`${OPENCLAW_DIR}/${rel}-wal`);
+      expect(cmd).toContain(`${OPENCLAW_DIR}/${rel}-shm`);
+    }
+    expect(r.clearedSidecars).toHaveLength(4);
+
+    // Order matters: removing the sidecars AFTER the push would delete the ones
+    // the restored database legitimately needs on its next open.
+    const kinds = t.ops.map((o) => o.op);
+    expect(kinds.indexOf('exec')).toBeLessThan(kinds.indexOf('pushTree'));
+  });
+
+  it('pushes the state dir with NO exclude — a restore is what puts the databases back', async () => {
+    // `agentPushExcludes` would add LIVE_DATABASE_EXCLUDES (`*.sqlite*`) here,
+    // which is exactly the gateway state a restore exists to return.
+    const root = project();
+    const dir = await makeBundle(root, '2026-09-07T14-03-11Z', {
+      databases: [join('state', 'openclaw.sqlite')],
+    });
+    const t = makeRecordingTransport();
+
+    await restoreAgentState({ agent: 'openclaw', transport: t, srcDir: join(dir, 'state') });
+
+    const push = t.ops.find((o) => o.op === 'pushTree');
+    expect(push?.args).toMatchObject({
+      hostSrcDir: join(dir, 'state'),
+      boxDestDir: OPENCLAW_DIR,
+    });
+    const opts = (push?.args as { opts?: { exclude?: string[] } }).opts;
+    expect(opts?.exclude ?? []).toEqual([]);
+  });
+
+  it('runs no removal when the bundle carries no database', async () => {
+    const root = project();
+    const dir = await makeBundle(root, '2026-09-07T14-03-11Z');
+    const t = makeRecordingTransport();
+
+    const r = await restoreAgentState({
+      agent: 'openclaw',
+      transport: t,
+      srcDir: join(dir, 'state'),
+    });
+
+    expect(r.clearedSidecars).toEqual([]);
+    expect(t.ops.map((o) => o.op)).toEqual(['pushTree']);
+  });
+});
+
+describe('resolveBotBundle', () => {
+  it('follows the `latest` link when no stamp is given', async () => {
+    const root = project();
+    await makeBundle(root, '2026-09-01T00-00-00Z');
+    await makeBundle(root, '2026-09-07T14-03-11Z');
+    await linkLatest(root, 'ada', '2026-09-01T00-00-00Z');
+
+    const b = await resolveBotBundle(root, 'ada');
+    expect(b.stamp).toBe('2026-09-01T00-00-00Z');
+    expect(b.stateDir).toBe(join(b.dir, 'state'));
+  });
+
+  it('falls back to the newest stamp when the link is missing', async () => {
+    // A bundle copied with a tool that drops symlinks must still restore —
+    // which is why `latest` is a relative link and not the only way in.
+    const root = project();
+    await makeBundle(root, '2026-09-01T00-00-00Z');
+    await makeBundle(root, '2026-09-07T14-03-11Z');
+
+    expect((await resolveBotBundle(root, 'ada')).stamp).toBe('2026-09-07T14-03-11Z');
+  });
+
+  it('honours an explicit stamp', async () => {
+    const root = project();
+    await makeBundle(root, '2026-09-01T00-00-00Z');
+    await makeBundle(root, '2026-09-07T14-03-11Z');
+    await linkLatest(root, 'ada', '2026-09-07T14-03-11Z');
+
+    expect((await resolveBotBundle(root, 'ada', '2026-09-01T00-00-00Z')).stamp).toBe(
+      '2026-09-01T00-00-00Z',
+    );
+  });
+
+  it('reports no state dir when the backup captured only the workspace', async () => {
+    const root = project();
+    await makeBundle(root, '2026-09-07T14-03-11Z', { state: false });
+    expect((await resolveBotBundle(root, 'ada')).stateDir).toBeUndefined();
+  });
+
+  it('names the directory when there is no backup at all', async () => {
+    const root = project();
+    await expect(resolveBotBundle(root, 'ada')).rejects.toThrow(/no backup of 'ada'/);
+  });
+
+  it('refuses a bundle whose workspace half is missing', async () => {
+    const root = project();
+    const dir = await makeBundle(root, '2026-09-07T14-03-11Z');
+    rmSync(join(dir, 'workspace'), { recursive: true });
+    await expect(resolveBotBundle(root, 'ada')).rejects.toThrow(/no workspace\//);
+  });
+});
+
+describe('readBackupManifest', () => {
+  it('refuses a manifest version this build does not restore', async () => {
+    // Half a bot is worse than a refusal: a newer layout could be half-applied.
+    const root = project();
+    const dir = botBackupDir(root, 'ada', '2026-09-07T14-03-11Z');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'manifest.json'), JSON.stringify({ version: 2, bot: 'ada' }));
+    await expect(readBackupManifest(dir)).rejects.toThrow(/version 2 is not one this build/);
+  });
+
+  it('refuses an unreadable manifest', async () => {
+    const root = project();
+    const dir = botBackupDir(root, 'ada', '2026-09-07T14-03-11Z');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'manifest.json'), 'not json');
+    await expect(readBackupManifest(dir)).rejects.toThrow(/not a readable backup manifest/);
+  });
+});
+
+describe('listBackups with a restore living beside the backups', () => {
+  it('counts only stamp-shaped directories', async () => {
+    // A restore writes its live `workspace/` next to the stamps. Counting it as
+    // a backup would give it a slot in the prune's ordering — and since
+    // `workspace` sorts after every stamp, make it the "newest" one.
+    const root = project();
+    await makeBundle(root, '2026-09-01T00-00-00Z');
+    await makeBundle(root, '2026-09-02T00-00-00Z');
+    await makeBundle(root, '2026-09-03T00-00-00Z');
+    mkdirSync(join(root, '.agentbox', 'bots', 'ada', 'workspace'), { recursive: true });
+    await linkLatest(root, 'ada', '2026-09-03T00-00-00Z');
+
+    expect(await listBackups(root, 'ada')).toEqual([
+      '2026-09-03T00-00-00Z',
+      '2026-09-02T00-00-00Z',
+      '2026-09-01T00-00-00Z',
+    ]);
+
+    const removed = await pruneBackups(root, 'ada', 2);
+    expect(removed).toEqual(['2026-09-01T00-00-00Z']);
+    // The live tree is untouched by a prune, whatever `--keep` says.
+    expect(await resolveBotBundle(root, 'ada')).toMatchObject({ stamp: '2026-09-03T00-00-00Z' });
+  });
+});


### PR DESCRIPTION
Phase 2 of [`docs/plans/bot-clone-spawn-plan.md`](https://github.com/madarco/agentbox/blob/agentbox/bot-restore/docs/plans/bot-clone-spawn-plan.md). Stacked on #373 (Phase 1, `download --backup`) — review or merge that first.

`--restore <bot>` recreates a bot from a backup bundle:

```bash
agentbox openclaw --restore ada                    # identity included
agentbox openclaw --restore ada --provider hetzner # on another provider
agentbox create   --restore ada                    # the workspace half only
```

## The PoC's answer was a bug, not a yes

The plan opened with a live gate: does pushing `state/` into a fresh box and restarting the gateway actually revive the bot? It does — **but only after the target's stale write-ahead logs are removed.**

A fresh openclaw box has already onboarded, so its `state/` holds a live `openclaw.sqlite` with its own `-wal`/`-shm`. Copying the bundle's main file over it leaves that WAL describing a database it no longer matches, and the gateway then refuses to start:

```
SQLite integrity_check failed for /home/vscode/.openclaw/state/openclaw.sqlite:
  row 1 missing from index idx_gateway_boot_lifecycle_started
```

— on a backoff loop, forever. The naive "rsync the state dir in" implementation ships a bot that never boots. That deletion is now the first thing `restoreAgentState` does, scoped to the databases the bundle actually replaces (a sidecar of one we are *not* overwriting may hold the only copy of committed rows).

## No create-path surgery was needed

The plan expected to write the state in before onboarding. `run_once: 'marker'` makes that both impossible and unnecessary: the marker is keyed by the task's command hash and lives on the box **rootfs**, not in the agent's config volume, so onboard runs once on every fresh box whatever that volume holds. Letting it run and then replacing what it wrote means the marker is already down and onboard never touches the restored identity again — on that boot or any later one, verified across a full `stop`/`start`.

So: create, stop the unit, push, restart. One order, every provider, no provider code touched.

## What else the implementation found

- **The state push must not go through `agentPushExcludes`** — it adds `LIVE_DATABASE_EXCLUDES` unconditionally, which matches `*.sqlite*`, precisely what a restore exists to put back. Pinned by a test.
- **The workspace half needs no plumbing.** The restored tree is the box's project, exactly as `clone`'s export dir is. `projectRoot` is that directory verbatim rather than `findProjectRoot`'s answer: the restore dir lives under the *original* project's `.agentbox/`, so walking up would have seeded the box from the template project instead.
- **A Phase 1 bug this exposed:** `listBackups` counted a restore's live `workspace/` as a backup, and `workspace` sorts after every stamp — so it would have become the newest "backup" the prune must keep.

## Verification (live)

| | |
|---|---|
| docker | same gateway token, the same automation row (**same id**) in the restored database, `openclaw config validate` clean, surviving a full box `stop`/`start` |
| hetzner | the acceptance test: a bundle captured on **docker**, restored onto a **VPS** — same token, same automation, config valid, workspace intact |
| `create --restore` | workspace half only, naming the agent whose identity it did not bring |

Both test boxes destroyed; the Hetzner API shows no orphan servers or firewalls. 4,832 tests pass, typecheck clean across 47 tasks, docs site compiles. Both new guards are mutation-checked.

## Deliberately still open

Recorded in the new [`bot-clone-spawn-backlog.md`](https://github.com/madarco/agentbox/blob/agentbox/bot-restore/docs/plans/bot-clone-spawn-backlog.md):

- **The source-box guard reads `manifest.boxId`**, so a second restore of the same bundle into a different `--into` directory is not refused. Restoring twice into the *same* directory is.
- **"Does OpenClaw refuse a duplicate identity?" is not answerable locally** — two gateways on one host with no channel configured never collide, and the collision that matters is at the channel provider. The hard error with `--force` is the safe default, chosen rather than measured.
- **`--restore` does not work against a remote hub**: the bundle is a local directory and the create API carries a `projectId`, never a path.
- **`download` is still the one CLI-inline command**, and `--restore` joins `--backup` there. Moving the whole command behind `/api/v1` — with a state-push route the restore can use — is one change, not three.

https://claude.ai/code/session_01ChpFVKPMobDd3xk3uwG6gj

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Restores gateway identity and SQLite state into live boxes; mistakes could cause duplicate identities or broken gateways, though guards (`assertSourceBoxNotRunning`, WAL clearing) mitigate the main failure modes.
> 
> **Overview**
> Adds **`--restore <bot>`** (with `--stamp`, `--into`, `--force`) so backups under `<project>/.agentbox/bots/` can seed a **new** box. **`agentbox create --restore`** copies the workspace into a live sibling dir (default `bots/<bot>/workspace`) and warns when the bundle also has agent state. **`agentbox <agent> --restore`** does the same plus, after the service is healthy, stops the unit, pushes captured state via **`restoreAgentState`**, and restarts—so gateway identity can return on another provider.
> 
> New CLI module **`_restore.ts`** centralizes bundle resolution, workspace staging, refusals (no positional box ref with restore, non-empty dest, source box still running), and **`stopUnit`** moved to **`service-action.ts`** for reuse.
> 
> In **`sandbox-core`**, **`resolveBotBundle`**, manifest checks, and **`restoreAgentState`** clear stale **`-wal`/`-shm`** before pushing SQLite files (avoids integrity-check boot loops) and bypass push excludes that would drop databases. **`listBackups`** now only counts stamp-shaped dirs so a restore’s live **`workspace/`** is not treated as a backup for prune.
> 
> Docs, changelog, plan/backlog updates, and unit tests cover guards and restore behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14c3545da02f8bd91bfe3a5bb091d2db85cd8017. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->